### PR TITLE
use <kbd> to format keyboard keys

### DIFF
--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -64,7 +64,7 @@ navigator.keyboard.lock();
 The following example captures the <kbd>W</kbd>, <kbd>A</kbd>, <kbd>S</kbd>, and <kbd>D</kbd> keys. It captures these keys
 regardless of which modifiers are used with the key press. Assuming a standard US QWERTY
 layout, registering `"KeyW"` ensures that <kbd>W</kbd>, <kbd>Shift</kbd>+<kbd>W</kbd>, <kbd>Control</kbd>+<kbd>W</kbd>,
-<kbd>Control+Shift+W</kbd>, and all other key modifier combinations with <kbd>W</kbd> are sent to the app.
+<kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>W</kbd>, and all other key modifier combinations with <kbd>W</kbd> are sent to the app.
 The same applies to for `"KeyA"`, `"KeyS"` and
 `"KeyD"`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Replaced "W" with <kbd>W</kbd> (using `<kbd>`)

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This page is inconsistent with [the sibling pages](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard_API) that correctly use `<kbd>`. 
The inconsistent use of quotation marks is also a bit weird.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
