### PR TITLE
Fix clarify visibilitychange event intro to mention all triggers

### DIFF
--- a/files/en-us/web/api/document/visibilitychange_event/index.md
+++ b/files/en-us/web/api/document/visibilitychange_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Document.visibilitychange_event
 
 {{APIRef}}
 
-The `visibilitychange` event is fired at the document when the contents of its tab have become visible or have been hidden.
+The `visibilitychange` event is fired at the document when its visibility status changes — for example, when the user switches browser tabs, navigates to a new page, minimizes or closes the browser, or on mobile, switches to a different app.
 
 The event is not cancelable.
 


### PR DESCRIPTION
  ### Description                                                                                                                                                      

  Updated the opening description of the `visibilitychange` event to mention all scenarios that trigger the event, not just tab switching.

  ### Motivation

  The previous description said the event fires "when the contents of its tab have become visible or have been hidden", which implies the event is only related to tab visibility. 
  
  This is misleading because the event also fires when the user navigates to a new page, minimizes or closes the browser, or switches to a different app on mobile.

  These cases were only mentioned later in the "Usage notes" section. Moving this information to the intro makes the document more accurate from the start.

  ### Additional details

  _No response_

  ### Related issues and pull requests

  Fixes #43092