### PR TITLE
fix: correct terminology for object initializer property names

### DIFF
--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -31,7 +31,7 @@ const obj = {
 };
 ```
 
-Each property name before colons is a property key (either an identifier name, a number literal, or a string literal), and each `valueN` is an expression whose value is assigned to the property name. The property name can also be an expression; computed keys need to be wrapped in square brackets. The [object initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) reference contains a more detailed explanation of the syntax.
+Each property name before the colon is either an identifier, a number literal, or a string literal, and each `valueN` is an expression whose value is assigned to the property name. The property name can also be an expression; computed keys need to be wrapped in square brackets. The [object initializer](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) reference contains a more detailed explanation of the syntax.
 
 In this example, the newly created object is assigned to a variable `obj` — this is optional. If you do not need to refer to this object elsewhere, you do not need to assign it to a variable. (Note that you may need to wrap the object literal in parentheses if the object appears where a statement is expected, so as not to have the literal be confused with a block statement.)
 


### PR DESCRIPTION
Replace incorrect use of 'identifier' with 'property key' and clarify that property names in object initializers can be identifier names, number literals, or string literals.

As noted in the issue, the original text incorrectly states that each property name is an 'identifier', but identifiers are only one of the valid property key types. Numbers and string literals are not identifiers.

Fixes #43095