### PR TITLE
fix: correct 'after' to 'before' in break-before property description

### DIFF
--- a/files/en-us/web/css/reference/properties/break-before/index.md
+++ b/files/en-us/web/css/reference/properties/break-before/index.md
@@ -107,9 +107,9 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
 - `avoid`
   - : Avoids any break (page, column, or region) from being inserted right before the principal box.
 - `always`
-  - : Forces a page break right after the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
+  - : Forces a page break right before the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
 - `all`
-  - : Forces a page break right after the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.
+  - : Forces a page break right before the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.
 
 #### Page break values
 


### PR DESCRIPTION
## Description

The `always` and `all` value descriptions for the `break-before` CSS property incorrectly state "Forces a page break right **after** the principal box" when it should be "right **before** the principal box".

This is a `break-before` property, so breaks should occur before the element, not after.

## Reference

- [CSS Fragmentation Level 4 spec](https://drafts.csswg.org/css-break-4/#valdef-break-before-always)

Fixes #43171