### PR TITLE
fix: correct 'after' to 'before' in break-before always/all descriptions

### DIFF
--- a/files/en-us/web/css/reference/properties/break-before/index.md
+++ b/files/en-us/web/css/reference/properties/break-before/index.md
@@ -107,9 +107,9 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
 - `avoid`
   - : Avoids any break (page, column, or region) from being inserted right before the principal box.
 - `always`
-  - : Forces a page break right after the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
+  - : Forces a page break right before the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
 - `all`
-  - : Forces a page break right after the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.
+  - : Forces a page break right before the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.
 
 #### Page break values
 


### PR DESCRIPTION
Fixes #43171

The `always` and `all` values for the `break-before` property incorrectly described forcing a page break "right after" the principal box. Since this is `break-before`, it should be "right before".

Changed:
- `always`: "Forces a page break right **after**" → "right **before**"
- `all`: "Forces a page break right **after**" → "right **before**"