### PR TITLE
Fix description for break-before: always

### DIFF
--- a/files/en-us/web/css/reference/properties/break-before/index.md
+++ b/files/en-us/web/css/reference/properties/break-before/index.md
@@ -107,7 +107,7 @@ Once forced breaks have been applied, soft breaks may be added if needed, but no
 - `avoid`
   - : Avoids any break (page, column, or region) from being inserted right before the principal box.
 - `always`
-  - : Forces a page break right after the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
+  - : Forces a page break right before the principal box. The type of this break is that of the immediately-containing fragmentation context. If we are inside a multicol container then it would force a column break, inside paged media (but not inside a multicol container) a page break.
 - `all`
   - : Forces a page break right after the principal box. Breaking through all possible fragmentation contexts. So a break inside a multicol container, which was inside a page container would force a column and page break.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Corrected the description of `break-before: always` to say "before" instead of "after".

### Motivation

The current description incorrectly stated that the break happens after the principal box. This change fixes the wording to match the actual behavior and improves accuracy for readers.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes #43171

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
