### PR TITLE
added the release note for position-try-order

### DIFF
--- a/files/en-us/mozilla/firefox/releases/148/index.md
+++ b/files/en-us/mozilla/firefox/releases/148/index.md
@@ -37,7 +37,7 @@ Firefox 148 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{cssxref("position-area")}} property in [CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning) now correctly keeps the anchored element within the viewport.
   ([Firefox bug 2008537](https://bugzil.la/2008537)).
 
-- The {{cssxref("position-try-order")}} property in [CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning) is now supported and allows changing the order in which position fallback options are tried based upon the space available. This also effects the {{cssxref("position-try")}} shorthand property.
+- The {{cssxref("position-try-order")}} property in [CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning) is now supported and allows changing the order in which position fallback options are tried based on the space available. This also affects the {{cssxref("position-try")}} shorthand property.
   ([Firefox bug 1989059](https://bugzil.la/1989059)).
 
 - The {{cssxref("overflow")}}, {{cssxref("overflow-x")}}, and {{cssxref("overflow-y")}} CSS properties can now be used on {{glossary("replaced elements")}} such as images, in the same way that they are used with other elements.


### PR DESCRIPTION
### Description

- Added Firefox release note for `position-try-order`

### Motivation

- Working on [MDN issue 42749](https://github.com/mdn/content/issues/42749)

### Related issues and pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/28821)