### PR TITLE
Clarify AudioBufferSourceNode.buffer behavior for null values

### DIFF
--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -10,12 +10,11 @@ browser-compat: api.AudioBufferSourceNode.buffer
 
 The **`buffer`** property of the {{domxref("AudioBufferSourceNode")}} interface provides the ability to play back audio using an {{domxref("AudioBuffer")}} as the source of the sound data.
 
-If the `buffer` property is set to `null`, the node outputs a single channel of silence in which every sample is 0, and stops immediately if `start()` has been called.
-
 ## Value
 
-An {{domxref("AudioBuffer")}} which contains the data representing the sound which the
-node will play.
+An {{domxref("AudioBuffer")}} which contains the data representing the sound which the node will play, or `null`.
+
+If set to `null`, the node outputs a single channel of silence in which every sample is 0, and stops immediately if `start()` has been called.
 
 ## Exceptions
 


### PR DESCRIPTION
### Description

Clarified that when `buffer` is set to `null`, the node outputs silence and stops immediately if `start()` has been called. The null behavior description has been moved to the Value section for better organization.

### Motivation

According to the [W3C Web Audio API specification](https://webaudio.github.io/web-audio-api/#playback-AudioBufferSourceNode), if `buffer` is `null` and `start()` has been called, the node stops immediately.

The current documentation only stated that the node "generates silence," which could lead readers to assume the node continues playing indefinitely (outputting zeros) until `stop()` is called manually. This update clarifies that the node stops immediately.