### PR TITLE
WebDriver conformance changes for Firefox 148

### DIFF
--- a/files/en-us/mozilla/firefox/releases/148/index.md
+++ b/files/en-us/mozilla/firefox/releases/148/index.md
@@ -83,7 +83,6 @@ Firefox 148 was released on [February 24, 2026](https://whattrainisitnow.com/rel
 - Fixed an issue in `network.getData` that caused a `RangeError` when decoding chunked response bodies due to a size mismatch ([Firefox bug 2004973](https://bugzil.la/2004973)).
 - Fixed an issue where the `browsingContext.userPromptOpened` and `browsingContext.userPromptClosed` events incorrectly reported the top-level context ID instead of the iframe's context ID ([Firefox bug 1964905](https://bugzil.la/1964905)).
 - Improved the performance of WebDriver BiDi commands by approximately 100 ms when the selected context is no longer available during the command execution ([Firefox bug 1934326](https://bugzil.la/1934326)).
--
 
 #### Marionette
 


### PR DESCRIPTION
This PR contains [all the changes to WebDriver BiDi and Marionette for the Firefox 148](https://bugzilla.mozilla.org/buglist.cgi?columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&query_format=advanced&product=Remote%20Protocol&resolution=FIXED&f1=cf_status_firefox148&o1=equals&v1=fixed&f2=cf_status_firefox147&o2=notequals&v2=fixed&f3=status_whiteboard&o3=notsubstring&v3=%5Bwptsync%20downstream%5D&component=Agent&component=Marionette&component=WebDriver%20BiDi&list_id=17861801) release.

@juliandescottes and @lutien can you please review? Thanks!