### PR TITLE
Add ignore-script false to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 audit=false
 engine-strict=true
+ignore-scripts=false


### PR DESCRIPTION
### Description

This adds `ignore-scripts=false` to `.npmrc`.

### Motivation

This repository depends on lifecycle scripts to run. Users may have disabled lifecycle scripts in ~/.npmrc. To make the project work for those users, `ignore-scripts` is explicitly set to false.

### Additional details

I disabled npm scripts for security reasons.

### Related issues and pull requests

N/A