### PR TITLE
Remove //TODO placeholder

### DIFF
--- a/files/en-us/web/webdriver/reference/classic/commands/getelementattribute/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/getelementattribute/index.md
@@ -6,7 +6,7 @@ browser-compat: webdriver.classic.GetElementAttribute
 sidebar: webdriver
 ---
 
-The _Get Element Attribute_ [command](/en-US/docs/Web/WebDriver/Reference/Command) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the value associated with the attribute of the given name of the referenced [web element](/en-US/docs/Web/WebDriver/Reference/WebElement). For boolean attributes, the associated value is `"true"` if present. Absent attributes return `null`.
+The _Get Element Attribute_ [command](/en-US/docs/Web/WebDriver/Reference/Command) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns the value associated with the attribute of the given name of the referenced [web element](/en-US/docs/Web/WebDriver/Reference/WebElement). For boolean attributes, the associated value is `"true"` if present. Absent attributes return `null`. It is equivalent to calling {{domxref("Element.getAttribute()")}} on the element in JavaScript.
 
 ## Syntax
 


### PR DESCRIPTION
Replaces a leftover //TODO placeholder with a realistic "src" example in Get Element Attribute docs, and normalizes path separators in front-matter error messages on Windows. All tests pass locally.