### PR TITLE
Remove duplicated content from MITM guide

### DIFF
--- a/files/en-us/web/security/attacks/mitm/index.md
+++ b/files/en-us/web/security/attacks/mitm/index.md
@@ -25,7 +25,7 @@ The [TLS guide](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security) desc
 
 - [Serve all resources over TLS](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security#mixed_content): not only HTML documents but all subresources such as scripts, stylesheets, images, and fonts.
 
-- If you redirect HTTP requests to use HTTPS, implement [strict transport security (HSTS)](/en-US/docs/Web/Security/Attacks/MITM#use_hsts_when_upgrading_http_requests).
+- If you redirect HTTP requests to use HTTPS, implement [strict transport security (HSTS)](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security#upgrading_http_connections).
 
 ## See also
 


### PR DESCRIPTION
https://github.com/mdn/content/pull/43253 added TLS guidance to the TLS guide, some of which was taken from the [MITM page](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/MITM). This PR removes that content from the MITM page, replacing it with pointers to the TLS guide.

I should really have done this in https://github.com/mdn/content/pull/43253, sorry.