### PR TITLE
fix: replace "Whack-a-Mole" idiom per inclusive language guide

### DIFF
--- a/files/en-us/games/anatomy/index.md
+++ b/files/en-us/games/anatomy/index.md
@@ -308,7 +308,7 @@ This may also apply to some of your own tasks. Those are good candidates to thro
 
 ## Summary
 
-I want to be clear that any of the above, or none of them, could be best for your game. The correct decision entirely depends on the trade-offs that you are willing (and unwilling) to make. The concern is mostly with switching to another option. Fortunately, I do not have any experience with this, but I have heard it is an excruciating game of Whack-a-Mole.
+I want to be clear that any of the above, or none of them, could be best for your game. The correct decision entirely depends on the trade-offs that you are willing (and unwilling) to make. The concern is mostly with switching to another option. Fortunately, I do not have any experience with this, but I have heard it is an excruciating exercise in chasing regressions.
 
 An important thing to remember for managed platforms, like the web, is that your loop may stop execution for significant periods of time. This could occur when the user unselects your tab and the browser sleeps (or slows) its `requestAnimationFrame` callback interval. You have many ways to deal with this situation and this could depend on whether your game is single player or multiplayer. Some choices are:
 


### PR DESCRIPTION
## Summary

Follow-up to #43256 — applies the new inclusive language guidance added in that PR.

Replaces a single instance of "Whack-a-Mole" (a figurative idiom implying violence toward animals) with "chasing regressions," which is both more inclusive and more precise in context.

**File changed:** `files/en-us/games/anatomy/index.md`

This was the only instance found in the content repo after a full search for figurative animal idioms.