### PR TITLE
Fix <absolute-size> spec link

### DIFF
--- a/files/en-us/web/css/reference/values/absolute-size/index.md
+++ b/files/en-us/web/css/reference/values/absolute-size/index.md
@@ -2,7 +2,7 @@
 title: <absolute-size>
 slug: Web/CSS/Reference/Values/absolute-size
 page-type: css-type
-spec-urls: https://drafts.csswg.org/css-fonts/#valdef-font-size-absolute-size
+spec-urls: https://drafts.csswg.org/css-fonts/#typedef-absolute-size
 sidebar: cssref
 ---
 


### PR DESCRIPTION
Fixes #43240
Update spec URL to the correct anchor (#typedef-absolute-size)

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
