### PR TITLE
Fix mismatched `#square` id reference in animation-timeline docs

### DIFF
--- a/files/en-us/web/css/reference/properties/animation-timeline/index.md
+++ b/files/en-us/web/css/reference/properties/animation-timeline/index.md
@@ -205,7 +205,7 @@ Our container includes three stretcher elements which will be wide enough to ens
 
 We define the container as a flex container, setting a {{cssxref("width")}} on the container that is half the width of it's combined flex children. Adding an {{cssxref("overflow-x")}} value of `scroll` sets it to have a horizontal scrollbar.
 
-Our scroll progress timeline, defined using the {{cssxref("scroll-timeline-name")}} and {{cssxref("scroll-timeline-axis")}} properties, is named `--square-timeline`. This timeline is applied to our `#square` element using `animation-timeline: --square-timeline`.
+Our scroll progress timeline, defined using the {{cssxref("scroll-timeline-name")}} and {{cssxref("scroll-timeline-axis")}} properties, is named `--square-timeline`. This timeline is applied to our `#shape` element using `animation-timeline: --square-timeline`.
 
 ```css live-sample___named_scroll live-sample___anonymous_scroll
 #container {


### PR DESCRIPTION
## Summary
- fix docs text in `animation-timeline` reference page
- replace `#square` with `#shape` in the “Setting a named scroll progress timeline” explanation to match the actual sample element id

Fixes #43189

## Testing
- docs-only change; verified the referenced live sample CSS/HTML uses `#shape`
