### PR TITLE
Correct displaying event properties example to do what's claimed

### DIFF
--- a/files/en-us/web/api/document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/index.md
@@ -587,13 +587,12 @@ td {
 ```
 
 ```js
-function showEventProperties(e) {
+function showEventProperties(event) {
   function addCell(row, text) {
     const cell = row.insertCell(-1);
     cell.appendChild(document.createTextNode(text));
   }
 
-  const event = e || window.event;
   document.getElementById("eventType").textContent = event.type;
 
   const table = document.createElement("table");


### PR DESCRIPTION
The last example (Displaying event object properties) is meant to "to display all the properties of the onload event object and their values". But the example did not register the appropriate event handler; instead it had an erroneous last line.