### PR TITLE
Fix comment typo on hue interpolation method

### DIFF
--- a/files/en-us/web/css/reference/values/gradient/repeating-conic-gradient/index.md
+++ b/files/en-us/web/css/reference/values/gradient/repeating-conic-gradient/index.md
@@ -49,7 +49,7 @@ repeating-conic-gradient(
 )
 
 /* Interpolation in polar color space
-  with longer hue interpolation method */
+  with shorter hue interpolation method */
 repeating-conic-gradient(in hsl shorter hue, red, blue 90deg, green 180deg)
 ```
 


### PR DESCRIPTION
Corrected comment typo "longer hue" -> "shorter hue"

### Description

Fix typo in repeating-conic-gradient reference where it says "longer hue" instead of "shorter hue"