### PR TITLE
Add 'unoccluded' to ignore list

### DIFF
--- a/.vscode/dictionaries/ignore-list.txt
+++ b/.vscode/dictionaries/ignore-list.txt
@@ -304,9 +304,9 @@ TUROPC
 Tweety
 UCCE
 ultricied
+unoccluded
 updatebg
 urlscheme
-unoccluded
 userconnect
 userdisconnect
 usermessage


### PR DESCRIPTION
### Description

Adds the word "unoccluded" to the project cspell dictionary to resolve a spell-check warning in the IntersectionObserverEntry documentation.

### Motivation

"unoccluded" is a valid technical term used to describe visibility state and is intentionally used in the documentation. Adding it to the dictionary prevents false-positive lint errors during CI checks.

### Additional details

The word appears in:
`files/en-us/web/api/intersectionobserverentry/index.md`

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/43304