### PR TITLE
Fix sanitizer usage in setHTMLUnsafe examples

### DIFF
--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -51,7 +51,7 @@ For example, if you wanted to inject unsafe HTML but for some reason you needed 
 const sanitizer = new Sanitizer(); // Default sanitizer
 sanitizer.allowAttribute("onblur"); // Allow onblur
 
-someElement.setHTMLUnsafe(untrustedString, { sanitizer });
+someElement.setHTMLUnsafe(untrustedString, { sanitizer: sanitizer });
 ```
 
 ### Sanitizer configuration
@@ -291,7 +291,7 @@ All other elements in the input string would be removed.
 
 ```js
 const sanitizer = new Sanitizer({ elements: ["p", "b", "div"] });
-someElement.setHTMLUnsafe(untrustedString, { sanitizer });
+someElement.setHTMLUnsafe(untrustedString, { sanitizer: sanitizer });
 ```
 
 Note that in this case you should normally use `setHTML()`.


### PR DESCRIPTION
### Description

Fix sanitizer usage in `setHTMLUnsafe` examples. Current example doesn't work.

### Motivation

Fix usage example so future readers won't have to spend time figuring out why the example code doesn't work.

### Additional details

There are problems in these examples in the following sections:
https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API#sanitization_methods
https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API#using_an_allow_sanitizer_configuration

### Related issues and pull requests

No.