### PR TITLE
Added missing dot

### DIFF
--- a/files/en-us/web/uri/reference/fragment/index.md
+++ b/files/en-us/web/uri/reference/fragment/index.md
@@ -7,7 +7,7 @@ spec-urls: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.5
 sidebar: urlsidebar
 ---
 
-The **fragment** of a URI is the last part of the URI, starting with the `#` character. It is used to identify a specific part of the resource, such as a section of a document or a position in a video. The fragment is not sent to the server when the URI is requested, but it is processed by the client (such as the browser) after the resource is retrieved.
+The **fragment** of a URI is the last part of the URI, starting with the `#` character. It is used to identify a specific part of the resource, such as a section of a document or a position in a video. The fragment is not sent to the server when the URI is requested; it is processed by the client (e.g., the browser) after the resource is retrieved.
 
 ## Syntax
 
@@ -28,7 +28,7 @@ http://www.example.com:80/path/to/myfile.html?key1=value1&key2=value2#SomewhereI
 ```
 
 `#SomewhereInTheDocument` is the _fragment_ of the URL, which is an anchor to another part of the resource itself. An anchor represents a sort of "bookmark" inside the resource, giving the browser the directions to show the content located at that spot. In an HTML document, for example, the browser will scroll to the point where the anchor is defined. It can be the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attribute of an element, and the browser will scroll to that element.
-In a video or audio document, it can be a [media fragment](https://www.w3.org/TR/media-frags/) in the form of `#t=...`, which makes the video or audio start playing from that time.
+In a video or audio document, it can be a [media fragment](/en-US/docs/Web/URI/Reference/Fragment/Media_fragments) in the form of `#t=...`, which makes the video or audio start playing from that time.
 
 There's a special [text fragment](/en-US/docs/Web/URI/Reference/Fragment/Text_fragments) feature that allows you to link to a specific part of a web page identified by its text content.
 


### PR DESCRIPTION
Added missing end-of-sentence dot at line 30 to fix this:
<img width="783" height="195" alt="image" src="https://github.com/user-attachments/assets/484e1131-1524-4c40-885a-daf9b842faf9" />

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
One sentence was missing is missing a dot at the end. In markdown the next sentence is on the next line but in rendered HTML it comes right after which makes it odd.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Sentences are meant to be finished with a dot character.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
