### PR TITLE
Add examples: CSS initial and inherit

### DIFF
--- a/files/en-us/web/css/reference/values/inherit/index.md
+++ b/files/en-us/web/css/reference/values/inherit/index.md
@@ -91,7 +91,7 @@ Notice how the inline element inherit all the properties of the parent `<p>`, in
 
 ### Excluding selected elements from a rule
 
-This example demonstrates how the inherit keyword can be used to exclude selected elements from a color rule, allowing them to use their parent's color instead.
+This example demonstrates how the `inherit` keyword can be used to exclude selected elements from a color rule, allowing them to use their parent's color instead.
 
 #### HTML
 

--- a/files/en-us/web/css/reference/values/initial/index.md
+++ b/files/en-us/web/css/reference/values/initial/index.md
@@ -14,7 +14,7 @@ On [inherited properties](/en-US/docs/Web/CSS/Guides/Cascade/Inheritance#inherit
 
 ### Basic usage
 
-In this example, we use the `initial` value to reset {{cssxref("color")}} and {{cssxref("font-size")}} for an element.
+In this example, we use the `initial` keyword to reset an element's {{cssxref("color")}} and {{cssxref("font-size")}} property values.
 
 #### HTML
 
@@ -31,7 +31,7 @@ In this example, we use the `initial` value to reset {{cssxref("color")}} and {{
 
 #### CSS
 
-We define a `color` and `font-size` on the paragraph, and reset the values on the {{htmlelement("em")}} by setting these property values to `initial`.
+We set `color` and `font-size` on the `<p>` element, then set those properties to `initial` on the {{htmlelement("em")}} element to reset them.
 
 ```css
 p {
@@ -49,7 +49,7 @@ em {
 
 {{EmbedLiveSample('Using_initial_to_reset_color_for_an_element')}}
 
-With the `initial` keyword in this example, the `color` and `font-size` values on the `em` element are restored to the initial values of [`color`](/en-US/docs/Web/CSS/Reference/Properties/color#formal_definition) and [`font-size`](/en-US/docs/Web/CSS/Reference/Properties/color#formal_definition), respectively, as defined in the specification.
+With the `initial` keyword in this example, the `color` and `font-size` values on the `em` element are restored to the initial values for [`color`](/en-US/docs/Web/CSS/Reference/Properties/color#formal_definition) and [`font-size`](/en-US/docs/Web/CSS/Reference/Properties/font-size#formal_definition), respectively.
 
 ## Specifications
 


### PR DESCRIPTION
Added live examples to CSS initial and inherit that demonstrate the features. 
Updated the only live example to not be dependent on color alone (a11y)