### PR TITLE
Simplify CSSPageDescriptors instance properties

### DIFF
--- a/files/en-us/web/api/csspagedescriptors/index.md
+++ b/files/en-us/web/api/csspagedescriptors/index.md
@@ -17,31 +17,23 @@ A `CSSPageDescriptors` object is accessed through the {{DOMxRef("CSSPageRule.sty
 
 {{InheritanceDiagram}}
 
-## Attributes
+## Instance properties
 
 _This interface also inherits properties of its parent, {{domxref("CSSStyleDeclaration")}}._
 
+The following property names, in kebab-case (accessed using [bracket notation](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics#bracket_notation)) and camel-case (accessed using [dot notation](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics#dot_notation)), each represent the value of a descriptor in the corresponding `@page` at-rule:
+
 - `margin`
   - : A string representing the `margin` property of the corresponding `@page` at-rule.
-- `margin-top`
+- `margin-top` or `marginTop`
   - : A string representing the `margin-top` property of the corresponding `@page` at-rule.
-- `marginTop`
-  - : A string representing the `margin-top` property of the corresponding `@page` at-rule.
-- `margin-right`
+- `margin-right` or `marginRight`
   - : A string representing the `margin-right` property of the corresponding `@page` at-rule.
-- `marginRight`
-  - : A string representing the `margin-right` property of the corresponding `@page` at-rule.
-- `margin-bottom`
+- `margin-bottom` or `marginBottom`
   - : A string representing the `margin-bottom` property of the corresponding `@page` at-rule.
-- `marginBottom`
-  - : A string representing the `margin-bottom` property of the corresponding `@page` at-rule.
-- `margin-left`
+- `margin-left` or `marginLeft`
   - : A string representing the `margin-left` property of the corresponding `@page` at-rule.
-- `marginLeft`
-  - : A string representing the `margin-left` property of the corresponding `@page` at-rule.
-- `page-orientation` {{experimental_inline}}
-  - : A string representing the `page-orientation` property of the corresponding `@page` at-rule.
-- `pageOrientation` {{experimental_inline}}
+- `page-orientation` or `pageOrientation` {{experimental_inline}}
   - : A string representing the `page-orientation` property of the corresponding `@page` at-rule.
 - `size`
   - : A string representing the `size` property of the corresponding `@page` at-rule.


### PR DESCRIPTION
### Description

Updated `CSSPageDescriptors` properties list to combine kebab-case and camel-case entries into single items, matching the pattern used by `CSSFontFaceDescriptors` and `CSSPositionTryDescriptors`. Also renamed the section from "Attributes" to "Instance properties" for consistency.

### Related issues and pull requests

Suggested in https://github.com/mdn/content/pull/43286#discussion_r2870085012.