### PR TITLE
Fix accidentally duplicated CSSMathValue description

### DIFF
--- a/files/en-us/web/api/css_typed_om_api/index.md
+++ b/files/en-us/web/api/css_typed_om_api/index.md
@@ -73,11 +73,11 @@ The {{domxref('CSSKeywordValue')}} interface of the CSS Typed Object Model API c
   - : An interface which creates an object to represent CSS keywords and other identifiers. When used where a string is expected, it will return the value of `CSSKeyword.value`.
 - {{domxref('CSSMathValue')}}
   - : A tree of subclasses representing numeric values that are more complicated than a single value and unit, including:
-    - {{domxref('CSSMathInvert')}} - represents a CSS {{cssxref("calc","calc()")}} value used as `calc(1 / <value>)`.
     - {{domxref('CSSMathMax')}} - represents the CSS {{cssxref("max","max()")}} function.
     - {{domxref('CSSMathMin')}} - represents the CSS {{cssxref("min","min()")}} function.
     - {{domxref('CSSMathNegate')}} - negates the value passed into it.
-    - {{domxref('CSSMathProduct')}} - represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
+    - {{domxref('CSSMathInvert')}} - represents a CSS {{cssxref("calc","calc()")}} value used as `calc(1 / <value>)`. This type is used internally by {{domxref('CSSNumericValue.div','div()')}}, to create an appropriate {{domxref('CSSMathProduct')}}.
+    - {{domxref('CSSMathProduct')}} - represents the result obtained by calling {{domxref('CSSNumericValue.mul','mul()')}} or {{domxref('CSSNumericValue.div','div()')}} on {{domxref('CSSNumericValue')}}.
     - {{domxref('CSSMathSum')}} - represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
 
 - {{domxref('CSSNumericValue')}}


### PR DESCRIPTION
### Description

The description for CSSMathSum was carried over to CSSMathProduct. This fixes that by creating an appropriate description for CSSMathProduct.

As a drive-by fix, I also made the description for CSSMathInvert clearer by explaining how it's used

### Motivation

I read the docs and saw that they were inaccurate! 

### Additional details

https://drafts.css-houdini.org/css-typed-om/#dom-cssnumericvalue-mul

### Related issues and pull requests

I don't see any related issues.