### PR TITLE
FF149 Relnote: HTMLMediaElement.captureStream()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -64,8 +64,8 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{domxref("HTMLMediaElement.captureStream()", "captureStream()")}} method of the {{domxref("HTMLMediaElement")}} interface is now supported.
   This returns an object that streams the real-time capture of the content in the element.
-  This can be used, for example, as a source for a WebRTC {{domxref("RTCPeerConnection")}}.
-  Previously this was available only as `mozCaptureStream()`, and the method was not compliant with the specification.
+  The stream can be used, for example, as a source for a WebRTC {{domxref("RTCPeerConnection")}}.
+  Previously, `captureStream()` was available only as the non-standard `mozCaptureStream()` method.
   ([Firefox bug 2017708](https://bugzil.la/2017708)).
 
 <!-- #### Removals -->

--- a/files/en-us/web/api/htmlmediaelement/capturestream/index.md
+++ b/files/en-us/web/api/htmlmediaelement/capturestream/index.md
@@ -31,7 +31,7 @@ A {{domxref('MediaStream')}} object which can be used as a source for audio and/
 ### Basic usage
 
 In this example, an event handler is established so that clicking a button starts capturing the contents of a media element with the ID `"playback"` into a {{domxref("MediaStream")}}.
-The stream can then be used for other purposes—like a source for streaming over WebRTC, to allow sharing prerecorded videos with another person during a video call.
+The stream can then be used for other purposes, such as a WebRTC stream to share prerecorded videos with another person during a video call.
 
 ```js
 document.querySelector(".playAndRecord").addEventListener("click", () => {


### PR DESCRIPTION
FF149 adds support for `HTMLElement.captureStream()` in https://bugzilla.mozilla.org/show_bug.cgi?id=2017708 

This adds a release note, and also updates the method docs to tidy up layout and remove notes that should be in BCD (being looked at in https://github.com/mdn/browser-compat-data/pull/29165)

Related work for this can be tracked in #43215