### PR TITLE
Fix decode() promise wording: clarify one promise per call

### DIFF
--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -24,7 +24,10 @@ decode(options)
     - `frameIndex` {{optional_inline}}
       - : An integer representing the index of the frame to decode. Defaults to `0` (the first frame).
     - `completeFramesOnly` {{optional_inline}}
-      - : A {{jsxref("boolean")}} defaulting to `true`. When `false` indicates that for progressive images the decoder may output an image with reduced detail. When `false`, each call to `decode()` returns a new promise that resolves once with the next available level of detail; call `decode()` again to receive further levels as they become available.
+      - : A {{jsxref("boolean")}} defaulting to `true`.
+        When `true`, the `Promise` returned by the method resolves only when the image is fully decoded.
+        When `false`, the method will return a new `Promise` that may resolve with a partially decoded image.
+        The method can be called repeatedly until `result.complete` is true, with each step providing an image with the next available level of detail.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Updates the ImageDecoder.decode() docs so the completeFramesOnly parameter is described in line with JavaScript promise semantics. The text now states that each call to decode() returns a new promise that settles once, and that further levels of detail are obtained by calling decode() again. Also fixes a typo in the progressive-decoding example comment and uses the correct variable name (imageDecoder) in the example.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The previous wording (“the promise returned by decode() will resolve exactly once for each new level of detail”) suggested that a single promise could resolve multiple times, which contradicts how promises work in JavaScript. A promise settles only once (either fulfilled or rejected). The change clarifies that multiple resolutions correspond to multiple calls to decode(), each returning its own promise.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
Parameter description: Reworded so it’s explicit that “each call to decode() returns a new promise that resolves once” and that “call decode() again to receive further levels as they become available.”
Example: Comment typo “is won’t” → “won’t”; imageDecode → imageDecoder for consistency with the first example.
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Fixes https://github.com/mdn/content/issues/43297 (Promise can't resolve multiple times)
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
