### PR TITLE
Editorial review: Document uniform_buffer_standard_layout WGSL extension

### DIFF
--- a/files/en-us/web/api/wgsllanguagefeatures/index.md
+++ b/files/en-us/web/api/wgsllanguagefeatures/index.md
@@ -45,6 +45,11 @@ The following WGSL language extensions are defined at [WGSL language extensions]
     > [!NOTE]
     > For the `subgroup_id` WGSL feature to be usable, the [`subgroups`](https://gpuweb.github.io/gpuweb/wgsl/#extension-subgroups) extension needs to be enabled in the {{domxref("GPUDevice")}} (see {{domxref("GPUSupportedFeatures")}}).
 
+- `uniform_buffer_standard_layout`
+  - : When available, uniform buffers use the same [memory layout constraints](https://gpuweb.github.io/gpuweb/wgsl/#address-space-layout-constraints) as storage buffers, which makes it easier to share data structures across both kinds of buffers. This means uniform buffers are no longer required to have 16-byte alignment on array elements, or to pad nested structure offsets to a multiple of 16 bytes.
+
+    See [WGSL uniform_buffer_standard_layout extension](https://developer.chrome.com/blog/new-in-webgpu-144#wgsl_uniform_buffer_standard_layout_extension) for more details.
+
 - `unrestricted_pointer_parameters`
   - : Loosens restrictions on pointers being passed to WGSL functions. When available, the following are allowed:
     - Parameter pointers to storage, uniform, and workgroup address spaces being passed to user-declared functions.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chrome 144 adds support for the `uniform_buffer_standard_layout` WGSL language extension. See https://chromestatus.com/feature/6680245553987584; also see https://developer.chrome.com/blog/new-in-webgpu-144#wgsl_uniform_buffer_standard_layout_extension for more context.

This PR documents the new extension on the `WGSLLanguageFeatures` page.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
