### PR TITLE
:recycle: Refactor: Fix grammatical error

### DIFF
--- a/files/en-us/web/api/range/createcontextualfragment/index.md
+++ b/files/en-us/web/api/range/createcontextualfragment/index.md
@@ -47,7 +47,7 @@ In the HTML case, if the context node would be `html`, for historical reasons th
 ### Security considerations
 
 The method does not perform any sanitization of the input to remove XSS-unsafe elements such as {{htmlelement("script")}}, or event handler content attributes.
-If the input is provided by a user, and the returned {{domxref("DocumentFragment")}} is subsequently injected into the DOM, this method can be therefore become a vector for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks.
+If the input is provided by a user, and the returned {{domxref("DocumentFragment")}} is subsequently injected into the DOM, this method can become a vector for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS) attacks.
 
 For example, the following code would inject the potentially dangerous user-provided string into the DOM.
 


### PR DESCRIPTION
### Description
Corrected a grammatical error in the `Range.createContextualFragment()` documentation by removing:

"be therefore"

### Motivation

This fix resolves a grammatical error and improves clarity and professionalism of the documentation for readers

### Additional details

No functional or content changes were made beyond correcting the grammatical error
