### PR TITLE
Remove SAFE_FOR_JQUERY usage in DOMPurify example

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
@@ -78,11 +78,11 @@ let cleanHTML = DOMPurify.sanitize(externalHTML);
 elem.innerHTML = cleanHTML;
 ```
 
-You can use any method to add the sanitized HTML to your DOM, for example jQuery's `.html()` function. Remember though that the `SAFE_FOR_JQUERY` flag needs to be used in this case:
+You can use any method to add the sanitized HTML to your DOM, for example jQuery's `.html()` function:
 
 ```js
 let elem = $("<div/>");
-let cleanHTML = DOMPurify.sanitize(externalHTML, { SAFE_FOR_JQUERY: true });
+let cleanHTML = DOMPurify.sanitize(externalHTML);
 elem.html(cleanHTML);
 ```
 


### PR DESCRIPTION
DOMPurify [removed](https://github.com/cure53/DOMPurify?tab=readme-ov-file#removed-configuration) the `SAFE_FOR_JQUERY` flag in [2.1.0](https://github.com/cure53/DOMPurify/releases/tag/2.1.0) (released in 2020) and claimed that it is “safe by default now for jQuery” since that version.