### PR TITLE
Fix order of gap property documentation

### DIFF
--- a/files/en-us/web/css/reference/properties/gap/index.md
+++ b/files/en-us/web/css/reference/properties/gap/index.md
@@ -62,8 +62,8 @@ gap: calc(20px + 10%);
 
 This property is a shorthand for the following CSS properties:
 
-- {{cssxref("column-gap")}}
 - {{cssxref("row-gap")}}
+- {{cssxref("column-gap")}}
 
 ## Syntax
 


### PR DESCRIPTION
The text should follow the order of the longhand properties, (rather than alphabetical, which is why i think they were in this order)
