### PR TITLE
Update pageshow event page to explain it might not mean the page is shown

### DIFF
--- a/files/en-us/web/api/window/pageshow_event/index.md
+++ b/files/en-us/web/api/window/pageshow_event/index.md
@@ -20,10 +20,10 @@ This includes:
 - {{Glossary("Prerender", "Prerendering")}} a page, even before it is activated.
 
 > [!WARNING]
-> Despite the name, the `pageshow` event does not fire when the page is actually _shown_ to the user. For example, it may be opened in a background tab or prerendered. If you are interested in responding to the pages being shown to the user, use the following events:
+> Despite the name, the `pageshow` event does not fire when the page is actually _shown_ to the user. For example, it may be opened in a background tab or prerendered. If you are interested in responding to the page being shown to the user, use the following events:
 >
 > - {{domxref("window/pagereveal_event", "pagereveal")}}: Sent when a page is first rendered.
-> - {{domxref("document/visibilitychange_event", "visibilitychange")}}: Sent each time the page's visibility changes.
+> - {{domxref("document/visibilitychange_event", "visibilitychange")}}: Sent each time a page's visibility changes.
 > - {{domxref("document/prerenderingchange_event", "prerenderingchange")}}: Sent when a prerendered page is activated.
 
 > [!NOTE]


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

The `pageshow` event is badly named IMHO and people think it means it fires when the page is "shown".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

We got a request to clarify this on a recent bug report: https://issues.chromium.org/issues/478909972#comment22

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

You can test this by:
- Opening https://chrome.dev/event-logger/
- Clicking the "clear" button to clear the log.
- Right clicking the "Navigate away (same-origin)" link and opening in a new (background) tab. This open the same page.
- Clicking anywhere so the current page re-reads all events (including those from the background tab - use the "Window Identifer" column to different events on this page versus the background tab).
- Noting the `pageshow` event has been logged (from the background tab) despite the page not being shown yet.
- Clicking on the other tab and noting `pagereveal` and `visibilitychange` events are logged.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

N/A

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
