### PR TITLE
Fix backslash escape in String.raw example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
@@ -109,7 +109,7 @@ String.raw`Hi ${"$"}{name}!`;
 String.raw`This is a backtick: ${"`"}`;
 // 'This is a backtick: `', the substitution inserts a single backtick.
 String.raw`A trailing backslash: ${"\\"}`;
-// 'A trailing backslash: \\', the substitution inserts a single backslash.
+// 'A trailing backslash: \', the substitution inserts a single backslash.
 ```
 
 This approach works for `String.raw` because it just concatenates the raw strings and the substitutions. In general, unfortunately, there's no way for a template literal tag to receive a `raw` string that contains unescaped template literal syntax.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Changed comment description to match what the outcome should be.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
I came across this mistake while reading the docs and do not want it to confuse others.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
The confusing part may be that the string in the comment is suppose to show what is displayed.
But showing what is displayed - 'A trailing backslash: \\' - may confuse someone who thinks that the backslash is escaping the quote character.

Or the examples confused me and they show what is being stored in the string - not what is being displayed.
In which case this change request is incorrect as 'A trailing backslash: \\\\' is being stored in the string.

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Nothing is related to this that I am aware of.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
