### PR TITLE
FF149 Relnote: mozCapureStream/MediaElementAudioSourceNode captured volume to spec

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -69,11 +69,11 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
   ([Firefox bug 2017708](https://bugzil.la/2017708)).
 
 - {{domxref("MediaElementAudioSourceNode")}} now respects the media element's volume when capturing audio for all types of sources (as required by the specification).
-  Previously setting the volume of the element did not affect the captured audio for {{domxref("MediaStream")}} sources.
+  Previously, setting the volume of the element did not affect the captured audio for {{domxref("MediaStream")}} sources.
   ([Firefox bug 2010427](https://bugzil.la/2010427)).
 
 - The {{domxref("HTMLMediaElement.captureStream()", "HTMLMediaElement.mozCaptureStream()")}} method now captures raw audio from the source without applying the media element's volume, regardless of the type of source the media element is playing (as required by the specification).
-  Previously the media element's volume affected the volume of the captured stream.
+  Prior to this change, the media element's volume affected the volume of the captured stream.
   ([Firefox bug 2010427](https://bugzil.la/2010427)).
 
 <!-- #### Removals -->


### PR DESCRIPTION
FF149 fixes some bugs around capturing streams and whether audio volume, which are described in https://bugzilla.mozilla.org/show_bug.cgi?id=2010427#c8

Specifically mozCapureStream() is supposted to capture a raw stream, unaffected by the underlying media element volume, while MediaElementAudioSourceNode is supposed to respect the setting of the raw stream. Now they do.

This is related to the updates in #43323

Related work for this can be tracked in #43215