### PR TITLE
Document CookieStore.set() maxAge option

### DIFF
--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -80,6 +80,9 @@ async function cookieTest() {
 cookieTest();
 ```
 
+> [!NOTE]
+> In [supporting browsers](/en-US/docs/Web/API/CookieStore/set#browser_compatibility), you can set the cookie's expiry using `maxAge` instead of `expires`.
+
 ### Getting cookies
 
 This example shows how you can get a particular cookie using {{domxref("CookieStore.get()")}} or all cookies using {{domxref("CookieStore.getAll()")}}.

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -59,7 +59,9 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting 
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the origin can not be {{glossary("Serialization", "serialized")}} to a URL.
 - {{jsxref("TypeError")}}
-  - : Thrown if setting the cookie with the given `name` and `value` or `options` fails.
+  - : Thrown if:
+    - Both the `expires` and `maxAge` properties are set.
+    - Setting the cookie with the given `name` and `value` or `options` fails in any other way.
 
 ## Examples
 
@@ -90,20 +92,21 @@ async function cookieTest() {
 
 ### Setting a cookie with options
 
-This example sets a cookie by passing an `options` object with `name`, `value`, `maxAge`, and `partitioned`.
+This example sets a cookie by passing an `options` object with `name`, `value`, `expires`, and `partitioned`.
 
 The code first waits for the cookie to be set: as this operation can fail, the operation is performed in a `try...catch` block and any errors are logged to the console.
 It then gets and logs the cookie that was just set.
 
 ```js
 async function cookieTest() {
+  const day = 24 * 60 * 60 * 1000;
   const cookieName = "cookie2";
   try {
     // Set cookie: passing options
     await cookieStore.set({
       name: cookieName,
       value: `${cookieName}-value`,
-      maxAge: 34560000,
+      expires: Date.now() + day,
       partitioned: true,
     });
   } catch (error) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Since version 145, Chrome has supported the [`CookieStore.set()`](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore/set) method's `maxAge` option; see https://chromestatus.com/feature/5190778418757632.

This PR documents the new option.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
