### PR TITLE
Update Masonry layout guide for css-grid-3 Masonry switch syntax

### DIFF
--- a/files/en-us/web/css/guides/grid_layout/masonry_layout/index.md
+++ b/files/en-us/web/css/guides/grid_layout/masonry_layout/index.md
@@ -16,18 +16,6 @@ Level 3 of the [CSS grid layout](/en-US/docs/Web/CSS/Guides/Grid_layout) specifi
 
 Masonry layout is a layout method where one axis uses a typical strict grid layout, most often columns, and the other a **stacking** (masonry) layout. On the stacking axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to fill the gaps.
 
-> [!NOTE]
-> The CSS Working Group obsoleted the previous switch syntax—`grid-template-rows: masonry` and `grid-template-columns: masonry` with `display: grid`—in favor of the display-based switch. See [CSS Working Group issue #12022](https://github.com/w3c/csswg-drafts/issues/12022) and the [Masonry feature overview](https://web-platform-dx.github.io/web-features-explorer/features/masonry/).
-
-## Masonry switch syntax
-
-You enable masonry layout by using one of these {{cssxref("display")}} values:
-
-- **`grid-lanes`** — block-level grid-lanes container
-- **`inline-grid-lanes`** — inline-level grid-lanes container
-
-The grid layout axis is defined with {{cssxref("grid-template-columns")}} or {{cssxref("grid-template-rows")}}; the masonry axis does not take a template.
-
 ## Creating a masonry layout
 
 To create the most common masonry layout where the columns are laid out in a grid, and the rows stack like masonry, use **`display: grid-lanes`** along with {{cssxref("grid-template-columns")}}.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Updates the [Masonry layout](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout) guide to match the current [CSS Grid Level 3](https://drafts.csswg.org/css-grid-3/) spec. The CSS Working Group obsoleted the previous switch syntax (`grid-template-rows: masonry` / `grid-template-columns: masonry` with `display: grid`) in favor of a display-based switch ([w3c/csswg-drafts#12022](https://github.com/w3c/csswg-drafts/issues/12022)).

### Changes

- **Switch syntax:** Document `display: grid-lanes` and `display: inline-grid-lanes` as the way to enable masonry layout; remove use of `grid-template-rows: masonry` and `grid-template-columns: masonry` from all examples.
- **New "Masonry switch syntax" section:** Placed after the intro; explains the two display values and that the grid axis is defined via `grid-template-columns` / `grid-template-rows` (the other axis is the stacking axis and has no template).
- **Obsoleted syntax note:** Add a `[!NOTE]` callout and in-section text that the previous syntax was obsoleted, with a link to the CSSWG issue and the [Masonry feature overview](https://web-platform-dx.github.io/web-features-explorer/features/masonry/).
- **Browser compatibility:** Clarify that the current compat table may reflect the old syntax and that support for `display: grid-lanes` will be tracked in browser-compat data as implementations ship.
- **See also:** Qualify the Smashing Magazine (2020) link as covering the previous `grid-template-*: masonry` syntax.
- **Doc style:** Use `> [!NOTE]` for the callout and descriptive link text (“CSS Working Group issue #12022”) for consistency with other CSS docs.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Related issues and pull requests
Fixes #41976
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
