### PR TITLE
Remove outdated note about anchors-valid (#43120)

### DIFF
--- a/files/en-us/web/css/reference/properties/position-visibility/index.md
+++ b/files/en-us/web/css/reference/properties/position-visibility/index.md
@@ -42,9 +42,9 @@ In some situations, you might not want to display an anchor-positioned element. 
 
 The `position-visibility` property can be used to `always` show the anchor-positioned element, or conditionally hide it in certain situations:
 
-- `anchors-visible`: When the associated anchor element is completely hidden.
-- `anchors-valid`: When the anchor-positioned element's `position-anchor` property doesn't reference a valid {{cssxref("anchor-name")}} set on an anchor element in the same document.
-- `no-overflow`: When the anchor-positioned element is partially or completely hidden.
+- `anchors-visible`: The associated anchor element is completely hidden.
+- `anchors-valid`: The anchor-positioned element's `position-anchor` property doesn't reference a valid {{cssxref("anchor-name")}} set on an anchor element in the same document.
+- `no-overflow`: The anchor-positioned element is partially or completely hidden.
 
 When an element is hidden due to `position-visibility`, it is referred to as **strongly hidden**. This means that it will act as though it and its descendant elements have a {{cssxref("visibility")}} value of `hidden` set, regardless of what their actual visibility value is.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

The page currently states:

```text
  "The specification also defines the `anchors-valid` value, which has not yet been implemented in any browser."
```

This is no longer accurate. `anchors-valid` is now supported in Firefox 147 and Safari 26.2.  
Since the browser compatibility section already reflects support, this line is redundant and has been removed.  

Fixes #43120
Relates to #29046

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
By removing that line it improves accuracy and clarity for developers.
