### PR TITLE
Remove outdated statement that browsers tend to handle the `popstate` event differently on page load

### DIFF
--- a/files/en-us/web/api/window/popstate_event/index.md
+++ b/files/en-us/web/api/window/popstate_event/index.md
@@ -47,8 +47,6 @@ These methods and their corresponding events can be used to add data to the hist
 
 Note that just calling `history.pushState()` or `history.replaceState()` won't trigger a `popstate` event. The `popstate` event will be triggered by doing a browser action such as a click on the back or forward button (or calling `history.back()` or `history.forward()` in JavaScript).
 
-Browsers used to handle the popstate event differently on page load. Chrome (prior to v34) and Safari (prior to v9.1) used to emit a `popstate` event on page load, but Firefox never did. All modern browsers are now aligned on not firing `popstate` on page load.
-
 > [!NOTE]
 > When writing functions that process `popstate` event it is important to take into account that properties like `window.location` will already reflect the state change (if it affected the current URL), but `document` might still not. If the goal is to catch the moment when the new document state is already fully in place, a zero-delay {{domxref("Window.setTimeout", "setTimeout()")}} method call should be used to effectively put its inner _callback_ function that does the processing at the end of the browser event loop: `window.onpopstate = () => setTimeout(doSomeThing, 0);`
 


### PR DESCRIPTION


### Description

Updated the section on the handling of popstate event on page load across different browsers.

### Motivation
I became unsure about the truthness of this MDN claim when cleaning up old code in https://github.com/emberjs/ember.js/pull/21204

### Additional details

WebKit commit https://github.com/nicolo-ribaudo/WebKit/commit/b5346999bbd28081e4fbcedeada78bc0b72f3934 — "popstate is fired at the wrong time on load" on October 2, 2015, which should align with 9.1. Also verified in browserstack: https://github.com/mdn/content/issues/43368#issuecomment-4019918353

### Related issues and pull requests
Fixes #43368
