### PR TITLE
Fix media query condition in iframe example

### DIFF
--- a/files/en-us/web/css/guides/cssom_view/viewport_concepts/index.md
+++ b/files/en-us/web/css/guides/cssom_view/viewport_concepts/index.md
@@ -119,7 +119,7 @@ If the iframe is set to 50vw, it will be 50% of the width of the `1200px` parent
 A width-based media query within the iframe document is relative to the iframe's viewport.
 
 ```css
-@media screen and (width >= 500px) {
+@media screen and (width <= 500px) {
   p {
     color: red;
   }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->
Text description and the media query condition contradict each other. Clearly, intent is to show that in zoomed state the iframe viewport shrinks to 400px (i.e. below 500px). Article: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/CSSOM_view/Viewport_concepts#iframe

<img width="768" height="305" alt="image" src="https://github.com/user-attachments/assets/9319e771-3c17-4617-b863-c0d86400f034" />

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Change media query to say lesser-or equal instead of greater-or-equal 500px
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
This typo might be quite confusing to the readers who are not very familiar with media queries.
