### PR TITLE
Fix typo in DOMParser parseFromString docs

### DIFF
--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -103,7 +103,7 @@ if (typeof trustedTypes === "undefined")
 ```
 
 Next we create a {{domxref("TrustedTypePolicy")}} that defines a {{domxref("TrustedTypePolicy/createHTML", "createHTML()")}} for transforming an input string into {{domxref("TrustedHTML")}} instances.
-Commonly, implementations of `createHTML()` use a library such as [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize the input as shown below:
+Commonly, implementations of `createHTML()` use a library such as [DOMPurify](https://github.com/cure53/DOMPurify) to sanitize the input, as shown below:
 
 ```js
 const policy = trustedTypes.createPolicy("my-policy", {


### PR DESCRIPTION
### Description

- Fixes a punctuation typo in the `DOMParser.parseFromString()` docs by changing `sanitize the, input` to `sanitize the input`.

### Motivation

- Keeps the example explanation readable without changing the meaning of the docs.

### Additional details

- Minor wording-only update in a single file.

### Related issues and pull requests

- N/A
