### PR TITLE
ci(pr-check-lint_content): refine workflow further

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -92,7 +92,7 @@ jobs:
           rm -r files *.md
 
           # Remove non-Markdown files from HEAD.
-          find pr_head/files -type f ! -name '*.md' -delete
+          find pr_head -type f ! -name '*.md' -delete
 
           # Move Markdown files from HEAD into BASE.
           mv pr_head/files pr_head/*.md .


### PR DESCRIPTION
### Description

Refines the `pr-check-lint_content`, moving only Markdown files, ignoring any non-Markdown files, including in the checkout root.

### Motivation

Completes the change in the previous refinement.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/content/pull/43073.