### PR TITLE
Fix: replace document.body.querySelector with document.querySelector

### DIFF
--- a/files/en-us/web/api/document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/index.md
@@ -401,9 +401,9 @@ div.child {
 #### JavaScript
 
 ```js
-const parent = document.body.querySelector(".parent");
+const parent = document.querySelector(".parent");
 
-const addChild = document.body.querySelector("#add-child");
+const addChild = document.querySelector("#add-child");
 addChild.addEventListener("click", () => {
   // Only add a child if we don't already have one
   // in addition to the text node "parent"
@@ -416,9 +416,9 @@ addChild.addEventListener("click", () => {
   parent.appendChild(child);
 });
 
-const removeChild = document.body.querySelector("#remove-child");
+const removeChild = document.querySelector("#remove-child");
 removeChild.addEventListener("click", () => {
-  const child = document.body.querySelector(".child");
+  const child = document.querySelector(".child");
   parent.removeChild(child);
 });
 ```


### PR DESCRIPTION
Replaced `document.body.querySelector` with `document.querySelector` in the DOM examples to follow the correct usage mentioned in the issue.

Fixes https://github.com/mdn/content/issues/43367