### PR TITLE
Add blank line between headers and body in HTTP/1.0 examples

### DIFF
--- a/files/en-us/web/http/guides/evolution_of_http/index.md
+++ b/files/en-us/web/http/guides/evolution_of_http/index.md
@@ -57,6 +57,7 @@ HTTP/1.0 200 OK
 Date: Tue, 15 Nov 1994 08:12:31 GMT
 Server: CERN/3.0 libwww/2.17
 Content-Type: text/html
+
 <HTML>
 A page with an image
   <IMG SRC="/my-image.gif">
@@ -73,6 +74,7 @@ HTTP/1.0 200 OK
 Date: Tue, 15 Nov 1994 08:12:32 GMT
 Server: CERN/3.0 libwww/2.17
 Content-Type: text/gif
+
 (image content)
 ```
 


### PR DESCRIPTION
Make HTTP/1.0 examples conform to the spec.

https://datatracker.ietf.org/doc/html/rfc1945#section-4.1

> Full-Request and Full-Response use the generic message format of RFC 822 for transferring entities. Both messages may include optional header fields (also known as "headers") and an entity body. The entity body is separated from the headers by a null line (i.e., a line with nothing preceding the CRLF).
