### PR TITLE
FF149 Relnote - allow more chars in DOM names/namespaces for elem/attribute methods

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -60,10 +60,10 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
   This allows developers to implement components that can be closed using device-native mechanisms, such as the <kbd>Esc</kbd> on Windows or the <kbd>Back</kbd> key on Android, in the same way as built-in components such as [dialogs](/en-US/docs/Web/HTML/Reference/Elements/dialog) and [popovers](/en-US/docs/Web/API/Popover_API).
   ([Firefox bug 1966073](https://bugzil.la/1966073)).
 
-- DOM methods now allow the same characters to be used for element and attribute names as the HTML parser (previously DOM methods were far more restrictive about the set of allowed characters).
-  ([Firefox bug 1773312](https://bugzil.la/1773312)).
-
+- DOM methods now allow wider range of characters for element and attribute names.
+  Previously, DOM methods were far more restrictive, but now they allow the same set of characters as the HTML parser.
   The affected methods are: {{domxref("Document/createAttribute","createAttribute()")}}, {{domxref("Document/createAttributeNS","createAttributeNS()")}}, {{domxref("Document/createElement","createElement()")}} and {{domxref("Document/createElementNS","createElementNS()")}} of the {{domxref("Document")}} interface, {{domxref("Element/toggleAttribute","toggleAttribute()")}}, {{domxref("Element/setAttribute","setAttribute()")}}, {{domxref("Element/setAttributeNS","setAttributeNS()")}} of the {{domxref("Element")}} interface, {{domxref("DOMImplementation/createDocument","createDocument()")}} of the {{domxref("DOMImplementation")}} interface, and {{domxref("CustomElementRegistry/define","define()")}} and {{domxref("CustomElementRegistry/whenDefined","whenDefined()")}} of the {{domxref("CustomElementRegistry/whenDefined","whenDefined()")}} interface.
+  ([Firefox bug 1773312](https://bugzil.la/1773312)).
 
 #### Media, WebRTC, and Web Audio
 


### PR DESCRIPTION
FF149 adds support for additional characters to be used in attribute and element names and namespaces in https://bugzilla.mozilla.org/show_bug.cgi?id=1773312. Previoulsy the DOM allowed you to only create them with XML characters, now the rules are less restrictive. 

This adds a release note.

Related docs work can be tracked in #43218

