### PR TITLE
Clarify offsetParent behavior for fixed-position elements

### DIFF
--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -25,8 +25,8 @@ If there is no positioned ancestor element, the `body` is returned.
 >
 > - The element or any ancestor has the `display` property set to
 >   `none`.
-> - The element has the `position` property set to `fixed` and it's the containing block is the viewport.
->   If the containing block is not the viewport, `offsetParent` it returns the nearest ancestor that forms
+> - The element has the `position` property set to `fixed` and its containing block is the viewport.
+>   If the containing block is not the viewport, `offsetParent` returns the nearest ancestor that forms
 >   a containing block, for example, an ancestor with `transform`, `perspective`, or `filter` styles set.
 > - The element is `<body>` or `<html>`.
 


### PR DESCRIPTION
### Description

Updated Note box in `HTMLElement.offsetParent` to clarify the behavior for elements with `position: fixed`.

- [x] `display: none` → null (No layout box)
- [x] `position: fixed` → null (Unless inside a containing block)
- [x] `Root elements` → null (<html> and <body>)

### Comparison

before;

> [!NOTE]
> `offsetParent` returns `null` in the following
> situations:
>
> - The element or any ancestor has the `display` property set to
>   `none`.
> - The element has the `position` property set to `fixed`
>   (Firefox returns `<body>`).
> - The element is `<body>` or `<html>`.

after:

> [!NOTE]
> `offsetParent` returns `null` in the following situations:
>
> - The element or any ancestor has the `display` property set to
>   `none`.
> - The element has the `position` property set to `fixed`. In this case,
>   `offsetParent` is `null` if the containing block is the viewport; otherwise
>   it returns the nearest ancestor that forms the containing block
>   (e.g., an ancestor with `transform`, `perspective`, or `filter`).
> - The element is `<body>` or `<html>`.

Fixes #43394