### PR TITLE
Clarify that (lang="") means explicitly unknown, not default.

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/lang/index.md
+++ b/files/en-us/web/html/reference/global_attributes/lang/index.md
@@ -10,7 +10,7 @@ sidebar: htmlsidebar
 The **`lang`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single {{glossary("BCP 47 language tag")}}.
 
 > [!NOTE]
-> If the value of `lang` is set to empty string the language is explicitly unknown. Therefore, it is recommended to always specify an appropriate value for this attribute.
+> If the value of `lang` is set to an empty string, the language is explicitly unknown. Therefore, it is recommended to always specify an appropriate value for this attribute.
 
 {{InteractiveExample("HTML Demo: lang", "tabbed-shorter")}}
 


### PR DESCRIPTION
### Description

The previous note on the `lang` attribute said the default value is the empty string.

That was incorrect, the **empty string** only applies when the attribute is explicitly set, which signals the language is explicitly `unknown`.

Spec reference:
```text
 If the resulting value is the empty string, then it must be interpreted as meaning that the language of the node is explicitly unknown.
```

 This PR updates the note to be spec-accurate and complements the [inheritance section](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang#inheritance).

### Preview

> [!NOTE]
> If the value of `lang` is set to empty string the language is explicitly unknown. Therefore, it is recommended to always specify an appropriate value for this attribute.

fixes #43259