### PR TITLE
Document backdrop root concept on backdrop-filter page

### DIFF
--- a/files/en-us/web/css/reference/properties/backdrop-filter/index.md
+++ b/files/en-us/web/css/reference/properties/backdrop-filter/index.md
@@ -124,51 +124,63 @@ The following example demonstrates how backdrop roots affect `backdrop-filter`. 
 ```
 
 ```css
+body {
+  display: flex;
+  column-gap: 16px;
+  padding: 16px;
+  background-image: conic-gradient(
+    gray 90deg,
+    silver 90deg 180deg,
+    gray 180deg 270deg,
+    silver 270deg
+  );
+  background-size: 32px 32px;
+}
+
 .parent {
+  position: relative;
   width: 256px;
   height: 256px;
-  position: relative;
-  display: inline-block;
 }
 
 .backdrop-root {
-  will-change: opacity;
   outline: 2px solid crimson;
+  will-change: opacity;
 }
 
 .square {
+  position: absolute;
+  top: 35px;
+  left: 40%;
   width: 25%;
   height: 25%;
-  position: absolute;
   border: 10px solid white;
-  left: 40%;
-  top: 35px;
 }
 
 .text {
+  position: absolute;
+  left: 40%;
+  color: white;
   font-size: 32px;
   font-weight: 500;
   text-align: center;
   line-height: 256px;
-  position: absolute;
-  left: 40%;
   filter: blur(1px);
-  color: white;
 }
 
 .overlay {
-  border-radius: 9999px;
-  outline: 1px solid #eaeaea;
-  width: 50%;
-  height: 50%;
   position: absolute;
   top: 25%;
   left: 50%;
+  width: 50%;
+  height: 50%;
+  outline: 3px solid gainsboro;
+  border-radius: 9999px;
   backdrop-filter: blur(10px);
 }
 ```
 
-{{EmbedLiveSample("Backdrop root", 600, 300)}}
+{{EmbedLiveSample("Backdrop root", "", 288)}}
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/backdrop-filter/index.md
+++ b/files/en-us/web/css/reference/properties/backdrop-filter/index.md
@@ -10,6 +10,24 @@ The **`backdrop-filter`** [CSS](/en-US/docs/Web/CSS) property lets you apply gra
 
 {{InteractiveExample("CSS Demo: backdrop-filter()")}}
 
+## Description
+
+The `backdrop-filter` property applies filter effects to the pixels painted _behind_ an element, up to the nearest ancestor that is a **backdrop root**. Content above the backdrop root is not affected.
+
+### Backdrop root
+
+A backdrop root is an element that establishes a boundary for `backdrop-filter` effects. The following elements are backdrop roots:
+
+- The root element ({{HTMLElement("html")}})
+- An element with a {{cssxref("filter")}} value other than `none`
+- An element with an {{cssxref("opacity")}} value less than `1`
+- An element with a {{cssxref("mask")}}, {{cssxref("mask-image")}}, {{cssxref("mask-border")}}, or {{cssxref("clip-path")}} value other than `none`
+- An element with a `backdrop-filter` value other than `none`
+- An element with a {{cssxref("mix-blend-mode")}} value other than `normal`
+- An element with {{cssxref("will-change")}} set to any of the above properties
+
+This means that if a parent element has `opacity: 0.9`, it becomes a backdrop root and any child's `backdrop-filter` will only blur the content between that parent and the child — not the content behind the parent. This is a common source of confusion when `backdrop-filter` appears to have no visible effect despite being correctly applied.
+
 ```css interactive-example-choice
 backdrop-filter: blur(10px);
 ```

--- a/files/en-us/web/css/reference/properties/backdrop-filter/index.md
+++ b/files/en-us/web/css/reference/properties/backdrop-filter/index.md
@@ -10,24 +10,6 @@ The **`backdrop-filter`** [CSS](/en-US/docs/Web/CSS) property lets you apply gra
 
 {{InteractiveExample("CSS Demo: backdrop-filter()")}}
 
-## Description
-
-The `backdrop-filter` property applies filter effects to the pixels painted _behind_ an element, up to the nearest ancestor that is a **backdrop root**. Content above the backdrop root is not affected.
-
-### Backdrop root
-
-A backdrop root is an element that establishes a boundary for `backdrop-filter` effects. The following elements are backdrop roots:
-
-- The root element ({{HTMLElement("html")}})
-- An element with a {{cssxref("filter")}} value other than `none`
-- An element with an {{cssxref("opacity")}} value less than `1`
-- An element with a {{cssxref("mask")}}, {{cssxref("mask-image")}}, {{cssxref("mask-border")}}, or {{cssxref("clip-path")}} value other than `none`
-- An element with a `backdrop-filter` value other than `none`
-- An element with a {{cssxref("mix-blend-mode")}} value other than `normal`
-- An element with {{cssxref("will-change")}} set to any of the above properties
-
-This means that if a parent element has `opacity: 0.9`, it becomes a backdrop root and any child's `backdrop-filter` will only blur the content between that parent and the child — not the content behind the parent. This is a common source of confusion when `backdrop-filter` appears to have no visible effect despite being correctly applied.
-
 ```css interactive-example-choice
 backdrop-filter: blur(10px);
 ```
@@ -107,6 +89,86 @@ backdrop-filter: unset;
   - : No filter is applied to the backdrop.
 - `<filter-value-list>`
   - : A space-separated list of {{cssxref("filter-function")}}s or an [SVG filter](/en-US/docs/Web/SVG/Reference/Element/filter) that will be applied to the backdrop. CSS `<filter-function>`s include {{CSSxRef("filter-function/blur", "blur()")}}, {{CSSxRef("filter-function/brightness", "brightness()")}}, {{CSSxRef("filter-function/contrast", "contrast()")}}, {{CSSxRef("filter-function/drop-shadow", "drop-shadow()")}}, {{CSSxRef("filter-function/grayscale", "grayscale()")}}, {{CSSxRef("filter-function/hue-rotate", "hue-rotate()")}}, {{CSSxRef("filter-function/invert", "invert()")}}, {{CSSxRef("filter-function/opacity", "opacity()")}}, {{CSSxRef("filter-function/saturate", "saturate()")}}, and {{CSSxRef("filter-function/sepia", "sepia()")}}.
+
+## Description
+
+The `backdrop-filter` property applies filter effects to the pixels painted _behind_ an element, up to the nearest ancestor that is a **backdrop root**. Content above the backdrop root is not affected.
+
+### Backdrop root
+
+A backdrop root is an element that establishes a boundary for `backdrop-filter` effects. The following elements are backdrop roots:
+
+- The root element ({{HTMLElement("html")}})
+- An element with a {{cssxref("filter")}} value other than `none`
+- An element with an {{cssxref("opacity")}} value less than `1`
+- An element with a {{cssxref("mask")}}, {{cssxref("mask-image")}}, {{cssxref("mask-border")}}, or {{cssxref("clip-path")}} value other than `none`
+- An element with a `backdrop-filter` value other than `none`
+- An element with a {{cssxref("mix-blend-mode")}} value other than `normal`
+- An element with {{cssxref("will-change")}} set to any of the above properties
+
+This means that if a parent element has `opacity: 0.9`, it becomes a backdrop root and any child's `backdrop-filter` will only blur the content between that parent and the child - not the content behind the parent. This is a common source of confusion when `backdrop-filter` appears to have no visible effect despite being correctly applied.
+
+The following example demonstrates how backdrop roots affect `backdrop-filter`. The first container has `will-change: opacity`, making it a backdrop root - notice that the blur circle only affects the text and square inside the container, not the checkered background behind it. The second container is not a backdrop root, so its blur circle affects everything behind it, including the page background.
+
+```html
+<div class="parent backdrop-root">
+  <div class="text">Text</div>
+  <div class="square"></div>
+  <div class="overlay"></div>
+</div>
+<div class="parent">
+  <div class="text">Text</div>
+  <div class="square"></div>
+  <div class="overlay"></div>
+</div>
+```
+
+```css
+.parent {
+  width: 256px;
+  height: 256px;
+  position: relative;
+  display: inline-block;
+}
+
+.backdrop-root {
+  will-change: opacity;
+  outline: 2px solid crimson;
+}
+
+.square {
+  width: 25%;
+  height: 25%;
+  position: absolute;
+  border: 10px solid white;
+  left: 40%;
+  top: 35px;
+}
+
+.text {
+  font-size: 32px;
+  font-weight: 500;
+  text-align: center;
+  line-height: 256px;
+  position: absolute;
+  left: 40%;
+  filter: blur(1px);
+  color: white;
+}
+
+.overlay {
+  border-radius: 9999px;
+  outline: 1px solid #eaeaea;
+  width: 50%;
+  height: 50%;
+  position: absolute;
+  top: 25%;
+  left: 50%;
+  backdrop-filter: blur(10px);
+}
+```
+
+{{EmbedLiveSample("Backdrop root", 600, 300)}}
 
 ## Formal definition
 


### PR DESCRIPTION
## Summary
- Add a Description section to the `backdrop-filter` CSS property page explaining that effects are bounded by the nearest ancestor backdrop root
- List the properties that create a backdrop root: `filter`, `opacity`, `mask`, `mask-image`, `mask-border`, `clip-path`, `backdrop-filter`, `mix-blend-mode`, and `will-change`
- Explain the common confusion when `backdrop-filter` appears to have no effect due to an ancestor backdrop root

## Motivation
Developers are frequently confused when `backdrop-filter` doesn't affect all pixels behind an element. The concept of a "backdrop root" (from Filter Effects Level 2) is not documented on MDN. A previous PR (#40627) attempted this but was closed due to merge conflicts; this is a fresh implementation incorporating reviewer feedback (using a dedicated Description section instead of a note).

Fixes #40602.

## Test plan
- [ ] Page renders correctly with new Description section
- [ ] All CSS property links resolve