### PR TITLE
Add client-side CORS solutions to error documentation

### DIFF
--- a/files/en-us/web/http/guides/cors/errors/corsmethodnotfound/index.md
+++ b/files/en-us/web/http/guides/cors/errors/corsmethodnotfound/index.md
@@ -33,6 +33,8 @@ Make sure your code only uses the permitted HTTP methods when accessing the serv
 > [!NOTE]
 > If the server includes any unrecognized or undefined method names in its `Access-Control-Allow-methods` header, a different error occurs: [Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Methods'](/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSInvalidAllowMethod).
 
+If the server is not under your control, see [Client-side considerations](/en-US/docs/Web/HTTP/Guides/CORS/Errors#client-side_considerations) for alternative approaches.
+
 ## See also
 
 - [CORS errors](/en-US/docs/Web/HTTP/Guides/CORS/Errors)

--- a/files/en-us/web/http/guides/cors/errors/corsmissingallowheaderfrompreflight/index.md
+++ b/files/en-us/web/http/guides/cors/errors/corsmissingallowheaderfrompreflight/index.md
@@ -17,6 +17,8 @@ The `Access-Control-Allow-Headers` header is sent by the server to let the clien
 
 This error occurs when attempting to preflight a header that is not expressly allowed (that is, it's not included in the list specified by the `Access-Control-Allow-Headers` header sent by the server). To fix this, the server needs to be updated so that it allows the indicated header, or you need to avoid using that header.
 
+If the server is not under your control, see [Client-side considerations](/en-US/docs/Web/HTTP/Guides/CORS/Errors#client-side_considerations) for alternative approaches.
+
 ## See also
 
 - [CORS errors](/en-US/docs/Web/HTTP/Guides/CORS/Errors)

--- a/files/en-us/web/http/guides/cors/errors/corsmissingalloworigin/index.md
+++ b/files/en-us/web/http/guides/cors/errors/corsmissingalloworigin/index.md
@@ -77,9 +77,9 @@ add_header 'Access-Control-Allow-Origin' 'https://example.com' always;
 
 If the remote server is not under your control and does not include the `Access-Control-Allow-Origin` header, you cannot fix this error on the server side. Consider these alternatives:
 
+- Restructure your request as a [simple request](/en-US/docs/Web/HTTP/Guides/CORS#simple_requests) to avoid triggering a preflight, if the server handles simple cross-origin requests.
 - If you don't need to read the response, use [`mode: "no-cors"`](/en-US/docs/Web/API/Request/mode) in your `fetch()` call. The response will be opaque (unreadable), but the request will succeed.
 - Route the request through a proxy server you control, which fetches the resource and returns it with appropriate CORS headers.
-- Restructure your request as a [simple request](/en-US/docs/Web/HTTP/Guides/CORS#simple_requests) to avoid triggering a preflight, if the server handles simple cross-origin requests.
 
 See [Client-side considerations](/en-US/docs/Web/HTTP/Guides/CORS/Errors#client-side_considerations) for more detail.
 

--- a/files/en-us/web/http/guides/cors/errors/corspreflightdidnotsucceed/index.md
+++ b/files/en-us/web/http/guides/cors/errors/corspreflightdidnotsucceed/index.md
@@ -22,6 +22,8 @@ performed. There are a couple of reasons why preflighting might fail:
 - The preflight request suffered any kind of networking error that might ordinarily
   occur.
 
+If the server is not under your control, see [Client-side considerations](/en-US/docs/Web/HTTP/Guides/CORS/Errors#client-side_considerations) for alternative approaches.
+
 ## See also
 
 - [CORS errors](/en-US/docs/Web/HTTP/Guides/CORS/Errors)

--- a/files/en-us/web/http/guides/cors/errors/index.md
+++ b/files/en-us/web/http/guides/cors/errors/index.md
@@ -29,6 +29,38 @@ additional information here).
 > [!NOTE]
 > For security reasons, specifics about what went wrong with a CORS request _are not available to JavaScript code_. All the code knows is that an error occurred. The only way to determine what specifically went wrong is to look at the browser's console for details.
 
+## Client-side considerations
+
+Most CORS errors can only be resolved on the server, because the server controls whether cross-origin access is allowed. However, there are some things you can do on the client side:
+
+### Avoid triggering a preflight
+
+Browsers send a [preflight request](/en-US/docs/Web/HTTP/Guides/CORS#preflighted_requests) before the actual request when certain conditions are met (custom headers, methods other than `GET`/`HEAD`/`POST`, or non-simple content types). If the server does not handle preflight requests, you can restructure your request to qualify as a [simple request](/en-US/docs/Web/HTTP/Guides/CORS#simple_requests):
+
+- Use only `GET`, `HEAD`, or `POST` methods.
+- Set only [CORS-safelisted request headers](/en-US/docs/Glossary/CORS-safelisted_request_header) (such as {{HTTPHeader("Accept")}}, {{HTTPHeader("Content-Language")}}, or {{HTTPHeader("Content-Type")}}).
+- Use only `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain` for {{HTTPHeader("Content-Type")}}.
+
+Simple requests bypass the preflight step entirely, which avoids a class of CORS errors related to preflight handling.
+
+### Use `no-cors` mode for opaque responses
+
+If you do not need to read the response body or headers - for example, when sending analytics beacons or loading resources into a cache via a service worker - you can set the {{domxref("Request/mode", "mode")}} to `"no-cors"` in a {{domxref("Window/fetch", "fetch()")}} call:
+
+```js
+fetch("https://api.example.com/log", {
+  method: "POST",
+  mode: "no-cors",
+  body: data,
+});
+```
+
+The response will be [opaque](/en-US/docs/Web/API/Response/type): its status is `0`, its headers are empty, and its body is not readable by JavaScript. This is by design - `no-cors` disables the CORS check, but in exchange you lose all access to the response content.
+
+### Use a proxy server
+
+If you do not control the remote server and it does not set CORS headers, you can route requests through a server you do control. Your server fetches the resource on your behalf and returns it with appropriate CORS headers. This approach adds latency and introduces a dependency on your proxy, but it works when other options are unavailable.
+
 ## CORS error messages
 
 Firefox's console displays messages in its console when requests fail due to CORS. Part of the error text is a "reason" message that provides added insight into what went wrong. The reason messages are listed below; click the message to open an article explaining the error in more detail and offering possible solutions.
@@ -48,8 +80,6 @@ Firefox's console displays messages in its console when requests fail due to COR
 - [Reason: invalid token 'xyz' in CORS header 'Access-Control-Allow-Headers'](/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSInvalidAllowHeader)
 - [Reason: missing token 'xyz' in CORS header 'Access-Control-Allow-Headers' from CORS preflight channel](/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSMissingAllowHeaderFromPreflight)
 - [Reason: Multiple CORS header 'Access-Control-Allow-Origin' not allowed](/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSMultipleAllowOriginNotAllowed)
-
-## Client-side considerations
 
 Most CORS errors can only be resolved on the server, because the server controls whether cross-origin access is allowed. However, there are some things you can do on the client side:
 


### PR DESCRIPTION
## Summary
- Add a "Client-side considerations" section to the CORS errors landing page covering three strategies: avoiding preflight via simple requests, using `no-cors` mode for opaque responses, and proxy servers
- Add a "If you don't control the server" section to the `CORSMissingAllowOrigin` error page pointing to these client-side alternatives

## Motivation
The CORS error documentation focuses entirely on server-side fixes. Developers who don't control the server have no guidance. A maintainer commented "Please feel free to change this doc in whatever way you feel appropriate."

Fixes #39378.

## Test plan
- [ ] Landing page renders with new section
- [ ] CORSMissingAllowOrigin page renders with new section
- [ ] All internal links resolve
- [ ] Code example renders correctly