### PR TITLE
FF149 ExprFeatures: CSSNumericalValue.to() + Relnote

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -399,6 +399,22 @@ The [`@container`](/en-US/docs/Web/CSS/Reference/At-rules/@container) CSS at-rul
 
 ## APIs
 
+### CSS Typed Object Model Level 1
+
+Implementation work has started on the [CSS Typed OM Level 1](https://drafts.css-houdini.org/css-typed-om/).
+For example, the {{domxref("CSSNumericValue/to","to()")}} method of the {{domxref("CSSNumericValue")}} interface is supported for converting a CSS numeric value from one unit to another.
+([Firefox bug 1278697](https://bugzil.la/1278697)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 149           | No                  |
+| Developer Edition | 149           | No                  |
+| Beta              | 149           | No                  |
+| Release           | 149           | No                  |
+
+- `layout.css.typed-om.enabled`
+  - : Set to `true` to enable.
+
 ### Notification actions and maxActions properties
 
 The {{domxref("Notification/actions","actions")}} read-only property and the [`maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) static read-only property of the {{domxref("Notification")}} interface are supported in Nightly on desktop.

--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -151,3 +151,8 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **`@container style()` queries** (Nightly): `layout.css.style-queries.enabled`
 
   The [`@container`](/en-US/docs/Web/CSS/Reference/At-rules/@container) CSS at-rule supports [`style()`](/en-US/docs/Web/CSS/Guides/Containment/Container_size_and_style_queries#container_style_queries) queries. This allows you to check if a container has a valid CSS declaration, a CSS property, or a custom property, and apply styles to its children accordingly. ([Firefox bug 2014404](https://bugzil.la/2014404)).
+
+- **CSS Typed Object Model Level 1**: `layout.css.typed-om.enabled`
+
+  The CSS Typed Object Model Level 1 specification is being implemented.
+  In this release, support for the {{domxref("CSSNumericValue/to","to()")}} method of the {{domxref("CSSNumericValue")}} interface was added, allowing the conversion of a CSS numeric value from one unit to another. ([Firefox bug 1278697](https://bugzil.la/1278697)).


### PR DESCRIPTION
FF149 adds support for [`CSSNumericValue.to()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSNumericValue/to) behind the pref `layout.css.typed-om.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=2013251

This is part of bigger work to implement the features in the CSS Typed Object Model Level 1 specification.

This adds and experimental features page and release note entry.

Related docs work can be tracked in #43211