### PR TITLE
CSSNumericalValue.to() fixes

### DIFF
--- a/files/en-us/web/api/cssnumericvalue/to/index.md
+++ b/files/en-us/web/api/cssnumericvalue/to/index.md
@@ -34,7 +34,7 @@ A {{domxref('CSSUnitValue')}}.
     - The `CSSNumericValue` on which the method is being called can't be resolved to a single value and type.
       This might occur if the value is calculated from a variable when the value of that variable can't be known in the context.
     - The value can't be converted to the new unit because it's not of the same category.
-      For example, you can't convert a value in metres to seconds.
+      For example, you can't convert meters to seconds.
 
 ## Examples
 


### PR DESCRIPTION
FF149 adds support for [`CSSNumericValue.to()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSNumericValue/to) behind the pref `layout.css.typed-om.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=2013251

This updates the docs for the method, which were somewhat incorrect based on the spec (incorrect return type, spec language that didn't mean anything to a normal reader).

Related docs work can be tracked in #43211