### PR TITLE
Fix @view-transition types syntax

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@view-transition/index.md
+++ b/files/en-us/web/css/reference/at-rules/@view-transition/index.md
@@ -30,8 +30,8 @@ For a cross-document view transition to work, the current and destination docume
 
 - `types`
   - : Specifies the view transition [types](/en-US/docs/Web/API/View_Transition_API/Using_types) to set on the active view transition for the current and destination documents. Possible values are:
-    - `<custom-ident>#`
-      - : One or more comma-separated {{cssxref("&lt;custom-ident>")}} values representing the types to set.
+    - `<custom-ident>+`
+      - : One or more space-separated {{cssxref("&lt;custom-ident>")}} values representing the types to set.
     - `none`
       - : No types are set.
 


### PR DESCRIPTION
### Description

Unlike `:active-view-transition-type(<custom-ident>#)`, the `types` descriptor for `@view-transition` takes values `none | <custom-ident>+`. The `types` values should be space separated.

### Additional details

- `types` descriptor syntax: https://drafts.csswg.org/css-view-transitions-2/#types-cross-doc
