### PR TITLE
Document canvas anti-fingerprinting pixel randomization

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -73,6 +73,9 @@ This method returns an `ImageData` object representing the pixel data for the ar
 > [!NOTE]
 > Any pixels outside the canvas are returned as transparent black in the resulting `ImageData` object.
 
+> [!NOTE]
+> Some browsers slightly randomize the pixel data returned by `getImageData()` as an anti-fingerprinting measure, so the values may not exactly match what was drawn. See [Anti-fingerprinting randomization](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData#anti-fingerprinting_randomization) for details.
+
 This method is also demonstrated in the article [Manipulating video using canvas](/en-US/docs/Web/API/Canvas_API/Manipulating_video_using_canvas).
 
 ## Creating a color picker

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -21,6 +21,14 @@ transparent black in the returned `ImageData` object.
 > Image data can be painted onto a canvas using the
 > {{domxref("CanvasRenderingContext2D.putImageData()", "putImageData()")}} method.
 
+## Anti-fingerprinting randomization
+
+Some browsers add small random perturbations to the pixel data returned by `getImageData()` as an anti-fingerprinting measure. [Canvas fingerprinting](https://en.wikipedia.org/wiki/Canvas_fingerprinting) works by drawing content to a canvas and reading back the pixel data, which varies subtly across devices due to differences in GPU hardware, drivers, and font rendering. By randomizing the readback data, browsers make it harder to create a stable fingerprint.
+
+When this protection is active, the color channel values in the returned {{domxref("ImageData")}} may differ by a small amount (typically a few units per channel) from the values that were originally drawn. For example, filling a rectangle with `rgb(255, 127, 0)` and reading it back may yield values like `[254, 128, 0, 255]` instead of `[255, 127, 0, 255]`. This randomization applies to all canvas readback — not only cross-origin content — because fingerprinting exploits same-origin drawing.
+
+This behavior also affects {{domxref("HTMLCanvasElement.toDataURL()")}} and {{domxref("HTMLCanvasElement.toBlob()")}}, since they encode the same (randomized) pixel data. Code that depends on reading back exact pixel values from a canvas — such as pixel-perfect round-trip tests or color-picking tools — may need to account for this variation.
+
 You can find more information about `getImageData()` and general
 manipulation of canvas contents in [Pixel manipulation with canvas](/en-US/docs/Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas).
 

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -17,6 +17,9 @@ Browsers are required to support `image/png`; many will support additional forma
 
 The created image will have a resolution of 96dpi for file formats that support encoding resolution metadata.
 
+> [!NOTE]
+> Some browsers randomize the pixel data encoded by this method as an anti-fingerprinting measure. This means the blob may not exactly match what was drawn to the canvas. See [Anti-fingerprinting randomization](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData#anti-fingerprinting_randomization) for details.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -21,6 +21,9 @@ The created image data will have a resolution of 96dpi for file formats that sup
 > [!WARNING]
 > `toDataURL()` encodes the whole image in an in-memory string. For larger images, this can have performance implications, and may even overflow browsers' URL length limit when assigned to {{domxref("HTMLImageElement.src")}}. You should generally prefer [`toBlob()`](/en-US/docs/Web/API/HTMLCanvasElement/toBlob) instead, in combination with {{domxref("URL/createObjectURL_static", "URL.createObjectURL()")}}.
 
+> [!NOTE]
+> Some browsers randomize the pixel data encoded by this method as an anti-fingerprinting measure. This means the encoded image may not exactly match what was drawn to the canvas. See [Anti-fingerprinting randomization](/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData#anti-fingerprinting_randomization) for details.
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
## Summary
- Add an "Anti-fingerprinting randomization" section to `getImageData()` explaining:
  - Why canvas is a fingerprinting vector (GPU/driver/font rendering differences)
  - What degree of perturbation to expect (a few units per color channel)
  - That it applies to all canvas readback, not just cross-origin content
- Add short notes with links on `toDataURL()`, `toBlob()`, and the pixel manipulation tutorial

Fixes #39084
Continues the work from #41906.

## Test plan
- [ ] Central section on getImageData renders correctly
- [ ] Cross-reference links from toDataURL, toBlob, and tutorial resolve to the anchor
- [ ] No markdownlint errors (heading hierarchy is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)