### PR TITLE
Clarify extractable parameter behavior for asymmetric keys in SubtleC…

### DIFF
--- a/files/en-us/web/api/subtlecrypto/generatekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/generatekey/index.md
@@ -33,8 +33,8 @@ generateKey(algorithm, extractable, keyUsages)
     - For [X25519](/en-US/docs/Web/API/SubtleCrypto/deriveKey#x25519): pass the string `X25519` or an object of the form `{ name: "X25519" }`.
 
 - `extractable`
-  - : A boolean value indicating whether it will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or {{domxref("SubtleCrypto.wrapKey()")}}. 
-     Note that when generating asymmetric key pairs (such as RSA or ECDSA), the `extractable` parameter determines whether the private key can be exported; the public key is always extractable.
+  - : A boolean value indicating whether it will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or {{domxref("SubtleCrypto.wrapKey()")}}.
+    Note that when generating asymmetric key pairs (such as RSA or ECDSA), the `extractable` parameter determines whether the private key can be exported; the public key is always extractable.
 - `keyUsages`
   - : An {{jsxref("Array")}} of strings indicating what can be done with the newly generated key.
     Possible values for array elements are:


### PR DESCRIPTION
### Description
Clarified how the `extractable` parameter behaves when SubtleCrypto.generateKey is used with asymmetric algorithms.

Fixes #39493