### PR TITLE
Clarify difference between Document.querySelector() and Element.querySelector()

### DIFF
--- a/files/en-us/web/api/document/queryselector/index.md
+++ b/files/en-us/web/api/document/queryselector/index.md
@@ -180,3 +180,4 @@ Selection and traversal on the DOM tree
 {{domxref("Document.querySelectorAll()")}}
 
 {{domxref("Element.querySelectorAll()")}}
+```


### PR DESCRIPTION
Adds a short section explaining the difference between
Document.querySelector() and Element.querySelector().

Includes a simple example demonstrating the difference in search scope.

Fixes #43367