### PR TITLE
Fix the mix-blend-mode compositing spec links to the csswg site

### DIFF
--- a/files/en-us/web/css/reference/properties/mix-blend-mode/index.md
+++ b/files/en-us/web/css/reference/properties/mix-blend-mode/index.md
@@ -79,9 +79,9 @@ mix-blend-mode: unset;
 - {{cssxref("&lt;blend-mode&gt;")}}
   - : The blending mode that should be applied.
 - `plus-darker`
-  - : Blending using the [_plus-darker_ compositing operator](https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_plus_darker).
+  - : Blending using the [_plus-darker_ compositing operator](https://drafts.csswg.org/compositing-2/#porterduffcompositingoperators_plus_darker).
 - `plus-lighter`
-  - : Blending using the [_plus-lighter_ compositing operator](https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_plus_lighter). Useful for cross-fade effects (prevents unwanted blinking when two overlaying elements animate their opacity in opposite directions).
+  - : Blending using the [_plus-lighter_ compositing operator](https://drafts.csswg.org/compositing-2/#porterduffcompositingoperators_plus_lighter). Useful for cross-fade effects (prevents unwanted blinking when two overlaying elements animate their opacity in opposite directions).
 
 ## Formal definition
 


### PR DESCRIPTION
### Description

Currently the links for explaining the plus-darker and plus-lighter values link to https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_plus_darker which gives a 404 page not found. This updates it to the csswg site spec at https://drafts.csswg.org/compositing-2/#porterduffcompositingoperators_plus_darker

### Motivation

Making this change so readers can see the correct specification for the compositing in mix-blend-mode

### Additional details

Do we need to update all the drafts.fxtf.org links on the site? I happened to notice this one here but seems like there's others on the site that all give 404s or redirect.
