### PR TITLE
Update fxtf spec URLs to the correct csswg URLs

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_module_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_module_page_template/index.md
@@ -42,8 +42,8 @@ sidebar: mdnsidebar
 >
 > ```plain
 > spec-urls:
->     - https://drafts.fxtf.org/filter-effects-2/
->     - https://drafts.fxtf.org/filter-effects-1/
+>     - https://drafts.csswg.org/filter-effects-2/
+>     - https://drafts.csswg.org/filter-effects-1/
 > ```
 >
 > - **sidebar**

--- a/files/en-us/web/css/guides/compositing_and_blending/index.md
+++ b/files/en-us/web/css/guides/compositing_and_blending/index.md
@@ -3,7 +3,7 @@ title: CSS compositing and blending
 short-title: Compositing and blending
 slug: Web/CSS/Guides/Compositing_and_blending
 page-type: css-module
-spec-urls: https://drafts.fxtf.org/compositing/
+spec-urls: https://drafts.csswg.org/compositing-1/
 sidebar: cssref
 ---
 

--- a/files/en-us/web/css/guides/filter_effects/index.md
+++ b/files/en-us/web/css/guides/filter_effects/index.md
@@ -4,8 +4,8 @@ short-title: Filter effects
 slug: Web/CSS/Guides/Filter_effects
 page-type: css-module
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects-2/
-  - https://drafts.fxtf.org/filter-effects-1/
+  - https://drafts.csswg.org/filter-effects-2/
+  - https://drafts.csswg.org/filter-effects-1/
 sidebar: cssref
 ---
 

--- a/files/en-us/web/css/guides/masking/index.md
+++ b/files/en-us/web/css/guides/masking/index.md
@@ -3,7 +3,7 @@ title: CSS masking
 short-title: Masking
 slug: Web/CSS/Guides/Masking
 page-type: css-module
-spec-urls: https://drafts.fxtf.org/css-masking/
+spec-urls: https://drafts.csswg.org/css-masking-1/
 sidebar: cssref
 ---
 

--- a/files/en-us/web/css/guides/motion_path/index.md
+++ b/files/en-us/web/css/guides/motion_path/index.md
@@ -3,7 +3,7 @@ title: CSS motion path
 short-title: Motion path
 slug: Web/CSS/Guides/Motion_path
 page-type: css-module
-spec-urls: https://drafts.fxtf.org/motion/
+spec-urls: https://drafts.csswg.org/motion-1/
 sidebar: cssref
 ---
 

--- a/files/en-us/web/css/reference/properties/mask-border-mode/index.md
+++ b/files/en-us/web/css/reference/properties/mask-border-mode/index.md
@@ -2,7 +2,7 @@
 title: mask-border-mode
 slug: Web/CSS/Reference/Properties/mask-border-mode
 page-type: css-property
-spec-urls: https://drafts.fxtf.org/css-masking-1/#the-mask-border-mode
+spec-urls: https://drafts.csswg.org/css-masking-1/#the-mask-border-mode
 sidebar: cssref
 ---
 

--- a/files/en-us/web/css/reference/properties/stroke/index.md
+++ b/files/en-us/web/css/reference/properties/stroke/index.md
@@ -9,7 +9,7 @@ sidebar: cssref
 The **`stroke`** [CSS](/en-US/docs/Web/CSS) property defines the color or SVG paint server used to draw an element's stroke. As such, `stroke` only has an effect on elements that can be given a stroke (for example, {{SVGElement('rect')}} or {{SVGElement('ellipse')}}); see the page on the SVG {{SVGAttr('stroke')}} attribute for a complete list. When declared, the CSS value overrides any value of the element's {{SVGAttr("stroke")}} SVG attribute.
 
 > [!NOTE]
-> According to the 4 April 2017 draft of the [CSS Fill and Stroke Module Level 3](https://drafts.fxtf.org/fill-stroke-3/#stroke-shorthand) specification, the `stroke` property is a shorthand for a number of other stroke properties. In practice, as of August 2024, browsers do not support the setting of other stroke-related values such as width or dash patterns via the `stroke` property, treating it instead as a direct analogue of the SVG {{SVGAttr("stroke")}} attribute.
+> According to the 4 April 2017 draft of the [CSS Fill and Stroke Module Level 3](https://drafts.csswg.org/fill-stroke-3/#stroke-shorthand) specification, the `stroke` property is a shorthand for a number of other stroke properties. In practice, as of August 2024, browsers do not support the setting of other stroke-related values such as width or dash patterns via the `stroke` property, treating it instead as a direct analogue of the SVG {{SVGAttr("stroke")}} attribute.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/color_value/index.md
+++ b/files/en-us/web/css/reference/values/color_value/index.md
@@ -7,7 +7,7 @@ sidebar: cssref
 ---
 
 The **`<color>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/Reference/Values/Data_types) represents a color.
-A `<color>` may also include an [alpha-channel](https://en.wikipedia.org/wiki/Alpha_compositing) _transparency value_, indicating how the color should [composite](https://drafts.fxtf.org/compositing-1/#simplealphacompositing) with its background.
+A `<color>` may also include an [alpha-channel](https://en.wikipedia.org/wiki/Alpha_compositing) _transparency value_, indicating how the color should [composite](https://drafts.csswg.org/compositing-1/#simplealphacompositing) with its background.
 
 > [!NOTE]
 > Although `<color>` values are precisely defined, their actual appearance may vary (sometimes significantly) from device to device. This is because most devices are not calibrated, and some browsers do not support output devices' [color profiles](https://en.wikipedia.org/wiki/ICC_profile).

--- a/files/en-us/web/svg/guides/svg_filters/index.md
+++ b/files/en-us/web/svg/guides/svg_filters/index.md
@@ -9,7 +9,7 @@ SVG allows us to use similar tools as the bitmap description language such as th
 
 Filters act like layers. When creating them, try applying and testing the effect step by step.
 
-This element has different attributes that help us create the clipping region. Between the filter tags, we can define the _primitives_ that allow us to implement the desired effect. One of these primitives is the [`<feGaussianBlur>`](/en-US/docs/Web/SVG/Reference/Element/feGaussianBlur). The keyword [`SourceAlpha`](https://drafts.fxtf.org/filter-effects/#attr-valuedef-in-sourcealpha) identifies the input for this primitive, is in this case input `in`. The amount of blur to be applied is done using the `stdDeviation` attribute.
+This element has different attributes that help us create the clipping region. Between the filter tags, we can define the _primitives_ that allow us to implement the desired effect. One of these primitives is the [`<feGaussianBlur>`](/en-US/docs/Web/SVG/Reference/Element/feGaussianBlur). The keyword [`SourceAlpha`](https://drafts.csswg.org/filter-effects-1/#attr-valuedef-in-sourcealpha) identifies the input for this primitive, is in this case input `in`. The amount of blur to be applied is done using the `stdDeviation` attribute.
 
 ## SVG filter example
 

--- a/files/en-us/web/svg/reference/attribute/amplitude/index.md
+++ b/files/en-us/web/svg/reference/attribute/amplitude/index.md
@@ -2,7 +2,7 @@
 title: amplitude
 slug: Web/SVG/Reference/Attribute/amplitude
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomponenttransfer-amplitude
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomponenttransfer-amplitude
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/clippathunits/index.md
+++ b/files/en-us/web/svg/reference/attribute/clippathunits/index.md
@@ -2,7 +2,7 @@
 title: clipPathUnits
 slug: Web/SVG/Reference/Attribute/clipPathUnits
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/css-masking-1/#element-attrdef-clippath-clippathunits
+spec-urls: https://drafts.csswg.org/css-masking-1/#element-attrdef-clippath-clippathunits
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/dx/index.md
+++ b/files/en-us/web/svg/reference/attribute/dx/index.md
@@ -3,8 +3,8 @@ title: dx
 slug: Web/SVG/Reference/Attribute/dx
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fedropshadow-dx
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feoffset-dx
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fedropshadow-dx
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feoffset-dx
   - https://svgwg.org/svg2-draft/text.html#TextElementDXAttribute
 sidebar: svgref
 ---

--- a/files/en-us/web/svg/reference/attribute/dy/index.md
+++ b/files/en-us/web/svg/reference/attribute/dy/index.md
@@ -3,8 +3,8 @@ title: dy
 slug: Web/SVG/Reference/Attribute/dy
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fedropshadow-dy
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feoffset-dy
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fedropshadow-dy
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feoffset-dy
   - https://svgwg.org/svg2-draft/text.html#TextElementDYAttribute
 sidebar: svgref
 ---

--- a/files/en-us/web/svg/reference/attribute/edgemode/index.md
+++ b/files/en-us/web/svg/reference/attribute/edgemode/index.md
@@ -2,7 +2,7 @@
 title: edgeMode
 slug: Web/SVG/Reference/Attribute/edgeMode
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-edgemode
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-feconvolvematrix-edgemode
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/exponent/index.md
+++ b/files/en-us/web/svg/reference/attribute/exponent/index.md
@@ -2,7 +2,7 @@
 title: exponent
 slug: Web/SVG/Reference/Attribute/exponent
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomponenttransfer-exponent
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomponenttransfer-exponent
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/height/index.md
+++ b/files/en-us/web/svg/reference/attribute/height/index.md
@@ -3,9 +3,9 @@ title: height
 slug: Web/SVG/Reference/Attribute/height
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-height
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-height
-  - https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-height
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-height
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-height
+  - https://drafts.csswg.org/css-masking-1/#element-attrdef-mask-height
   - https://svgwg.org/svg2-draft/geometry.html#Sizing
   - https://svgwg.org/svg2-draft/pservers.html#PatternElementHeightAttribute
 sidebar: svgref

--- a/files/en-us/web/svg/reference/attribute/in/index.md
+++ b/files/en-us/web/svg/reference/attribute/in/index.md
@@ -2,7 +2,7 @@
 title: in
 slug: Web/SVG/Reference/Attribute/in
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-in
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-in
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/in2/index.md
+++ b/files/en-us/web/svg/reference/attribute/in2/index.md
@@ -3,9 +3,9 @@ title: in2
 slug: Web/SVG/Reference/Attribute/in2
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fedisplacementmap-in2
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-in2
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feblend-in2
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fedisplacementmap-in2
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomposite-in2
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feblend-in2
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/intercept/index.md
+++ b/files/en-us/web/svg/reference/attribute/intercept/index.md
@@ -3,7 +3,7 @@ title: intercept
 slug: Web/SVG/Reference/Attribute/intercept
 page-type: svg-attribute
 browser-compat: svg.elements.feFuncR
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomponenttransfer-intercept
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomponenttransfer-intercept
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/kernelunitlength/index.md
+++ b/files/en-us/web/svg/reference/attribute/kernelunitlength/index.md
@@ -3,9 +3,9 @@ title: kernelUnitLength
 slug: Web/SVG/Reference/Attribute/kernelUnitLength
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-kernelunitlength
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-kernelunitlength
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feconvolvematrix-kernelunitlength
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespecularlighting-kernelunitlength
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fediffuselighting-kernelunitlength
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feconvolvematrix-kernelunitlength
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/operator/index.md
+++ b/files/en-us/web/svg/reference/attribute/operator/index.md
@@ -3,8 +3,8 @@ title: operator
 slug: Web/SVG/Reference/Attribute/operator
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-femorphology-operator
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomposite-operator
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-femorphology-operator
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomposite-operator
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/preserveaspectratio/index.md
+++ b/files/en-us/web/svg/reference/attribute/preserveaspectratio/index.md
@@ -3,7 +3,7 @@ title: preserveAspectRatio
 slug: Web/SVG/Reference/Attribute/preserveAspectRatio
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-feimage-preserveaspectratio
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feimage-preserveaspectratio
   - https://svgwg.org/svg2-draft/coords.html#PreserveAspectRatioAttribute
 sidebar: svgref
 ---

--- a/files/en-us/web/svg/reference/attribute/result/index.md
+++ b/files/en-us/web/svg/reference/attribute/result/index.md
@@ -2,7 +2,7 @@
 title: result
 slug: Web/SVG/Reference/Attribute/result
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-result
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-result
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/slope/index.md
+++ b/files/en-us/web/svg/reference/attribute/slope/index.md
@@ -3,7 +3,7 @@ title: slope
 slug: Web/SVG/Reference/Attribute/slope
 page-type: svg-attribute
 browser-compat: svg.elements.feFuncR
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomponenttransfer-slope
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomponenttransfer-slope
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/specularexponent/index.md
+++ b/files/en-us/web/svg/reference/attribute/specularexponent/index.md
@@ -3,8 +3,8 @@ title: specularExponent
 slug: Web/SVG/Reference/Attribute/specularExponent
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-specularexponent
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-specularexponent
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespecularlighting-specularexponent
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-specularexponent
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/surfacescale/index.md
+++ b/files/en-us/web/svg/reference/attribute/surfacescale/index.md
@@ -3,8 +3,8 @@ title: surfaceScale
 slug: Web/SVG/Reference/Attribute/surfaceScale
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-surfacescale
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-surfacescale
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fediffuselighting-surfacescale
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespecularlighting-surfacescale
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/tablevalues/index.md
+++ b/files/en-us/web/svg/reference/attribute/tablevalues/index.md
@@ -2,7 +2,7 @@
 title: tableValues
 slug: Web/SVG/Reference/Attribute/tableValues
 page-type: svg-attribute
-spec-urls: https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomponenttransfer-tablevalues
+spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomponenttransfer-tablevalues
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/type/index.md
+++ b/files/en-us/web/svg/reference/attribute/type/index.md
@@ -85,7 +85,7 @@ SVG element: {{SVGElement("feColorMatrix")}}
       <th scope="row">Normative document</th>
       <td>
         <a
-          href="https://drafts.fxtf.org/filter-effects/#element-attrdef-fecolormatrix-type"
+          href="https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecolormatrix-type"
           rel="external"
           >Filter Effects Module Level 1</a
         >
@@ -119,7 +119,7 @@ SVG elements: {{SVGElement("feFuncR")}}, {{SVGElement("feFuncG")}}, {{SVGElement
       <th scope="row">Normative document</th>
       <td>
         <a
-          href="https://drafts.fxtf.org/filter-effects/#element-attrdef-fecomponenttransfer-type"
+          href="https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomponenttransfer-type"
           rel="external"
           >Filter Effects Module Level 1</a
         >
@@ -152,7 +152,7 @@ SVG element: {{SVGElement("feTurbulence")}}
       <th scope="row">Normative document</th>
       <td>
         <a
-          href="https://drafts.fxtf.org/filter-effects/#element-attrdef-feturbulence-type"
+          href="https://drafts.csswg.org/filter-effects-1/#element-attrdef-feturbulence-type"
           rel="external"
           >Filter Effects Module Level 1</a
         >

--- a/files/en-us/web/svg/reference/attribute/values/index.md
+++ b/files/en-us/web/svg/reference/attribute/values/index.md
@@ -3,7 +3,7 @@ title: values
 slug: Web/SVG/Reference/Attribute/values
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fecolormatrix-values
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecolormatrix-values
   - https://svgwg.org/specs/animations/#ValuesAttribute
 sidebar: svgref
 ---

--- a/files/en-us/web/svg/reference/attribute/width/index.md
+++ b/files/en-us/web/svg/reference/attribute/width/index.md
@@ -3,9 +3,9 @@ title: width
 slug: Web/SVG/Reference/Attribute/width
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-width
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-width
-  - https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-width
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-width
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-width
+  - https://drafts.csswg.org/css-masking-1/#element-attrdef-mask-width
   - https://svgwg.org/svg2-draft/geometry.html#Sizing
   - https://svgwg.org/svg2-draft/pservers.html#PatternElementWidthAttribute
 sidebar: svgref

--- a/files/en-us/web/svg/reference/attribute/x/index.md
+++ b/files/en-us/web/svg/reference/attribute/x/index.md
@@ -3,11 +3,11 @@ title: x
 slug: Web/SVG/Reference/Attribute/x
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-x
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-x
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fepointlight-x
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-x
-  - https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-x
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-x
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-x
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fepointlight-x
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-x
+  - https://drafts.csswg.org/css-masking-1/#element-attrdef-mask-x
   - https://svgwg.org/svg2-draft/geometry.html#X
   - https://svgwg.org/svg2-draft/pservers.html#PatternElementXAttribute
   - https://svgwg.org/svg2-draft/text.html#TextElementXAttribute

--- a/files/en-us/web/svg/reference/attribute/y/index.md
+++ b/files/en-us/web/svg/reference/attribute/y/index.md
@@ -3,11 +3,11 @@ title: y
 slug: Web/SVG/Reference/Attribute/y
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-y
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-y
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fepointlight-y
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-filter-primitive-y
-  - https://drafts.fxtf.org/css-masking-1/#element-attrdef-mask-y
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-y
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-y
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fepointlight-y
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-y
+  - https://drafts.csswg.org/css-masking-1/#element-attrdef-mask-y
   - https://svgwg.org/svg2-draft/geometry.html#Y
   - https://svgwg.org/svg2-draft/pservers.html#PatternElementYAttribute
   - https://svgwg.org/svg2-draft/text.html#TextElementYAttribute

--- a/files/en-us/web/svg/reference/attribute/z/index.md
+++ b/files/en-us/web/svg/reference/attribute/z/index.md
@@ -3,8 +3,8 @@ title: z
 slug: Web/SVG/Reference/Attribute/z
 page-type: svg-attribute
 spec-urls:
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fepointlight-z
-  - https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-z
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fepointlight-z
+  - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-z
 sidebar: svgref
 ---
 

--- a/files/jsondata/SpecData.json
+++ b/files/jsondata/SpecData.json
@@ -111,7 +111,7 @@
   },
   "Compositing": {
     "name": "Compositing and Blending Level 1",
-    "url": "https://drafts.fxtf.org/compositing-1/",
+    "url": "https://drafts.csswg.org/compositing-1/",
     "status": "CR"
   },
   "Console API": {
@@ -586,7 +586,7 @@
   },
   "CSS Masks": {
     "name": "CSS Masking Module Level 1",
-    "url": "https://drafts.fxtf.org/css-masking-1/",
+    "url": "https://drafts.csswg.org/css-masking-1/",
     "status": "CR"
   },
   "CSS Non-element Selectors": {
@@ -896,12 +896,12 @@
   },
   "Filters 1.0": {
     "name": "Filter Effects Module Level 1",
-    "url": "https://drafts.fxtf.org/filter-effects/",
+    "url": "https://drafts.csswg.org/filter-effects-1/",
     "status": "WD"
   },
   "Filters 2.0": {
     "name": "Filter Effects Module Level 2",
-    "url": "https://drafts.fxtf.org/filter-effects-2/",
+    "url": "https://drafts.csswg.org/filter-effects-2/",
     "status": "ED"
   },
   "Frame Timing": {
@@ -936,7 +936,7 @@
   },
   "Geometry Interfaces": {
     "name": "Geometry Interfaces Module Level 1",
-    "url": "https://drafts.fxtf.org/geometry/",
+    "url": "https://drafts.csswg.org/geometry-1/",
     "status": "CR"
   },
   "Gyroscope": {
@@ -1201,7 +1201,7 @@
   },
   "Motion Path Level 1": {
     "name": "Motion Path Module Level 1",
-    "url": "https://drafts.fxtf.org/motion-1/",
+    "url": "https://drafts.csswg.org/motion-1/",
     "status": "WD"
   },
   "Navigation Timing": {


### PR DESCRIPTION
### Description

Following on from #43445, want to update the drafts.fxtf.org specification URLs that either give 404s or redirect when they should be the drafts.csswg.org URLs. Therefore do a search for most of the usages of it and replace them with the correct URL

### Motivation

Update so people get the correct specification URL instead of a 404

### Additional details

Info at https://drafts.fxtf.org/
Let me know if any of these shouldn't be updated for whatever reason, it was mostly a find replace but I did check all the new URLs loaded correctly
