### PR TITLE
Deduplicate content from CSS gradient color hint guidance

### DIFF
--- a/files/en-us/web/css/guides/images/using_gradients/index.md
+++ b/files/en-us/web/css/guides/images/using_gradients/index.md
@@ -187,7 +187,7 @@ div {
 
 ### Gradient hints
 
-By default, the gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark.
+By default, a gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient, letting you control the {{Glossary("interpolation")}}, or progression, between two color stops. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark. To highlight the difference the color hint can make, the second example does not contain the hint:
 
 ```html hidden
 <div class="color-hint"></div>
@@ -279,36 +279,6 @@ In the first example above, the lime goes from the 0% mark, which is implied, to
 In the second example, the second color stop for each color is at the same location as the first color stop for the adjacent color, creating a striped effect.
 
 In both examples, the gradient is written twice: the first is the CSS Images Level 3 method of repeating the color for each stop and the second example is the CSS Images Level 4 multiple color stop method of including two color-stop-lengths in a linear-color-stop declaration.
-
-### Controlling the progression of a gradient
-
-By default, a gradient evenly progresses between the colors of two adjacent color stops, with the midpoint between those two color stops being the midpoint color value. You can control the {{Glossary("interpolation")}}, or progression, between two color stops by including a color hint location. In this example, the color reaches the midpoint between lime and cyan 20% of the way through the gradient rather than 50% of the way through. The second example does not contain the hint to highlight the difference the color hint can make:
-
-```html hidden
-<div class="color-hint-gradient"></div>
-<div class="regular-progression"></div>
-```
-
-```css hidden
-div {
-  width: 120px;
-  height: 120px;
-  float: left;
-  margin-right: 10px;
-  box-sizing: border-box;
-}
-```
-
-```css
-.color-hint-gradient {
-  background: linear-gradient(to top, lime, 20%, cyan);
-}
-.regular-progression {
-  background: linear-gradient(to top, lime, cyan);
-}
-```
-
-{{ EmbedLiveSample('Controlling_the_progression_of_a_gradient', 120, 120) }}
 
 ### Overlaying gradients
 

--- a/files/en-us/web/css/guides/images/using_gradients/index.md
+++ b/files/en-us/web/css/guides/images/using_gradients/index.md
@@ -185,7 +185,7 @@ div {
 
 {{ EmbedLiveSample('Creating_hard_lines', 120, 120) }}
 
-### Gradient hints
+### Controlling the progression of a gradient using color hints
 
 By default, a gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient, letting you control the {{Glossary("interpolation")}}, or progression, between two color stops. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark. To highlight the difference the color hint can make, the second example does not contain the hint:
 

--- a/files/en-us/web/css/guides/images/using_gradients/index.md
+++ b/files/en-us/web/css/guides/images/using_gradients/index.md
@@ -185,35 +185,6 @@ div {
 
 {{ EmbedLiveSample('Creating_hard_lines', 120, 120) }}
 
-### Gradient hints
-
-By default, a gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient, letting you control the {{Glossary("interpolation")}}, or progression, between two color stops. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark. To highlight the difference the color hint can make, the second example does not contain the hint:
-
-```html hidden
-<div class="color-hint"></div>
-<div class="simple-linear"></div>
-```
-
-```css hidden
-div {
-  width: 120px;
-  height: 120px;
-  float: left;
-  margin-right: 10px;
-}
-```
-
-```css
-.color-hint {
-  background: linear-gradient(blue, 10%, pink);
-}
-.simple-linear {
-  background: linear-gradient(blue, pink);
-}
-```
-
-{{ EmbedLiveSample('Gradient_hints', 120, 120) }}
-
 ### Creating color bands & stripes
 
 To include a solid, non-transitioning color area within a gradient, include two positions for the color stop. Color stops can have two positions, which is equivalent to two consecutive color stops with the same color at different positions. The color will reach full saturation at the first color stop, maintain that saturation through to the second color stop, and transition to the adjacent color stop's color through the adjacent color stop's first position.
@@ -279,6 +250,36 @@ In the first example above, the lime goes from the 0% mark, which is implied, to
 In the second example, the second color stop for each color is at the same location as the first color stop for the adjacent color, creating a striped effect.
 
 In both examples, the gradient is written twice: the first is the CSS Images Level 3 method of repeating the color for each stop and the second example is the CSS Images Level 4 multiple color stop method of including two color-stop-lengths in a linear-color-stop declaration.
+
+### Controlling the progression of a gradient using color hints
+
+By default, a gradient evenly progresses between the colors of two adjacent color stops, with the midpoint between those two color stops being the midpoint color value. You can control the {{Glossary("interpolation")}}, or progression, between two color stops by including a color hint location. In this example, the color reaches the midpoint between lime and cyan 20% of the way through the gradient rather than 50% of the way through. The second example does not contain the hint to highlight the difference the color hint can make:
+
+```html hidden
+<div class="color-hint-gradient"></div>
+<div class="regular-progression"></div>
+```
+
+```css hidden
+div {
+  width: 120px;
+  height: 120px;
+  float: left;
+  margin-right: 10px;
+  box-sizing: border-box;
+}
+```
+
+```css
+.color-hint-gradient {
+  background: linear-gradient(to top, lime, 20%, cyan);
+}
+.regular-progression {
+  background: linear-gradient(to top, lime, cyan);
+}
+```
+
+{{ EmbedLiveSample('Controlling_the_progression_of_a_gradient_using_color_hints', 120, 120) }}
 
 ### Overlaying gradients
 

--- a/files/en-us/web/css/guides/images/using_gradients/index.md
+++ b/files/en-us/web/css/guides/images/using_gradients/index.md
@@ -185,7 +185,7 @@ div {
 
 {{ EmbedLiveSample('Creating_hard_lines', 120, 120) }}
 
-### Controlling the progression of a gradient using color hints
+### Gradient hints
 
 By default, a gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient, letting you control the {{Glossary("interpolation")}}, or progression, between two color stops. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark. To highlight the difference the color hint can make, the second example does not contain the hint:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

In the "*Using CSS gradients*" guidance, I've combined duplicate content about gradient hints.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Hi.

> ### Gradient hints
> By default, the gradient transitions evenly from one color to the next. You can include a color-hint to move the midpoint of the transition value to a certain point along the gradient. In this example, we've moved the midpoint of the transition from the 50% mark to the 10% mark.
> 
> ...
> 
> ### Controlling the progression of a gradient
> 
> By default, a gradient evenly progresses between the colors of two adjacent color stops, with the midpoint between those two color stops being the midpoint color value. You can control the {{Glossary("interpolation")}}, or progression, between two color stops by including a color hint location. In this example, the color reaches the midpoint between lime and cyan 20% of the way through the gradient rather than 50% of the way through. The second example does not contain the hint to highlight the difference the color hint can make: ...
> 
> *from: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Images/Using_gradients*

I've thought that the above two paragraphs are talking about the really same thing. We can make that useful article a bit shorter by removing duplicate thing.

A screenshot of the rendered webpage:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7432b3fa-4fb3-4fc9-abb9-2582dccf173d" />

Of course, we can preserve the "Controlling the progression of a gradient" heading instead.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

I use AI tools. I know what I've written.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

none

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
