### PR TITLE
FF149 Relnote: CSS font-family: math and MathML

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -26,7 +26,10 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### MathML -->
+### MathML
+
+- The CSS [`font-family: math`](/en-US/docs/Web/CSS/Reference/Properties/font-family#math) property is now supported, and applied to {{mathmlelement('math')}} elements by default.
+  This ensures that websites can use an appropriate math font and/or MathML without having to know what fonts are present on the underlying OS. ([Firefox bug 2014703](https://bugzil.la/2014703)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/web/css/reference/properties/font-family/index.md
+++ b/files/en-us/web/css/reference/properties/font-family/index.md
@@ -146,7 +146,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
     - `ui-rounded`
       - : The default user interface font that has rounded features.
     - `math`
-      - : This is for the particular stylistic concerns of representing mathematics: superscript and subscript, brackets that cross several lines, nesting expressions, and double struck glyphs with distinct meanings.
+      - : Font that addresses the particular stylistic concerns of representing mathematics: superscript and subscript, brackets that cross several lines, nesting expressions, and double struck glyphs with distinct meanings.
         UA stylesheets may set `math { font-family: math }` so that the {{MathMLElement("math")}} element uses appropriate fonts by default.
     - `fangsong`
       - : A particular style of Chinese characters that are between serif-style Song and cursive-style Kai forms. This style is often used for government documents.


### PR DESCRIPTION
FF149 enables the CSS `font-family: math` property and applies it by default on the MathML `<math>` element. This adds a release note and tweaks the property text.

Related docs work can be tracked in #43209
