### PR TITLE
FF148 Relnote: createImageBitmap() - resizeQuality option plus bug

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -57,6 +57,10 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
+- The [`options.resizeQuality`](/en-US/docs/Web/API/Window/createImageBitmap#resizequality) parameter is now supported by {{domxref("Window.createImageBitmap()")}} and {{domxref("WorkerGlobalScope.createImageBitmap()")}}.
+  In addition, the methods now allow both resize options ([`options.resizeWidth`](/en-US/docs/Web/API/Window/createImageBitmap#resizewidth) or [`options.resizeHeight`](/en-US/docs/Web/API/Window/createImageBitmap#resizeheight)) and image bitmap parameters ([`sx`, `sy`, `sw`, and `sh`](/en-US/docs/Web/API/Window/createImageBitmap#sx)) to be set at the same time — previously setting both returned the unscaled source bitmap.
+  ([Firefox bug 2010125](https://bugzil.la/2010125)).
+
 #### DOM
 
 - The [`HTMLSelectElement.showPicker()`](/en-US/docs/Web/API/HTMLInputElement/showPicker#showpicker_for_a_datalist_input) method is now supported for a list of options defined in a {{htmlelement("datalist")}}.


### PR DESCRIPTION
FF149 adds support for `options.resizeQuality` in [`Window.createImageBitmap()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap) (and worker variant) in https://bugzilla.mozilla.org/show_bug.cgi?id=2010125

It also fixed a bug where setting both resize* options and an image bitmap to create the image from would result in the method not working.

This adds the release note.

Related docs work can be tracked in #43429