### PR TITLE
Make \u{...} syntax more unambiguous

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -227,6 +227,7 @@ console.log(moods.match(regexpEmoticons));
         <code>\x<em>hh</em></code>
       </td>
       <td>
+        <a href="/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape"><strong>Hex escape:</strong></a>
         Matches the character with the code <code><em>hh</em></code> (two
         hexadecimal digits).
       </td>
@@ -236,17 +237,19 @@ console.log(moods.match(regexpEmoticons));
         <code>\u<em>HHHH</em></code>
       </td>
       <td>
+        <a href="/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape"><strong>Unicode escape:</strong></a>
         Matches a UTF-16 code-unit with the value
         <code><em>HHHH</em></code> (four hexadecimal digits).
       </td>
     </tr>
     <tr>
       <td>
-        <code>\u{<em>HHHH</em>}</code>
+        <code>\u{<em>H…H</em>}</code>
       </td>
       <td>
+        <a href="/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape"><strong>Unicode code point escape:</strong></a>
         (Only when the <code>u</code> flag is set.) Matches the character with
-        the Unicode value <code>U+<em>HHHH</em></code> (1 to 6 hexadecimal digits).
+        the Unicode value <code>U+<em>H…H</em></code> (1 to 6 hexadecimal digits).
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -212,6 +212,7 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` sy
         <code>\x<em>hh</em></code>
       </td>
       <td>
+        <a href="/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape"><strong>Hex escape:</strong></a>
         Matches the character with the code <code><em>hh</em></code> (two
         hexadecimal digits).
       </td>
@@ -221,17 +222,19 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` sy
         <code>\u<em>HHHH</em></code>
       </td>
       <td>
+        <a href="/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape"><strong>Unicode escape:</strong></a>
         Matches a UTF-16 code-unit with the value
         <code><em>HHHH</em></code> (four hexadecimal digits).
       </td>
     </tr>
     <tr>
       <td>
-        <code>\u{<em>HHHH</em>}</code>
+        <code>\u{<em>H…H</em>}</code>
       </td>
       <td>
+        <a href="/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape"><strong>Unicode code point escape:</strong></a>
         (Only when the <code>u</code> flag is set.) Matches the character with
-        the Unicode value <code>U+<em>HHHH</em></code> (1 to 6 hexadecimal digits).
+        the Unicode value <code>U+<em>H…H</em></code> (1 to 6 hexadecimal digits).
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/javascript/guide/regular_expressions/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/index.md
@@ -82,8 +82,8 @@ If you want to look at all the special characters that can be used in regular ex
         <code>\d</code>, <code>\D</code>, <code>\w</code>, <code>\W</code>,
         <code>\s</code>, <code>\S</code>, <code>\t</code>, <code>\r</code>,
         <code>\n</code>, <code>\v</code>, <code>\f</code>, <code>[\b]</code>,
-        <code>\0</code>, <code>\c<em>X</em></code>, <code>\x<em>hh</em></code>,
-        <code>\u<em>HHHH</em></code>, <code>\u<em>{HHHH}</em></code>,
+        <code>\0</code>, <code>\c<em>X</em></code>, <code>\x<em>HH</em></code>,
+        <code>\u<em>HHHH</em></code>, <code>\u<em>{H…H}</em></code>,
         <code><em>x</em>|<em>y</em></code>
       </td>
       <td>

--- a/files/en-us/web/javascript/reference/regular_expressions/character_escape/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_escape/index.md
@@ -20,7 +20,7 @@ A **character escape** represents a character that may not be able to be conveni
 
 \xHH
 \uHHHH
-\u{HHH}
+\u{H…H}
 ```
 
 > [!NOTE]
@@ -28,8 +28,8 @@ A **character escape** represents a character that may not be able to be conveni
 
 ### Parameters
 
-- `HHH`
-  - : A hexadecimal number representing the Unicode code point of the character. The `\xHH` form must have two hexadecimal digits; the `\uHHHH` form must have four; the `\u{HHH}` form may have 1 to 6 hexadecimal digits.
+- `H…H`
+  - : A hexadecimal number representing the Unicode code point of the character. The `\xHH` form must have two hexadecimal digits; the `\uHHHH` form must have four; the `\u{H…H}` form may have 1 to 6 hexadecimal digits.
 
 ## Description
 
@@ -47,7 +47,7 @@ The following character escapes are recognized in regular expressions:
   - : Represents the character with the given hexadecimal Unicode code point. The hexadecimal number must be exactly two digits long.
 - `\uHHHH`
   - : Represents the character with the given hexadecimal Unicode code point. The hexadecimal number must be exactly four digits long. Two such escape sequences can be used to represent a surrogate pair in [Unicode-aware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode). (In Unicode-unaware mode, they are always two separate characters.)
-- `\u{HHH}`
+- `\u{H…H}`
   - : ([Unicode-aware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode) only) Represents the character with the given hexadecimal Unicode code point. The hexadecimal number can be from 1 to 6 digits long.
 
 In [Unicode-unaware mode](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode), escape sequences that are not one of the above become _identity escapes_: they represent the character that follows the backslash. For example, `\a` represents the character `a`. This behavior limits the ability to introduce new escape sequences without causing backward compatibility issues, and is therefore forbidden in Unicode-aware mode.


### PR DESCRIPTION
### Description

Fix `\u{...}` escape description in the regex character classes guide to correctly state 1–6 hex digits instead of implying only 4 or 5. Also added a link to the Character escape reference page for consistency with other rows in the table.

### Motivation

The guide page said `\u{hhhh} or \u{hhhhh}`, which misleads readers into thinking only 4 or 5 hex digits are valid. The Character escape reference page already correctly says 1–6 digits. This fix makes both pages consistent.

### Related issues and pull requests

Fixes #43446
