### PR TITLE
fix: Fix misleading lexical  claim in setInterval docs to match the actual example

### DIFF
--- a/files/en-us/web/api/window/setinterval/index.md
+++ b/files/en-us/web/api/window/setinterval/index.md
@@ -113,67 +113,73 @@ While this pattern does not guarantee execution on a fixed interval, it does gua
 
 ### Functions are called with the global `this`
 
-Methods or functions passed to `setInterval()` do not run in the same execution context as `setInterval()`, and hence do not have the same [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) as the function that called `setInterval()`.
-Instead the called function has a `this` keyword set to the `window` (or `global`) object.
+The functions passed to `setInterval()` is run with normal function call semantics for determining the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this).
 This problem is explained in detail in the [JavaScript reference](/en-US/docs/Web/JavaScript/Reference/Operators/this#callbacks).
 
-The following example demonstrates how this can cause unexpected behavior (using `setTimeout()` instead of `setInterval()`, but the problem applies to both timers):
+For non-arrow functions, the `this` context is set to the [`globalThis`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) (an alias for [`window`](/en-US/docs/Web/API/Window/window) in browsers) object.
+
+The following example demonstrates how this can cause unexpected behavior. Here, when we pass the method `counter.count` directly to `setInterval()`, the `this` context is lost, and the method is called on the global object instead of the `Counter` instance, resulting in a `TypeError` when the `count` method tries to access `this`:
 
 ```js
-myArray = ["zero", "one", "two"];
+class Counter {
+  constructor() {
+    this.data = new Map();
+  }
 
-myArray.myMethod = function (sProperty) {
-  alert(arguments.length > 0 ? this[sProperty] : this);
-};
+  count(item) {
+    this.data.set(item, (this.data.get(item) || 0) + 1);
+  }
+}
 
-myArray.myMethod(); // prints "zero,one,two"
-myArray.myMethod(1); // prints "one"
-setTimeout(myArray.myMethod, 1000); // Alerts "[object Window]" after 1 second
-setTimeout(myArray.myMethod, 1500, "1"); // Alerts "undefined" after 1.5 seconds
+const counter = new Counter();
+
+counter.count("foo"); // Successfully adds "foo" to the map
+setInterval(counter.count, 1000, "bar");
+// TypeError: Cannot read properties of undefined (reading 'set')
 ```
 
-One way to work around this is to wrap the method call in a function, so the method is called on the object directly using dot notation:
+To work around this, you must make sure that the function passed to `setInterval` has the correct `this` context. There are three main ways to do this:
 
-```js
-setTimeout(() => myArray.myMethod(), 1000); // Alert "zero,one,two" after 1 second
-setTimeout(() => myArray.myMethod(1), 1500); // Alert "one" after 1.5 seconds
-setTimeout(() => myArray.myMethod(2), 3000); // Alert "two" after 3 seconds
-```
+1. If you want to explicitly specify the `this` context, instead of passing the method directly, wrap the method call in another anonymous function that explicitly calls the method with the correct context:
 
-Another approach is to use [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), which have a lexical `this` — meaning they inherit `this` from the surrounding scope instead of having their own. This is useful when your callback needs to access `this` directly:
+   ```js
+   setInterval(() => counter.count("bar"), 1000);
+   setInterval(function () {
+     counter.count("bar");
+   }, 1000);
+   ```
 
-```js
-const counter = {
-  count: 0,
-  start() {
-    // Arrow function inherits "this" from start(), so this.count works
-    setInterval(() => {
-      this.count++;
-      console.log(this.count);
-    }, 1000);
-  },
-};
+2. If you want to use the `this` context of the code that calls `setInterval()`, always use an arrow function, which inherits the `this` context of its enclosing scope:
 
-counter.start(); // Logs 1, 2, 3, ...
-```
+   ```js example-bad
+   class Counter {
+     // …
+     repeatedCount(item) {
+       // BAD: the `this` context is lost in the callback
+       setInterval(function () {
+         this.data.set(item, (this.data.get(item) || 0) + 1);
+       }, 1000);
+     }
+   }
+   ```
 
-If you used a regular `function` expression instead, `this` would refer to the global object (`window`), not `counter`:
+   ```js example-good
+   class Counter {
+     // …
+     repeatedCount(item) {
+       // GOOD: the arrow function inherits the `this` context of `repeatedCount()`
+       setInterval(() => {
+         this.data.set(item, (this.data.get(item) || 0) + 1);
+       }, 1000);
+     }
+   }
+   ```
 
-```js
-const counter = {
-  count: 0,
-  start() {
-    // Regular function has its own "this", which is "window" here
-    setInterval(function () {
-      this.count++; // "this" is window, not counter!
-      console.log(this.count); // NaN
-    }, 1000);
-  },
-};
-```
+3. If you want to avoid extra function wrappers (which increase memory usage) while explicitly specifying the `this` context, you can use the [`Function.prototype.bind()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) method to create a new function with the correct `this` context:
 
-You might also use the [`Function.prototype.bind()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) method, which lets you specify the value that should be used as `this` for all calls to a given function.
-That lets you bypass problems where it's unclear what `this` will be, depending on the context from which your function was called.
+   ```js
+   setInterval(counter.count.bind(counter), 1000, "bar");
+   ```
 
 ### Security considerations
 

--- a/files/en-us/web/api/window/settimeout/index.md
+++ b/files/en-us/web/api/window/settimeout/index.md
@@ -111,52 +111,73 @@ If the order that an asynchronous method completes does matter, then you can use
 
 ### Functions are called with the global `this`
 
-Methods or functions passed to `setTimeout()` do not run in the same execution context as `setTimeout()`, and hence do not have the same [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) as the function that called `setTimeout()`.
-Instead the called function has a `this` keyword set to the `window` (or `global`) object.
+The functions passed to `setTimeout()` is run with normal function call semantics for determining the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this).
 This problem is explained in detail in the [JavaScript reference](/en-US/docs/Web/JavaScript/Reference/Operators/this#callbacks).
 
-The following example demonstrates how this can cause unexpected behavior:
+For non-arrow functions, the `this` context is set to the [`globalThis`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) (an alias for [`window`](/en-US/docs/Web/API/Window/window) in browsers) object.
+
+The following example demonstrates how this can cause unexpected behavior. Here, when we pass the method `counter.count` directly to `setTimeout()`, the `this` context is lost, and the method is called on the global object instead of the `Counter` instance, resulting in a `TypeError` when the `count` method tries to access `this`:
 
 ```js
-const myObject = {
-  log() {
-    console.log(`myProperty: ${this.myProperty}`);
-  },
-  myProperty: 12,
-};
+class Counter {
+  constructor() {
+    this.data = new Map();
+  }
 
-myObject.log(); // myProperty: 12
-setTimeout(myObject.log, 1000); // myProperty: undefined
+  count(item) {
+    this.data.set(item, (this.data.get(item) || 0) + 1);
+  }
+}
+
+const counter = new Counter();
+
+counter.count("foo"); // Successfully adds "foo" to the map
+setTimeout(counter.count, 1000, "bar");
+// TypeError: Cannot read properties of undefined (reading 'set')
 ```
 
-You can use a wrapper function, such as an [arrow function](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), to adopt the `this` of the function in which `setTimeout()` is called (arrow functions have a lexical `this`).
+To work around this, you must make sure that the function passed to `setTimeout` has the correct `this` context. There are three main ways to do this:
 
-You can test this with the following code:
+1. If you want to explicitly specify the `this` context, instead of passing the method directly, wrap the method call in another anonymous function that explicitly calls the method with the correct context:
 
-```js
-// Arrow function callback
-setTimeout(() => myObject.log(), 2000); // myProperty: 12 after 2 seconds
+   ```js
+   setTimeout(() => counter.count("bar"), 1000);
+   setTimeout(function () {
+     counter.count("bar");
+   }, 1000);
+   ```
 
-// Anonymous function callback
-setTimeout(function () {
-  myObject.log();
-}, 3000); // myProperty: 12 after 3 seconds
-```
+2. If you want to use the `this` context of the code that calls `setTimeout()`, always use an arrow function, which inherits the `this` context of its enclosing scope:
 
-You might also use the [`Function.prototype.bind()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) method, which lets you specify the value that should be used as `this` for all calls to a given function.
-That lets you bypass problems where it's unclear what `this` will be, depending on the context from which your function was called:
+   ```js example-bad
+   class Counter {
+     // …
+     delayedCount(item) {
+       // BAD: the `this` context is lost in the callback
+       setTimeout(function () {
+         this.data.set(item, (this.data.get(item) || 0) + 1);
+       }, 1000);
+     }
+   }
+   ```
 
-```js
-const myArray = ["zero", "one", "two"];
-const myBoundMethod = function (sProperty) {
-  console.log(arguments.length > 0 ? this[sProperty] : this);
-}.bind(myArray);
+   ```js example-good
+   class Counter {
+     // …
+     delayedCount(item) {
+       // GOOD: the arrow function inherits the `this` context of `delayedCount()`
+       setTimeout(() => {
+         this.data.set(item, (this.data.get(item) || 0) + 1);
+       }, 1000);
+     }
+   }
+   ```
 
-myBoundMethod(); // prints "zero,one,two" because 'this' is bound to myArray in the function
-myBoundMethod(1); // prints "one"
-setTimeout(myBoundMethod, 1.0 * 1000); // still prints "zero,one,two" after 1 second because of the binding
-setTimeout(myBoundMethod, 1.5 * 1000, "1"); // prints "one" after 1.5 seconds
-```
+3. If you want to avoid extra function wrappers (which increase memory usage) while explicitly specifying the `this` context, you can use the [`Function.prototype.bind()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) method to create a new function with the correct `this` context:
+
+   ```js
+   setTimeout(counter.count.bind(counter), 1000, "bar");
+   ```
 
 ### Non-number delay values are silently coerced into numbers
 


### PR DESCRIPTION
### Description

Updated the text in the "Functions are called with the global `this`" section of the `setInterval` page. Removed the incorrect claim about arrow functions using lexical `this`, since the example just wraps the method call with dot notation.

### Motivation

The old text said the example demonstrates lexical `this`, but it doesn't - the arrow function simply calls `myArray.myMethod()` directly, which works because of dot notation, not lexical `this`. This was confusing and technically incorrect.

### Related issues and pull requests

Fixes #43441
