### PR TITLE
FF149 @container style() allows but ignores !important

### DIFF
--- a/files/en-us/web/css/guides/containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/guides/containment/container_size_and_style_queries/index.md
@@ -22,7 +22,7 @@ There are three types of container queries:
 
 - **[Container style queries](/en-US/docs/Web/CSS/Reference/At-rules/@container#container_style_queries)**
   - : Style queries enable applying styles to elements based on a containing element's style features, where any non-empty element can be a style query container. A style feature can be a CSS property, CSS [custom property](/en-US/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties), or a valid CSS [declaration](/en-US/docs/Web/CSS/Guides/Syntax/Introduction#css_declarations).
-    This allows you to apply styles to any element's descendants based on any property, declaration, or computed value — for example if the container is `display: inline flex`, or has a non-transparent background color.
+    This allows you to apply styles to any container element's descendants based on its style features — such as whether it has a `display: inline` flex declaration set, or the value of a custom property.
 
 - **[Container scroll-state queries](/en-US/docs/Web/CSS/Guides/Conditional_rules/Container_scroll-state_queries)**
   - : Scroll-state queries allow you to selectively apply CSS rules to a container's descendants based on scroll-state conditions, such as whether the queried element is partially scrolled or whether the container is snapped to a scroll snap container. The containing elements need to be explicitly declared as _scroll-state query containers_.

--- a/files/en-us/web/css/reference/at-rules/@container/index.md
+++ b/files/en-us/web/css/reference/at-rules/@container/index.md
@@ -487,7 +487,7 @@ The following container query checks if the [computed value](/en-US/docs/Web/CSS
 
 Style features that query a shorthand property are true if the computed values match for each of its longhand properties, and false otherwise. For example, `@container style(border: 2px solid red)` will resolve to true if all 12 longhand properties (`border-bottom-style`, etc.) that make up that shorthand are true.
 
-Note that `!important` is allowed in style queries but will be ignored.
+Note that [`!important`](/en-US/docs/Web/CSS/Reference/Values/important) is allowed in style queries but is ignored.
 
 ```css
 /* !important is valid but has no effect */


### PR DESCRIPTION
This updated does two things.
1. Updates the "Using container size and style queries" doc to:
   - Update legacy note that only style queries with custom properties are supported. I believe all the types are - certainly that is what the `@container` docs indicate and the BCD seems to show.
   - Link the Container style queries intro to the more detailed section on `@container` doc.
2. Adds a note in `@container` docs that `!important` is allowed in style queries but ignored. This apparently is not clear in the spec but is in a [WPT test that is passed by all browsers](https://wpt.fyi/results/css/css-conditional/container-queries/at-container-style-parsing.html?label=experimental&label=master&aligned). This came up in https://bugzilla.mozilla.org/show_bug.cgi?id=2014095 and I think is worthy of a mention.

Related docs work can be tracked in in #43216