### PR TITLE
fix: Weekly spelling check

### DIFF
--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -69,6 +69,7 @@ backgroundfetchabort
 backgroundfetchclick
 backgroundfetchfail
 backgroundfetchsuccess
+bufferedchange
 BACKTAB
 backzone
 Basetime
@@ -220,12 +221,16 @@ emptytext
 emsdk
 enable-tracejit
 enableiOES
+endstreaming
+onendstreaming
+onstartstreaming
 enterpictureinpicture
 equalsize
 EquationiOES
 ethi
 ethioaa
 exitpictureinpicture
+startstreaming
 exnref
 Exsel
 externref


### PR DESCRIPTION
Fixes #43450

Adds Web API terms flagged as unknown words by the weekly spell check. The words `bufferedchange`, `endstreaming`, `startstreaming`, `onendstreaming`, and `onstartstreaming` are valid API names used in MDN docs, not typos. Adds them to `.vscode/dictionaries/code-entities.txt` in alphabetical order alongside similar API terms like `backgroundfetchsuccess` and `enterpictureinpicture`. Verified by confirming the words appear correctly in the dictionary file.