### PR TITLE
FF149 ExprFeat/Relnote: CSS text-box and longhand props

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -319,6 +319,22 @@ The CSS `text-decoration-trim` property allows you to specify {{cssxref("text-de
 - `layout.css.text-decoration-trim.enabled`
   - : Set to `true` to enable.
 
+### `text-box`, `text-box-edge`, `text-box-trim`
+
+The CSS {{cssxref("text-box")}} shorthand property, or the corresponding {{cssxref("text-box-trim")}} and {{cssxref("text-box-edge")}} longhand properties, allow you to trim space from the block-start and block-end edges of a text element's block container, aligning the container edges with the actual ink bounds of the text rather than the abstract box edges defined by font metrics.
+This makes it possible to achieve consistent visual spacing around text regardless of which font is used.
+([Firefox bug 2013458](https://bugzil.la/2013458)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 149           | No                  |
+| Developer Edition | 149           | No                  |
+| Beta              | 149           | No                  |
+| Release           | 149           | No                  |
+
+- `layout.css.text-box.enabled`
+  - : Set to `true` to enable.
+
 ### `@custom-media` at-rule
 
 The {{cssxref("@custom-media")}} CSS at-rule defines aliases for long or complex media queries. Instead of repeating the same hardcoded `<media-query-list>` in multiple `@media` at-rules, it can be defined once in a `@custom-media` at-rule and referenced throughout the stylesheet whenever needed. ([Firefox bug 1744292](https://bugzil.la/1744292)).

--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -137,3 +137,10 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **`alpha` & `colorspace` attributes in `color` input elements** (Nightly only): `dom.forms.html_color_picker.enabled`
 
   The HTML [`<input type="color">`](/en-US/docs/Web/HTML/Reference/Elements/input/color) element supports [`alpha`](/en-US/docs/Web/HTML/Reference/Elements/input/color#alpha) & [`colorspace`](/en-US/docs/Web/HTML/Reference/Elements/input/color#colorspace) attributes. ([Firefox bug 1919718](https://bugzil.la/1919718)).
+
+- **`text-box`, `text-box-trim` and `text-box-edge` properties**: `layout.css.text-box.enabled`
+
+  The CSS {{cssxref("text-box")}} shorthand property, and the corresponding {{cssxref("text-box-trim")}} and {{cssxref("text-box-edge")}} longhand properties, are now supported.
+  These allow you to trim space from the block-start and block-end edges of a text element's block container, aligning the container edges with the actual ink bounds of the text rather than the abstract box edges defined by font metrics.
+  This makes it possible to achieve consistent visual spacing around text regardless of which font is used.
+  ([Firefox bug 2013458](https://bugzil.la/2013458)).


### PR DESCRIPTION
FF149 adds support for the shorthand CSS property [`text-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-box) , corresponding longhand properties [`text-box-trim`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-box-trim) and [`text-box-edge`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-box-edge), and the value [`text-edge`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/text-edge) behind the preference `layout.css.text-box.enabled` in https://bugzilla.mozilla.org/show_bug.cgi?id=2013458.

This adds an experimental features entry and a release note entry that are essentially the same.
Tried to catch a flavour of what this does, which is make it possible to align text within a box so that it is visually positioned consistently for different fonts.

Related docs work can be tracked in #43208