### PR TITLE
docs: clarify performance.now() returns floating-point values

### DIFF
--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -24,6 +24,9 @@ None.
 
 Returns a {{domxref("DOMHighResTimeStamp")}} measured in milliseconds.
 
+> [!NOTE]
+> The value returned by `performance.now()` is a floating-point number and may include fractional milliseconds, not just integers.
+
 ## Description
 
 ### `Performance.now` vs. `Date.now`


### PR DESCRIPTION
Fixes #42952

Adds clarification that performance.now() returns a floating-point number, which may include fractional milliseconds.