### PR TITLE
Add Baseline banner to Fullscreen API page

### DIFF
--- a/files/en-us/web/api/fullscreen_api/index.md
+++ b/files/en-us/web/api/fullscreen_api/index.md
@@ -7,7 +7,6 @@ browser-compat:
   - api.Document.fullscreenEnabled
   - api.Document.exitFullscreen
   - api.Element.requestFullscreen
-  - api.Document.fullscreen
 ---
 
 {{DefaultAPISidebar("Fullscreen API")}}


### PR DESCRIPTION
This page was referencing the `browser-compat` data for the deprecated `api.Document.fullscreen` feature, which doesn't have a corresponding feature ID in `web-features`. As a result, it doesn't display a Baseline banner.

By removing that key from `browser-compat`, the page will show the correct Baseline status banner.
