### PR TITLE
Factor out Deferred Fetch documentation, shows Baseline on Fetch API

### DIFF
--- a/files/en-us/web/api/fetch_api/index.md
+++ b/files/en-us/web/api/fetch_api/index.md
@@ -2,9 +2,7 @@
 title: Fetch API
 slug: Web/API/Fetch_API
 page-type: web-api-overview
-browser-compat:
-  - api.fetch
-  - api.Window.fetchLater
+browser-compat: api.fetch
 ---
 
 {{DefaultAPISidebar("Fetch API")}}
@@ -33,25 +31,12 @@ The {{domxref("Window/fetchLater", "fetchLater()")}} API enables a developer to 
 
 - {{domxref("Window.fetch()")}} and {{domxref("WorkerGlobalScope.fetch()")}}
   - : The `fetch()` method used to fetch a resource.
-- {{domxref("Window.fetchLater()")}}
-  - : Used to make a deferred fetch request.
-- {{domxref("DeferredRequestInit")}}
-  - : Represents the set of options that can be used to configure a deferred fetch request.
-- {{domxref("FetchLaterResult")}}
-  - : Represents the result of requesting a deferred fetch.
 - {{DOMxRef("Headers")}}
   - : Represents response/request headers, allowing you to query them and take different actions depending on the results.
 - {{DOMxRef("Request")}}
   - : Represents a resource request.
 - {{DOMxRef("Response")}}
   - : Represents the response to a request.
-
-## HTTP headers
-
-- {{HTTPHeader("Permissions-Policy/deferred-fetch", "deferred-fetch")}}
-  - : Controls the [top-level quota](/en-US/docs/Web/API/Fetch_API/Using_Deferred_Fetch#quotas) for the `fetchLater()` API.
-- {{HTTPHeader("Permissions-Policy/deferred-fetch-minimal", "deferred-fetch-minimal")}}
-  - : Controls the [shared cross-origin subframe quota](/en-US/docs/Web/API/Fetch_API/Using_Deferred_Fetch#quotas) for the `fetchLater()` API.
 
 ## Specifications
 

--- a/files/en-us/web/api/fetch_api/using_deferred_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_deferred_fetch/index.md
@@ -2,6 +2,7 @@
 title: Using Deferred Fetch
 slug: Web/API/Fetch_API/Using_Deferred_Fetch
 page-type: guide
+browser-compat: api.Window.fetchLater
 ---
 
 {{DefaultAPISidebar("Fetch API")}}
@@ -235,3 +236,27 @@ Assuming a top-level document at `a.com`, which embeds `<iframe src="https://b.c
 1. The top-level frame of `a.com` has the default 512KiB quota.
 2. `<iframe src="https://b.com/">` receives 8KiB of the default shared quota of 128KiB.
 3. The 8KiB is not transferred to `a.com` when `<iframe src="https://b.com/">` redirects there, but it can share the full top-level quota again, and the previously-allocated 8KiB quota is released.
+
+## Interfaces
+
+- {{domxref("Window.fetchLater()")}}
+  - : Used to make a deferred fetch request.
+- {{domxref("DeferredRequestInit")}}
+  - : Represents the set of options that can be used to configure a deferred fetch request.
+- {{domxref("FetchLaterResult")}}
+  - : Represents the result of requesting a deferred fetch.
+
+## HTTP headers
+
+- {{HTTPHeader("Permissions-Policy/deferred-fetch", "deferred-fetch")}}
+  - : Controls the [top-level quota](/en-US/docs/Web/API/Fetch_API/Using_Deferred_Fetch#quotas) for the `fetchLater()` API.
+- {{HTTPHeader("Permissions-Policy/deferred-fetch-minimal", "deferred-fetch-minimal")}}
+  - : Controls the [shared cross-origin subframe quota](/en-US/docs/Web/API/Fetch_API/Using_Deferred_Fetch#quotas) for the `fetchLater()` API.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Factor out Deferred Fetch documentation from the main "Fetch API" page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
After this change, we now show a "Baseline: Widely Available" banner on the "Fetch API" page, and a "Baseline: Limited Availability" banner on the "Using Deferred Fetch" page.


### Related issues and pull requests

Fixes #43479

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
