### PR TITLE
added release note for vertical-align as shorthand property

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -41,6 +41,8 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{CSSXRef("shape-outside")}} CSS property now supports the [`xywh()`](/en-US/docs/Web/CSS/Reference/Values/basic-shape/xywh) function as a value. This allows you to define a shape for inline content to wrap around, using distances from the left (`x`) and top (`y`) edges of the containing block and a width (`w`) and height (`h`). ([Firefox bug 1983187](https://bugzil.la/1983187)).
 
+- The {{CSSXRef("vertical-align")}} CSS property is now a shorthand property for {{CSSXRef("alignment-baseline")}}, {{CSSXRef("baseline-shift")}} and {{CSSXRef("baseline-source")}} properties. ([Firefox bug 1830771](https://bugzil.la/1830771)).
+
 <!-- #### Removals -->
 
 <!-- ### JavaScript -->


### PR DESCRIPTION
### Description

- Added Firefox release note for `vertical-align` to be a shorthand property

### Motivation

- Workiong on [MDN issue #43198](https://github.com/mdn/content/issues/43198)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/43484)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/29290)
- [Data PR](https://github.com/mdn/data/pull/1054)
