### PR TITLE
Testing backticks in front matter title on two HTML pages

### DIFF
--- a/files/en-us/web/html/reference/elements/input/number/index.md
+++ b/files/en-us/web/html/reference/elements/input/number/index.md
@@ -1,5 +1,5 @@
 ---
-title: <input type="number">
+title: '`<input type="number">` HTML attribute value'
 slug: Web/HTML/Reference/Elements/input/number
 page-type: html-attribute-value
 browser-compat: html.elements.input.type_number

--- a/files/en-us/web/html/reference/global_attributes/is/index.md
+++ b/files/en-us/web/html/reference/global_attributes/is/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML is global attribute
+title: "`is` HTML global attribute"
 short-title: is
 slug: Web/HTML/Reference/Global_attributes/is
 page-type: html-attribute


### PR DESCRIPTION
### Description

For standardizing our titles on reference pages, backtick support has been added in mdn/rari#552, which is now available in mdn/content.

In this PR, I'm trying out the backticks on two reference pages in HTML.

`rari` is correctly outputting `titleHTML` in the JSON:
- `"titleHTML"`: `"<code>is</code> HTML global attribute"`
- `"titleHTML"`: `'<code>&lt;input type="number"&gt;</code> HTML attribute value'`

### Additional details

`fred` still needs to be updated to read `titleHTML` from rari's output and render it in page `<h1>`.
Also, after `fred` starts rendering `<code>` tags in the title, they'd need to be styled appropriately.

Meanwhile, title updates need not be blocked by `fred` work and can proceed in parallel.

### Related issues and pull requests

- https://github.com/mdn/content/issues/39894
- https://github.com/mdn/mdn/issues/811