### PR TITLE
WebDriver conformance changes for Firefox 149

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -111,10 +111,10 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### WebDriver BiDi
 
 - Added support for automatic user prompt handling, which can be configured through capabilities with the `session.new` command. ([Firefox bug 1905086](https://bugzil.la/1905086)).
-- Implemented the `browser.setDownloadBehavior` command, which lets clients allow or prohibit the downloads and also set a custom download folder. This behavior can be configured per session or per user contexts. ([Firefox bug 1989022](https://bugzil.la/1989022)).
+- Added the `browser.setDownloadBehavior` command, which lets clients allow or prohibit the downloads and also set a custom download folder. This behavior can be configured per session or per user contexts. ([Firefox bug 1989022](https://bugzil.la/1989022)).
+- Added the `script.realmCreated` and `script.realmDestroyed` events for worker realms (for dedicated, shared and service workers). ([Firefox bug 1936770](https://bugzil.la/1936770)).
 - Fixed an issue where the `browsingContext.userPromptOpened` and `browsingContext.userPromptClosed` events incorrectly reported the top-level context ID instead of the iframe's context ID on Android. ([Firefox bug 2007385](https://bugzil.la/2007385)).
 - Fixed the serialization for DOM nodes to stop exposing User Agent specific shadow roots. ([Firefox bug 2016673](https://bugzil.la/2016673)).
-- Implemented the `script.realmCreated` and `script.realmDestroyed` events for worker realms (for dedicated, shared and service workers). ([Firefox bug 1936770](https://bugzil.la/1936770)).
 - Updated the logic of applying different settings to new browsing contexts to make sure that in the case of creating a browsing context with the `window.open` command, emulations, viewport overrides and preload scripts apply before the command returns. ([Firefox bug 1985997](https://bugzil.la/1985997), [Firefox bug 2005546](https://bugzil.la/2005546), and [Firefox bug 2005558](https://bugzil.la/2005558)).
 
 #### Marionette


### PR DESCRIPTION
This PR contains [all the changes to WebDriver BiDi and Marionette for the Firefox 149](https://bugzilla.mozilla.org/buglist.cgi?query_format=advanced&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&f1=cf_status_firefox149&o1=equals&v2=fixed&v3=%5Bwptsync%20downstream%5D&component=Agent&component=Marionette&component=WebDriver%20BiDi&resolution=FIXED&f3=status_whiteboard&f2=cf_status_firefox148&o3=notsubstring&list_id=17890932&product=Remote%20Protocol&o2=notequals&v1=fixed) release.