### PR TITLE
Fixes to beforetoggle event page

### DIFF
--- a/files/en-us/web/api/htmlelement/beforetoggle_event/index.md
+++ b/files/en-us/web/api/htmlelement/beforetoggle_event/index.md
@@ -38,7 +38,7 @@ A {{domxref("ToggleEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Examples
 
-The examples below demonstrates how the `beforetoggle` event might be used for a {{domxref("Popover_API", "popover", "", "nocode")}} element.
+The examples below demonstrate how the `beforetoggle` event might be used for a {{domxref("Popover_API", "popover", "", "nocode")}} element.
 The same examples would work similarly on a {{htmlelement("dialog")}} element.
 
 ### Basic example
@@ -99,7 +99,7 @@ popover.addEventListener("beforetoggle", (event) => {
 
 The `beforetoggle` event is cancelable if fired when opening an element.
 
-Below we show how a popover that might first check if it is allowed to open, and if not, call {{domxref("Event.preventDefault()")}} to cancel the event.
+Below we show how a popover might first check if it is allowed to open, and if not, call {{domxref("Event.preventDefault()")}} to cancel the event.
 In this example we use a checkbox to set whether the popover can open or not: in a more "full featured" example this might depend on the application state, or the data in the popover being ready to display.
 
 #### HTML


### PR DESCRIPTION
### Description

I've removed the example about beforetoggle event coalescing as event coalescing only applies to the toggle event and seems to have been left in when using the toggle event page as a template for this newer page without realising that event coalescing doesn't apply to the beforetoggle event.

I noticed the "The same examples would work similarly on the other element types." sentence didn't make a lot of sense considering both the elements that might be used with the beforetoggle event were already mentioned in the previous sentence thus making there no other element types. Instead of removing the sentence I've opted to move the mention of the dialog element from the previous sentence into this one as none of the examples use the dialog element and I think it would then be more fitting to mention it in this sentence instead.

Fixed some typos:

- Removed "gets" from "[...] code gets adds [...]".
- Swapped "button" with "popover" in "[...] the button can be opened." as the popover is what can be opened and not the button.
- Swapped some mentions of "button" to "checkbox" so that the checkbox is always referred to by the same word and to distinguish it from the button that toggles the popover.
- Removed "don't" from "First we set up the code to simulate a state where we don't want to allow the popover to open." because the checkbox starts out checked it starts out in a state where the popover is allowed to open. An alternative fix would be instead of changing the text, the checked attribute can be removed from the checkbox so that the example starts out in a state where the popover isn't allowed to open. I opted to change the text, but this might be preferable as then the example starts out showing how the popover is preventet from opening.
