### PR TITLE
FF149 @container <container-query> optional

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@container/index.md
+++ b/files/en-us/web/css/reference/at-rules/@container/index.md
@@ -10,12 +10,12 @@ The **`@container`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/Gu
 Style declarations are filtered by a condition and applied to the container if the condition is true.
 The condition is evaluated when the queried container size, [`<style-feature>`](#container_style_queries), or scroll-state changes.
 
-The condition must specify one or both of a {{cssxref("container-name")}} and a `<container-condition>`.
+The condition must specify one or both of {{cssxref("container-name")}} and `<container-query>`.
 
 The {{cssxref("container-name")}} property specifies a list of query container names, which are used to filter which containers are targeted by the `@container` rules.
-The container features in the `<container-condition>` are evaluated against the selected containers.
-If no `<container-name>` is specified, the `<container-condition>` rules apply to the nearest ancestor query container that has the matching [`container-type`](/en-US/docs/Web/CSS/Reference/Properties/container-type).
-If no `<container-condition>` is specified, the named container is selected.
+The container features in the `<container-query>` are evaluated against the selected containers.
+If no `<container-name>` is specified, the `<container-query>` features are evaluated against the nearest ancestor query container that has the matching [`container-type`](/en-US/docs/Web/CSS/Reference/Properties/container-type).
+If no `<container-query>` is specified, named containers are selected.
 
 ## Syntax
 


### PR DESCRIPTION
FF149 adds support for [`@container`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@container) selections where the [`<container-query>`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@container#container-query) part is optional in https://bugzilla.mozilla.org/show_bug.cgi?id=2016474

What this means is that you can just declare that a container maps to a particular named element.

This change updates the @container docs to make it clear that either or both, but not neither, of the conditions must be present. 

Related docs work can be tracked in https://github.com/mdn/content/issues/43212