### PR TITLE
docs: improve readability of strict mode property assignment intro

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -123,7 +123,7 @@ mistypeVarible = 17;
 
 #### Failing to assign to object properties
 
-In strict mode, certain object property assignments throw errors instead of failing silently. There are three ways to fail a property assignment:
+In strict mode, certain assignments throw errors instead of failing silently. There are three ways to fail a property assignment:
 
 - assignment to a non-writable data property
 - assignment to a getter-only accessor property


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Rephrases the introduction to the "Failing to assign to object properties" section of the ["Strict mode" page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The current phrasing is somewhat ambiguous on first glance:

> Strict mode makes assignments which would otherwise silently fail to throw an exception.

It can read as if strict mode is actually *performing* some sort of assignment. This pull request attempts to clarify how strict mode *affects* how certain assignments behave.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
N/A

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->
N/A

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
