### PR TITLE
FF149Relnote: @container condition-query is optional

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -43,6 +43,10 @@ Firefox 149 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{CSSXRef("vertical-align")}} CSS property is now a shorthand property for {{CSSXRef("alignment-baseline")}}, {{CSSXRef("baseline-shift")}} and {{CSSXRef("baseline-source")}} properties. ([Firefox bug 1830771](https://bugzil.la/1830771)).
 
+- The [`<container-query>`](/en-US/docs/Web/CSS/Reference/At-rules/@container#container-query) part of the {{cssxref("@container")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules) condition is now optional.
+  This allows matching against containers based solely on their names.
+  ([Firefox bug 2016474](https://bugzil.la/2016474)).
+
 <!-- #### Removals -->
 
 <!-- ### JavaScript -->


### PR DESCRIPTION
FF149 adds support for [`@container`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@container) selections where the [`<container-query>`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@container#container-query) part is optional - in https://bugzilla.mozilla.org/show_bug.cgi?id=2016474

This allows you to just select a container based on its name only:

```css
@container --name {}
```

This adds the release note.

Related docs work can be tracked in https://github.com/mdn/content/issues/43212