### PR TITLE
ci(pr-check-lint_content): run reviewdog in separate workflow

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -1,4 +1,4 @@
-name: Lint and review content files
+name: Lint content
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-and-review-docs:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-reviewdog.yml
+++ b/.github/workflows/pr-reviewdog.yml
@@ -3,7 +3,7 @@ name: PR Reviewdog
 on:
   workflow_run:
     workflows:
-      - "Lint and review content files"
+      - "Lint content"
     types:
       - completed
 


### PR DESCRIPTION
### Description

- Extracts the reviewdog portion of the `pr-check-lint_content` workflow into a separate `pr-reviewdog` workflow (privileged, with status reporting), by passing diff and Markdownlint log as an artifact.
- Makes the `pr-check-lint_content` workflow unprivileged, and simplifies it by removing now-obsolete safeguards.

### Motivation

- Eliminate risk of code injection.
- Make it easier to simplify the lint workflow in the future.

### Additional details

Tested on my personal fork:

- Pushed [this branch/commit to caugner:main](https://github.com/caugner/content/commit/3bf3046e761f767d43caf2e26bf21188f1b15cab).
- Opened [a PR](https://github.com/caugner/content/pull/1) with changes causing lint failures.
- The [Lint content](https://github.com/caugner/content/actions/runs/23639785325/job/68857350929?pr=1) workflow ran, and uploaded both the diff and the Markdownlint log as an artifact.
- The [PR Reviewdog](https://github.com/caugner/content/actions/runs/23639804817) workflow picked it up.

Note: Reviewdog refuses to use `github-pr-review` reporter when run in a non-PR workflow (`workflow_run`), so we need to pretend we're not in GitHub CI by hiding `GITHUB_ACTIONS` from it.

### Related issues and pull requests

Same as:

- https://github.com/mdn/translated-content/pull/34668
- https://github.com/mdn/translated-content-de/pull/237