### PR TITLE
[Editorial review] BiDi - Add pages for browser module commands

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/close/index.md
@@ -1,0 +1,75 @@
+---
+title: browser.close command
+short-title: browser.close
+slug: Web/WebDriver/Reference/BiDi/Modules/browser/close
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browser.close
+sidebar: webdriver
+---
+
+The `browser.close` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module closes the browser and ends all active WebDriver sessions. Tabs are closed without running [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handler functions. The response is sent before the WebSocket connection is closed.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browser.close",
+  "params": {}
+}
+```
+
+### Parameters
+
+None. However, you must include the `params` field and set it to an empty object (`{}`).
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+### Errors
+
+- `unable to close browser`
+  - : There are other active WebDriver sessions open at the time the command is sent.
+    Browsers may return this error before continuing to close.
+
+## Examples
+
+### Closing the browser
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), send the following message to close the browser:
+
+```json
+{
+  "id": 1,
+  "method": "browser.close",
+  "params": {}
+}
+```
+
+Before closing, the browser responds successfully as shown here:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+After the response, the WebSocket connection closes as the browser shuts down.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) command
+- [`session.end`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/end) command
+- [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) command
+- [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts) command
+- [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -1,0 +1,111 @@
+---
+title: browser.createUserContext command
+short-title: browser.createUserContext
+slug: Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browser.createUserContext
+sidebar: webdriver
+---
+
+The `browser.createUserContext` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module creates a new [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in the browser.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browser.createUserContext",
+  "params": {}
+}
+```
+
+### Parameters
+
+Set `params` to an empty object (`{}`) or include any of the following optional fields:
+
+- `acceptInsecureCerts` {{optional_inline}}
+  - : A boolean that indicates whether untrusted TLS certificates (for example, self-signed or expired) are accepted within this user context. When set, it overrides the [session-level](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#acceptinsecurecerts) `acceptInsecureCerts` setting for this user context.
+- `proxy` {{optional_inline}}
+  - : An object that specifies the proxy configuration the browser should use for network requests within this user context. When set, it overrides the [session-level](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#proxy) `proxy` setting for this user context.
+- `unhandledPromptBehavior` {{optional_inline}}
+  - : An object that specifies the default behavior when a user prompt (such as an `alert`, `confirm`, or `prompt` dialog) is encountered within this user context. When set, it overrides the [session-level](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#unhandledpromptbehavior) `unhandledPromptBehavior` setting for this user context.
+
+### Return value
+
+The `result` object in the response with the following field:
+
+- `userContext`
+  - : A string that uniquely identifies the created user context.
+
+### Errors
+
+- `unsupported operation`
+  - : `acceptInsecureCerts` is `true` but the browser does not support accepting insecure TLS connections, or `proxy` is specified but the browser cannot configure proxy settings for this user context or cannot apply the given proxy configuration.
+
+## Examples
+
+### Creating a user context with default settings
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), send the following message to create a user context:
+
+```json
+{
+  "id": 1,
+  "method": "browser.createUserContext",
+  "params": {}
+}
+```
+
+The browser responds with a successful user context creation as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "userContext": "4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"
+  }
+}
+```
+
+### Creating a user context with a proxy
+
+Send the following message to create a user context that routes network requests through a proxy:
+
+```json
+{
+  "id": 2,
+  "method": "browser.createUserContext",
+  "params": {
+    "proxy": {
+      "proxyType": "manual",
+      "httpProxy": "127.0.0.1:80"
+    }
+  }
+}
+```
+
+The browser responds with a successful user context creation as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "userContext": "7d9e2a1b-5c3f-4e6d-8a7b-2c1d0e9f8a7b"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) command
+- [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts) command
+- [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -22,8 +22,8 @@ The `browser.createUserContext` [command](/en-US/docs/Web/WebDriver/Reference/Bi
 
 Set `params` to an empty object (`{}`) or include any of the following optional fields:
 
-- `acceptInsecureCerts` {{optional_inline}}
-  - : A boolean that indicates whether untrusted TLS certificates (for example, self-signed or expired) are accepted within this user context. When set, it overrides the [session-level](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#acceptinsecurecerts) `acceptInsecureCerts` setting for this user context.
+- [`acceptInsecureCerts`](/en-US/docs/Web/WebDriver/Reference/Capabilities/acceptInsecureCerts) {{optional_inline}}
+  - : A boolean that controls whether untrusted TLS certificates (for example, self-signed or expired) are accepted within this user context. When set, it overrides the [session-level](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#acceptinsecurecerts) `acceptInsecureCerts` setting for this user context.
 - `proxy` {{optional_inline}}
   - : An object that specifies the proxy configuration the browser should use for network requests within this user context. When set, it overrides the [session-level](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#proxy) `proxy` setting for this user context.
 - `unhandledPromptBehavior` {{optional_inline}}
@@ -31,7 +31,7 @@ Set `params` to an empty object (`{}`) or include any of the following optional 
 
 ### Return value
 
-The `result` object in the response with the following field:
+The following field in the `result` object of the response describes the created user context:
 
 - `userContext`
   - : A string that uniquely identifies the created user context.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -29,6 +29,9 @@ Set `params` to an empty object (`{}`) or include any of the following optional 
 - `unhandledPromptBehavior` {{optional_inline}}
   - : An object that specifies the default behavior when a user prompt (such as an `alert`, `confirm`, or `prompt` dialog) is encountered within this user context. When set, it overrides the [session-level](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#unhandledpromptbehavior) `unhandledPromptBehavior` setting for this user context.
 
+> [!NOTE]
+> When a parameter is set, it applies to all existing and future tabs within this user context.
+
 ### Return value
 
 The following field in the `result` object of the response describes the created user context:

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getclientwindows/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getclientwindows/index.md
@@ -36,7 +36,7 @@ The following field in the `result` object of the response describes the client 
     - `clientWindow`
       - : A string that uniquely identifies the client window.
     - `height`
-      - : A number that indicates the height of the window in CSS pixels.
+      - : A number that indicates the height of the window in {{glossary("CSS pixel", "CSS pixels")}}.
     - `state`
       - : A string that indicates the current state of the window.
         - `"fullscreen"`
@@ -48,11 +48,11 @@ The following field in the `result` object of the response describes the client 
         - `"normal"`
           - : Indicates that the window is in its normal (restored) state.
     - `width`
-      - : A number that indicates the width of the window in CSS pixels.
+      - : A number that indicates the width of the window in {{glossary("CSS pixel", "CSS pixels")}}.
     - `x`
-      - : A number that indicates the x-coordinate of the window in CSS pixels, measured from the left edge of the screen area.
+      - : A number that indicates the x-coordinate of the window in {{glossary("CSS pixel", "CSS pixels")}}, measured from the left edge of the screen area.
     - `y`
-      - : A number that indicates the y-coordinate of the window in CSS pixels, measured from the top edge of the screen area.
+      - : A number that indicates the y-coordinate of the window in {{glossary("CSS pixel", "CSS pixels")}}, measured from the top edge of the screen area.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getclientwindows/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getclientwindows/index.md
@@ -1,0 +1,137 @@
+---
+title: browser.getClientWindows command
+short-title: browser.getClientWindows
+slug: Web/WebDriver/Reference/BiDi/Modules/browser/getClientWindows
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browser.getClientWindows
+sidebar: webdriver
+---
+
+The `browser.getClientWindows` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module returns a list of [client windows](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#client_windows).
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browser.getClientWindows",
+  "params": {}
+}
+```
+
+### Parameters
+
+None. However, you must include the `params` field and set it to an empty object (`{}`).
+
+### Return value
+
+The following field in the `result` object of the response describes the client windows in the browser:
+
+- `clientWindows`
+  - : An array of objects, each representing a client window.
+    The array may be empty if the browser has no open windows.
+    Each object has the following fields:
+    - `active`
+      - : A boolean that indicates whether the client window can receive keyboard input from the operating system.
+        This can mean a tab within the window has system focus, or the browser UI itself is focused.
+    - `clientWindow`
+      - : A string that uniquely identifies the client window.
+    - `height`
+      - : A number that indicates the height of the window in CSS pixels.
+    - `state`
+      - : A string that indicates the current state of the window.
+        - `"fullscreen"`
+          - : Indicates that the window is in fullscreen mode.
+        - `"maximized"`
+          - : Indicates that the window is maximized to fill the screen area.
+        - `"minimized"`
+          - : Indicates that the window is minimized (hidden from view).
+        - `"normal"`
+          - : Indicates that the window is in its normal (restored) state.
+    - `width`
+      - : A number that indicates the width of the window in CSS pixels.
+    - `x`
+      - : A number that indicates the x-coordinate of the window in CSS pixels, measured from the left edge of the screen area.
+    - `y`
+      - : A number that indicates the y-coordinate of the window in CSS pixels, measured from the top edge of the screen area.
+
+## Examples
+
+### Getting all client windows
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), send the following message to retrieve all client windows:
+
+```json
+{
+  "id": 1,
+  "method": "browser.getClientWindows",
+  "params": {}
+}
+```
+
+The browser responds successfully with the list of client windows as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "clientWindows": [
+      {
+        "active": true,
+        "clientWindow": "09a7bf22-c52d-4011-88ad-507a7e0012c7",
+        "height": 970,
+        "state": "normal",
+        "width": 1280,
+        "x": 4,
+        "y": 38
+      }
+    ]
+  }
+}
+```
+
+### Getting client windows when multiple browser windows are open
+
+When multiple browser windows are open, the browser responds with one entry per window as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "clientWindows": [
+      {
+        "active": true,
+        "clientWindow": "09a7bf22-c52d-4011-88ad-507a7e0012c7",
+        "height": 800,
+        "state": "normal",
+        "width": 1280,
+        "x": 0,
+        "y": 26
+      },
+      {
+        "active": false,
+        "clientWindow": "b3f8a1e5-d4c2-4e9f-8b3a-1f2e3d4c5b6a",
+        "height": 0,
+        "state": "minimized",
+        "width": 0,
+        "x": 0,
+        "y": 0
+      }
+    ]
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) command
+- [`browser.setClientWindowState`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setClientWindowState) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
@@ -24,7 +24,7 @@ None. However, you must include the `params` field and set it to an empty object
 
 ### Return value
 
-The `result` object in the response with the following fields:
+The following field in the `result` object of the response describes the user contexts in the browser:
 
 - `userContexts`
   - : An array of one or more objects, each representing a user context.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
@@ -1,0 +1,112 @@
+---
+title: browser.getUserContexts command
+short-title: browser.getUserContexts
+slug: Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browser.getUserContexts
+sidebar: webdriver
+---
+
+The `browser.getUserContexts` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module returns a list of all current [user contexts](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in the browser.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browser.getUserContexts",
+  "params": {}
+}
+```
+
+### Parameters
+
+None. However, you must include the `params` field and set it to an empty object (`{}`).
+
+### Return value
+
+The `result` object in the response with the following fields:
+
+- `userContexts`
+  - : An array of one or more objects, each representing a user context.
+    Each object has the following field:
+    - `userContext`
+      - : A string that uniquely identifies the user context.
+        The default user context has the value `"default"`; it always exists and cannot be removed, so the array is never empty.
+
+## Examples
+
+### Getting a list of user contexts
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), send the following message to get a list of all user contexts:
+
+```json
+{
+  "id": 1,
+  "method": "browser.getUserContexts",
+  "params": {}
+}
+```
+
+When only the default user context exists, the browser responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "userContexts": [
+      {
+        "userContext": "default"
+      }
+    ]
+  }
+}
+```
+
+### Getting a list of user contexts after creating additional ones
+
+After creating a few user contexts with [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext), send the following message to list all of them:
+
+```json
+{
+  "id": 2,
+  "method": "browser.getUserContexts",
+  "params": {}
+}
+```
+
+The browser responds with all user contexts, including the `default` one, as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "userContexts": [
+      {
+        "userContext": "default"
+      },
+      {
+        "userContext": "4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"
+      },
+      {
+        "userContext": "7d9e2a1b-5c3f-4e6d-8a7b-2c1d0e9f8a7b"
+      }
+    ]
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) command
+- [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) command
+- [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
@@ -7,7 +7,21 @@ browser-compat: webdriver.bidi.browser
 sidebar: webdriver
 ---
 
-The **`browser`** module contains commands for managing the browser, including user contexts, client windows, and download behavior.
+The **`browser`** module contains commands for managing the browser, including client windows, user contexts, and download behavior.
+
+## Client windows
+
+A client window is an OS-level browser window, which includes the viewport (the area where web content is displayed) and browser UI elements such as the address bar and toolbars.
+
+Each client window has the following properties:
+
+- A unique string identifier (`clientWindow`).
+- A state (`state`) indicating whether the window is normal, maximized, minimized, or fullscreen.
+- An active state (`active`) indicating whether the window can receive keyboard input from the operating system.
+- A position expressed as `x` and `y` coordinates in CSS pixels from the left and top edges of the screen, respectively.
+- A size expressed as `width` and `height` in CSS pixels.
+
+A list of client windows can be obtained using [`browser.getClientWindows`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getClientWindows) and their state can be changed using [`browser.setClientWindowState`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setClientWindowState).
 
 ## User contexts
 
@@ -15,21 +29,9 @@ A user context is a collection of zero or more top-level contexts (tabs) within 
 
 Each user context has a unique string identifier (user context ID). The browser always has a default user context with the ID `"default"`, which cannot be removed.
 
+Multiple tabs from different user contexts can share the same [client window](#client_windows).
+
 User contexts can be created using [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) and removed using [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext).
-
-## Client windows
-
-A client window is a browser window, which includes the viewport (the area where web content is displayed) and browser UI elements such as the address bar and toolbars.
-
-Each client window has the following properties:
-
-- A unique string identifier (client window ID)
-- A position expressed as `x` and `y` coordinates in CSS pixels from the left and top edges of the screen, respectively
-- A size expressed as `width` and `height` in CSS pixels
-
-Multiple tabs from different [user contexts](#user_contexts) can share the same client window.
-
-A list of client windows can be obtained using [`browser.getClientWindows`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getClientWindows) and their state can be changed using [`browser.setClientWindowState`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setClientWindowState).
 
 ## Commands
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
@@ -7,7 +7,23 @@ browser-compat: webdriver.bidi.browser
 sidebar: webdriver
 ---
 
-The **`browser`** module contains commands for managing the browser.
+The **`browser`** module contains commands for managing the browser, including user contexts, client windows, and download behavior.
+
+## User contexts
+
+A user context is a collection of zero or more top-level contexts (tabs) within the browser. Tabs within the same user context share the same browser storage (such as cookies and session data), while tabs in different user contexts are completely isolated from one another and do not share any browser data. A user context with no tabs is called an empty user context.
+
+Each user context has a unique string identifier (user context ID). The browser always has a default user context with the ID `"default"`, which cannot be removed.
+
+User contexts can be created using [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) and removed using [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext).
+
+## Commands
+
+{{ListSubPages}}
+
+## Events
+
+The `browser` module has no associated events.
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
@@ -18,8 +18,8 @@ Each client window has the following properties:
 - A unique string identifier (`clientWindow`).
 - A state (`state`) indicating whether the window is normal, maximized, minimized, or fullscreen.
 - An active state (`active`) indicating whether the window can receive keyboard input from the operating system.
-- A position expressed as `x` and `y` coordinates in CSS pixels from the left and top edges of the screen, respectively.
-- A size expressed as `width` and `height` in CSS pixels.
+- A position expressed as `x` and `y` coordinates in {{glossary("CSS pixel", "CSS pixels")}} from the left and top edges of the screen, respectively.
+- A size expressed as `width` and `height` in {{glossary("CSS pixel", "CSS pixels")}}.
 
 A list of client windows can be obtained using [`browser.getClientWindows`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getClientWindows) and their state can be changed using [`browser.setClientWindowState`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setClientWindowState).
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
@@ -17,6 +17,20 @@ Each user context has a unique string identifier (user context ID). The browser 
 
 User contexts can be created using [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) and removed using [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext).
 
+## Client windows
+
+A client window is a browser window, which includes the viewport (the area where web content is displayed) and browser UI elements such as the address bar and toolbars.
+
+Each client window has the following properties:
+
+- A unique string identifier (client window ID)
+- A position expressed as `x` and `y` coordinates in CSS pixels from the left and top edges of the screen, respectively
+- A size expressed as `width` and `height` in CSS pixels
+
+Multiple tabs from different [user contexts](#user_contexts) can share the same client window.
+
+A list of client windows can be obtained using [`browser.getClientWindows`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getClientWindows) and their state can be changed using [`browser.setClientWindowState`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setClientWindowState).
+
 ## Commands
 
 {{ListSubPages}}

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browser.removeUserContext
 sidebar: webdriver
 ---
 
-The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module removes the specified [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) and all its tabs across all windows. Tabs are closed without running [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handler functions.
+The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module removes the specified [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) and all its tabs across all windows. Tabs are closed without running the [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handler functions.
 
 > [!WARNING]
 > This command is irreversible, and all storage associated with the user context is permanently deleted.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -7,7 +7,10 @@ browser-compat: webdriver.bidi.browser.removeUserContext
 sidebar: webdriver
 ---
 
-The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module removes the specified [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) and all its tabs, thereby removing its associated storage. Tabs are closed without running [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handler functions.
+The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module removes the specified [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) and all its tabs across all windows. Tabs are closed without running [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handler functions.
+
+> [!WARNING]
+> This command is irreversible, and all storage associated with the user context is permanently deleted.
 
 ## Syntax
 
@@ -37,7 +40,7 @@ The `result` field in the response is an empty object (`{}`).
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
   - : The `userContext` field is `"default"`. The default user context cannot be removed.
 - `no such user context`
-  - : No user context with the given `userContext` ID is found.
+  - : No user context with the given user context ID is found.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -1,0 +1,82 @@
+---
+title: browser.removeUserContext command
+short-title: browser.removeUserContext
+slug: Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browser.removeUserContext
+sidebar: webdriver
+---
+
+The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module removes the specified [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) and all its tabs, thereby removing its associated storage. Tabs are closed without running [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handler functions.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browser.removeUserContext",
+  "params": {
+    "userContext": "<userContextId>"
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `userContext`
+  - : A string that specifies the ID of the user context to remove.
+    The default user context (`"default"`) cannot be removed.
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : The `userContext` field is `"default"`. The default user context cannot be removed.
+- `no such user context`
+  - : No user context with the given `userContext` ID is found.
+
+## Examples
+
+### Removing a user context
+
+Consider a scenario where you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new). After [creating a user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) with `browser.createUserContext`, send the following message if you want to remove it:
+
+```json
+{
+  "id": 1,
+  "method": "browser.removeUserContext",
+  "params": {
+    "userContext": "4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"
+  }
+}
+```
+
+The browser responds with a successful removal as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) command
+- [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) command
+- [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts) command
+- [`browser.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/close) command
+- [`session.end`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/end) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
@@ -41,8 +41,8 @@ The `params` field contains:
 
 The `alwaysMatch` and `firstMatch` objects can include the following features:
 
-- [`acceptInsecureCerts`](/en-US/docs/Web/WebDriver/Reference/Capabilities/acceptInsecureCerts) {{optional_inline}}
-  - : A boolean that indicates whether untrusted TLS certificates (for example, self-signed or expired) are accepted for the duration of the session.
+- `acceptInsecureCerts` {{optional_inline}}
+  - : A boolean that controls whether untrusted TLS certificates (for example, self-signed or expired) are accepted for the duration of the session.
 - `browserName` {{optional_inline}}
   - : A string that specifies the name of the browser to use (for example, `"firefox"` or `"chrome"`).
 - `browserVersion` {{optional_inline}}

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/status/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/status/index.md
@@ -26,7 +26,7 @@ None. However, you must include the `params` field and set it to an empty object
 
 ### Return value
 
-The `result` object in the response with the following fields:
+The following fields in the `result` object of the response describe the current status of the browser:
 
 - `ready`
   - : A boolean that indicates whether the browser is ready to create new sessions.

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -15,7 +15,10 @@ sidebar:
     children:
       - link: /Web/WebDriver/Reference/BiDi/Modules/bluetooth
         code: true
-      - link: /Web/WebDriver/Reference/BiDi/Modules/browser
+      - type: listSubPages
+        path: /Web/WebDriver/Reference/BiDi/Modules/browser
+        link: /Web/WebDriver/Reference/BiDi/Modules/browser
+        details: closed
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext
         code: true


### PR DESCRIPTION
### Description

This PR adds the following pages:
  - `browser.close`
  - `browser.createUserContext`
  - `browser.getClientWindows`
  - `browser.getUserContexts`
  - `browser.removeUserContext`

Note:
Since support is mixed right now, I'll add pages for `browser.setClientWindowState` and `browser.setDownloadBehavior` in a future PR.

### Additional details

 The browser landing page includes two new sections:
  - User contexts
  - Client windows

These can likely by moved to a guide in the future.

### Spec links

- browser.close: https://w3c.github.io/webdriver-bidi/#command-browser-close
- browser.createUserContext: https://w3c.github.io/webdriver-bidi/#command-browser-createUserContext
- browser.getClientWindows: https://w3c.github.io/webdriver-bidi/#command-browser-getClientWindows
- browser.getUserContexts: https://w3c.github.io/webdriver-bidi/#command-browser-getUserContexts
- browser.removeUserContext: https://w3c.github.io/webdriver-bidi/#command-browser-removeUserContext

### Related issue

Doc issue: mdn/mdn#339