### PR TITLE
Remove `browser-compat` data from Fullscreen API Guide

### DIFF
--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -2,9 +2,6 @@
 title: Guide to the Fullscreen API
 slug: Web/API/Fullscreen_API/Guide
 page-type: guide
-browser-compat:
-  - api.Document.fullscreenEnabled
-  - api.Document.fullscreen
 ---
 
 {{DefaultAPISidebar("Fullscreen API")}}


### PR DESCRIPTION


### Description

Removes `browser-compat` data from https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API/Guide

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

https://github.com/mdn/content/pull/43478#discussion_r2972267707

@hamishwillee wrote:

> Guide pages generally do not have browser compat data - though this is "allowed" for newer APIs where support is sketchy. This data is definititely going to be removed when someone notices. Let's remove it now.

### Related issues and pull requests

* Relates to PR #43478

