### PR TITLE
fix: CSS prop `-webkit-margin-*`

### DIFF
--- a/files/en-us/web/css/reference/webkit_extensions/index.md
+++ b/files/en-us/web/css/reference/webkit_extensions/index.md
@@ -42,8 +42,6 @@ User agents based on WebKit or Blink (such as Safari and Chrome) support several
 
 ### M
 
-- `-webkit-margin-after`
-- `-webkit-margin-before`
 - {{CSSxRef("-webkit-mask-box-image")}}: See {{cssxref("mask-border")}} and {{cssxref("border-image")}}.
 - {{CSSxRef("-webkit-mask-box-image", "-webkit-mask-box-image-outset")}}: See {{cssxref("mask-border")}} and {{cssxref("border-image")}}.
 - {{CSSxRef("-webkit-mask-box-image", "-webkit-mask-box-image-repeat")}}: See {{cssxref("mask-border")}} and {{cssxref("border-image")}}.
@@ -129,8 +127,10 @@ For each of the properties below, use the standard equivalents.
 ### J-Z
 
 - `-webkit-line-clamp`: Use {{CSSxRef("line-clamp")}}.
-- `-webkit-margin-end`: Use {{CSSxRef("margin-block-end")}}.
-- `-webkit-margin-start`: Use {{CSSxRef("margin-block-start")}}.
+- `-webkit-margin-after`: Use {{CSSxRef("margin-block-end")}}.
+- `-webkit-margin-before`: Use {{CSSxRef("margin-block-start")}}.
+- `-webkit-margin-end`: Use {{CSSxRef("margin-inline-end")}}.
+- `-webkit-margin-start`: Use {{CSSxRef("margin-inline-start")}}.
 - `-webkit-padding-after`: Use {{CSSxRef("padding-block-end")}}.
 - `-webkit-padding-before`: Use {{CSSxRef("padding-block-start")}}.
 - `-webkit-padding-end`: Use {{CSSxRef("padding-inline-end")}}.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
`-webkit-margin-{start,end}` should map to `margin-inline-*` instead of `margin-block-*`
`-webkit-margin-{after,before}` is mapped by autoprefixer in https://github.com/postcss/autoprefixer/issues/324#issuecomment-71799469 to `margin-inline-*`, they are also corrected in https://github.com/mdn/browser-compat-data/pull/1897

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
