### PR TITLE
Ff149 relnote islamic umalqura

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -33,7 +33,7 @@ Firefox 149 was released on [March 24, 2026](https://whattrainisitnow.com/releas
 ### JavaScript
 
 - The `"islamic-umalqura"` [calendar](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_calendar_types) is now supported by {{jsxref("Intl")}}.
-  This string will be in the list of calendars returned by {{jsxref("Intl.supportedValuesOf()")}}, and can be set as the [`options.calendar`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#calendar) parameter in the [`DateTimeFormat()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat)/
+  This string will be in the list of calendars returned by {{jsxref("Intl.supportedValuesOf()")}}, and can be set as the [`options.calendar`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#calendar) parameter in the [`DateTimeFormat()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat).
   ([Firefox bug 2011505](https://bugzil.la/2011505)).
 
 ### APIs


### PR DESCRIPTION
FF149 adds support for  `islamic-umalqura` calendar in https://bugzilla.mozilla.org/show_bug.cgi?id=2011505. This adds a release note.

Related docs work can be tracked in #43203

