### PR TITLE
FF149 ShadowRoot referenceTarget and friends minor update

### DIFF
--- a/files/en-us/web/api/element/attachshadow/index.md
+++ b/files/en-us/web/api/element/attachshadow/index.md
@@ -428,5 +428,6 @@ The example below should show the content of the slots displayed in the appropri
 - {{domxref("ShadowRoot.mode")}}
 - {{domxref("ShadowRoot.delegatesFocus")}}
 - {{domxref("ShadowRoot.slotAssignment")}}
+- {{domxref("ShadowRoot.referenceTarget")}}
 - Declaratively attach a shadow root with the [`shadowrootmode`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode) attribute of the [`<template>` element](/en-US/docs/Web/HTML/Reference/Elements/template)
 - [Declarative shadow DOM](https://web.dev/articles/declarative-shadow-dom) on web.dev (2023)

--- a/files/en-us/web/api/htmltemplateelement/index.md
+++ b/files/en-us/web/api/htmltemplateelement/index.md
@@ -30,6 +30,8 @@ _This interface inherits the properties of {{domxref("HTMLElement")}}._
   - : A boolean that reflects the value of the [`shadowrootclonable`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootclonable) attribute of the associated `<template>` element.
 - {{domxref("HTMLTemplateElement.shadowRootCustomElementRegistry", "shadowRootCustomElementRegistry")}}
   - : A string that reflects the value of the [`shadowrootcustomelementregistry`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootcustomelementregistry) attribute of the associated `<template>` element, indicating that the declarative shadow root will use a scoped {{domxref("CustomElementRegistry")}}.
+- {{domxref("HTMLTemplateElement.shadowRootReferenceTarget", "shadowRootReferenceTarget")}}
+  - : A nullable string that reflects the value of the [`shadowrootreferencetarget`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootreferencetarget) attribute of the associated `<template>` element.
 - {{domxref("HTMLTemplateElement.shadowRootSerializable", "shadowRootSerializable")}}
   - : A boolean that reflects the value of the [`shadowrootserializable`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootserializable) attribute of the associated `<template>` element.
 - {{domxref("HTMLTemplateElement.shadowRootSlotAssignment", "shadowRootSlotAssignment")}}

--- a/files/en-us/web/api/htmltemplateelement/shadowrootreferencetarget/index.md
+++ b/files/en-us/web/api/htmltemplateelement/shadowrootreferencetarget/index.md
@@ -1,0 +1,33 @@
+---
+title: "HTMLTemplateElement: shadowRootReferenceTarget property"
+short-title: shadowRootReferenceTarget
+slug: Web/API/HTMLTemplateElement/shadowRootReferenceTarget
+page-type: web-api-instance-property
+browser-compat: api.HTMLTemplateElement.shadowRootReferenceTarget
+---
+
+{{APIRef("Web Components")}}
+
+The **`shadowRootReferenceTarget`** property of the {{domxref("HTMLTemplateElement")}} interface reflects the value of the [`shadowrootreferencetarget`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootreferencetarget) attribute of the associated [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) element.
+
+> [!NOTE]
+> This property is not useful for developers, and is only documented for completeness.
+> If a `<template>` element is used to declaratively create a [`ShadowRoot`](/en-US/docs/Web/API/ShadowRoot), then this object and property do not exist.
+> Otherwise, if an `HTMLTemplateElement` is created, the value of this property is irrelevant because the object is not a shadow root and cannot subsequently be changed to a shadow root.
+
+## Value
+
+Reflects the value of the [`shadowrootreferencetarget`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootreferencetarget) attribute of the associated [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) element.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`shadowrootreferencetarget`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootdelegatesfocus) attribute of the `<template>` element
+- [`ShadowRoot.referenceTarget`](/en-US/docs/Web/API/ShadowRoot/delegatesFocus)

--- a/files/en-us/web/api/shadowroot/index.md
+++ b/files/en-us/web/api/shadowroot/index.md
@@ -40,8 +40,8 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
 - {{DOMxRef("ShadowRoot.pointerLockElement")}} {{ReadOnlyInline}}
   - : Returns the {{DOMxRef('Element')}} set as the target for mouse events while the pointer is locked.
     `null` if lock is pending, pointer is unlocked, or if the target is in another tree.
-- `ShadowRoot.referenceTarget` {{Experimental_Inline}} {{non-standard_inline}}
-  - : A nullable string value that indicates the effective target of any element reference made against the shadow host from outside the host element. The value should be the ID of an element inside the shadow DOM. If set, target references to the host element from outside the shadow DOM will cause the referenced target element to become the effective target of the reference to the host element.
+- {{DOMxRef("ShadowRoot.referenceTarget")}} {{Experimental_Inline}} {{non-standard_inline}}
+  - : A nullable string value that represents the effective target of any element reference made against the shadow host from outside the host element.
 - {{DOMxRef("ShadowRoot.serializable")}} {{ReadOnlyInline}}
   - : A boolean that indicates whether the shadow root is serializable.
     A serializable shadow root inside an element will be serialized by {{DOMxRef('Element.getHTML()')}} or {{DOMxRef('ShadowRoot.getHTML()')}} when its [`options.serializableShadowRoots`](/en-US/docs/Web/API/Element/getHTML#serializableshadowroots) parameter is set `true`.

--- a/files/en-us/web/api/shadowroot/referencetarget/index.md
+++ b/files/en-us/web/api/shadowroot/referencetarget/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ShadowRoot.referenceTarget
 
 The **`referenceTarget`** property of the {{domxref("ShadowRoot")}} interface is a nullable string that represents the effective target of any element reference made against the shadow host from outside the host element.
 
-Some elements are associated with other elements using attributes that reference their `id` attribute.
+Some elements are associated with other elements using attributes that take _element references_: strings that specify the other element's `id`.
 For example, a {{htmlelement("label")}} element can use the {{htmlattribute("for")}} attribute to specify the `id` of the element it is labelling.
 Similarly, {{htmlattribute("popovertarget")}} can be used to indicate the `id` of an element that will be triggered by a {{htmlelement("button")}}, and [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) can indicate the element that supplies its [ARIA](/en-US/docs/Web/Accessibility/ARIA/Guides) description.
 

--- a/files/en-us/web/api/shadowroot/referencetarget/index.md
+++ b/files/en-us/web/api/shadowroot/referencetarget/index.md
@@ -1,0 +1,106 @@
+---
+title: "ShadowRoot: referenceTarget property"
+short-title: referenceTarget
+slug: Web/API/ShadowRoot/referenceTarget
+page-type: web-api-instance-property
+browser-compat: api.ShadowRoot.referenceTarget
+---
+
+{{APIRef("Shadow DOM")}}
+
+The **`referenceTarget`** property of the {{domxref("ShadowRoot")}} interface is a nullable string that represents the effective target of any element reference made against the shadow host from outside the host element.
+
+Some elements are associated with other elements using attributes that reference their `id` attribute.
+For example, a {{htmlelement("label")}} element can use the {{htmlattribute("for")}} attribute to specify the `id` of the element it is labelling.
+Similarly, {{htmlattribute("popovertarget")}} can be used to indicate the `id` of an element that will be triggered by a {{htmlelement("button")}}, and [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) can indicate the element that supplies its [ARIA](/en-US/docs/Web/Accessibility/ARIA/Guides) description.
+
+Direct references can only be created between elements in the same DOM or from an element in a shadow DOM to another element in a host DOM.
+You can't create a direct `id` reference from a host DOM into shadow DOM because this would break encapsulation.
+Instead you must do so indirectly, using a `referenceTarget`.
+
+The `referenceTarget` should be the id of an element inside the shadow DOM (or can be set `null` to remove the reference).
+In order to target an element within the shadow DOM, an element in the host DOM references the host element.
+The browser will then use the `referenceTarget` id, if set, as the _effective_ target of references to the host element.
+
+This approach maintains the encapsulation of the shadow root.
+For a closed shadow DOM the host DOM doesn't have direct visibility or even knowledge of the actual target element, and the browser doesn't modify the properties of the effective target.
+
+> [!NOTE]
+> If you set the label on a shadow DOM element using this approach you will not see a change in the corresponding `aria-label`.
+> Instead the browser computes any relationships when needed — so you can observe them in the accessibility inspector or via computed values.
+
+This same property is also set when a shadow root created programmatically, using the [`options.referenceTarget`](/en-US/docs/Web/API/Element/attachShadow#referencetarget) parameter passed to {{domxref("Element.attachShadow()")}}, or declaratively using the [`shadowrootreferencetarget`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootreferencetarget) attribute of the [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) element.
+
+## Value
+
+A string.
+
+This will be the id of an element inside the shadow DOM, or `null` if no reference target is set.
+
+## Examples
+
+### Basic usage
+
+```html
+<label for="consent">I consent to cookies</label>
+<sp-checkbox id="consent"></sp-checkbox>
+
+<hr />
+<div id="log"></div>
+```
+
+```js
+function log(...args) {
+  const debug = document.getElementById("log");
+  debug.innerHTML += args.join(" ") + "<br>";
+}
+```
+
+```js
+customElements.define(
+  "sp-checkbox",
+  class Checkbox extends HTMLElement {
+    checked = "mixed";
+
+    constructor() {
+      super();
+      this.shadowRoot_ = this.attachShadow({
+        mode: "closed",
+        //referenceTarget: "input",
+      });
+
+      this.shadowRoot_.referenceTarget = "input";
+
+      this.render();
+    }
+    render() {
+      this.shadowRoot_.innerHTML = `
+            <input id="input"
+                   type="checkbox"
+                   ${this.checked == "true" ? "checked" : ""}
+                   aria-checked=${this.checked == "indeterminate" ? "mixed" : this.checked}>
+            <span id="box"></span>`;
+
+      const input = this.shadowRoot_.getElementById("input");
+
+      log("aria-checked:", input.getAttribute("aria-checked"));
+      log("aria-label:", input.getAttribute("aria-label"));
+      log("aria-labelledby:", input.getAttribute("aria-labelledby"));
+    }
+  },
+);
+```
+
+{{EmbedLiveSample("Basic usage")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`options.referenceTarget`] argument to {{domxref(`Element.attachShadow()`)}}

--- a/files/en-us/web/html/reference/elements/template/index.md
+++ b/files/en-us/web/html/reference/elements/template/index.md
@@ -46,6 +46,8 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 - `shadowrootreferencetarget` {{Experimental_Inline}} {{non-standard_inline}}
   - : Sets the value of the `referenceTarget` property of a [`ShadowRoot`](/en-US/docs/Web/API/ShadowRoot) created using this element. The value should be the ID of an element inside the shadow DOM. If set, target references to the host element from outside the shadow DOM will cause the referenced target element to become the effective target of the reference to the host element.
 
+    This is the declarative equivalent of passing the [`options.referenceTarget`](/en-US/docs/Web/API/Element/attachShadow#referencetarget) parameter to {{domxref("Element.attachShadow()")}}.
+
 - `shadowrootserializable`
   - : Sets the value of the [`serializable`](/en-US/docs/Web/API/ShadowRoot/serializable) property of a [`ShadowRoot`](/en-US/docs/Web/API/ShadowRoot) created using this element to `true`.
     If set, the shadow root may be serialized by calling the {{DOMxRef('Element.getHTML()')}} or {{DOMxRef('ShadowRoot.getHTML()')}} methods with the `options.serializableShadowRoots` parameter set `true`.


### PR DESCRIPTION
FF149 added support for `referenceTarget` and `shadowRootReferenceTarget` attributes behind a pref. These are already mostly documented in #42323. This is pretty basic, but it was and remains about the right level because this isnt supported in releases or preview yet. At that point we should create guide material and cross link (this can be generated from the [explainer](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/reference-target-explainer.md).

What this does is get us a little bit closer so that when we have to update there is less to do.
1. Update the docs to use correct templates
2. Add linked individual property property docs rather than just the top level doc.

I have put a little bit more work into `ShadowRoot.referenceTarget` docs because it ONLY affects this property. So we could in theory add examples and so on to this without being confusing for other docs. See inline comments.

Related docs work can be tracked in #43453