### PR TITLE
Clarify JXL support is nightly only on 149

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -139,6 +139,6 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
   The CSS Typed Object Model Level 1 specification is being implemented.
   In this release, support for the {{domxref("CSSNumericValue/to","to()")}} method of the {{domxref("CSSNumericValue")}} interface was added, allowing the conversion of a CSS numeric value from one unit to another. ([Firefox bug 1278697](https://bugzil.la/1278697)).
 
-- **JPEG XL image support: Rust-based decoder**: `image.jxl.enabled`
+- **JPEG XL image support: Rust-based decoder** (Nightly only): `image.jxl.enabled`
 
   The previous C++ [JPEG XL](https://jpeg.org/jpegxl/) image decoder has been replaced with a new Rust-based implementation that uses the `jxl-rs` library. ([Firefox bug 1986393](https://bugzil.la/1986393)).


### PR DESCRIPTION
Followup to #43400 

It caused some confusion: https://www.phoronix.com/news/Mozilla-Firefox-149