### PR TITLE
Fix #43525: Improve clarity of dispatchEvent() return value

### DIFF
--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -37,7 +37,7 @@ dispatchEvent(event)
 
 ### Return value
 
-`false` if `event` is cancelable, and at least one of the event handlers which received `event` called {{domxref("Event.preventDefault()")}}. Otherwise `true`.
+The `dispatchEvent()` method returns `false` if the event is cancelable and at least one of the event listeners calls {{domxref("Event.preventDefault()")}}. Otherwise, it returns `true`.
 
 ### Exceptions
 


### PR DESCRIPTION
This PR fixes a misleading sentence in the dispatchEvent() documentation.

### Changes made:
- Converted the return value description into a clear and complete sentence
- Improved readability for beginners

### Result:
The behavior of dispatchEvent() return value is now easier to understand.

Closes #43525

### Proof of change: ISSUE (false if event is cancelable, and at least one of the event handlers which received event called Event.preventDefault(). Otherwise true.)
(Screenshot attach here)

<img width="554" height="144" alt="Screenshot from 2026-03-24 14-31-16" src="https://github.com/user-attachments/assets/876e9fa9-4192-4361-befd-c7ce6da5ccee" />

<img width="1299" height="691" alt="Screenshot from 2026-03-24 14-32-20" src="https://github.com/user-attachments/assets/f0c565d0-bccb-48b1-a4c7-5f573a63e908" />

