### PR TITLE
Fix wrapping in requestClose example

### DIFF
--- a/files/en-us/web/api/closewatcher/requestclose/index.md
+++ b/files/en-us/web/api/closewatcher/requestclose/index.md
@@ -42,7 +42,9 @@ watcher.onclose = () => {
   picker.remove();
 };
 
-picker.querySelector(".close-button").onclick = () => watcher.requestClose();
+picker.querySelector(".close-button").onclick = () => {
+  watcher.requestClose();
+};
 ```
 
 ## Specifications


### PR DESCRIPTION
Otherwise the requestClose() command drops onto the next line and the nesting is ambiguous.
