### PR TITLE
Cross-link to the user guide on split view

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -10,7 +10,7 @@ Moves one or more tabs to a new position in the same window or to a different wi
 
 You can only move tabs to and from windows whose {{WebExtAPIRef('windows.WindowType', 'WindowType')}} is `"normal"`.
 
-When the call moves a tab or tabs in a split view, Firefox moves the tabs in the split view together to preserve the split view. In Chrome, moving a tab away from the other tab in a split view removes the split view.
+When the call moves a tab or tabs in a [split view](https://support.mozilla.org/en-US/kb/split-view-firefox), Firefox moves the tabs in the split view together to preserve the split view. In Chrome, moving a tab away from the other tab in a split view removes the split view.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -108,7 +108,7 @@ Lists the changes to the state of the tab that is updated. To learn more about t
 - `pinned` {{optional_inline}}
   - : `boolean`. The tab's new pinned state.
 - `splitViewId` {{optional_inline}}
-  - : `integer`. The ID of the split view the tab belongs to. Set to {{WebExtAPIRef('tabs.SPLIT_VIEW_ID_NONE')}} when the tab doesn't belong to a split view.
+  - : `integer`. The ID of the [split view](https://support.mozilla.org/en-US/kb/split-view-firefox) the tab belongs to. Set to {{WebExtAPIRef('tabs.SPLIT_VIEW_ID_NONE')}} when the tab doesn't belong to a split view.
 - `status` {{optional_inline}}
   - : `string`. The status of the tab. Can be either _loading_ or _complete_.
 - `title` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -49,7 +49,7 @@ let querying = browser.tabs.query(queryInfo)
     - `pinned` {{optional_inline}}
       - : `boolean`. Whether the tabs are pinned.
     - `splitViewId` {{optional_inline}}
-      - : `integer`. The ID of the split view the tab belongs to. Set to {{WebExtAPIRef('tabs.SPLIT_VIEW_ID_NONE')}} to query the tabs that don't belong to a split view.
+      - : `integer`. The ID of the [split view](https://support.mozilla.org/en-US/kb/split-view-firefox) the tab belongs to. Set to {{WebExtAPIRef('tabs.SPLIT_VIEW_ID_NONE')}} to query the tabs that don't belong to a split view.
     - `status` {{optional_inline}}
       - : {{WebExtAPIRef('tabs.TabStatus')}}. Whether the tabs have completed loading.
     - `title` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/remove/index.md
@@ -10,7 +10,7 @@ Closes one or more tabs.
 
 If any of the tabs are:
 
-- part of a split view, the split view is removed.
+- part of a split view, the [split view](https://support.mozilla.org/en-US/kb/split-view-firefox) is removed.
 - the last tab in a group, the group is removed.
 
 ## Syntax

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/tab/index.md
@@ -65,7 +65,7 @@ Values of this type are objects. They contain the following properties:
 - `sessionId` {{optional_inline}}
   - : `string`. The session ID used to uniquely identify a `Tab` obtained from the {{WebExtAPIRef('sessions')}} API.
 - `splitViewId` {{optional_inline}}
-  - : `integer`. The ID of the split view the tab belongs to. Set to {{WebExtAPIRef('tabs.SPLIT_VIEW_ID_NONE')}} when the tab doesn't belong to a split view.
+  - : `integer`. The ID of the [split view](https://support.mozilla.org/en-US/kb/split-view-firefox) the tab belongs to. Set to {{WebExtAPIRef('tabs.SPLIT_VIEW_ID_NONE')}} when the tab doesn't belong to a split view.
 - `status` {{optional_inline}}
   - : `string`. Either _loading_ or _complete_.
 - `successorTabId` {{optional_inline}}

--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -101,7 +101,7 @@ Firefox 149 was released on [March 24, 2026](https://whattrainisitnow.com/releas
 
 ## Changes for add-on developers
 
-- Adds initial support for split view. This support covers:
+- Adds initial support for [split view](https://support.mozilla.org/en-US/kb/split-view-firefox). This support covers:
   - Inclusion of the split view ID in {{WebExtAPIRef("tabs.query")}}, {{WebExtAPIRef("tabs.onUpdated")}}, and {{WebExtAPIRef("tabs.Tab")}}
   - Documentation of the behavior when {{WebExtAPIRef("tabs.move")}} or {{WebExtAPIRef("tabs.remove")}} include tabs in a split view.
     ([Firefox bug 1993037](https://bugzil.la/1993037))


### PR DESCRIPTION
### Description

Add links to the SUMO user documentation for split view mentions.

### Motivation

To provide more information for developers unfamiliar with the split view feature.

### Related issues and pull requests

This is a follow up to [Bug-1993037 addition of splitViewId to the tabs API](https://github.com/mdn/content/pull/43284) #43284
