### PR TITLE
Node.js server without a framework: decodeURI

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/node_server_without_framework/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/node_server_without_framework/index.md
@@ -37,7 +37,8 @@ const STATIC_PATH = path.join(process.cwd(), "./static");
 const toBool = [() => true, () => false];
 
 const prepareFile = async (url) => {
-  const paths = [STATIC_PATH, url];
+  const urlAsPath = decodeURI(url);
+  const paths = [STATIC_PATH, urlAsPath];
   if (url.endsWith("/")) paths.push("index.html");
   const filePath = path.join(...paths);
   const pathTraversal = !filePath.startsWith(STATIC_PATH);


### PR DESCRIPTION
### Description

In general case, decoding URI is needed to transform it to a usable file path without %percent encoded whitespaces etc.
