### PR TITLE
Changes example in CSS invert() to use appropriate classes.

### DIFF
--- a/files/en-us/web/css/reference/values/filter-function/invert/index.md
+++ b/files/en-us/web/css/reference/values/filter-function/invert/index.md
@@ -130,6 +130,7 @@ td {
   padding: 5px;
 }
 ```
+
 ```html hidden
 <table>
   <thead>

--- a/files/en-us/web/css/reference/values/filter-function/invert/index.md
+++ b/files/en-us/web/css/reference/values/filter-function/invert/index.md
@@ -151,7 +151,7 @@ td {
       <td>
         <img
           class="svgFilter"
-          href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
+          src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="Pride flag" />
       </td>
       <td>

--- a/files/en-us/web/css/reference/values/filter-function/invert/index.md
+++ b/files/en-us/web/css/reference/values/filter-function/invert/index.md
@@ -130,7 +130,6 @@ td {
   padding: 5px;
 }
 ```
-
 ```html hidden
 <table>
   <thead>
@@ -149,11 +148,10 @@ td {
           alt="Pride flag" />
       </td>
       <td>
-          <img
-            class="svgFilter"
-            href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
-            alt="Pride flag"
-          />
+        <img
+          class="svgFilter"
+          href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
+          alt="Pride flag" />
       </td>
       <td>
         <img

--- a/files/en-us/web/css/reference/values/filter-function/invert/index.md
+++ b/files/en-us/web/css/reference/values/filter-function/invert/index.md
@@ -144,24 +144,16 @@ td {
     <tr>
       <td>
         <img
-          class="svgFilter"
+          class="filter"
           src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
           alt="Pride flag" />
       </td>
       <td>
-        <svg id="svg" height="220" width="220" overflow="visible">
-          <filter id="svgInvert">
-            <feComponentTransfer>
-              <feFuncR type="table" tableValues="0.3 0" />
-              <feFuncG type="table" tableValues="0.3 0" />
-              <feFuncB type="table" tableValues="0.3 0" />
-            </feComponentTransfer>
-          </filter>
-          <image
+          <img
+            class="svgFilter"
             href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
-            xlink:href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
-            filter="url('#svgInvert')" />
-        </svg>
+            alt="Pride flag"
+          />
       </td>
       <td>
         <img

--- a/files/en-us/web/css/reference/values/filter-function/invert/index.md
+++ b/files/en-us/web/css/reference/values/filter-function/invert/index.md
@@ -149,10 +149,19 @@ td {
           alt="Pride flag" />
       </td>
       <td>
-        <img
-          class="svgFilter"
-          src="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
-          alt="Pride flag" />
+        <svg id="svg" height="220" width="220" overflow="visible">
+          <filter id="svgInvert">
+            <feComponentTransfer>
+              <feFuncR type="table" tableValues="0.3 0" />
+              <feFuncG type="table" tableValues="0.3 0" />
+              <feFuncB type="table" tableValues="0.3 0" />
+            </feComponentTransfer>
+          </filter>
+          <image
+            href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
+            xlink:href="https://mdn.github.io/shared-assets/images/examples/progress-pride-flag.jpg"
+            filter="url('#svgInvert')" />
+        </svg>
       </td>
       <td>
         <img


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Applies the css invert to the item in the example labelled `invert() filter` instead of the SVG invert for the `SVG filter equivalent`, and fixes the SVG filter equivalent with a class as the document's text explains rather than as an inline SVG.

### Motivation

The changes keep the content accurate and make the playground more useable.

<!-- ### Additional details -->

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
