### PR TITLE
Correcting vertical-rl and vertical-lr descriptions.

### DIFF
--- a/files/en-us/web/css/reference/properties/writing-mode/index.md
+++ b/files/en-us/web/css/reference/properties/writing-mode/index.md
@@ -83,9 +83,9 @@ The `writing-mode` property is specified as one of the values listed below. The 
 - `horizontal-tb`
   - : For `ltr` scripts, content flows horizontally from left to right. For `rtl` scripts, content flows horizontally from right to left. The next horizontal line is positioned below the previous line.
 - `vertical-rl`
-  - : For `ltr` scripts, content flows vertically from top to bottom, and the next vertical line is positioned to the left of the previous line. For `rtl` scripts, content flows vertically from bottom to top, and the next vertical line is always positioned to the left of the previous line.
+  - : For `ltr` scripts, content flows vertically from top to bottom, and the next vertical line is positioned to the left of the previous line. For `rtl` scripts, content flows vertically from bottom to top, and the next vertical line is positioned to the left of the previous line.
 - `vertical-lr`
-  - : For `ltr` scripts, content flows vertically from top to bottom, and the next vertical line is positioned to the right of the previous line. For `rtl` scripts, content flows vertically from bottom to top, and the next vertical line is always positioned to the right of the previous line.
+  - : For `ltr` scripts, content flows vertically from top to bottom, and the next vertical line is positioned to the right of the previous line. For `rtl` scripts, content flows vertically from bottom to top, and the next vertical line is positioned to the right of the previous line.
 - `sideways-rl`
   - : For `ltr` scripts, content flows vertically from top to bottom. For `rtl` scripts, content flows vertically from bottom to top. All the glyphs, even those in vertical scripts, are set sideways toward the right.
 - `sideways-lr`


### PR DESCRIPTION
### Description

Updated the descriptions so that the next vertical line is always positioned according to the writing mode, independent of script direction.

both `vertical-rl` and `vertical-lr` share:

> LTR → top-to-bottom
> RTL → bottom-to-top

* `vertical-rl` : lines stack to the left.
* `vertical-lr` : lines stack to the right.

Fixes #43546