### PR TITLE
FF150 ExprFeat: customElementRegistry on Document, Element, ShadowRoot

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -399,6 +399,27 @@ The [`@container`](/en-US/docs/Web/CSS/Reference/At-rules/@container) CSS at-rul
 
 ## APIs
 
+### Scoped custom element registries
+
+Support for [scoped custom element registries](/en-US/docs/Web/API/Web_components/Using_custom_elements#scoped_custom_element_registries) is being implemented.
+Scoped registries allow a shadow tree to create an independent {{domxref("CustomElementRegistry")}} whose definitions only apply to that specific DOM subtree.
+This can be used to avoid collisions where multiple web components declare elements with the same name.
+
+The implementation includes:
+
+- `customElementRegistry` property on {{domxref("Document")}}, {{domxref("Element")}}, and {{domxref("ShadowRoot")}}.
+  ([Firefox bug 2018900](https://bugzil.la/2018900)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 150           | No                  |
+| Developer Edition | 150           | No                  |
+| Beta              | 150           | No                  |
+| Release           | 150           | No                  |
+
+- `dom.scoped-custom-element-registries.enabled`
+  - : Set to `true` to enable.
+
 ### CSS Typed Object Model Level 1
 
 Implementation work has started on the [CSS Typed OM Level 1](https://drafts.css-houdini.org/css-typed-om/).

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -90,3 +90,9 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 These features are shipping in Firefox 150 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+
+- **Scoped custom element registries**: `dom.scoped-custom-element-registries.enabled`
+
+  The {{domxref("CustomElementRegistry","customElementRegistry")}} property is supported on {{domxref("Document")}}, {{domxref("Element")}}, and {{domxref("ShadowRoot")}}.
+  This allows the definition of [scoped custom element registries](/en-US/docs/Web/API/Web_components/Using_custom_elements#scoped_custom_element_registries).
+  ([Firefox bug 2018900](https://bugzil.la/2018900)).


### PR DESCRIPTION
FF150 added support for  [`Element.customElementRegistry`](https://developer.mozilla.org/en-US/docs/Web/API/Element/customElementRegistry), [`Document.customElementRegistry`](https://developer.mozilla.org/en-US/docs/Web/API/Document/customElementRegistry) [`ShadowRoot.customElementRegistry`](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/customElementRegistry) behind the preference `dom.scoped-custom-element-registries.enabled`.

This adds the experimental features page update and corresponding link from FF150 release note page.

Related docs work can be tracked in #43555