### PR TITLE
‎`browser_specific_settings` version dot releases rejected by AMO

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/browser_specific_settings/index.md
@@ -89,7 +89,7 @@ The `gecko` sub-key supports these properties:
     See [Extensions and the Add-on ID](https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/) for more information about setting extension IDs.
 
 - `strict_min_version`
-  - : Minimum version of Gecko to support. If the Firefox version on which the extension is being installed or run is below this version, the extension is not installed or not run. If not provided, all versions earlier than `strict_max_version` are supported. "\*" is not valid in this field.
+  - : Minimum version of Gecko to support. If the Firefox version on which the extension is being installed or run is below this version, the extension is not installed or not run. If not provided, all versions earlier than `strict_max_version` are supported. Neither "\*" nor dot releases are valid in this field, e.g. a value of "140.0" will work while "140.1" will fail the validation on *addons.mozilla.org* with error **Unknown "strict_min_version" 140.1 for Firefox**.
 - `strict_max_version`
   - : Maximum version of Gecko to support. If the Firefox version on which the extension is being installed or run is above this version, the extension is not installed or not run. Defaults to "\*", which disables checking for a maximum version.
 - `update_url`


### PR DESCRIPTION
Added info about dot releases being invalid

### Description

Added info that dot releases are invalid

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Information on this was missing, it costs us addon-devs time to stumble across validation issues while submitting an addon.

### Additional details

<img width="309" height="71" alt="grafik" src="https://github.com/user-attachments/assets/511e8283-dd1e-40a0-88ae-b4b07985d5f0" />
