### PR TITLE
docs: remove incorrect null remark for CanvasRenderingContext2D.canvas

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
@@ -10,8 +10,7 @@ browser-compat: api.CanvasRenderingContext2D.canvas
 
 The **`CanvasRenderingContext2D.canvas`** property, part of the
 [Canvas API](/en-US/docs/Web/API/Canvas_API), is a read-only reference to the
-{{domxref("HTMLCanvasElement")}} object that is associated with a given context. It
-might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if there is no associated {{HTMLElement("canvas")}} element.
+{{domxref("HTMLCanvasElement")}} object that is associated with a given context.
 
 ## Value
 


### PR DESCRIPTION

### Description

Removed the incorrect statement claiming that the CanvasRenderingContext2D.canvas property can be null.


### Motivation

Per the HTML Living Standard and WebIDL, the 2D context creation algorithm initializes the canvas attribute to the target element. It cannot subsequently become null, and removing this remark prevents developers from performing unnecessary null checks.


### Additional details

As noted in the linked issue, the IDL confirms this property cannot be null, and the specification states the attribute must return the value it was initialized to when the object was created.


### Related issues and pull requests
Fixes #43612

