### PR TITLE
Remove incorrect null note from CanvasRenderingContext2D.canvas docs

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
@@ -10,9 +10,7 @@ browser-compat: api.CanvasRenderingContext2D.canvas
 
 The **`CanvasRenderingContext2D.canvas`** property, part of the
 [Canvas API](/en-US/docs/Web/API/Canvas_API), is a read-only reference to the
-{{domxref("HTMLCanvasElement")}} object that is associated with a given context. It
-might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if there is no associated {{HTMLElement("canvas")}} element.
-
+{{domxref("HTMLCanvasElement")}} object that is associated with a given context. 
 ## Value
 
 A {{domxref("HTMLCanvasElement")}} object.


### PR DESCRIPTION
## Summary
This PR removes the incorrect sentence stating that `CanvasRenderingContext2D.canvas` might be null.

## Context
This change addresses issue #43612.

## Notes
This is a minimal docs-only change with no unrelated edits.