### PR TITLE
Correct Opera accesskey shortcut on Linux

### DIFF
--- a/files/en-us/web/html/reference/global_attributes/accesskey/index.md
+++ b/files/en-us/web/html/reference/global_attributes/accesskey/index.md
@@ -60,7 +60,8 @@ The way to activate the accesskey depends on the browser and its platform:
     </tr>
     <tr>
       <th>Opera</th>
-      <td colspan="2"><kbd>Alt</kbd> + <kbd><em>key</em></kbd></td>
+      <td><kbd>Alt</kbd> + <kbd><em>key</em></kbd></td>
+      <td><kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd><em>key</em></kbd></td>
       <td><kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd><em>key</em></kbd></td>
     </tr>
   </tbody>


### PR DESCRIPTION
Opera running on Linux uses the same keystrokes that Mozilla Firefox on Linux does.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

### Description

Improved accuracy of documentation.

### Motivation

This will help developers so they can easily know how to test the accesskey feature properly in Opera on Linux.

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
