### PR TITLE
FF150 Relnote: Document.caretPositionFromPoint(options.shadowRoots)

### DIFF
--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -54,6 +54,10 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### DOM
 
+- The [`options.shadowRoots`](/en-US/docs/Web/API/Document/caretPositionFromPoint#shadowroots) argument of the {{domxref('Document.caretPositionFromPoint()')}} method is now supported.
+  This allows the method to return the node containing the caret from within a shadow DOM, provided its associated {{domxref("ShadowRoot")}} was passed as an option.
+  ([Firefox bug 1914596](https://bugzil.la/1914596)).
+
 - The non-standard {{domxref("Document/caretRangeFromPoint","caretRangeFromPoint()")}} method of the {{domxref("Document")}} interface is now supported. ([Firefox bug 1550635](https://bugzil.la/1550635)).
 
 <!-- #### Media, WebRTC, and Web Audio -->


### PR DESCRIPTION
FF150  added support for [`options.shadowRoots`](https://developer.mozilla.org/en-US/docs/Web/API/Document/caretPositionFromPoint#shadowroots) in `Document.caretPositionFromPoint()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1914596. This adds a release note.

Related docs work can be tracked in #43563