### PR TITLE
FF150 Relnote: CSSFontFaceDescriptors

### DIFF
--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -78,7 +78,10 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
   This allows the method to return the node containing the caret from within a shadow DOM, provided its associated {{domxref("ShadowRoot")}} was passed as an option.
   ([Firefox bug 1914596](https://bugzil.la/1914596)).
 
+- The {{domxref("CSSFontFaceDescriptors")}} interface is now supported, and an instance of this type is returned by the {{domxref("CSSFontFaceRule.style")}} property. ([Firefox bug 2019904](https://bugzil.la/2019904)).
+
 - The non-standard {{domxref("Document/caretRangeFromPoint","caretRangeFromPoint()")}} method of the {{domxref("Document")}} interface is now supported. ([Firefox bug 1550635](https://bugzil.la/1550635)).
+
 - The `ariaNotify()` method is now supported on {{domxref("Document/ariaNotify","Document")}} and {{domxref("Element/ariaNotify","Element")}}.
   This queues a string of text to be announced by a {{glossary("screen reader")}}, providing a more ergonomic and reliable alternative to [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
   ([Firefox bug 2018095](https://bugzil.la/2018095)).

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -24,7 +24,12 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 
 ## Examples
 
-This example uses the CSS found as an example on the {{cssxref("@font-face")}} page. The first {{domxref("CSSRule")}} returned will be a `CSSFontFaceRule`.
+### Accessing @font-face properties
+
+This example defines a {{cssxref("@font-face")}} rule and then iterates the rules on the page to the associated `CSSFontFaceRule`.
+It then logs some of the properties.
+
+#### CSS
 
 ```css
 @font-face {
@@ -36,10 +41,46 @@ This example uses the CSS found as an example on the {{cssxref("@font-face")}} p
 }
 ```
 
-```js
-const myRules = document.styleSheets[0].cssRules;
-console.log(myRules[0]); // A CSSFontFaceRule
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
 ```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+const myRules = document.getElementById("css-output").sheet.cssRules;
+for (const rule of myRules) {
+  if (rule instanceof CSSFontFaceRule) {
+    log(`this: ${rule}`);
+    log(` cssText: ${rule.cssText}`);
+    log(` parentRule: ${rule.parentRule}`);
+    log(` parentStyleSheet: ${rule.parentStyleSheet}`);
+    log(` type: ${rule.type}`);
+    log(` style: ${rule.style}`);
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Accessing @font-face properties", "100%", "250px")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -26,7 +26,7 @@ _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 
 ### Accessing @font-face properties
 
-This example defines a {{cssxref("@font-face")}} rule and then iterates the rules on the page to the associated `CSSFontFaceRule`.
+This example defines a {{cssxref("@font-face")}} rule and then iterates over the rules on the page until the associated `CSSFontFaceRule` is found.
 It then logs some of the properties.
 
 #### CSS

--- a/files/en-us/web/api/cssfontfacerule/style/index.md
+++ b/files/en-us/web/api/cssfontfacerule/style/index.md
@@ -14,26 +14,76 @@ The read-only **`style`** property of the {{domxref("CSSFontFaceRule")}} interfa
 
 A {{domxref("CSSFontFaceDescriptors")}} object.
 
-Although the `style` property itself is read-only in the sense that you can't replace the `CSSFontFaceDescriptors` object, you can still assign to the `style` property directly, which is equivalent to assigning to its {{domxref("CSSStyleDeclaration/cssText", "cssText")}} property. You can also modify the `CSSFontFaceDescriptors` object using the {{domxref("CSSStyleDeclaration/setProperty", "setProperty()")}} and {{domxref("CSSStyleDeclaration/removeProperty", "removeProperty()")}} methods.
+Although the `style` property itself is read-only in the sense that you can't replace the `CSSFontFaceDescriptors` object, you can still assign to the `style` property directly, which is equivalent to assigning to its {{domxref("CSSStyleDeclaration/cssText", "cssText")}} property.
+You can also modify the `CSSFontFaceDescriptors` object using the {{domxref("CSSStyleDeclaration/setProperty", "setProperty()")}} and {{domxref("CSSStyleDeclaration/removeProperty", "removeProperty()")}} methods.
 
 ## Examples
 
-This example uses the CSS found as an example on the {{cssxref("@font-face")}} page. The first {{domxref("CSSRule")}} returned will be a `CSSFontFaceRule`. The `style` property returns a {{domxref("CSSFontFaceDescriptors")}} object with the properties `fontFamily`, `fontWeight`, and `src` populated with the information from the rule.
+### Basic usage
+
+This example defines a {{cssxref("@font-face")}} rule and then uses `CSSFontFaceDescriptors` to read back the descriptor values.
+
+#### CSS
 
 ```css
 @font-face {
   font-family: "MyHelvetica";
   src:
-    local("Helvetica Neue Bold"), local("HelveticaNeue-Bold"),
-    url("MgOpenModernaBold.woff2");
+    local("Helvetica Neue Bold"),
+    local("HelveticaNeue-Bold"),
+    url("MgOpenModernaBold.woff2") format("woff2");
   font-weight: bold;
+  font-style: normal;
+  font-display: swap;
 }
 ```
 
-```js
-const myRules = document.styleSheets[0].cssRules;
-console.log(myRules[0].style); // A CSSFontFaceDescriptors
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
 ```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+#### JavaScript
+
+```js
+const myRules = document.getElementById("css-output").sheet.cssRules;
+for (const rule of myRules) {
+  if (rule instanceof CSSFontFaceRule) {
+    const descriptors = rule.style;
+    if (descriptors instanceof CSSStyleDeclaration) {
+      log(`rule.style is a CSSStyleDeclaration.`);
+    } else {
+      log(`rule.style is a CSSFontFaceDescriptors.`);
+    }
+    log("Descriptors:");
+    log(` font-family: ${descriptors.fontFamily}`);
+    log(` src: ${descriptors.src}`);
+    log(` font-weight: ${descriptors["font-weight"]}`);
+    log(` font-style: ${descriptors.fontStyle}`);
+    log(` font-display: ${descriptors["font-display"]}`);
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Basic usage", "100%", "250px")}}
 
 ## Specifications
 


### PR DESCRIPTION
FF150 adds support for `CSSFontFaceRule.style` being a `CSSFontFaceDescriptors`. This adds a release note and minor updates to docs.

- [x] Release note
- [x] CSSFontFaceRule - make into live example

Related docs work can be tracked in #43564
