### PR TITLE
docs: fix typo in [\w-] regex example

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -56,7 +56,7 @@ console.log(moods.match(regexpEmoticons));
         <p>
           For example, <code>[\w-]</code> is the same as
           <code>[A-Za-z0-9_-]</code>. They both match the "b" in "brisket", the
-          "c" in "chop", and the "n" in "non-profit".
+          "c" in "chop", and the "-" in "non-profit".
         </p>
         <p>
           When the <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets"><code>unicodeSets</code></a> (<code>v</code>) flag is enabled, the character class has some additional features. See the <a href="/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class">character class</a> reference for more information.


### PR DESCRIPTION
### Description
Updated the regex character class example for `[\w-]` to correctly identify the hyphen (`-`) as the intended match in the string "non-profit".

### Motivation
The previous text stated that the pattern matches the "n" in "non-profit". Since `\w` already matches "n", the original example failed to demonstrate the actual effect of adding the hyphen to the character set. Changing it to match the "-" makes the technical distinction clear for learners.

### Additional details
N/A

### Related issues and pull requests
N/A