### PR TITLE
Corrected CSS typo in mozilla extensions docs (Issue #43640)

### DIFF
--- a/files/en-us/web/css/reference/mozilla_extensions/index.md
+++ b/files/en-us/web/css/reference/mozilla_extensions/index.md
@@ -131,7 +131,7 @@ Support for the prefixed version is typically dropped eventually, so use the sta
 - `-moz-element` {{deprecated_inline}}: Use {{CSSxRef("element")}}.
 - {{CSSxRef("-moz-image-rect")}} {{deprecated_inline}}
 
-### order-style and outline-style
+### border-style and outline-style
 
 **Properties:** {{CSSxRef("border-style")}} and {{CSSxRef("outline-style")}}.
 


### PR DESCRIPTION
Corrected "order-style" to "border-style" in the section describing -moz-prefixed property values for border-style and outline-style. (Issue #43640)