### PR TITLE
Fix execCommand typo: highlightColor to hiliteColor

### DIFF
--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -68,8 +68,8 @@ execCommand(commandName, showDefaultUI, valueArgument)
       - : Deletes the character ahead of the [cursor](https://en.wikipedia.org/wiki/Cursor_%28computers%29)'s position, identical to hitting the Delete key on a Windows keyboard.
     - `heading`
       - : Adds a heading element around a selection or insertion point line. Requires the tag-name string as a value argument (i.e., `"H1"`, `"H6"`). (Not supported by Safari.)
-    - `highlightColor`
-      - : Changes the background color for the selection or at the insertion point. Requires a color value string as a value argument. `useCSS` must be `true` for this to function.
+  - `hiliteColor`
+  - : Changes the background color for the selection or at the insertion point. Requires a color value string as a value argument. `useCSS` must be `true` for this to function.
     - `increaseFontSize`
       - : Adds a {{HTMLElement("big")}} tag around the selection or at the insertion point.
     - `indent`


### PR DESCRIPTION
Fixes a typo in the execCommand documentation by renaming `highlightColor` to `hiliteColor`, matching the command name referenced in the issue.