### PR TITLE
Add missing commands in execCommand

### DIFF
--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -91,6 +91,8 @@ execCommand(commandName, showDefaultUI, valueArgument)
 
     - `insertImage`
       - : Inserts an image at the insertion point (deletes selection). Requires a URL string for the image's `src` as a value argument. The requirements for this string are the same as `createLink`.
+    - `insertLineBreak`
+      - : Deletes the selection, and replaces it with a [line break element](/en-US/docs/Web/HTML/Reference/Elements/br).
     - `insertOrderedList`
       - : Creates a [numbered ordered list](/en-US/docs/Web/HTML/Reference/Elements/ol) for the selection or at the insertion point.
     - `insertUnorderedList`


### PR DESCRIPTION
### Description

Changed `˙highlightColor` to `hiliteColor` and added `insertLineBreak`.

### Motivation

For the readers to have up to date informations.

### Additional details

[w3c](https://w3c.github.io/editing/docs/execCommand/)

### Related issues and pull requests

Fixes #43634 
