### PR TITLE
fix: remove duplicate word 'the' in CSP violation docs

### DIFF
--- a/files/en-us/web/api/cspviolationreport/linenumber/index.md
+++ b/files/en-us/web/api/cspviolationreport/linenumber/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ReportingObserver.ReportingObserver.options_parameter.types_
 
 The **`lineNumber`** property of the {{domxref("CSPViolationReport")}} dictionary indicates the line number in the source file where the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/Guides/CSP) violation was triggered.
 
-This property is used with the {{domxref("CSPViolationReport.sourceFile")}} and {{domxref("CSPViolationReport.columnNumber")}} properties, which together provide the the exact location in the source that caused the violation.
+This property is used with the {{domxref("CSPViolationReport.sourceFile")}} and {{domxref("CSPViolationReport.columnNumber")}} properties, which together provide the exact location in the source that caused the violation.
 
 Note that the browser extracts the value from _the global object_ of the file that triggered the violation.
 If the resource that triggers the CSP violation is not loaded, the value will be `null`.

--- a/files/en-us/web/api/cspviolationreport/sourcefile/index.md
+++ b/files/en-us/web/api/cspviolationreport/sourcefile/index.md
@@ -13,7 +13,7 @@ The **`sourceFile`** property of the {{domxref("CSPViolationReport")}} dictionar
 For a violation triggered by the use of an inline script, `sourceFile` is the URL of the current document.
 Similarly, if a document successfully loads a script that then violates the document CSP, the `sourceFile` is the URL of the script.
 
-This property is used with the {{domxref("CSPViolationReport.lineNumber")}} and {{domxref("CSPViolationReport.columnNumber")}} properties, which together provide the the exact location in the source that caused the violation.
+This property is used with the {{domxref("CSPViolationReport.lineNumber")}} and {{domxref("CSPViolationReport.columnNumber")}} properties, which together provide the exact location in the source that caused the violation.
 
 Note however that if a document with a CSP that blocks external resources attempts to load an external resource, `sourceFile` will be `null`.
 This is because the browser extracts the value from _the global object_ of the file that triggered the violation.

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
@@ -10,7 +10,7 @@ browser-compat: api.SecurityPolicyViolationEvent.columnNumber
 
 The **`columnNumber`** read-only property of the {{domxref("SecurityPolicyViolationEvent")}} interface is the character position in the source file line of the document or worker script at which the [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/Guides/CSP) violation occurred.
 
-This property is used with the {{domxref("SecurityPolicyViolationEvent.sourceFile")}} and {{domxref("SecurityPolicyViolationEvent.lineNumber")}} properties, which together provide the the exact location in the source that caused the violation.
+This property is used with the {{domxref("SecurityPolicyViolationEvent.sourceFile")}} and {{domxref("SecurityPolicyViolationEvent.lineNumber")}} properties, which together provide the exact location in the source that caused the violation.
 
 ## Value
 


### PR DESCRIPTION
## Description

Remove duplicate word "the" in three CSP-related documentation pages.

**Before:** "which together provide the the exact location in the source"
**After:** "which together provide the exact location in the source"

### Affected files:
- `CSPViolationReport.lineNumber`
- `CSPViolationReport.sourceFile`
- `SecurityPolicyViolationEvent.columnNumber`

No functional or structural changes.