### PR TITLE
Fix broken reference in .mjs vs .js section of Modules guide

### DIFF
--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -71,7 +71,7 @@ If you really value the clarity of using `.mjs` for modules versus using `.js` f
 It is also worth noting that:
 
 - Some tools may never support `.mjs`.
-- The `<script type="module">` attribute is used to denote when a module is being pointed to, as you'll see below.
+- The `<script type="module">` attribute is used to denote when a module is being pointed to, as described in [Applying the module to your HTML](#applying_the_module_to_your_html).
 
 ## Exporting module features
 


### PR DESCRIPTION
## Summary

In the JavaScript Modules guide, the ".mjs versus .js" aside says "as you'll see below" when referring to `<script type="module">` usage, but doesn't link to the relevant section. The referenced content is far down the page in "Applying the module to your HTML," which makes the vague reference confusing.

This replaces the loose "as you'll see below" text with a direct anchor link to the correct section.

Fixes #43662