### PR TITLE
Fix: Replace Cyrillic with Mongolian script in writing mode example

### DIFF
--- a/files/en-us/web/css/guides/writing_modes/writing_mode_systems/index.md
+++ b/files/en-us/web/css/guides/writing_modes/writing_mode_systems/index.md
@@ -60,7 +60,7 @@ Han-based systems are commonly written using a left-to-right inline direction wi
 Mongolian-based systems are typically written vertically, top to bottom, in columns that flow left to right; a top-to-bottom inline direction with a left-to-right block flow direction. This differs from Chinese, Japanese, and Korean, whose vertical text columns are read right to left. It derives from the fact that Mongolian script descended from Old Uyghur, which was written left-to-right.
 
 ```html
-<p lang="mn-MONG" dir="auto">Үүнийг монгол хэлээр бичжээ</p>
+<p lang="mn-MONG" dir="auto">ᠮᠣᠩᠭᠣᠯ ᠪᠢᠴᠢᠭ</p>
 ```
 
 To render the writing modes correctly, we use the global HTML [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir) attribute. Because browsers can turn off CSS styling, it is recommended to use the `dir` attribute and {{htmlelement("bdo")}} element to ensure correct bidirectional layout in the absence of a style sheet, rather than the CSS {{cssxref("direction")}} property.


### PR DESCRIPTION
### Description
Replaced the Cyrillic script in the Mongolian writing mode example with proper Mongolian script.

### Motivation
The previous example used Cyrillic text, which does not reflect the vertical writing system of Mongolian. This change ensures the example accurately demonstrates Mongolian writing behavior.

### Related issues
Closes #43515