### PR TITLE
Fix syntax error in stroke property example

### DIFF
--- a/files/en-us/web/css/reference/properties/stroke/index.md
+++ b/files/en-us/web/css/reference/properties/stroke/index.md
@@ -16,7 +16,7 @@ The **`stroke`** [CSS](/en-US/docs/Web/CSS) property defines the color or SVG pa
 ```css
 /* assorted color values */
 stroke: rgb(153 51 102 / 1);
-stroke: color-mix(in lch, var(--primaryColor) 35%, gray 15%));
+stroke: color-mix(in lch, var(--primaryColor) 35%, gray 15%);
 stroke: dodgerblue;
 stroke: currentColor;
 stroke: transparent;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Fix syntax error in stroke property example
your example is wrong, i remove a right parenthesis and fix it
### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
A:because this wrong example may confuse readers
### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
in this page you are wrong:
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/stroke
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
