### PR TITLE
FF150 Relnote: Sanitizer.replaceElementWithChildren() return false for <html>

### DIFF
--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -52,6 +52,9 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
+- The {{domxref("Sanitizer.replaceElementWithChildren()")}} method will now return `false` if the element to be replaced is {{htmlelement("html")}} in the HTML [namespace](/en-US/docs/Web/API/Sanitizer/replaceElementWithChildren#namespace).
+  In other words, you can't use this method to create a {{domxref("Sanitizer")}} that will replace the HTML element with its inner content. ([Firefox bug 2022176](https://bugzil.la/2022176)).
+
 #### DOM
 
 - The [`options.shadowRoots`](/en-US/docs/Web/API/Document/caretPositionFromPoint#shadowroots) argument of the {{domxref('Document.caretPositionFromPoint()')}} method is now supported.

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -53,7 +53,7 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 ### APIs
 
 - The {{domxref("Sanitizer.replaceElementWithChildren()")}} method will now return `false` if the element to be replaced is {{htmlelement("html")}} in the HTML [namespace](/en-US/docs/Web/API/Sanitizer/replaceElementWithChildren#namespace).
-  In other words, you can't use this method to create a {{domxref("Sanitizer")}} that will replace the HTML element with its inner content. ([Firefox bug 2022176](https://bugzil.la/2022176)).
+  In other words, you can't use this method to create a {{domxref("Sanitizer")}} that will replace the `<html>` element with its inner content. ([Firefox bug 2022176](https://bugzil.la/2022176)).
 
 #### DOM
 

--- a/files/en-us/web/api/sanitizer/replaceelementwithchildren/index.md
+++ b/files/en-us/web/api/sanitizer/replaceelementwithchildren/index.md
@@ -29,9 +29,9 @@ replaceElementWithChildren(element)
 
 ### Return value
 
-`true` if the operation changed the configuration to set the element to be replaced by its children, and `false` otherwise.
+A boolean value: `true` if the operation updated the `Sanitizer` configuration to replace the element with its children, and `false` otherwise.
 
-The method returns `false` if the sanitizer was already configured to replace the given element, or if the replacement element was {{htmlelement("html")}} in the HTML namespace.
+The method returns `false` if the sanitizer is already configured to replace the given element, or if the replacement element is {{htmlelement("html")}} in the HTML namespace.
 
 ## Examples
 

--- a/files/en-us/web/api/sanitizer/replaceelementwithchildren/index.md
+++ b/files/en-us/web/api/sanitizer/replaceelementwithchildren/index.md
@@ -29,7 +29,9 @@ replaceElementWithChildren(element)
 
 ### Return value
 
-`true` if the operation changed the configuration to set the element to be replaced by its children, and `false` if the sanitizer was already replacing the element.
+`true` if the operation changed the configuration to set the element to be replaced by its children, and `false` otherwise.
+
+The method returns `false` if the sanitizer was already configured to replace the given element, or if the replacement element was {{htmlelement("html")}} in the HTML namespace.
 
 ## Examples
 


### PR DESCRIPTION
[`Sanitizer.replaceElementWithChildren()`](https://developer.mozilla.org/en-US/docs/Web/API/Sanitizer/replaceElementWithChildren) returns `false` for `<html>` elements in the HTML namespace from https://bugzilla.mozilla.org/show_bug.cgi?id=2022176

This adds a release note and update to the docs.

Related docs work can be tracked in #43559