### PR TITLE
Fix `include_subdomains` description for NEL header

### DIFF
--- a/files/en-us/web/http/guides/network_error_logging/index.md
+++ b/files/en-us/web/http/guides/network_error_logging/index.md
@@ -33,7 +33,7 @@ The following object keys can be specified in the NEL header:
 - max_age
   - : Specifies the lifetime of the policy, in seconds (in a similar way to e.g., HSTS policies are time-restricted). The referenced reporting group should have a lifetime at least as long as the NEL policy.
 - include_subdomains
-  - : If `true`, this NEL policy is also enabled for all subdomains of the origin, but only for network errors that occur during DNS resolution.  The NEL policy will not be enabled for subdomains if `include_subdomains` is not present, is `false`, or for other (non-DNS-related) network errors. The reporting group must also be set to include subdomains for this option to have effect.
+  - : If `true`, this NEL policy is also enabled for all subdomains of the origin, but only for network errors that occur during DNS resolution. The NEL policy will not be enabled for subdomains if `include_subdomains` is not present, is `false`, or for other (non-DNS-related) network errors. The reporting group must also be set to include subdomains for this option to have effect.
 - success_fraction
   - : Floating point value between 0 and 1 which specifies the proportion of **successful** network requests to report. Defaults to 0, so that no successful network requests will be reported if the key is not present in the JSON payload.
 - failure_fraction


### PR DESCRIPTION
### Description

Fix `include_subdomains` description for the NEL header to clarify that it only applies to dns phase reports, not all report types.

### Motivation

The previous description stated that `include_subdomains` applies the policy to "all subdomains under the origin", without mentioning that this is limited to dns phase reports only. This was inaccurate per the spec and could mislead developers.

### Additional details

Per the [NEL spec](https://w3c.github.io/network-error-logging/#include-subdomains), the `include_subdomains` member enables the policy for subdomains only for `dns` phase reports. If the member is not present, is false, or the report phase is not `dns`, the policy will not apply to subdomains.

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/43673
