### PR TITLE
fix(css): simplify misleading grid syntax examples

### DIFF
--- a/files/en-us/web/css/reference/properties/grid/index.md
+++ b/files/en-us/web/css/reference/properties/grid/index.md
@@ -93,14 +93,14 @@ grid: minmax(400px, min-content) / repeat(auto-fill, 50px);
    [ auto-flow && dense? ] <'grid-auto-columns'>? values */
 grid: 200px / auto-flow;
 grid: 30% / auto-flow dense;
-grid: repeat(3, [line1 line2 line3] 200px) / auto-flow 300px;
+grid: repeat(3, 200px) / auto-flow 300px;
 grid: [line1] minmax(20em, max-content) / auto-flow dense 40%;
 
 /* [ auto-flow && dense? ] <'grid-auto-rows'>? /
    <'grid-template-columns'> values */
 grid: auto-flow / 200px;
 grid: auto-flow dense / 30%;
-grid: auto-flow 300px / repeat(3, [line1 line2 line3] 200px);
+grid: auto-flow 300px / repeat(3, 200px);
 grid: auto-flow dense 40% / [line1] minmax(20em, max-content);
 
 /* Global values */


### PR DESCRIPTION
Simplifies two `grid` syntax examples by removing repeated line names that can be misleading.

Fixes mdn/content#41176
