### PR TITLE
Mention default receiver behavior for Reflect.get()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
@@ -40,7 +40,7 @@ Reflect.get(target, propertyKey, receiver)
 - `propertyKey`
   - : The name of the property to get.
 - `receiver` {{optional_inline}}
-  - : The value of `this` provided for the call to `target` if a getter is encountered. Defaults to `target` when this value is not provided.
+  - : The value of `this` provided for the call to `target` if a getter is encountered. Defaults to `target`.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/get/index.md
@@ -40,7 +40,7 @@ Reflect.get(target, propertyKey, receiver)
 - `propertyKey`
   - : The name of the property to get.
 - `receiver` {{optional_inline}}
-  - : The value of `this` provided for the call to `target` if a getter is encountered.
+  - : The value of `this` provided for the call to `target` if a getter is encountered. Defaults to `target` when this value is not provided.
 
 ### Return value
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
@@ -41,7 +41,7 @@ Reflect.set(target, propertyKey, value, receiver)
 - `value`
   - : The value to set.
 - `receiver` {{optional_inline}}
-  - : The value of `this` provided for the call to the setter for `propertyKey` on `target`. If provided and `target` does not have a setter for `propertyKey`, the property will be set on `receiver` instead.
+  - : The value of `this` provided for the call to the setter for `propertyKey` on `target`. If provided and `target` does not have a setter for `propertyKey`, the property will be set on `receiver` instead. Defaults to `target`.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Mention the default `Reflect.get()` behavior when the optional `receiver` parameter is not provided.

### Motivation

I was looking for this information but couldn't find it on MDN.

### Additional details

https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.get

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
