### PR TITLE
DEVOPS-5836: Adds .claude/settings.local.json and mcp-vscode.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _githistory.json
 .DS_Store
 .idea
 *.log
+.claude/settings.local.json
+mcp-vscode.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ _githistory.json
 *.log
 .claude/settings.local.json
 mcp-vscode.json
+.claude/settings.local.json
+mcp-vscode.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ _githistory.json
 *.log
 .claude/settings.local.json
 mcp-vscode.json
-.claude/settings.local.json
-mcp-vscode.json


### PR DESCRIPTION
## Summary
Adds `.claude/settings.local.json` and `mcp-vscode.json` to `.gitignore`.

`.claude/settings.local.json` is the user-specific local override file for Claude Code and should not be committed. We are intentionally not ignoring the entire \.claude/` directory as shared project config may exist there.

`mcp-vscode.json` is the VS Code MCP configuration file that should not be committed.

Fixes DEVOPS-5836