### PR TITLE
Fix incorrect term usage in the "So what can it really do?" section(button)

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/what_is_javascript/index.md
+++ b/files/en-us/learn_web_development/core/scripting/what_is_javascript/index.md
@@ -113,7 +113,7 @@ The core client-side JavaScript language consists of some common programming fea
 
 - Store useful values inside variables. In the above example for instance, we ask for a new name to be entered then store that name in a variable called `name`.
 - Operations on pieces of text (known as "strings" in programming). In the above example we take the string "Player 1: " and join it to the `name` variable to create the complete text label, e.g., "Player 1: Chris".
-- Running code in response to certain events occurring on a web page. We used a {{domxref("Element/click_event", "click")}} event in our example above to detect when the label is clicked and then run the code that updates the text label.
+- Running code in response to certain events occurring on a web page. We used a {{domxref("Element/click_event", "click")}} event in our example above to detect when the button is clicked and then run the code that updates the text label.
 - And much more!
 
 What is even more exciting however is the functionality built on top of the client-side JavaScript language. So-called **Application Programming Interfaces** (**APIs**) provide you with extra superpowers to use in your JavaScript code.


### PR DESCRIPTION
### Description

This pull request fixes incorrect term usage in "So what can it really do?" section, as the UI element clicked by the user is a button, not a label.

### Motivation

The original term usage is just plain wrong.

### Additional details

N/A

### Related issues and pull requests

Fixes #43729.