### PR TITLE
chore: fix flaws in `{{Next}}` + `{{NextMenu}}` macros

### DIFF
--- a/files/en-us/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
+++ b/files/en-us/learn_web_development/core/frameworks_libraries/svelte_getting_started/index.md
@@ -5,7 +5,7 @@ page-type: learn-module-chapter
 sidebar: learnsidebar
 ---
 
-{{NextMenu("Learn_web_development/Core/Frameworks_libraries/Svelte_todo_list_beginning", "Learn_web_development/Core/Frameworks_libraries")}}
+{{NextMenu("Learn_web_development/Core/Frameworks_libraries/Svelte_Todo_list_beginning", "Learn_web_development/Core/Frameworks_libraries")}}
 
 In this article we'll provide a quick introduction to the [Svelte framework](https://svelte.dev/). We will see how Svelte works and what sets it apart from the rest of the frameworks and tools we've seen so far. Then we will learn how to set up our development environment, create a sample app, understand the structure of the project, and see how to run it locally and build it for production.
 
@@ -507,4 +507,4 @@ In Svelte:
 - The top-level variables of a component constitute its state.
 - Reactivity is fired just by assigning a new value to a top-level variable.
 
-{{NextMenu("Learn_web_development/Core/Frameworks_libraries/Svelte_todo_list_beginning", "Learn_web_development/Core/Frameworks_libraries")}}
+{{NextMenu("Learn_web_development/Core/Frameworks_libraries/Svelte_Todo_list_beginning", "Learn_web_development/Core/Frameworks_libraries")}}

--- a/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
+++ b/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
@@ -5,7 +5,7 @@ page-type: tutorial-chapter
 sidebar: learnsidebar
 ---
 
-{{NextMenu("Learn_web_development/Getting_started/Web_standards/The_Web_standards_model", "Learn_web_development/Getting_started/Web_standards")}}
+{{NextMenu("Learn_web_development/Getting_started/Web_standards/The_web_standards_model", "Learn_web_development/Getting_started/Web_standards")}}
 
 _How the web works_ provides a high-level description of what happens when you use a web browser to navigate to a web page, explaining the magic that goes on behind the scenes to deliver the relevant code to your computer for the browser to assemble into something you can look at.
 


### PR DESCRIPTION
### Description

Fix flaws in `{{Next}}` and `{{NextMenu}}` macros.

### Motivation

Resolve flaws reported by rari.

### Additional details

Ran `cargo run -- content fix-flaws --content` with rari from https://github.com/mdn/rari/pull/619, which adds these macros to the list of fixable templates.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.
