### PR TITLE
Document RTCIdentityAssertion idp/name and RTCPeerConnection.idpLoginUrl

### DIFF
--- a/files/en-us/web/api/rtcidentityassertion/idp/index.md
+++ b/files/en-us/web/api/rtcidentityassertion/idp/index.md
@@ -1,0 +1,54 @@
+---
+title: "RTCIdentityAssertion: idp property"
+short-title: idp
+slug: Web/API/RTCIdentityAssertion/idp
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.RTCIdentityAssertion.idp
+---
+
+{{APIRef("WebRTC")}}{{SeeCompatTable}}
+
+The **`idp`** property of the {{domxref("RTCIdentityAssertion")}} interface indicates the domain name of the {{Glossary("Identity provider", "identity provider")}} (IdP) that validated the identity assertion (a verified claim of the remote peer's identity).
+
+## Value
+
+A string containing the domain name of the identity provider that validated this identity.
+
+## Examples
+
+### Displaying the identity provider domain
+
+In this example, the {{domxref("RTCPeerConnection.peerIdentity")}} promise resolves with an {{domxref("RTCIdentityAssertion")}} whose `idp` property is logged to the console.
+
+```js
+const pc = new RTCPeerConnection();
+
+// …
+
+async function getIdentityProvider() {
+  try {
+    const identity = await pc.peerIdentity;
+    console.log(`Identity provider: ${identity.idp}`);
+  } catch (err) {
+    console.error("Failed to get peer identity:", err);
+  }
+}
+
+getIdentityProvider();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("RTCIdentityAssertion.name")}}
+- {{domxref("RTCPeerConnection.peerIdentity")}}
+- [WebRTC API](/en-US/docs/Web/API/WebRTC_API)

--- a/files/en-us/web/api/rtcidentityassertion/index.md
+++ b/files/en-us/web/api/rtcidentityassertion/index.md
@@ -14,9 +14,33 @@ The **`RTCIdentityAssertion`** interface of the [WebRTC API](/en-US/docs/Web/API
 ## Instance properties
 
 - {{domxref("RTCIdentityAssertion.idp")}} {{Experimental_Inline}}
-  - : Indicates the provider of the identity assertion.
+  - : Indicates the domain name of the {{Glossary("Identity provider", "identity provider")}} (IdP) that validated the identity.
 - {{domxref("RTCIdentityAssertion.name")}} {{Experimental_Inline}}
-  - : Indicates the name of the identity assertion provider.
+  - : Indicates the verified peer identity as a string in an email address-like format.
+
+## Examples
+
+### Accessing the remote peer's identity
+
+In this example, a function asynchronously waits for the remote peer's identity to be verified via {{domxref("RTCPeerConnection.peerIdentity")}}, then logs the {{Glossary("Identity provider", "identity provider")}} domain and the peer's identity name.
+
+```js
+const pc = new RTCPeerConnection();
+
+// …
+
+async function logPeerIdentity() {
+  try {
+    const identity = await pc.peerIdentity;
+    console.log(`IdP domain: ${identity.idp}`);
+    console.log(`Peer name: ${identity.name}`);
+  } catch (err) {
+    console.error("Could not verify peer identity:", err);
+  }
+}
+
+logPeerIdentity();
+```
 
 ## Specifications
 
@@ -25,3 +49,9 @@ The **`RTCIdentityAssertion`** interface of the [WebRTC API](/en-US/docs/Web/API
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("RTCPeerConnection.peerIdentity")}}
+- {{domxref("RTCPeerConnection.getIdentityAssertion()")}}
+- [WebRTC API](/en-US/docs/Web/API/WebRTC_API)

--- a/files/en-us/web/api/rtcidentityassertion/name/index.md
+++ b/files/en-us/web/api/rtcidentityassertion/name/index.md
@@ -1,0 +1,54 @@
+---
+title: "RTCIdentityAssertion: name property"
+short-title: name
+slug: Web/API/RTCIdentityAssertion/name
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.RTCIdentityAssertion.name
+---
+
+{{APIRef("WebRTC")}}{{SeeCompatTable}}
+
+The **`name`** property of the {{domxref("RTCIdentityAssertion")}} interface indicates the verified peer identity. It is a string in an email address-like format (for example, `user@example.com`), as defined by {{RFC(5322)}}.
+
+## Value
+
+A string containing the verified peer identity in an {{RFC(5322)}} email address-like format (for example, `alice@identity.example.com`).
+
+## Examples
+
+### Logging the verified peer identity name
+
+In this example, the {{domxref("RTCPeerConnection.peerIdentity")}} promise is awaited to obtain the identity assertion, and then the peer's verified identity name is logged.
+
+```js
+const pc = new RTCPeerConnection();
+
+// …
+
+async function logPeerName() {
+  try {
+    const identity = await pc.peerIdentity;
+    console.log(`Peer identity: ${identity.name}`);
+  } catch (err) {
+    console.error("Could not verify peer identity:", err);
+  }
+}
+
+logPeerName();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("RTCIdentityAssertion.idp")}}
+- {{domxref("RTCPeerConnection.peerIdentity")}}
+- [WebRTC API](/en-US/docs/Web/API/WebRTC_API)

--- a/files/en-us/web/api/rtcpeerconnection/idploginurl/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/idploginurl/index.md
@@ -1,0 +1,58 @@
+---
+title: "RTCPeerConnection: idpLoginUrl property"
+short-title: idpLoginUrl
+slug: Web/API/RTCPeerConnection/idpLoginUrl
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnection.idpLoginUrl
+---
+
+{{APIRef("WebRTC")}}
+
+The **`idpLoginUrl`** read-only property of the {{domxref("RTCPeerConnection")}} interface returns a string containing the URL the application can open to allow the user to log in to the {{Glossary("Identity provider", "identity provider")}} (IdP). This value is `null` until the IdP indicates that login is needed.
+
+When a call to {{domxref("RTCPeerConnection.getIdentityAssertion()")}} fails because the IdP requires user authentication, the resulting promise is rejected with an {{domxref("RTCError")}} whose {{domxref("RTCError.errorDetail", "errorDetail")}} is `"idp-need-login"`. The browser then sets this property to the login URL provided by the IdP. The application can open this URL (for example, in a popup window or iframe) to allow the user to complete the login process before retrying the identity assertion.
+
+## Value
+
+A string containing the IdP login URL, or `null` if no login is needed.
+
+## Examples
+
+### Handling an IdP login requirement
+
+In this example, the application attempts to gather an identity assertion. If the IdP rejects the attempt because the user is not authenticated, the application opens the login URL provided in `idpLoginUrl`.
+
+```js
+const pc = new RTCPeerConnection();
+pc.setIdentityProvider("login.example.com");
+
+pc.getIdentityAssertion().catch((error) => {
+  if (pc.idpLoginUrl) {
+    console.log(`IdP login required at: ${pc.idpLoginUrl}`);
+    // Open the login page in a popup window
+    const loginWindow = window.open(
+      pc.idpLoginUrl,
+      "idp-login",
+      "width=500,height=600",
+    );
+  } else {
+    console.error("Identity assertion failed:", error);
+  }
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebRTC API](/en-US/docs/Web/API/WebRTC_API)
+- {{domxref("RTCPeerConnection.peerIdentity")}}
+- {{domxref("RTCPeerConnection.getIdentityAssertion()")}}
+- {{domxref("RTCPeerConnection.setIdentityProvider()")}}
+- {{domxref("RTCIdentityAssertion")}}

--- a/files/en-us/web/api/rtcpeerconnection/idploginurl/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/idploginurl/index.md
@@ -8,9 +8,9 @@ browser-compat: api.RTCPeerConnection.idpLoginUrl
 
 {{APIRef("WebRTC")}}
 
-The **`idpLoginUrl`** read-only property of the {{domxref("RTCPeerConnection")}} interface returns a string containing the URL the application can open to allow the user to log in to the {{Glossary("Identity provider", "identity provider")}} (IdP). This value is `null` until the IdP indicates that login is needed.
+The **`idpLoginUrl`** read-only property of the {{domxref("RTCPeerConnection")}} interface returns a string containing the URL endpoint the application can open to log users in to the {{Glossary("Identity provider", "identity provider")}} (IdP). This value is `null` until the IdP indicates that login is needed.
 
-When a call to {{domxref("RTCPeerConnection.getIdentityAssertion()")}} fails because the IdP requires user authentication, the resulting promise is rejected with an {{domxref("RTCError")}} whose {{domxref("RTCError.errorDetail", "errorDetail")}} is `"idp-need-login"`. The browser then sets this property to the login URL provided by the IdP. The application can open this URL (for example, in a popup window or iframe) to allow the user to complete the login process before retrying the identity assertion.
+When a call to {{domxref("RTCPeerConnection.getIdentityAssertion()")}} fails because the IdP requires user authentication, the resulting promise is rejected with an {{domxref("RTCError")}} whose {{domxref("RTCError.errorDetail", "errorDetail")}} is `"idp-need-login"`. The browser then sets this property to the login URL provided by the IdP. The application can open this URL (for example, in a pop-up window or `<iframe>`) to allow the user to complete the login process before retrying the identity assertion.
 
 ## Value
 

--- a/files/en-us/web/api/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/index.md
@@ -39,7 +39,7 @@ _Also inherits properties from {{DOMxRef("EventTarget")}}._
     This lets you detect, for example, when collection of ICE candidates has finished.
     Possible values are: `new`, `gathering`, or `complete`.
 - {{DOMxRef("RTCPeerConnection.idpLoginUrl", "idpLoginUrl")}} {{ReadOnlyInline}}
-  - : Returns a string containing the URL to which the application can navigate to allow the user to log in to the {{Glossary("Identity provider", "identity provider")}} (IdP). May be `null` if no login is needed.
+  - : Returns a string containing the endpoint the application can navigate to, to log users in to the {{Glossary("Identity provider", "identity provider")}} (IdP). May be `null` if no login is needed.
 - {{DOMxRef("RTCPeerConnection.localDescription", "localDescription")}} {{ReadOnlyInline}}
   - : Returns an {{DOMxRef("RTCSessionDescription")}}
     describing the session for the local end of the connection.

--- a/files/en-us/web/api/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/index.md
@@ -38,6 +38,8 @@ _Also inherits properties from {{DOMxRef("EventTarget")}}._
   - : Returns a string that describes connection's ICE gathering state.
     This lets you detect, for example, when collection of ICE candidates has finished.
     Possible values are: `new`, `gathering`, or `complete`.
+- {{DOMxRef("RTCPeerConnection.idpLoginUrl", "idpLoginUrl")}} {{ReadOnlyInline}}
+  - : Returns a string containing the URL to which the application can navigate to allow the user to log in to the {{Glossary("Identity provider", "identity provider")}} (IdP). May be `null` if no login is needed.
 - {{DOMxRef("RTCPeerConnection.localDescription", "localDescription")}} {{ReadOnlyInline}}
   - : Returns an {{DOMxRef("RTCSessionDescription")}}
     describing the session for the local end of the connection.


### PR DESCRIPTION
### Description

**New pages**
- `API/RTCIdentityAssertion/idp` — `idp` property
- `API/RTCIdentityAssertion/name` — `name` property
- `API/RTCPeerConnection/idpLoginUrl` — `idpLoginUrl` property

**Updated pages**
- `API/RTCPeerConnection` — Added `idpLoginUrl` to the list of instance properties
- `API/RTCIdentityAssertion` — Fixed `name` property description, added examples and See also section

### Motivation

Document properties supported only in Firefox.

### Additional details

- BCD: [RTCIdentityAssertion.idp](https://github.com/mdn/browser-compat-data/blob/main/api/RTCIdentityAssertion.json)
- BCD: [RTCIdentityAssertion.name](https://github.com/mdn/browser-compat-data/blob/main/api/RTCIdentityAssertion.json)
- BCD: [RTCPeerConnection.idpLoginUrl](https://github.com/mdn/browser-compat-data/blob/main/api/RTCPeerConnection.json)