### PR TITLE
Support for userscripts without dev mode in Chrome

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
@@ -18,7 +18,7 @@ This API offers capabilities similar to {{WebExtAPIRef("scripting")}} but with f
 To use this API, you need the `userScripts` permission and [`host_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) for sites where you want to run scripts. However, the approach to enabling the use of this API varies between browsers:
 
 - In Firefox, `userScripts` is an [optional-only permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions#optional-only_permissions) declared in the `optional_permissions` manifest key. Your extension must check that the permission has been granted by checking the availability of the `userScripts` API namespace or using {{WebExtAPIRef("permissions.contains()")}} and, if not, request it using {{WebExtAPIRef("permissions.request()")}}.
-- in Chrome, `userScripts` is an install time requested permission declared in the [`permissions` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). However, to enable use of the API, users must [turn on the developer environment in Chrome](https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users).
+- in Chrome, `userScripts` is an install-time requested permission declared in the [`permissions` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). However, up to and including Chrome 147, users needed to [enable the developer environment in Chrome](https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users) to use the API.
 
 ## Execution worlds
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
@@ -18,7 +18,7 @@ This API offers capabilities similar to {{WebExtAPIRef("scripting")}} but with f
 To use this API, you need the `userScripts` permission and [`host_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) for sites where you want to run scripts. However, the approach to enabling the use of this API varies between browsers:
 
 - In Firefox, `userScripts` is an [optional-only permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions#optional-only_permissions) declared in the `optional_permissions` manifest key. Your extension must check that the permission has been granted by checking the availability of the `userScripts` API namespace or using {{WebExtAPIRef("permissions.contains()")}} and, if not, request it using {{WebExtAPIRef("permissions.request()")}}.
-- in Chrome, `userScripts` is an install-time requested permission declared in the [`permissions` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). However, up to and including Chrome 147, users needed to [enable the developer environment in Chrome](https://developer.chrome.com/docs/extensions/reference/api/userScripts#developer_mode_for_extension_users) to use the API.
+- in Chrome, `userScripts` is an install-time requested permission declared in the [`permissions` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). However, users must [use the `chrome://extensions/` UI to enable use of the API](https://developer.chrome.com/docs/extensions/reference/api/userScripts#enable-user-scripts-api).
 
 ## Execution worlds
 


### PR DESCRIPTION
### Description

Chrome removed the need to enable the developer tools to use the userScript API in Chrome 148.

### Related issues and pull requests

See https://issues.chromium.org/issues/390138269, which was fixed by https://chromium-review.googlesource.com/c/chromium/src/+/7692015.
<img width="1415" height="241" alt="image" src="https://github.com/user-attachments/assets/0bc332b3-74ef-4c41-acc6-5b736b6f12a4" />
