### PR TITLE
Added documentation that sibling combinators to the right of :scope never match

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_scope/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_scope/index.md
@@ -31,24 +31,6 @@ Which element(s) `:scope` matches depends on the context in which it is used:
 
 ## Examples
 
-### Sibling combinators to the right of `:scope` never match
-
-The relationship defined by `:scope` is always ancestor-to-descendant from the scope root. Because of that, putting a sibling combinator to the right of `:scope` creates a selector that can never match.
-
-```css
-:scope + p {
-  color: red;
-}
-
-:scope ~ * {
-  color: red;
-}
-```
-
-In this case, no element can be both "a sibling of `:scope`" and also inside the same scoped matching relationship, so these selectors never produce a match.
-
-In Firefox, selectors like these can trigger a warning in DevTools because they will never match.
-
 ### Using `:scope` as an alternative to `:root`
 
 This example shows that `:scope` is equivalent to `:root` when used at the root level of a stylesheet. In this case, the provided CSS colors the background of the `<html>` element orange.
@@ -160,6 +142,24 @@ document.getElementById("results").textContent = [...selected]
 The scope of `context` is the element with the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) of `context`. The selected elements are the `<div>` elements that are direct children of that context — `element-1` and `element-2` — but not their descendants.
 
 {{ EmbedLiveSample('Using :scope in JavaScript') }}
+
+### Sibling combinators to the right of `:scope` never match
+
+The relationship defined by `:scope` is always ancestor-to-descendant from the scope root. Because of that, putting a sibling combinator to the right of `:scope` creates a selector that can never match.
+
+```css
+:scope + p {
+  color: red;
+}
+
+:scope ~ * {
+  color: red;
+}
+```
+
+In this case, no element can be both "a sibling of `:scope`" and also inside the same scoped matching relationship, so these selectors never produce a match.
+
+In Firefox, selectors like these can trigger a warning in DevTools because they will never match.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/selectors/_colon_scope/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_scope/index.md
@@ -31,6 +31,24 @@ Which element(s) `:scope` matches depends on the context in which it is used:
 
 ## Examples
 
+### Sibling combinators to the right of `:scope` never match
+
+The relationship defined by `:scope` is always ancestor-to-descendant from the scope root. Because of that, putting a sibling combinator to the right of `:scope` creates a selector that can never match.
+
+```css
+:scope + p {
+  color: red;
+}
+
+:scope ~ * {
+  color: red;
+}
+```
+
+In this case, no element can be both "a sibling of `:scope`" and also inside the same scoped matching relationship, so these selectors never produce a match.
+
+In Firefox, selectors like these can trigger a warning in DevTools because they will never match.
+
 ### Using `:scope` as an alternative to `:root`
 
 This example shows that `:scope` is equivalent to `:root` when used at the root level of a stylesheet. In this case, the provided CSS colors the background of the `<html>` element orange.

--- a/files/en-us/web/css/reference/selectors/_colon_scope/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_scope/index.md
@@ -157,7 +157,7 @@ The relationship defined by `:scope` is always ancestor-to-descendant from the s
 }
 ```
 
-Selectors never match may trigger a warning in browser DevTools.
+Selectors that never match may trigger a warning in browser DevTools.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/selectors/_colon_scope/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_scope/index.md
@@ -147,7 +147,7 @@ The scope of `context` is the element with the [`id`](/en-US/docs/Web/HTML/Refer
 
 The relationship defined by `:scope` is always ancestor-to-descendant from the scope root. Because of that, putting a sibling combinator to the right of `:scope` creates a selector that can never match, because no element can both be within the selector scope and also be a sibling of `:scope`.
 
-```css
+```css example-bad
 :scope + p {
   color: red;
 }

--- a/files/en-us/web/css/reference/selectors/_colon_scope/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_scope/index.md
@@ -145,7 +145,7 @@ The scope of `context` is the element with the [`id`](/en-US/docs/Web/HTML/Refer
 
 ### Sibling combinators to the right of `:scope` never match
 
-The relationship defined by `:scope` is always ancestor-to-descendant from the scope root. Because of that, putting a sibling combinator to the right of `:scope` creates a selector that can never match.
+The relationship defined by `:scope` is always ancestor-to-descendant from the scope root. Because of that, putting a sibling combinator to the right of `:scope` creates a selector that can never match, because no element can both be within the selector scope and also be a sibling of `:scope`.
 
 ```css
 :scope + p {
@@ -157,9 +157,7 @@ The relationship defined by `:scope` is always ancestor-to-descendant from the s
 }
 ```
 
-In this case, no element can be both "a sibling of `:scope`" and also inside the same scoped matching relationship, so these selectors never produce a match.
-
-In Firefox, selectors like these can trigger a warning in DevTools because they will never match.
+Selectors never match may trigger a warning in browser DevTools.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Added a note section that describes that sibling combinators to the right of :scope never match.
Explicit examples showing :scope + * and :scope ~ * as selectors that never match with firefox generated warnings.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
It updates the documentation and makes the reader to understand proper working of scope without bugs.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" --> Fixes #42364
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
