### PR TITLE
Remove mentions of AppCache from Apache guide

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/apache_configuration_htaccess/index.md
@@ -174,7 +174,6 @@ Servers should use `text/javascript` for JavaScript resources as indicated in th
   # Manifest files
     AddType application/manifest+json     webmanifest
     AddType application/x-web-app-manifest+json         webapp
-    AddType text/cache-manifest           appcache
   # Media files
     AddType audio/mp4                     f4a f4b m4a
     AddType audio/ogg                     oga ogg opus
@@ -237,7 +236,7 @@ Serve the following file types with the `charset` parameter set to `UTF-8` using
 
 ```apacheconf
 <IfModule mod_mime.c>
-  AddCharset utf-8 .appcache \
+  AddCharset utf-8 \
     .bbaw \
     .css \
     .htc \


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

A while ago MDN removed majority of documentation about obsolete AppCache, but left behind two menions in Apache config guide. This commit cleans them up.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Consistency.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

N/A

### Related issues and pull requests

N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
