### PR TITLE
Improve replace() try-it example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -12,18 +12,16 @@ The **`replace()`** method of {{jsxref("String")}} values returns a new string w
 {{InteractiveExample("JavaScript Demo: String.prototype.replace()")}}
 
 ```js interactive-example
-const paragraph = "The quick brown fox jumps over the lazy fox.";
+const paragraph = "This dog's name is just Dog! Yes, that is the name.";
 
-console.log(paragraph.replace("fox", "cat"));
-// Expected output: "The quick brown cat jumps over the lazy fox."
+console.log(paragraph.replace("name", "nickname"));
+// Expected output: "This dog's nickname is just Dog! Yes, that is the name."
 
-const regex = /FOX/i;
-console.log(paragraph.replace(regex, "cat"));
-// Expected output: "The quick brown cat jumps over the lazy fox."
+console.log(paragraph.replace(/\bis\b/, "was"));
+// Expected output: "This dog's name was just Dog! Yes, that is the name."
 
-const globalRegex = /fox/gi;
-console.log(paragraph.replace(globalRegex, "cat"));
-// Expected output: "The quick brown cat jumps over the lazy cat."
+console.log(paragraph.replace(/\bis\b/g, "was"));
+// Expected output: "This dog's name was just Dog! Yes, that was the name."
 ```
 
 ## Syntax

--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -12,14 +12,18 @@ The **`replace()`** method of {{jsxref("String")}} values returns a new string w
 {{InteractiveExample("JavaScript Demo: String.prototype.replace()")}}
 
 ```js interactive-example
-const paragraph = "I think Ruth's dog is cuter than your dog!";
+const paragraph = "The quick brown fox jumps over the lazy fox.";
 
-console.log(paragraph.replace("Ruth's", "my"));
-// Expected output: "I think my dog is cuter than your dog!"
+console.log(paragraph.replace("fox", "cat"));
+// Expected output: "The quick brown cat jumps over the lazy fox."
 
-const regex = /dog/i;
-console.log(paragraph.replace(regex, "ferret"));
-// Expected output: "I think Ruth's ferret is cuter than your dog!"
+const regex = /FOX/i;
+console.log(paragraph.replace(regex, "cat"));
+// Expected output: "The quick brown cat jumps over the lazy fox."
+
+const globalRegex = /fox/gi;
+console.log(paragraph.replace(globalRegex, "cat"));
+// Expected output: "The quick brown cat jumps over the lazy cat."
 ```
 
 ## Syntax

--- a/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replaceall/index.md
@@ -12,15 +12,13 @@ The **`replaceAll()`** method of {{jsxref("String")}} values returns a new strin
 {{InteractiveExample("JavaScript Demo: String.prototype.replaceAll()")}}
 
 ```js interactive-example
-const paragraph = "I think Ruth's dog is cuter than your dog!";
+const paragraph = "This dog's name is just Dog! Yes, that is the name.";
 
-console.log(paragraph.replaceAll("dog", "monkey"));
-// Expected output: "I think Ruth's monkey is cuter than your monkey!"
+console.log(paragraph.replaceAll("name", "nickname"));
+// Expected output: "This dog's nickname is just Dog! Yes, that is the nickname."
 
-// Global flag required when calling replaceAll with regex
-const regex = /dog/gi;
-console.log(paragraph.replaceAll(regex, "ferret"));
-// Expected output: "I think Ruth's ferret is cuter than your ferret!"
+console.log(paragraph.replaceAll(/\bis\b/g, "was"));
+// Expected output: "This dog's name was just Dog! Yes, that was the name."
 ```
 
 ## Syntax


### PR DESCRIPTION
### Description

Updates the `Try it` example for `String.prototype.replace()` so it more clearly shows the difference between string replacement, case-insensitive regex replacement, and global regex replacement.

### Motivation

The previous example did not clearly demonstrate that when `pattern` is a string, only the first occurrence is replaced. It also did not make the effect of the regex `i` flag very clear.

### Additional details

The new example uses a more natural sentence and shows three distinct cases:
- string replacement, which replaces only the first matching substring
- regex replacement with `i`, which performs a single case-insensitive match
- regex replacement with `gi`, which replaces all matches

### Related issues and pull requests

Fixes #43720
