### PR TITLE
fix example to better show replace only affects first match

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -12,10 +12,10 @@ The **`replace()`** method of {{jsxref("String")}} values returns a new string w
 {{InteractiveExample("JavaScript Demo: String.prototype.replace()")}}
 
 ```js interactive-example
-const paragraph = "I think Ruth's dog is cuter than your dog!";
+const paragraph = "I think Ruth's dog is cuter than Ruth's cat!";
 
 console.log(paragraph.replace("Ruth's", "my"));
-// Expected output: "I think my dog is cuter than your dog!"
+// Expected output: "I think my dog is cuter than Ruth's cat!"
 
 const regex = /dog/i;
 console.log(paragraph.replace(regex, "ferret"));


### PR DESCRIPTION
the previous example only had one "Ruth's" so it didnt really show the behaviour clearly

added another occurrence so its obvious only the first one gets replaced