### PR TITLE
docs: fix typo in AbortSignal console error message

### DIFF
--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -135,7 +135,7 @@ try {
     console.error("Timeout: It took more than 5 seconds to get the result!");
   } else if (err.name === "AbortError") {
     console.error(
-      "Fetch aborted by user action (browser stop button, closing tab, etc.",
+      "Fetch aborted by user action (browser stop button, closing tab, etc.)",
     );
   } else {
     // A network error, or some other problem.


### PR DESCRIPTION
### Description

Fixed a missing `closing parenthesis` in the console.error message within the `AbortSignal example code.`

### Motivation

To improve the accuracy and readability of the example code.