### PR TITLE
FF150 Expr Feature - multiple JS import maps

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -398,7 +398,7 @@ The [`@container`](/en-US/docs/Web/CSS/Reference/At-rules/@container) CSS at-rul
 ### Multiple import maps
 
 Support for [multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps).
-These are easier to use and more robust, because developers no longer need to know all their module mappings up front, and declare them in a single import map before loading any modules.
+These give developers more flexibility when structuring and loading JavaScript modules, because they no longer need to know all their module mappings up front, and declare them in a single import map loading any modules.
 ([Firefox bug 1916277](https://bugzil.la/1916277)).
 
 | Release channel   | Version added | Enabled by default? |

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -395,7 +395,21 @@ The [`@container`](/en-US/docs/Web/CSS/Reference/At-rules/@container) CSS at-rul
 
 ## JavaScript
 
-**No experimental features in this release cycle.**
+### Multiple import maps
+
+Support for [multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps).
+These are easier to use and more robust, because developers no longer need to know all their module mappings up front, and declare them in a single import map before loading any modules.
+([Firefox bug 1916277](https://bugzil.la/1916277)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 150           | No                  |
+| Developer Edition | 150           | No                  |
+| Beta              | 150           | No                  |
+| Release           | 150           | No                  |
+
+- `dom.multiple_import_maps.enabled`
+  - : Set to `true` to enable.
 
 ## APIs
 

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -106,3 +106,8 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
   The {{domxref("CustomElementRegistry","customElementRegistry")}} property is supported on {{domxref("Document")}}, {{domxref("Element")}}, and {{domxref("ShadowRoot")}}.
   This allows the definition of [scoped custom element registries](/en-US/docs/Web/API/Web_components/Using_custom_elements#scoped_custom_element_registries).
   ([Firefox bug 2018900](https://bugzil.la/2018900)).
+
+- **Multiple import maps**: `dom.multiple_import_maps.enabled`
+
+  [Multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps) support means that developers no longer need to know all their module mappings up front and declare them in a single import map before loading any modules.
+  ([Firefox bug 1916277](https://bugzil.la/1916277)).

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -109,5 +109,5 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **Multiple import maps**: `dom.multiple_import_maps.enabled`
 
-  [Multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps) support means that developers no longer need to know all their module mappings up front and declare them in a single import map before loading any modules.
+  [Multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps) give developers more flexibility when structuring and loading JavaScript modules.
   ([Firefox bug 1916277](https://bugzil.la/1916277)).

--- a/files/en-us/web/html/reference/elements/script/type/importmap/index.md
+++ b/files/en-us/web/html/reference/elements/script/type/importmap/index.md
@@ -166,6 +166,8 @@ For example, the map below defines integrity metadata for the `square.js` module
 
 ### Merging multiple import maps
 
+Supporting browsers can declare one or more import maps anywhere in the document, provided they are defined before any module that depends on them is loaded (earlier specifications allowed only a single declaration that must be made before any module is loaded).
+
 Internally, browsers maintain a single global import map representation. When multiple import maps are included in a document, their contents are merged into the global import map when they are registered.
 
 For example, consider the following two import maps:

--- a/files/en-us/web/html/reference/elements/script/type/importmap/index.md
+++ b/files/en-us/web/html/reference/elements/script/type/importmap/index.md
@@ -166,7 +166,7 @@ For example, the map below defines integrity metadata for the `square.js` module
 
 ### Merging multiple import maps
 
-Supporting browsers can declare one or more import maps anywhere in the document, provided they are defined before any module that depends on them is loaded (earlier specifications allowed only a single declaration that must be made before any module is loaded).
+Supporting browsers can declare one or more import maps anywhere in the document, provided they are defined before any module that depends on them is loaded (some [browser versions](#browser_compatibility) allow only a single import map declaration, which must appear before any module is loaded).
 
 Internally, browsers maintain a single global import map representation. When multiple import maps are included in a document, their contents are merged into the global import map when they are registered.
 


### PR DESCRIPTION
FF150 adds support for [multiple import maps](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps) behind a pref (`dom.multiple_import_maps.enabled`). This adds an experimental feature and release note entry.

It also adds a minor clarification to the JS doc.

Related docs work can be tracked in #43551