### PR TITLE
Document TimeEvent: detail, property, initTimeEvent()

### DIFF
--- a/files/en-us/web/api/timeevent/detail/index.md
+++ b/files/en-us/web/api/timeevent/detail/index.md
@@ -1,0 +1,31 @@
+---
+title: "TimeEvent: detail property"
+short-title: detail
+slug: Web/API/TimeEvent/detail
+page-type: web-api-instance-property
+browser-compat: api.TimeEvent.detail
+---
+
+{{APIRef("SVG")}}
+
+The **`TimeEvent.detail`** read-only property provides contextual information about the event, depending on the event type.
+
+For `repeatEvent` events, `detail` contains the current repeat iteration as a non-negative integer. Because the event is not raised for the first iteration, the value will always be 1 or greater.
+
+For `beginEvent` and `endEvent` events, `detail` is always `0`.
+
+## Value
+
+A `long`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("TimeEvent")}}

--- a/files/en-us/web/api/timeevent/index.md
+++ b/files/en-us/web/api/timeevent/index.md
@@ -21,7 +21,7 @@ The **`TimeEvent`** interface, a part of [SVG SMIL](/en-US/docs/Web/SVG/Guides/S
 ## Instance methods
 
 - {{domxref("TimeEvent.initTimeEvent()")}}
-  - : Used to initialize the value of a TimeEvent created through the DocumentEvent interface. This method may only be called before the TimeEvent has been dispatched via the dispatchEvent method, though it may be called multiple times during that phase if necessary.
+  - : Initializes the value of a {{domxref("TimeEvent")}} created using {{domxref("Document.createEvent()")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/timeevent/inittimeevent/index.md
+++ b/files/en-us/web/api/timeevent/inittimeevent/index.md
@@ -1,0 +1,56 @@
+---
+title: "TimeEvent: initTimeEvent() method"
+short-title: initTimeEvent()
+slug: Web/API/TimeEvent/initTimeEvent
+page-type: web-api-instance-method
+browser-compat: api.TimeEvent.initTimeEvent
+---
+
+{{APIRef("SVG")}}
+
+The **`TimeEvent.initTimeEvent()`** method initializes the value of a {{domxref("TimeEvent")}} created using {{domxref("Document.createEvent()")}}.
+
+This method may only be called before the event has been dispatched via {{domxref("EventTarget.dispatchEvent()")}}. If called multiple times, the final call takes precedence.
+
+## Syntax
+
+```js-nolint
+initTimeEvent(type, view, detail)
+```
+
+### Parameters
+
+- `type`
+  - : A string specifying the event type.
+- `view` {{optional_inline}}
+  - : The {{domxref("Window")}} from which the event was generated, or `null`. Defaults to `null`.
+- `detail` {{optional_inline}}
+  - : A `long` providing contextual information about the event. Defaults to `0`.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+### Dispatching a repeatEvent
+
+```js
+const evt = document.createEvent("TimeEvent");
+evt.initTimeEvent("repeatEvent", window, 2);
+svgElement.dispatchEvent(evt);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("TimeEvent")}}
+- {{domxref("Document.createEvent()")}}
+- {{domxref("EventTarget.dispatchEvent()")}}

--- a/files/en-us/web/api/timeevent/inittimeevent/index.md
+++ b/files/en-us/web/api/timeevent/inittimeevent/index.md
@@ -12,9 +12,14 @@ The **`TimeEvent.initTimeEvent()`** method initializes the value of a {{domxref(
 
 This method may only be called before the event has been dispatched via {{domxref("EventTarget.dispatchEvent()")}}. If called multiple times, the final call takes precedence.
 
+> [!NOTE]
+> {{domxref("Document.createEvent()")}} is deprecated in favor of event constructors, but `TimeEvent` has no dedicated constructor. {{domxref("CustomEvent")}} is not an equivalent replacement, as it does not produce a `TimeEvent` instance with the interface's `view` and `detail` attributes.
+
 ## Syntax
 
 ```js-nolint
+initTimeEvent(type)
+initTimeEvent(type, view)
 initTimeEvent(type, view, detail)
 ```
 
@@ -23,7 +28,7 @@ initTimeEvent(type, view, detail)
 - `type`
   - : A string specifying the event type.
 - `view` {{optional_inline}}
-  - : The {{domxref("Window")}} from which the event was generated, or `null`. Defaults to `null`.
+  - : The {{domxref("Window")}} from which the event was generated. If `null` or omitted, the {{domxref("TimeEvent.view")}} attribute of the event will be `null`. Defaults to `null`.
 - `detail` {{optional_inline}}
   - : A `long` providing contextual information about the event. Defaults to `0`.
 

--- a/files/en-us/web/api/timeevent/inittimeevent/index.md
+++ b/files/en-us/web/api/timeevent/inittimeevent/index.md
@@ -13,7 +13,7 @@ The **`TimeEvent.initTimeEvent()`** method initializes the value of a {{domxref(
 This method may only be called before the event has been dispatched via {{domxref("EventTarget.dispatchEvent()")}}. If called multiple times, the final call takes precedence.
 
 > [!NOTE]
-> {{domxref("Document.createEvent()")}} is deprecated in favor of event constructors, but `TimeEvent` has no dedicated constructor. {{domxref("CustomEvent")}} is not an equivalent replacement, as it does not produce a `TimeEvent` instance with the interface's `view` and `detail` attributes.
+> {{domxref("Document.createEvent()")}} is deprecated in favor of event constructors, but `TimeEvent` has no dedicated constructor. {{domxref("CustomEvent")}} is not a valid replacement, as it does not produce a `TimeEvent` instance with the interface's `view` and `detail` attributes.
 
 ## Syntax
 

--- a/files/en-us/web/api/timeevent/view/index.md
+++ b/files/en-us/web/api/timeevent/view/index.md
@@ -1,0 +1,27 @@
+---
+title: "TimeEvent: view property"
+short-title: view
+slug: Web/API/TimeEvent/view
+page-type: web-api-instance-property
+browser-compat: api.TimeEvent.view
+---
+
+{{APIRef("SVG")}}
+
+The **`TimeEvent.view`** read-only property identifies the {{glossary("WindowProxy")}} from which the event was generated.
+
+## Value
+
+A {{glossary("WindowProxy")}} object, or `null`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("TimeEvent")}}

--- a/files/en-us/web/api/timeevent/view/index.md
+++ b/files/en-us/web/api/timeevent/view/index.md
@@ -12,7 +12,7 @@ The **`TimeEvent.view`** read-only property identifies the {{glossary("WindowPro
 
 ## Value
 
-A {{glossary("WindowProxy")}} object, or `null`.
+A {{glossary("WindowProxy")}} object identifying the window that generated the event, or `null` if no window is associated.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

**New pages**

- `API/TimeEvent/detail` — `detail` property
- `API/TimeEvent/view` — `view` property
- `API/TimeEvent/initTimeEvent` — `initTimeEvent()` method

### Motivation

Document members of the `TimeEvent` interface supported since Firefox 4.

### Additional details

- [BCD: TimeEvent](https://github.com/mdn/browser-compat-data/blob/main/api/TimeEvent.json)