### PR TITLE
Document WebTransportSendStream getWriter()

### DIFF
--- a/files/en-us/web/api/webtransportsendstream/getwriter/index.md
+++ b/files/en-us/web/api/webtransportsendstream/getwriter/index.md
@@ -1,0 +1,63 @@
+---
+title: "WebTransportSendStream: getWriter() method"
+short-title: getWriter()
+slug: Web/API/WebTransportSendStream/getWriter
+page-type: web-api-instance-method
+browser-compat: api.WebTransportSendStream.getWriter
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`getWriter()`** method of the {{domxref("WebTransportSendStream")}} interface returns a new `WebTransportWriter` object and locks the stream to that instance. While the stream is locked, no other writer can be acquired until this one is released.
+
+`WebTransportWriter` is a subclass of {{domxref("WritableStreamDefaultWriter")}} that additionally provides the `atomicWrite()` and `commit()` methods.
+
+## Syntax
+
+```js-nolint
+getWriter()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A `WebTransportWriter` object instance.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : The stream is already locked to another writer.
+
+## Examples
+
+The following example shows how to open a unidirectional stream over a {{domxref("WebTransport")}} connection and use `getWriter()` to write chunks of data to it.
+
+```js
+const transport = new WebTransport("https://example.com/webtransport");
+await transport.ready;
+
+const stream = await transport.createUnidirectionalStream();
+const writer = stream.getWriter();
+
+const encoder = new TextEncoder();
+await writer.write(encoder.encode("Hello"));
+await writer.write(encoder.encode(", world!"));
+await writer.close();
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("WritableStream.getWriter()")}}
+- {{domxref("WritableStreamDefaultWriter")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportsendstream/index.md
+++ b/files/en-us/web/api/webtransportsendstream/index.md
@@ -25,17 +25,17 @@ When a bidirectional stream is initiated by the remote end, an object of this ty
 
 _Also inherits properties from its parent interface, {{domxref("WritableStream")}}._
 
-- {{domxref("WebTransportSendStream.getStats()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with statistics related to this stream.
+- {{domxref("WebTransportSendStream.sendOrder")}}
+  - : Indicates the send priority of this stream relative to other streams for which the value has been set.
 
 ## Instance methods
 
 _Also inherits methods from its parent interface, {{domxref("WritableStream")}}._
 
+- {{domxref("WebTransportSendStream.getStats()")}}
+  - : Returns a {{jsxref("Promise")}} that resolves with statistics related to this stream.
 - {{domxref("WebTransportSendStream.getWriter()")}}
   - : Returns a new `WebTransportWriter` object and locks the stream to it. While the stream is locked, no other writer can be acquired until this one is released.
-- {{domxref("WebTransportSendStream.sendOrder")}}
-  - : Indicates the send priority of this stream relative to other streams for which the value has been set.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportsendstream/index.md
+++ b/files/en-us/web/api/webtransportsendstream/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.WebTransportSendStream
 ---
 
-{{APIRef("WebTransport API")}}{{securecontext_header}} {{AvailableInWorkers}}
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
 The `WebTransportSendStream` interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} is a specialized {{domxref("WritableStream")}} that is used to send outbound data in both unidirectional or bidirectional {{domxref("WebTransport")}} streams.
 
@@ -32,8 +32,8 @@ _Also inherits properties from its parent interface, {{domxref("WritableStream")
 
 _Also inherits methods from its parent interface, {{domxref("WritableStream")}}._
 
-<!-- WebTransportSendStream.sendGroup not implemented in any browser -->
-
+- {{domxref("WebTransportSendStream.getWriter()")}}
+  - : Returns a new `WebTransportWriter` object and locks the stream to it. While the stream is locked, no other writer can be acquired until this one is released.
 - {{domxref("WebTransportSendStream.sendOrder")}}
   - : Indicates the send priority of this stream relative to other streams for which the value has been set.
 


### PR DESCRIPTION
### Description

**New pages**

- `API/WebTransportSendStream/getWriter` — `getWriter()` method

**Updated pages**

- `API/WebTransportSendStream` — Added `getWriter()` to the list of instance methods

### Motivation

Document `WebTransportSendStream.getWriter()` supported since Firefox 114 and Safari 26.4.

### Additional details

- [BCD: WebTransportSendStream.getWriter](https://github.com/mdn/browser-compat-data/blob/main/api/WebTransportSendStream.json#L90)