### PR TITLE
docs: change inline style example to avoid confusion

### DIFF
--- a/files/en-us/web/http/reference/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/style-src-attr/index.md
@@ -84,7 +84,7 @@ document.querySelector("div").style.cssText = "display:inline;";
 Style properties that are set directly on the element's {{domxref("HTMLElement/style", "style")}} property will not be blocked, allowing users to safely manipulate styles via JavaScript:
 
 ```js
-document.querySelector("div").style.display = "none";
+document.querySelector("div").style.display = "inline";
 ```
 
 Note that using JavaScript might independently be blocked using the {{CSP("script-src")}} CSP directive.

--- a/files/en-us/web/http/reference/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/style-src-attr/index.md
@@ -71,14 +71,14 @@ Content-Security-Policy: style-src-attr 'none'
 …the inline style applied to the element below will not be applied:
 
 ```html
-<div style="display:none">Foo</div>
+<div style="display:inline">Foo</div>
 ```
 
 The policy would also block any styles applied in JavaScript by setting the `style` attribute directly, or by setting {{domxref("CSSStyleDeclaration.cssText", "cssText")}}:
 
 ```js
-document.querySelector("div").setAttribute("style", "display:none;");
-document.querySelector("div").style.cssText = "display:none;";
+document.querySelector("div").setAttribute("style", "display:inline;");
+document.querySelector("div").style.cssText = "display:inline;";
 ```
 
 Style properties that are set directly on the element's {{domxref("HTMLElement/style", "style")}} property will not be blocked, allowing users to safely manipulate styles via JavaScript:

--- a/files/en-us/web/http/reference/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/style-src-attr/index.md
@@ -71,14 +71,14 @@ Content-Security-Policy: style-src-attr 'none'
 …the inline style applied to the element below will not be applied:
 
 ```html
-<div style="display:inline">Foo</div>
+<div style="display: inline">Foo</div>
 ```
 
 The policy would also block any styles applied in JavaScript by setting the `style` attribute directly, or by setting {{domxref("CSSStyleDeclaration.cssText", "cssText")}}:
 
 ```js
-document.querySelector("div").setAttribute("style", "display:inline;");
-document.querySelector("div").style.cssText = "display:inline;";
+document.querySelector("div").setAttribute("style", "display: inline");
+document.querySelector("div").style.cssText = "display: inline";
 ```
 
 Style properties that are set directly on the element's {{domxref("HTMLElement/style", "style")}} property will not be blocked, allowing users to safely manipulate styles via JavaScript:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

### Description

On [Content-Security-Policy: style-src-attr directive > Examples > Violation cases](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/style-src-attr#violation_cases), change the style attribute value to something that does not use a keyword.

### Motivation

I intend to avoid possible confusion. A user might think `style-src-attr 'none'` blocks `<div style="display:none">Foo</div>` because it has "none" in the attribute value. (At least one user was confused… me.)

### Additional details

N/A

### Related issues and pull requests

N/A