### PR TITLE
FF150 Relnote: Devtools response tab specific message on redirect

### DIFF
--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -16,7 +16,10 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Changes for web developers
 
-<!-- ### Developer Tools -->
+### Developer Tools
+
+- A specific message is now displayed in the [_Response tab_ of the Network pane](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/request_details/index.html#response-tab) to indicate why there is no response data when a request has been redirected.
+  ([Firefox bug 2016679](https://bugzil.la/2016679)).
 
 ### HTML
 


### PR DESCRIPTION
FF150 modifies devtools Network panel such that the response tab has a specific message if the response is empty due to a redirect in https://bugzilla.mozilla.org/show_bug.cgi?id=2016679. This adds a release note.

Related docs work can be tracked in #43554