### PR TITLE
Issue 21826: Restore browser-extension-template recommendation

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -230,4 +230,8 @@ When approaching a cross-platform extension development, the differences between
 
 The bulk of your cross-platform work is likely to focus on handling variations among the API features supported by the main browsers. You may also need to account for differences between the content script and background script implementations. Creating your `manifest.json` files should be relatively straightforward and something you can do manually. You then need to account for the variations in the processes for submitting to each extension store.
 
+> [!CALLOUT]
+>
+> You can use [browser-extension-template](https://github.com/fregante/browser-extension-template) to quickly set up a working project for building and publishing a browser extension.
+
 Following the advice in this article, you should be able to create an extension that works well on all of the four main browsers, enabling you to deliver your extension features to more people.


### PR DESCRIPTION
### Description

The recommendation for using [browser-extension-template](https://github.com/fregante/browser-extension-template) to set up an extension project was removed from the [Build a cross-browser extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension) page in October 2022. At that time, the template was updated to Manifest V3, but the how-to page has not been updated. 

The how-to page has been updated to cover Manifest V3, so the recommendation can be restored.

### Related issues and pull requests

Fixes #121826