### PR TITLE
Element.ariaLabelledByElements/areia-labelledby - clarify label generic elements

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-labelledby/index.md
@@ -19,7 +19,7 @@ All interactive elements must have an accessible name. `aria-labelledby` can be 
 
 If there is no content that can be referenced to create an accessible name, the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) attribute should be used instead.
 
-The purpose of `aria-labelledby` is the same as that of `aria-label`. It provides the user with a recognizable, accessible name for an interactive element. If an element has both attributes set, `aria-labelledby` will be used. `aria-labelledby` takes precedence over all other methods of providing an accessible name, including `aria-label`, {{HTMLElement('label')}}, and the element's inner text.
+The purpose of `aria-labelledby` is the same as that of `aria-label`. It provides the user with a recognizable, accessible name for an interactive element. If an element has both attributes set, `aria-labelledby` will be used. `aria-labelledby` also takes precedence over most other methods of providing an accessible name, such as {{HTMLElement('label')}}, and the element's inner text. Note that {{domxref("Element.ariaLabelledByElements")}} has the highest precedence for setting the ARIA label.
 
 The `aria-labelledby` and [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby) attributes both reference other elements to calculate text alternatives. `aria-labelledby` should reference brief text that provides the element with an accessible name. `aria-describedby` is used to reference longer content that provides a description. If there is no element in the DOM that provides a brief label appropriate for an accessible name for an interactive element, use `aria-label` to define the accessible name for an interactive element.
 
@@ -37,7 +37,11 @@ The following example uses `aria-labelledby` to provide an accessible name for a
 <span id="tac">I agree to the Terms and Conditions.</span>
 ```
 
-Note that while using `aria-labelledby` is similar in this situation to using an HTML {{HTMLElement('label')}} element with the `for` attribute, there are some very important differences. The `aria-labelledby` attribute only defines the accessible name. It doesn't provide any of `<label>`'s other functionality, such as making clicking on the labeling element activate the input it is associated with. That has to be added back in with JavaScript.
+> [!NOTE]
+> {{htmlelement("span")}} elements have the [`generic` role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role) by default, and can't use `aria-labelledby` unless they also specify a role that can provide an accessible name.
+> Here we do that with `role="checkbox"`.
+
+While using `aria-labelledby` is similar in this situation to using an HTML {{HTMLElement('label')}} element with the `for` attribute, there are some very important differences. The `aria-labelledby` attribute only defines the accessible name. It doesn't provide any of `<label>`'s other functionality, such as making clicking on the labeling element activate the input it is associated with. That has to be added back in with JavaScript.
 
 Fortunately, the HTML {{HTMLElement('input')}} with `type="checkbox"` works with native `<label>`. When feasible, use the following:
 

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -26,7 +26,7 @@ When written, the assigned array is copied: subsequent changes to the array do n
 The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.
 Unlike `aria-labelledby`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attribute.
 
-For example, this might be used to label a container element, such as a {{htmlelement("div")}} or {{htmlelement("span")}} (provided it has been given an [appropriate ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby#associated_roles)), or a grouping of elements, such as an image with a slider that can be used to change its opacity.
+For example, this might be used to label a container element, such as a {{htmlelement("div")}} or {{htmlelement("span")}} (provided it has been given an [appropriate ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby#associated_roles)).
 The property takes precedence over other mechanisms for providing an accessible name for elements, and may therefore also be used to provide a name for elements that would normally get it from their inner content or from an associated element such as a label.
 
 The property reflects the element's [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -10,11 +10,8 @@ browser-compat: api.Element.ariaLabelledByElements
 
 The **`ariaLabelledByElements`** property of the {{domxref("Element")}} interface is an array containing the element (or elements) that provide an accessible name for the element it is applied to.
 
-The property is primarily intended to provide a label for elements that don't have a standard method for defining their accessible name.
-For example, this might be used to name a generic container element, such as a {{htmlelement("div")}} or {{htmlelement("span")}}, or a grouping of elements, such as an image with a slider that can be used to change its opacity.
-The property takes precedence over other mechanisms for providing an accessible name for elements, and may therefore also be used to provide a name for elements that would normally get it from their inner content or from an associated element such as a label.
-
-The [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) topic contains additional information about how the attribute and property should be used.
+The property reflects [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) (in some circumstances) and is similarly intended to provide a label for elements that don't have a standard method for defining their accessible name.
+The main difference is that the property can be used to provide label text from elements that don't have an `id`, and takes precedence over all other methods of setting the ARIA label.
 
 ## Value
 
@@ -29,9 +26,14 @@ When written, the assigned array is copied: subsequent changes to the array do n
 The property is a flexible alternative to using the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute to set the accessible name.
 Unlike `aria-labelledby`, the elements assigned to this property do not have to have an [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attribute.
 
+For example, this might be used to label a container element, such as a {{htmlelement("div")}} or {{htmlelement("span")}} (provided it has been given an [appropriate ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby#associated_roles)), or a grouping of elements, such as an image with a slider that can be used to change its opacity.
+The property takes precedence over other mechanisms for providing an accessible name for elements, and may therefore also be used to provide a name for elements that would normally get it from their inner content or from an associated element such as a label.
+
 The property reflects the element's [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) attribute when it is defined, but only for listed reference `id` values that match valid in-scope elements.
 If the property is set, then the corresponding attribute is cleared.
 For more information about reflected element references and scope see [Reflected element references](/en-US/docs/Web/API/Document_Object_Model/Reflected_attributes#reflected_element_references) in the _Reflected attributes_ guide.
+
+See [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) for additional information about how the attribute and property should be used.
 
 ## Examples
 


### PR DESCRIPTION
This tidies `Element.ariaLabelledByElements` and `aria-labelledby` to make it clear that you can't apply them to div/span elements unless they have an appropriate ARIA role set (their role is "generic" by default. I also tidied `Element.ariaLabelledByElements` to move more information into the description, and just keep the most essential info in the top section.

Fixes #43765