### PR TITLE
Fixed typo in getDay() range - was 1-7 now 0-6

### DIFF
--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -147,7 +147,7 @@ function checkDeadlines() {
 }
 ```
 
-First we grab the current date and time by creating a blank `Date` object. The `Date` object has a number of methods to extract various parts of the date and time inside it. Here we fetch the current minutes (gives an easy numerical value), hours (gives an easy numerical value), day of the month (`getDate()` is needed for this, as `getDay()` returns the day of the week, 1-7), month (returns a number from 0-11, see below), and year (`getFullYear()` is needed; `getYear()` is deprecated, and returns a weird value that is not much use to anyone!)
+First we grab the current date and time by creating a blank `Date` object. The `Date` object has a number of methods to extract various parts of the date and time inside it. Here we fetch the current minutes (gives an easy numerical value), hours (gives an easy numerical value), day of the month (`getDate()` is needed for this, as `getDay()` returns the day of the week, 0-6), month (returns a number from 0-11, see below), and year (`getFullYear()` is needed; `getYear()` is deprecated, and returns a weird value that is not much use to anyone!)
 
 ```js
 function checkDeadlines() {


### PR DESCRIPTION
### Description

getDay() range incorrectly mentioned as one-indexed (1-7) instead of zero-indexed (0-6)

### Motivation

Fixing typo/incorrect content

### Additional details
Change suggested based on getDay() docs:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay#:~:text=An%20integer%2C%20between%200%20and%206%2C%20representing%20the%20day%20of%20the%20week%20for%20the%20given%20date%20according%20to%20local%20time%3A%200%20for%20Sunday%2C%201%20for%20Monday%2C%202%20for%20Tuesday%2C%20and%20so%20on

### Related issues and pull requests

