### PR TITLE
ReportingAPI: List of reports - draft

### DIFF
--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -75,6 +75,21 @@ The only difference is that server reports are JSON serializations of the object
 
 A list of documented report types and their corresponding report dictionary are given in the [`options.types`](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) parameter passed to the `ReportingObserver()` constructor.
 
+##### XXXXX
+
+| Type                           | Report object                                   | Local | Server | Notes                                                                                            |
+| ------------------------------ | ----------------------------------------------- | ----- | ------ | ------------------------------------------------------------------------------------------------ |
+| `coep`                         | {{domxref("COEPViolationReport")}}              | Y     | Y      | {{httpheader("Cross-Origin-Embedder-Policy")}} (COEP) violations                                 |
+| `coop`                         | {{domxref("COOPViolationReport")}}              | Y     | Y      | {{httpheader("Cross-Origin-Opener-Policy")}} (COOP) violations                                   |
+| `crash`                        | {{domxref("CrashReport")}}                      | N     | Y      | Browser crash reports                                                                            |
+| `csp-violation`                | {{domxref("CSPViolationReport")}}               | Y     | Y      | [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/Guides/CSP) violations                      |
+| `deprecation`                  | {{domxref("DeprecationReport")}}                | Y     | Y      | Deprecated features used by the site.                                                            |
+| `document-policy-violation`    | {{domxref("DocumentPolicyViolationReport")}}    | ??    | Y      | {{httpheader("Document-Policy")}} violations                                                     |
+| `integrity-violation`          | {{domxref("IntegrityViolationReport")}}         | Y     | Y      | {{httpheader("Integrity-Policy")}} violations                                                    |
+| `intervention`                 | {{domxref("InterventionReport")}}               | Y     | Y      | Features blocked by the user agent, for example, if an ad significantly impacts page performance |
+| `network-error`                | {{domxref("NetworkErrorReport")}}               | Y     | N      | Network error report                                                                             |
+| `permissions-policy-violation` | {{domxref("PermissionsPolicyViolationReport")}} | Y     | Y      | {{httpheader("Permissions-Policy")}} violations                                                  |
+
 ### Generating reports via WebDriver
 
 The Reporting API spec also defines a Generate Test Report [WebDriver](/en-US/docs/Web/WebDriver) extension, which allows you to simulate report generation during automation. Reports generated via WebDriver are observed by any registered `ReportingObserver` objects present in the loaded website. This is not yet documented.


### PR DESCRIPTION
This is in progress work to provide a list of all reports and how they are accessed for reporting API.
Fixes #43688

This will have the parent grouping. Still working on the pages that it needs before this can go in though. This is all being tested still.


- [ ] Document-Policy violations https://wicg.github.io/document-policy/#configure-reporting and https://chromestatus.com/feature/5756689661820928 and https://github.com/mdn/mdn/issues/394 and https://github.com/WICG/document-policy/blob/main/document-policy-explainer.md
- [ ] Permission policy violations
  - [ ] https://github.com/mdn/content/pull/43783
  - [ ] https://github.com/mdn/browser-compat-data/pull/29500
- [ ] Network errors - to be done - see https://w3c.github.io/network-error-logging/#concept-network-error-reports https://w3c.github.io/network-error-logging/#nel-response-header [Network Error Logging](/en-US/docs/Web/HTTP/Guides/Network_Error_Logging)
- [ ] Crash reports 
  - [ ] #43791
  - [ ] https://github.com/mdn/browser-compat-data/pull/29475
- [ ] coop to be done - ([spec](https://html.spec.whatwg.org/multipage/browsers.html#coop-reporting))
- [ ] csp-next - https://wicg.github.io/csp-next/scripting-policy.html - appears dormant and not implementd