### PR TITLE
[Editorial review] BiDi - Add page for log module event

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/index.md
@@ -18,7 +18,7 @@ Both command and event names use the module name as a prefix: `module_name.comma
 
 ## Commands
 
-A command is an asynchronous operation sent from the client to the browser. Each command message you send to the browser has three fields:
+A command is an asynchronous operation sent from the client to the browser. Each command message _you send_ to the browser has three fields:
 
 - `id`: A number you assign to the command. Unlike HTTP where each request waits for a response, a WebSocket connection can have multiple commands in flight at the same time and responses may arrive out of order. The `id` lets you match each response to the command that triggered it.
 - `method`: The command to run, in the form `module_name.command_name`.
@@ -45,6 +45,12 @@ To receive events, the client must first subscribe to them using the `session.su
 
 The client can subscribe to a specific event or to all events in a module. For example, subscribing to `"browsingContext.contextCreated"` subscribes the client to that single event, while subscribing to `"browsingContext"` subscribes the client to every event in the `browsingContext` module.
 
+Every event notification _you receive_ from the browser has three fields:
+
+- `type`: Always `"event"`.
+- `method`: The event name, in the form `module_name.event_name`.
+- `params`: An object containing the event-specific data. The structure of `params` is specific to each event.
+
 The following is a sample event message sent by the browser when the client is subscribed to `log.entryAdded` and a console message is logged (some fields have been omitted for brevity):
 
 ```json
@@ -53,11 +59,10 @@ The following is a sample event message sent by the browser when the client is s
   "method": "log.entryAdded",
   "params": {
     "type": "console",
-    "method": "log",
-    "realm": null,
     "level": "info",
     "text": "Hello world",
-    "timestamp": 1657282076037
+    "timestamp": 1657282076037,
+    "method": "log"
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
@@ -48,7 +48,7 @@ All log entry objects include the following fields:
 In addition to the [common fields](#common-fields), log entry objects with `"type": "console"` also include:
 
 - `args`
-  - : An array of objects that represent the arguments passed to the console method. Each object has a `type` field and optional `value`, `handle`, and `internalId` fields.
+  - : An array of objects that represent the arguments passed to the console method. Each object has a `type` field (such as `"string"`, `"number"`, `"boolean"`, or `"array"`) and optional `value`, `handle`, and `internalId` fields.
 - `method`
   - : A string that contains the name of the console method that was called (for example, `"log"`, `"error"`, `"assert"`, `"debug"`, `"trace"`, `"warn"`).
 
@@ -56,7 +56,7 @@ In addition to the [common fields](#common-fields), log entry objects with `"typ
 
 ### Receiving an event for a console log
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `log.entryAdded` active, the browser sends a `log.entryAdded` event when a script evaluates `console.log("hello", [1, 2, 3])`:
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `log.entryAdded` active, the browser sends a `log.entryAdded` event when a script evaluates `console.log("hello", [1, true, "foo"])`:
 
 ```json
 {
@@ -78,13 +78,13 @@ With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_
         "type": "array",
         "value": [
           { "type": "number", "value": 1 },
-          { "type": "number", "value": 2 },
-          { "type": "number", "value": 3 }
+          { "type": "boolean", "value": true },
+          { "type": "string", "value": "foo" }
         ]
       }
     ],
     "level": "info",
-    "text": "hello 1,2,3",
+    "text": "hello 1,true,foo",
     "timestamp": 1712345678901,
     "stackTrace": {
       "callFrames": [

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
@@ -11,7 +11,7 @@ The `log.entryAdded` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#ev
 
 ## Event data
 
-The `params` field in the event notification is a log entry object. Based on the source of the log, the log entry object has different types: `"console"`, `"javascript"`, or any other string. Each type may provide additional fields specific to that source.
+The `params` field in the event notification is a log entry object. Based on the source of the log, the log entry object has different types: `"console"` or `"javascript"`. Each type may provide additional fields specific to that source.
 
 ### Common fields
 
@@ -34,21 +34,21 @@ All log entry objects include the following fields:
 - `stackTrace` {{optional_inline}}
   - : An object with a `callFrames` array that represents the [JavaScript stack](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/stackTrace) at the point the entry was created. Each item in the array is a stack frame with the following fields: `columnNumber`, `functionName`, `lineNumber`, and `url`.
 - `text`
-  - : A string that contains the log message, or `null` if not available.
+  - : A string that contains the log message or `null` if not available. For console entries, it is the concatenation of all stringified arguments joined by spaces, and for JavaScript errors, it is generally the error message.
+    The exact format is browser-dependent, so don't rely on this value for assertions in tests.
 - `timestamp`
   - : A non-negative integer that represents the time when the log entry was created, in UTC, as milliseconds elapsed since the epoch ({{jsxref("Date.now()")}}).
 - `type`
   - : A string that identifies the source of the log entry. It has one of the following values:
     - `"console"`: Indicates that the log entry was generated from a call to a console API method (for example, {{domxref("console/log_static", "console.log()")}}, {{domxref("console/warn_static", "console.warn()")}}). Log entry objects of this type include [additional fields](#console-entry-fields).
     - `"javascript"`: Indicates that the log entry was generated from an unhandled JavaScript error.
-    - Any other string: Indicates an implementation-defined log source.
 
 ### `"console"` log entry fields
 
 In addition to the [common fields](#common-fields), log entry objects with `"type": "console"` also include:
 
 - `args`
-  - : An array of objects that represent the arguments passed to the console method. Each object has a `type` field and a `value` field.
+  - : An array of objects that represent the arguments passed to the console method. Each object has a `type` field and optional `value`, `handle`, and `internalId` fields.
 - `method`
   - : A string that contains the name of the console method that was called (for example, `"log"`, `"error"`, `"assert"`, `"debug"`, `"trace"`, `"warn"`).
 
@@ -56,7 +56,7 @@ In addition to the [common fields](#common-fields), log entry objects with `"typ
 
 ### Receiving an event for a console log
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `log.entryAdded` active, the browser sends a `log.entryAdded` event when a script evaluates `console.log("hello", "world")`:
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `log.entryAdded` active, the browser sends a `log.entryAdded` event when a script evaluates `console.log("hello", [1, 2, 3])`:
 
 ```json
 {
@@ -75,13 +75,27 @@ With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_
         "value": "hello"
       },
       {
-        "type": "string",
-        "value": "world"
+        "type": "array",
+        "value": [
+          { "type": "number", "value": 1 },
+          { "type": "number", "value": 2 },
+          { "type": "number", "value": 3 }
+        ]
       }
     ],
     "level": "info",
-    "text": "hello world",
-    "timestamp": 1712345678901
+    "text": "hello 1,2,3",
+    "timestamp": 1712345678901,
+    "stackTrace": {
+      "callFrames": [
+        {
+          "columnNumber": 8,
+          "functionName": "",
+          "lineNumber": 1,
+          "url": "https://example.com/app.js"
+        }
+      ]
+    }
   }
 }
 ```
@@ -109,7 +123,17 @@ With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_
     ],
     "level": "warn",
     "text": "something went wrong",
-    "timestamp": 1712345678950
+    "timestamp": 1712345678950,
+    "stackTrace": {
+      "callFrames": [
+        {
+          "columnNumber": 8,
+          "functionName": "",
+          "lineNumber": 1,
+          "url": "https://example.com/app.js"
+        }
+      ]
+    }
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
@@ -1,0 +1,165 @@
+---
+title: log.entryAdded event
+short-title: log.entryAdded
+slug: Web/WebDriver/Reference/BiDi/Modules/log/entryAdded
+page-type: webdriver-event
+browser-compat: webdriver.bidi.log.entryAdded_event
+sidebar: webdriver
+---
+
+The `log.entryAdded` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`log`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/log) module fires when a new log entry is created in the browser, from either a console API call or an unhandled JavaScript error.
+
+## Event data
+
+The `params` field in the event notification is a log entry object. Based on the source of the log, the log entry object has different types: `"console"`, `"javascript"`, or any other string. Each type may provide additional fields specific to that source.
+
+### Common fields
+
+All log entry objects include the following fields:
+
+- `level`
+  - : A string that indicates the severity of the log entry. It has one of the following values:
+    - `"debug"`: A debug-level message (from {{domxref("console/debug_static", "console.debug()")}} or {{domxref("console/trace_static", "console.trace()")}}).
+    - `"info"`: An informational message (from {{domxref("console/log_static", "console.log()")}}, {{domxref("console/info_static", "console.info()")}}, and [other console methods](/en-US/docs/Web/API/console) that don't produce a more specific level).
+    - `"warn"`: A warning message (from {{domxref("console/warn_static", "console.warn()")}}).
+    - `"error"`: An error message (from {{domxref("console/error_static", "console.error()")}} or {{domxref("console/assert_static", "console.assert()")}}).
+- `source`
+  - : An object that identifies the [realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms) where the log entry was created. It contains the following fields:
+    - `realm`
+      - : A string that contains the ID of the realm.
+    - `context` {{optional_inline}}
+      - : A string that contains the ID of the context in which the log entry was created.
+    - `userContext` {{optional_inline}}
+      - : A string that contains the ID of the user context in which the script-related event occurred.
+- `stackTrace` {{optional_inline}}
+  - : An object with a `callFrames` array that represents the [JavaScript stack](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/stackTrace) at the point the entry was created. Each item in the array is a stack frame with the following fields: `columnNumber`, `functionName`, `lineNumber`, and `url`.
+- `text`
+  - : A string that contains the log message, or `null` if not available.
+- `timestamp`
+  - : A non-negative integer that represents the time when the log entry was created, in UTC, as milliseconds elapsed since the epoch ({{jsxref("Date.now()")}}).
+- `type`
+  - : A string that identifies the source of the log entry. It has one of the following values:
+    - `"console"`: Indicates that the log entry was generated from a call to a console API method (for example, {{domxref("console/log_static", "console.log()")}}, {{domxref("console/warn_static", "console.warn()")}}). Log entry objects of this type include [additional fields](#console-entry-fields).
+    - `"javascript"`: Indicates that the log entry was generated from an unhandled JavaScript error.
+    - Any other string: Indicates an implementation-defined log source.
+
+### `"console"` log entry fields
+
+In addition to the [common fields](#common-fields), log entry objects with `"type": "console"` also include:
+
+- `args`
+  - : An array of objects that represent the arguments passed to the console method. Each object has a `type` field and a `value` field.
+- `method`
+  - : A string that contains the name of the console method that was called (for example, `"log"`, `"error"`, `"assert"`, `"debug"`, `"trace"`, `"warn"`).
+
+## Examples
+
+### Receiving an event for a console log
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `log.entryAdded` active, the browser sends a `log.entryAdded` event when a script evaluates `console.log("hello", "world")`:
+
+```json
+{
+  "type": "event",
+  "method": "log.entryAdded",
+  "params": {
+    "type": "console",
+    "method": "log",
+    "source": {
+      "realm": "7c37f4c0-abcd-1234-ef56-789012345678",
+      "context": "6B3D5B3A-6571-432B-8E96-E53B5C2ECBB5"
+    },
+    "args": [
+      {
+        "type": "string",
+        "value": "hello"
+      },
+      {
+        "type": "string",
+        "value": "world"
+      }
+    ],
+    "level": "info",
+    "text": "hello world",
+    "timestamp": 1712345678901
+  }
+}
+```
+
+### Receiving an event for a console warning
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `log.entryAdded` active, the browser sends a `log.entryAdded` event when a script evaluates `console.warn("something went wrong")`:
+
+```json
+{
+  "type": "event",
+  "method": "log.entryAdded",
+  "params": {
+    "type": "console",
+    "method": "warn",
+    "source": {
+      "realm": "7c37f4c0-abcd-1234-ef56-789012345678",
+      "context": "6B3D5B3A-6571-432B-8E96-E53B5C2ECBB5"
+    },
+    "args": [
+      {
+        "type": "string",
+        "value": "something went wrong"
+      }
+    ],
+    "level": "warn",
+    "text": "something went wrong",
+    "timestamp": 1712345678950
+  }
+}
+```
+
+### Receiving an event for an unhandled JavaScript error
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `log.entryAdded` active, the browser sends a `log.entryAdded` event when an unhandled JavaScript error occurs:
+
+```json
+{
+  "type": "event",
+  "method": "log.entryAdded",
+  "params": {
+    "type": "javascript",
+    "level": "error",
+    "source": {
+      "realm": "7c37f4c0-abcd-1234-ef56-789012345678",
+      "context": "6B3D5B3A-6571-432B-8E96-E53B5C2ECBB5"
+    },
+    "text": "ReferenceError: undefinedVariable is not defined",
+    "timestamp": 1712345679100,
+    "stackTrace": {
+      "callFrames": [
+        {
+          "columnNumber": 27,
+          "functionName": "",
+          "lineNumber": 3,
+          "url": "https://example.com/app.js"
+        },
+        {
+          "columnNumber": 18,
+          "functionName": "",
+          "lineNumber": 3,
+          "url": "https://example.com/app.js"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command
+- [`console`](/en-US/docs/Web/API/console) API

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/index.md
@@ -9,6 +9,14 @@ sidebar: webdriver
 
 The **`log`** module provides an event for monitoring browser log entries, including [console API](/en-US/docs/Web/API/console) output and unhandled JavaScript errors.
 
+## Commands
+
+The `log` module has no associated commands.
+
+## Events
+
+{{ListSubPages}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.log
 sidebar: webdriver
 ---
 
-The **`log`** module contains events related to logging.
+The **`log`** module provides an event for monitoring browser log entries, including [console API](/en-US/docs/Web/API/console) output and unhandled JavaScript errors.
 
 ## Specifications
 

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -23,7 +23,10 @@ sidebar:
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/input
         code: true
-      - link: /Web/WebDriver/Reference/BiDi/Modules/log
+      - type: listSubPages
+        path: /Web/WebDriver/Reference/BiDi/Modules/log
+        link: /Web/WebDriver/Reference/BiDi/Modules/log
+        details: closed
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/network
         code: true

--- a/front-matter-config.json
+++ b/front-matter-config.json
@@ -376,6 +376,7 @@
                 "webdriver-command",
                 "webdriver-capability",
                 "webdriver-error",
+                "webdriver-event",
                 "reference"
               ]
             }


### PR DESCRIPTION
### Description

This PR adds a page for the `log.entryAdded` event, the only one event in the `log` module (it has no commands).

Also:
- Updated the `log.entryAdded` example in the modules landing page.
- Added a list of the event notification fields to the overview [Events](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) section.
This now makes it parallel to the command message fields in the [Commands](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) section.

### Spec link

https://w3c.github.io/webdriver-bidi/#module-log

### For editorial review

Since this is the first page of its kind (a BiDi event), I've added the `webdriver-event` page-type to the `front-matter-config.json` file.

### Related issue

Doc issue: mdn/mdn#339