### PR TITLE
External 'See also' link update

### DIFF
--- a/files/en-us/web/api/css_custom_highlight_api/index.md
+++ b/files/en-us/web/api/css_custom_highlight_api/index.md
@@ -234,7 +234,7 @@ The result is shown below. Type text within the search field to highlight matche
 
 ## See also
 
-- [CSS Custom Highlight API: The Future of Highlighting Text Ranges on the Web](https://css-tricks.com/css-custom-highlight-api-early-look/)
 - HTML [`contentEditable`](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) attribute
 - CSS {{cssxref("pseudo-elements")}}
 - [CSS custom highlight API](/en-US/docs/Web/CSS/Guides/Custom_highlight_API) module
+- [CSS Custom Highlight API: The Future of Highlighting Text Ranges on the Web](https://css-tricks.com/css-custom-highlight-api-early-look/) via CSS-Tricks (2022)


### PR DESCRIPTION
Updated the reference for the CSS Custom Highlight API article to include the source and year, and as it's external, put it at the end of the list