### PR TITLE
[WebExtensions] Deprecate runtime.PlatformInfo.nacl_arch

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/index.md
@@ -26,8 +26,8 @@ It also provides messaging APIs enabling you to:
   - : Identifies the browser's processor architecture.
 - {{WebExtAPIRef("runtime.PlatformInfo")}}
   - : Contains information about the platform the browser is running on.
-- {{WebExtAPIRef("runtime.PlatformNaclArch")}}
-  - : The native client architecture. This may be different from `PlatformArch` on some platforms.
+- {{WebExtAPIRef("runtime.PlatformNaclArch")}} {{deprecated_inline}}
+  - : The deprecated enumeration value representing Google Native Client architecture. Consider migrating to `PlatformArch`, which is supported by Safari and Mozilla, and represents the true CPU architecture and conveys correct bitness information on ARM.
 - {{WebExtAPIRef("runtime.RequestUpdateCheckStatus")}}
   - : Result of a call to {{WebExtAPIRef("runtime.requestUpdateCheck()")}}.
 - {{WebExtAPIRef("runtime.OnInstalledReason")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platforminfo/index.md
@@ -16,8 +16,8 @@ Values of this type are objects, which contain the following properties:
   - : {{WebExtAPIRef('runtime.PlatformOs')}}. The platform's operating system.
 - `arch`
   - : {{WebExtAPIRef('runtime.PlatformArch')}}. The platform's processor architecture.
-- `nacl_arch`
-  - : {{WebExtAPIRef('runtime.PlatformNaclArch')}}. The native client architecture. This may be different from `arch` on some platforms.
+- `nacl_arch` {{deprecated_inline}}
+  - : {{WebExtAPIRef('runtime.PlatformNaclArch')}}. The Google Native Client architecture. Only Chromium-based browsers support this attribute, and Chromium is removing it. Consider migrating to `arch`, which contains equivalent information and is more descriptive on some platforms (ARM and RISC-V).
 
 {{WebExtExamples}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -6,11 +6,23 @@ browser-compat: webextensions.api.runtime.PlatformNaclArch
 sidebar: addonsidebar
 ---
 
-The native client architecture. This may be different from arch on some platforms.
+> [!NOTE]
+> **This type is deprecated** in favor of {{WebExtAPIRef("runtime.PlatformArch")}}. `PlatformArch` is also available in {{WebExtAPIRef("runtime.PlatformInfo")}}, which you obtain using {{WebExtAPIRef("runtime.getPlatformInfo()")}}.
 
-## Type
+The enumerated value representing the CPU instruction set architecture of Google Native Client used by the browser. This enum is deprecated, following the removal of Google Native Client from Google Chrome. As of 2026, Chromium intends to remove this enum.
 
-Values of this type are strings. Possible values are: `"arm"`, `"x86-32"`, `"x86-64"`.
+## Possible values
+
+- `ARM`
+  - : The string literal `"arm"`. Represents all versions of the ARM ISA, including all 32-bit and 64-bit variants. Equivalent to [`PlatformArch.arm`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#arm) (32-bit variant) and `PlatformArch.arm64` combined into one value.
+- `X86_32`
+  - : The string literal `"x86-32"`. Represents the 32-bit variant of the x86 architecture. Equivalent to [`PlatformArch.x86_32`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#x86-32).
+- `X86_64`
+  - : The string literal `"x86-64"`. Represents the 64-bit variant of the x86 architecture. Equivalent to [`PlatformArch.X86_64`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#x86-64).
+- `MIPS`
+  - : The string literal `"mips"`. Represents the 32-bit variant of the MIPS ISA, which was never supported by official releases. Equivalent to `PlatformArch.mips`.
+- `MIPS64`
+  - : The string literal `"mips64"`. Represents the 64-bit variant of the MIPS ISA, which was never supported by official releases. Equivalent to `PlatformArch.mips64`.
 
 {{WebExtExamples}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -11,7 +11,7 @@ sidebar: addonsidebar
 
 The enumerated value representing the CPU instruction set architecture of Google Native Client used by the browser. This enum is deprecated, following the removal of Google Native Client from Google Chrome. As of 2026, Chromium intends to remove this enum.
 
-## Possible values
+## Type
 
 - `ARM`
   - : The string literal `"arm"`. Represents all versions of the ARM ISA, including all 32-bit and 64-bit variants. Equivalent to [`PlatformArch.arm`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#arm) (32-bit variant) and `PlatformArch.arm64` combined into one value.


### PR DESCRIPTION



<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chromium is the only engine which supported Google Native Client (NaCl) and `runtime.PlatformInfo.nacl_arch` WebExtension API. Chromium removed NaCl and is currently in the process of removal of associated WebExtension API remnants.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Update MDN in line with Chromium development.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Google Chrome deprecated `runtime.PlatformInfo.nacl_arch` and `runtime.PlatformNaclArch`. Google plans to run an experiment removing `nacl_arch` from `runtime.getPlatformInfo()` and we would like to increase awareness of this deprecation. Hardcoded constant enum `runtime.PlatformNaclArch` is not part of this experiment, but will be removed shortly after `runtime.PlatformInfo.nacl_arch` removal.
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

Details:
https://github.com/chromium/chromium/commit/913e0c02f12a758e69b3a5effff0d725f38556d3
https://github.com/chromium/chromium/commit/6e62e12f5ec58a0d830f72b61e09fb2c6ea4962a
https://github.com/chromium/chromium/commit/9b227965e420bdc5e49c03c1c80e0ac927ab29e7

### Related issues and pull requests

I will prepare BCD PR shortly.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->

CC @oliverdunk