### PR TITLE
Use borderify name for borderify example extension

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -28,7 +28,7 @@ Using a suitable [text editor](/en-US/docs/Learn_web_development/Howto/Tools_and
 
 ```json
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Borderify",
   "version": "1.0",
 

--- a/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_first_webextension/index.md
@@ -40,7 +40,7 @@ Using a suitable [text editor](/en-US/docs/Learn_web_development/Howto/Tools_and
 
   "browser_specific_settings": {
     "gecko": {
-      "id": "beastify@mozilla.org",
+      "id": "borderify@mozilla.org",
       "data_collection_permissions": {
         "required": ["none"]
       }


### PR DESCRIPTION
### Description

beastify@mozilla.org seems to be a copy-paste from the second extension at https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension

Feel free to close if it intentionally uses the same ID as that one.


I did not test this tutorial, either before or after the changes in this PR. The explanation says this ID is used for publishing and the tutorial does not include publishing, so I assume this ID is unused for this tutorial.

### Motivation

As a reader it is unclear why this ID should be beastify@mozilla.org

### Additional details

N.A.

### Related issues and pull requests

N.A.