### PR TITLE
Update Firefox 150 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -93,20 +93,20 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### General
 
-- Fixed an issue where having pending downloads when closing the session could be blocked by a prompt. The prompt is now dismissed automatically. ([Firefox bug 2003840](https://bugzil.la/2003840))
+- Fixed an issue where having pending downloads when closing the browser could be blocked by a prompt. The prompt is now dismissed automatically. ([Firefox bug 2003840](https://bugzil.la/2003840)).
 
 #### WebDriver BiDi
 
-- Added the `emulation.setNetworkConditions` command, which only supports the `type: offline` at the moment. Using this, you can emulate offline mode either on specific browsing contexts, on user contexts (a.k.a. containers) or globally. ([Firefox bug 1993079](https://bugzil.la/1993079))
-- Improved our support for non utf-8 header values across all the `network` module commands and events. They are now properly serialized to `BytesValue`. ([Firefox bug 1994996](https://bugzil.la/1994996))
-- Fixed a bug with download events, which would be missing the `navigation` property when triggered by a link with `target="_blank"`. ([Firefox bug 1999481](https://bugzil.la/1999481))
-- Updated the `log.entryAdded` event to only be emitted for console API calls that use the "printer". With this change, using `console.clear` or `console.time` no longer triggers an event. ([Firefox bug 1866749](https://bugzil.la/1866749))
-- Fixed a race condition with the `browsingContext.setViewport` command which could timeout if several contexts were created in parallel. ([Firefox bug 2019511](https://bugzil.la/2019511))
-- Improved the `browsingContext.locateNodes` command to allow retrieving the HTML element (documentElement). ([Firefox bug 2020578](https://bugzil.la/2020578))
+- Added the `emulation.setNetworkConditions` command, which supports the `type: offline` at the moment. Using this, you can emulate offline mode either on specific browsing contexts, on user contexts (a.k.a. containers) or globally. ([Firefox bug 1993079](https://bugzil.la/1993079)).
+- Improved our support for non utf-8 header values across all the `network` module commands and events. They are now properly serialized to `BytesValue`. ([Firefox bug 1994996](https://bugzil.la/1994996)).
+- Fixed a bug for download events triggered by a response with the "Content-Disposition" header. Such events were missing the `navigation` property if the download was initiated by a link with `target="_blank"`. ([Firefox bug 1999481](https://bugzil.la/1999481)).
+- Updated the `log.entryAdded` event to only be emitted for console API calls that actually print a message in browser developer tools (see also the console specification: [using the printer](https://console.spec.whatwg.org/#printer)). With this change, using `console.clear` or `console.time` no longer triggers an event. ([Firefox bug 1866749](https://bugzil.la/1866749)).
+- Fixed a race condition with the `browsingContext.setViewport` command which could timeout if several contexts were created in parallel. ([Firefox bug 2019511](https://bugzil.la/2019511)).
+- Improved the `browsingContext.locateNodes` command to allow retrieving the HTML element (`documentElement`) of a page when using the `css` locator. ([Firefox bug 2020578](https://bugzil.la/2020578)).
 
 #### Marionette
 
-- Fixed the `WebDriver:getShadowRoot` command to stop returning user-agent shadow roots. ([Firefox bug 2016741](https://bugzil.la/2016741))
+- Fixed the `WebDriver:getShadowRoot` command to stop returning user-agent shadow roots. ([Firefox bug 2016741](https://bugzil.la/2016741)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -89,13 +89,24 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Fixed an issue where having pending downloads when closing the session could be blocked by a prompt. The prompt is now dismissed automatically. ([Firefox bug 2003840](https://bugzil.la/2003840))
 
-<!-- #### Marionette -->
+#### WebDriver BiDi
+
+- Added the `emulation.setNetworkConditions` command, which only supports the `type: offline` at the moment. Using this, you can emulate offline mode either on specific browsing contexts, on user contexts (a.k.a. containers) or globally. ([Firefox bug 1993079](https://bugzil.la/1993079))
+- Improved our support for non utf-8 header values across all the `network` module commands and events. They are now properly serialized to `BytesValue`. ([Firefox bug 1994996](https://bugzil.la/1994996))
+- Fixed a bug with download events, which would be missing the `navigation` property when triggered by a link with `target="_blank"`. ([Firefox bug 1999481](https://bugzil.la/1999481))
+- Updated the `log.entryAdded` event to only be emitted for console API calls that use the "printer". With this change, using `console.clear` or `console.time` no longer triggers an event. ([Firefox bug 1866749](https://bugzil.la/1866749))
+- Fixed a race condition with the `browsingContext.setViewport` command which could timeout if several contexts were created in parallel. ([Firefox bug 2019511](https://bugzil.la/2019511))
+- Improved the `browsingContext.locateNodes` command to allow retrieving the HTML element (documentElement). ([Firefox bug 2020578](https://bugzil.la/2020578))
+
+#### Marionette
+
+- Fixed the `WebDriver:getShadowRoot` command to stop returning user-agent shadow roots. ([Firefox bug 2016741](https://bugzil.la/2016741))
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Release notes update based on the following list of [relnote worthy bugs](https://bugzilla.mozilla.org/buglist.cgi?v1=fixed&resolution=FIXED&f2=cf_status_firefox149&query_format=advanced&o1=equals&f1=cf_status_firefox150&o2=notequals&status_whiteboard=[webdriver:relnote]&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&status_whiteboard_type=substring&v2=fixed&list_id=17932840).

(needs review from @whimboo / @lutien before merging)