### PR TITLE
Add CSS revert-rule keyword

### DIFF
--- a/files/en-us/web/css/reference/values/data_types/index.md
+++ b/files/en-us/web/css/reference/values/data_types/index.md
@@ -33,6 +33,8 @@ These types include keywords and identifiers as well as strings, and URLs.
       - : Rolls back the cascade to the value of the earlier origin.
     - {{CSSXref("revert-layer")}}
       - : Rolls back the cascade to the value of the earlier [cascade layer](/en-US/docs/Web/CSS/Reference/At-rules/@layer).
+    - {{CSSXref("revert-rule")}}
+      - : Rolls back the cascade as if the current style rule were not present.
     - {{CSSXref("unset")}}
       - : Acts as `inherit` or `initial` depending on whether the property is inherited or not.
 - {{cssxref("&lt;custom-ident&gt;")}}

--- a/files/en-us/web/css/reference/values/data_types/index.md
+++ b/files/en-us/web/css/reference/values/data_types/index.md
@@ -34,7 +34,7 @@ These types include keywords and identifiers as well as strings, and URLs.
     - {{CSSXref("revert-layer")}}
       - : Rolls back the cascade to the value of the earlier [cascade layer](/en-US/docs/Web/CSS/Reference/At-rules/@layer).
     - {{CSSXref("revert-rule")}}
-      - : Rolls back the cascade as if the current style rule were not present.
+      - : Rolls back the cascade to the value of an earlier matching style rule.
     - {{CSSXref("unset")}}
       - : Acts as `inherit` or `initial` depending on whether the property is inherited or not.
 - {{cssxref("&lt;custom-ident&gt;")}}

--- a/files/en-us/web/css/reference/values/inherit/index.md
+++ b/files/en-us/web/css/reference/values/inherit/index.md
@@ -159,5 +159,5 @@ The `<h2>` elements are all `green`. However, if they are nested in a {{htmlelem
 
 ## See also
 
-- {{cssxref("initial")}}, {{cssxref("revert")}}, {{cssxref("revert-layer")}}, and {{cssxref("unset")}} keywords
+- {{cssxref("initial")}}, {{cssxref("revert")}}, {{cssxref("revert-layer")}}, {{cssxref("revert-rule")}}, and {{cssxref("unset")}} keywords
 - [Inheritance](/en-US/docs/Web/CSS/Guides/Cascade/Inheritance)

--- a/files/en-us/web/css/reference/values/initial/index.md
+++ b/files/en-us/web/css/reference/values/initial/index.md
@@ -8,7 +8,7 @@ sidebar: cssref
 
 The **`initial`** [CSS](/en-US/docs/Web/CSS) keyword applies the [initial (or default) value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#initial_value) of a property to an element. It can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}. With `all` set to `initial`, all CSS properties can be restored to their respective initial values in one go instead of restoring each one separately.
 
-On [inherited properties](/en-US/docs/Web/CSS/Guides/Cascade/Inheritance#inherited_properties), the initial value may be unexpected. You should consider using the {{cssxref("inherit")}}, {{cssxref("unset")}}, {{cssxref("revert")}}, or {{cssxref("revert-layer")}} keywords instead.
+On [inherited properties](/en-US/docs/Web/CSS/Guides/Cascade/Inheritance#inherited_properties), the initial value may be unexpected. You should consider using the {{cssxref("inherit")}}, {{cssxref("unset")}}, {{cssxref("revert")}}, {{cssxref("revert-layer")}}, or {{cssxref("revert-rule")}} keywords instead.
 
 ## Examples
 
@@ -61,6 +61,6 @@ With the `initial` keyword in this example, the `color` and `font-size` values o
 
 ## See also
 
-- {{cssxref("inherit")}}, {{cssxref("revert")}}, {{cssxref("revert-layer")}}, and {{cssxref("unset")}} keywords
+- {{cssxref("inherit")}}, {{cssxref("revert")}}, {{cssxref("revert-layer")}}, {{cssxref("revert-rule")}}, and {{cssxref("unset")}} keywords
 - {{cssxref("all")}}
 - [Inheritance](/en-US/docs/Web/CSS/Guides/Cascade/Inheritance)

--- a/files/en-us/web/css/reference/values/revert-layer/index.md
+++ b/files/en-us/web/css/reference/values/revert-layer/index.md
@@ -154,6 +154,7 @@ The style for all `<li>` elements rolls back to the defaults in the user-agent o
 - {{cssxref("initial")}}
 - {{cssxref("inherit")}}
 - {{cssxref("revert")}}
+- {{cssxref("revert-rule")}}
 - {{cssxref("unset")}}
 - {{cssxref("all")}}
 - [CSS cascading and inheritance](/en-US/docs/Web/CSS/Guides/Cascade) module

--- a/files/en-us/web/css/reference/values/revert-rule/index.md
+++ b/files/en-us/web/css/reference/values/revert-rule/index.md
@@ -1,0 +1,175 @@
+---
+title: revert-rule
+slug: Web/CSS/Reference/Values/revert-rule
+page-type: css-keyword
+browser-compat: css.types.global_keywords.revert-rule
+sidebar: cssref
+---
+
+The **`revert-rule`** [CSS-wide keyword](/en-US/docs/Web/CSS/Reference/Values/Data_types#css-wide_keywords) rolls back the value of a property as if the current [style rule](/en-US/docs/Web/CSS/Syntax#css_rulesets) had not been present at all. The cascade then determines the value from the remaining declarations — this could be another rule in the same [cascade layer](/en-US/docs/Web/CSS/Reference/At-rules/@layer), a rule in a different layer, a different [style origin](/en-US/docs/Glossary/Style_origin), or a [defaulted value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#defaulting) (inherited or initial).
+
+The `revert-rule` keyword behaves like {{cssxref("revert-layer")}} in the animation origin.
+
+This keyword can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
+
+## Revert-rule vs. revert-layer vs. revert
+
+The `revert-rule`, {{cssxref("revert-layer")}}, and {{cssxref("revert")}} keywords each roll back the cascade, but at different levels of granularity:
+
+- {{cssxref("revert")}} removes all declarations from the current [style origin](/en-US/docs/Glossary/Style_origin), rolling back to the previous origin (for example, from author styles to user-agent styles).
+- {{cssxref("revert-layer")}} removes all declarations from the current [cascade layer](/en-US/docs/Web/CSS/Reference/At-rules/@layer), rolling back to the previous layer within the same origin.
+- `revert-rule` removes only the declarations from the current style rule. Other rules in the same cascade layer still apply.
+
+This makes `revert-rule` useful for conditionally ignoring specific declarations within a rule while still respecting declarations from other rules in the same layer.
+
+## Examples
+
+### Rolling back to the previous rule
+
+In this example, two rules target the same element. The second rule uses `revert-rule` on the `color` property, which causes the cascade to determine the value as if the `p.special` rule were not present, falling back to the value established by the first rule.
+
+#### HTML
+
+```html
+<p class="special">This paragraph has special styling.</p>
+```
+
+#### CSS
+
+```css hidden
+body {
+  font-family: system-ui;
+}
+
+@supports not (color: revert-rule) {
+  body::before {
+    content: "Your browser doesn't support the revert-rule keyword yet.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1em;
+  }
+}
+```
+
+```css
+p {
+  color: blue;
+  font-weight: bold;
+}
+
+p.special {
+  color: revert-rule;
+  border: 1px solid currentcolor;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Rolling_back_to_the_previous_rule', '100%', 120)}}
+
+The paragraph text is blue (from the `p` rule), because the `color: revert-rule` declaration in the `p.special` rule causes it to be ignored for the `color` property. The `font-weight: bold` and `border` declarations are unaffected.
+
+### Reverting from a style attribute
+
+When `revert-rule` is used in a [style attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/style), it causes the cascade to act as if the style attribute were not present, since the style attribute is treated as its own style rule.
+
+#### HTML
+
+```html
+<p style="color: revert-rule">This text uses the stylesheet color.</p>
+```
+
+#### CSS
+
+```css hidden
+body {
+  font-family: system-ui;
+}
+
+@supports not (color: revert-rule) {
+  body::before {
+    content: "Your browser doesn't support the revert-rule keyword yet.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1em;
+  }
+}
+```
+
+```css
+p {
+  color: green;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('Reverting_from_a_style_attribute', '100%', 120)}}
+
+The paragraph displays in green because `revert-rule` removes the style attribute's declaration from the cascade, and the `p { color: green; }` rule takes effect.
+
+### A chain of revert-rule
+
+The `revert-rule` keyword removes the current rule from the cascade entirely. If the resulting winning rule also uses `revert-rule`, that rule is likewise removed, continuing back through earlier rules.
+
+#### HTML
+
+```html
+<p class="a b">This text is styled by a chain of revert-rule values.</p>
+```
+
+#### CSS
+
+```css hidden
+body {
+  font-family: system-ui;
+}
+
+@supports not (color: revert-rule) {
+  body::before {
+    content: "Your browser doesn't support the revert-rule keyword yet.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1em;
+  }
+}
+```
+
+```css
+p {
+  color: red;
+}
+p.a {
+  color: green;
+}
+p.b {
+  color: revert-rule;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample('A_chain_of_revert-rule', '100%', 120)}}
+
+The `p.b` rule is removed from the cascade by `revert-rule`. Among the remaining rules, `p.a` wins over `p` due to higher [specificity](/en-US/docs/Web/CSS/Guides/Cascade/Specificity), so the text is green.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{cssxref("initial")}}
+- {{cssxref("inherit")}}
+- {{cssxref("revert")}}
+- {{cssxref("revert-layer")}}
+- {{cssxref("unset")}}
+- {{cssxref("all")}}
+- [CSS cascading and inheritance](/en-US/docs/Web/CSS/Guides/Cascade) module

--- a/files/en-us/web/css/reference/values/revert-rule/index.md
+++ b/files/en-us/web/css/reference/values/revert-rule/index.md
@@ -6,9 +6,9 @@ browser-compat: css.types.global_keywords.revert-rule
 sidebar: cssref
 ---
 
-The **`revert-rule`** [CSS-wide keyword](/en-US/docs/Web/CSS/Reference/Values/Data_types#css-wide_keywords) rolls back the value of a property as if the current [style rule](/en-US/docs/Web/CSS/Syntax#css_rulesets) had not been present at all. The cascade then determines the value from the remaining declarations — this could be another rule in the same [cascade layer](/en-US/docs/Web/CSS/Reference/At-rules/@layer), a rule in a different layer, a different [style origin](/en-US/docs/Glossary/Style_origin), or a [defaulted value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#defaulting) (inherited or initial).
+The **`revert-rule`** [CSS-wide keyword](/en-US/docs/Web/CSS/Reference/Values/Data_types#css-wide_keywords) rolls back the cascaded value of a property to the value it would have had if the current [style rule](/en-US/docs/Web/CSS/Syntax#css_rulesets) had not been present. The cascade then determines the value from the remaining declarations — this could be another rule in the same [cascade layer](/en-US/docs/Web/CSS/Reference/At-rules/@layer), a rule in a different layer, a different [style origin](/en-US/docs/Glossary/Style_origin), or a [default value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#defaulting) (`inherited` or `initial`).
 
-The `revert-rule` keyword behaves like {{cssxref("revert-layer")}} in the animation origin.
+When used inside a [CSS animation](/en-US/docs/Web/CSS/CSS_animations) (the animation origin), the `revert-rule` keyword behaves like {{cssxref("revert-layer")}}.
 
 This keyword can be applied to any CSS property, including the CSS shorthand property {{cssxref("all")}}.
 
@@ -66,13 +66,13 @@ p.special {
 
 #### Result
 
-{{EmbedLiveSample('Rolling_back_to_the_previous_rule', '100%', 120)}}
+{{EmbedLiveSample('Rolling back to the previous rule', '100%', 120)}}
 
-The paragraph text is blue (from the `p` rule), because the `color: revert-rule` declaration in the `p.special` rule causes it to be ignored for the `color` property. The `font-weight: bold` and `border` declarations are unaffected.
+The paragraph text is blue from the `p` rule because `color: revert-rule` causes the `color` declaration in `p.special` to be ignored. The `font-weight` and `border` declarations are unaffected.
 
 ### Reverting from a style attribute
 
-When `revert-rule` is used in a [style attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/style), it causes the cascade to act as if the style attribute were not present, since the style attribute is treated as its own style rule.
+When `revert-rule` is used in a [style attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/style), it causes the cascade to act as if the style attribute were not present. This works because the style attribute is treated as its own style rule.
 
 #### HTML
 
@@ -106,13 +106,13 @@ p {
 
 #### Result
 
-{{EmbedLiveSample('Reverting_from_a_style_attribute', '100%', 120)}}
+{{EmbedLiveSample('Reverting from a style attribute', '100%', 120)}}
 
-The paragraph displays in green because `revert-rule` removes the style attribute's declaration from the cascade, and the `p { color: green; }` rule takes effect.
+The paragraph text is green because `revert-rule` causes the cascade to ignore the style attribute's declaration, and the `p` rule takes effect.
 
-### A chain of revert-rule
+### Chaining multiple `revert-rule` values
 
-The `revert-rule` keyword removes the current rule from the cascade entirely. If the resulting winning rule also uses `revert-rule`, that rule is likewise removed, continuing back through earlier rules.
+If multiple rules use `revert-rule` for the same property, the cascade ignores each of them in turn, continuing back through earlier rules until it finds a concrete value.
 
 #### HTML
 
@@ -143,7 +143,7 @@ p {
   color: red;
 }
 p.a {
-  color: green;
+  color: revert-rule;
 }
 p.b {
   color: revert-rule;
@@ -152,9 +152,9 @@ p.b {
 
 #### Result
 
-{{EmbedLiveSample('A_chain_of_revert-rule', '100%', 120)}}
+{{EmbedLiveSample('Chaining multiple revert-rule values', '100%', 120)}}
 
-The `p.b` rule is removed from the cascade by `revert-rule`. Among the remaining rules, `p.a` wins over `p` due to higher [specificity](/en-US/docs/Web/CSS/Guides/Cascade/Specificity), so the text is green.
+Both the `p.b` and `p.a` rules are ignored by `revert-rule`. The cascade falls through to the `p` rule, so the text is red.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/revert/index.md
+++ b/files/en-us/web/css/reference/values/revert/index.md
@@ -157,5 +157,6 @@ Also, if neither the user agent nor the user override the `<h3>` or `<section>` 
 - Use the {{cssxref("initial")}} keyword to set a property to its initial value.
 - Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
 - Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
+- Use the {{cssxref("revert-rule")}} keyword to reset a property as if the current style rule were not present.
 - Use the {{cssxref("unset")}} keyword to set a property to its inherited value if it inherits or to its initial value if not.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.

--- a/files/en-us/web/css/reference/values/revert/index.md
+++ b/files/en-us/web/css/reference/values/revert/index.md
@@ -157,6 +157,6 @@ Also, if neither the user agent nor the user override the `<h3>` or `<section>` 
 - Use the {{cssxref("initial")}} keyword to set a property to its initial value.
 - Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
 - Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
-- Use the {{cssxref("revert-rule")}} keyword to reset a property as if the current style rule were not present.
+- Use the {{cssxref("revert-rule")}} keyword to reset a property to the value of an earlier matching style rule.
 - Use the {{cssxref("unset")}} keyword to set a property to its inherited value if it inherits or to its initial value if not.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.

--- a/files/en-us/web/css/reference/values/unset/index.md
+++ b/files/en-us/web/css/reference/values/unset/index.md
@@ -102,4 +102,5 @@ p {
 - Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
 - Use the {{cssxref("revert")}} keyword to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
 - Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
+- Use the {{cssxref("revert-rule")}} keyword to reset a property as if the current style rule were not present.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.

--- a/files/en-us/web/css/reference/values/unset/index.md
+++ b/files/en-us/web/css/reference/values/unset/index.md
@@ -102,5 +102,5 @@ p {
 - Use the {{cssxref("inherit")}} keyword to make an element's property the same as its parent.
 - Use the {{cssxref("revert")}} keyword to reset a property to the value established by the user-agent stylesheet (or by user styles, if any exist).
 - Use the {{cssxref("revert-layer")}} keyword to reset a property to the value established in a previous cascade layer.
-- Use the {{cssxref("revert-rule")}} keyword to reset a property as if the current style rule were not present.
+- Use the {{cssxref("revert-rule")}} keyword to reset a property to the value of an earlier matching style rule.
 - The {{cssxref("all")}} property lets you reset all properties to their initial, inherited, reverted, or unset state at once.


### PR DESCRIPTION
### Description

Adds reference for the CSS `revert-rule` keyword.

Changes:
- New page: `Web/CSS/Reference/Values/revert-rule`
- Add `revert-rule` to the CSS-wide keywords list in `data_types`
- Add `revert-rule` to the "See also" sections for relevant keywords

### Motivation

The `revert-rule` shipped in Firefox 150 and is in Safari TP.

### Additional details

- Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2017307

### Related issues and pull requests

- Project mdn/content#43552
- BCD https://github.com/mdn/browser-compat-data/pull/29489