### PR TITLE
Fix '1' + 2n BigInt example on Addition page

### DIFF
--- a/files/en-us/web/javascript/reference/operators/addition/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition/index.md
@@ -70,14 +70,14 @@ false + false; // 0
 1n + 2n; // 3n
 ```
 
-You cannot mix BigInt and number operands in addition.
+You cannot mix BigInt and number operands in addition. `null`, `undefined`, and boolean values are coerced to numbers and are forbidden as well.
 
 ```js example-bad
 1n + 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 2 + 1n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 ```
 
-Strings are an exception: because the string branch is tested first, adding a string to a BigInt produces string concatenation rather than a `TypeError`.
+Strings have priority over over types, so adding a string to a BigInt produces string concatenation rather than a `TypeError`.
 
 ```js
 "1" + 2n; // "12"

--- a/files/en-us/web/javascript/reference/operators/addition/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition/index.md
@@ -75,7 +75,12 @@ You cannot mix BigInt and number operands in addition.
 ```js example-bad
 1n + 2; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 2 + 1n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
-"1" + 2n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
+```
+
+Strings are an exception: because the string branch is tested first, adding a string to a BigInt produces string concatenation rather than a `TypeError`.
+
+```js
+"1" + 2n; // "12"
 ```
 
 To do addition with a BigInt and a non-BigInt, convert either operand:


### PR DESCRIPTION
### Description

Correct the BigInt/string addition example on the `+` operator page. The previous example marked `"1" + 2n` as throwing a `TypeError`, but it actually produces `"12"` via string concatenation because the `+` operator checks for a string operand before the BigInt/Number mix check.

### Motivation

The reported example misled readers about the precedence of string concatenation over the BigInt/Number type-mix rule, which is already described earlier on the same page in the Description section. You can verify the behavior in any JS console:

```js
"1" + 2n; // "12"
```

### Additional details

- Removed `"1" + 2n; // TypeError: ...` from the `example-bad` block.
- Added a short note right after the `example-bad` block explaining that strings are an exception (the string branch of `+` is tested first), with a positive example: `"1" + 2n; // "12"`.

### Related issues and pull requests

Fixes #43807
