### PR TITLE
Add CSS overscroll-behavior fix to Firefox 150 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -49,6 +49,8 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The media-based pseudo-classes {{cssxref(":buffering")}}, {{cssxref(":muted")}}, {{cssxref(":paused")}}, {{cssxref(":playing")}}, {{cssxref(":seeking")}}, {{cssxref(":stalled")}}, and {{cssxref(":volume-locked")}} are now supported. They allow you to style {{htmlelement("audio")}} and {{htmlelement("video")}} elements based on their current state, such as playing or paused. ([Firefox bug 2020775](https://bugzil.la/2020775)).
 
+- The {{cssxref("overscroll-behavior")}} CSS property (and its longhand properties {{cssxref("overscroll-behavior-x")}}, {{cssxref("overscroll-behavior-y")}}, {{cssxref("overscroll-behavior-block")}}, and {{cssxref("overscroll-behavior-inline")}}) now correctly apply to scroll containers that have no scrollable overflow, such as elements with `overflow: hidden`. Previously, the property was ignored on such elements. ([Firefox bug 1837436](https://bugzil.la/1837436)).
+
 <!-- #### Removals -->
 
 <!-- ### JavaScript -->

--- a/files/en-us/web/css/reference/properties/overscroll-behavior/index.md
+++ b/files/en-us/web/css/reference/properties/overscroll-behavior/index.md
@@ -128,6 +128,8 @@ In some cases, these behaviors are not desirable. You can use `overscroll-behavi
 
 Note that this property applies only to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Reference/Elements/iframe) is not a scroll container, setting this property on an iframe has no effect. To control scroll chaining from an iframe, set `overscroll-behavior` on both the [`<html>`](/en-US/docs/Web/HTML/Reference/Elements/html) and the [`<body>`](/en-US/docs/Web/HTML/Reference/Elements/body) elements of the iframe's document.
 
+A {{Glossary("Scroll_container", "scroll container")}} that has no scrollable overflow (for example, when `overflow: hidden` is set and the content doesn't extend beyond the container) is always considered to be at its {{Glossary("Scroll_boundary", "scroll boundary")}}. So setting a non-default `overscroll-behavior` such as `contain` or `none` on it will prevent scroll chaining to ancestor scroll containers. This can be used to prevent background scrolling while a dialog or overlay is open.
+
 ## Formal definition
 
 {{cssinfo}}

--- a/files/en-us/web/css/reference/properties/overscroll-behavior/index.md
+++ b/files/en-us/web/css/reference/properties/overscroll-behavior/index.md
@@ -128,7 +128,7 @@ In some cases, these behaviors are not desirable. You can use `overscroll-behavi
 
 Note that this property applies only to {{Glossary("Scroll_container", "scroll containers")}}. In particular, since an [`<iframe>`](/en-US/docs/Web/HTML/Reference/Elements/iframe) is not a scroll container, setting this property on an iframe has no effect. To control scroll chaining from an iframe, set `overscroll-behavior` on both the [`<html>`](/en-US/docs/Web/HTML/Reference/Elements/html) and the [`<body>`](/en-US/docs/Web/HTML/Reference/Elements/body) elements of the iframe's document.
 
-A {{Glossary("Scroll_container", "scroll container")}} that has no scrollable overflow (for example, when `overflow: hidden` is set and the content doesn't extend beyond the container) is always considered to be at its {{Glossary("Scroll_boundary", "scroll boundary")}}. So setting a non-default `overscroll-behavior` such as `contain` or `none` on it will prevent scroll chaining to ancestor scroll containers. This can be used to prevent background scrolling while a dialog or overlay is open.
+A {{Glossary("Scroll_container", "scroll container")}} that has no scrollable overflow, such as an element with `overflow: hidden`, is always considered to be at its {{Glossary("Scroll_boundary", "scroll boundary")}}. So setting a non-default `overscroll-behavior` such as `contain` or `none` on it will prevent scroll chaining to ancestor scroll containers. This can be used to prevent background scrolling while a dialog or overlay is open.
 
 ## Formal definition
 


### PR DESCRIPTION
### Description

- Adds `overscroll-behavior` fix to Firefox 150 release notes
- Adds a paragraph to content explaining the behavior

### Motivation

The `overscroll-behavior` is fixed in Firefox 150 and Chrome 144.

### Additional details

- Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1837436

### Related issues and pull requests

- Project mdn/content#43553
- BCD TODO