### PR TITLE
Mark attributionsrc deprecated

### DIFF
--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -31,7 +31,7 @@ open(url, target, windowFeatures)
 
 - `windowFeatures` {{optional_inline}}
   - : A string containing a comma-separated list of window features in the form `name=value`. Boolean values can be set to true using one of: `name`, `name=yes`, `name=true`, or `name=n` where `n` is any non-zero integer. These features include options such as the window's default size and position, whether or not to open a minimal popup window, and so forth. The following options are supported:
-    - `attributionsrc` {{experimental_inline}}
+    - `attributionsrc` {{deprecated_inline}}
       - : Indicates that you want the browser to send an {{httpheader("Attribution-Reporting-Eligible")}} header along with the `open()` call. This call must be made with [transient activation](/en-US/docs/Glossary/Transient_activation) (i.e., inside a user interaction event handle such as `click`), within five seconds of user interaction. On the server-side this is used to trigger sending an {{httpheader("Attribution-Reporting-Register-Source")}} header in the response to complete registration of an attribution source.
 
         In addition, the browser is also triggered to store the associated source data (as provided in the {{httpheader("Attribution-Reporting-Register-Source")}} response header) when the `open()` method completes.


### PR DESCRIPTION
### Description

Replaces the experimental mark with the deprecated mark like has been done in https://github.com/mdn/content/pull/42353.