### PR TITLE
Release 151 split-view tab group and move fixes

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.tabs.group
 sidebar: addonsidebar
 ---
 
-Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group. All tabs in a tab group must be adjacent, and tabs are moved if needed. Any pinned tabs are unpinned before grouping.
+Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group. All tabs in a tab group must be adjacent, and tabs are moved if needed. A split view is added to the group if either of its tabs is specified. Any pinned tabs are unpinned before grouping.
 
 If a call moves tabs out of tab groups and any of those tab groups become empty, the empty tab groups are removed.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/group/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.tabs.group
 sidebar: addonsidebar
 ---
 
-Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group. All tabs in a tab group must be adjacent, and tabs are moved if needed. A split view is added to the group if either of its tabs is specified. Any pinned tabs are unpinned before grouping.
+Adds one or more tabs to a group or, if no group is specified, adds the tabs to a new group. All tabs in a tab group must be adjacent, and tabs are moved if needed. A [split view](/en-US/docs/Mozilla/Add-ons/WebExtensions/Working_with_the_Tabs_API#working_with_tab_split_views) is added to the group if either of its tabs is specified. Any pinned tabs are unpinned before grouping.
 
 If a call moves tabs out of tab groups and any of those tab groups become empty, the empty tab groups are removed.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.tabs.ungroup
 sidebar: addonsidebar
 ---
 
-Removes one or more tabs from their respective tab groups. If any groups become empty, they are deleted.
+Removes one or more tabs from their respective tab groups. A split view is removed from the group if either of its tabs is specified. If any groups become empty, they are deleted.
 
 All tabs in a tab group must be adjacent. If necessary, an ungrouped tab is moved before or after the tab group to maintain this requirement.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ungroup/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.tabs.ungroup
 sidebar: addonsidebar
 ---
 
-Removes one or more tabs from their respective tab groups. A split view is removed from the group if either of its tabs is specified. If any groups become empty, they are deleted.
+Removes one or more tabs from their respective tab groups. A [split view](/en-US/docs/Mozilla/Add-ons/WebExtensions/Working_with_the_Tabs_API#working_with_tab_split_views) is removed from the group if either of its tabs is specified. If any groups become empty, they are deleted.
 
 All tabs in a tab group must be adjacent. If necessary, an ungrouped tab is moved before or after the tab group to maintain this requirement.
 

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -72,8 +72,8 @@ Firefox 151 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
-- {{WebExtAPIRef("tab.group")}} and {{WebExtAPIRef("tab.ungroup")}} now correctly add and remove a split view when a call includes one of the split view's tabs. Previously, a call would fail or close the split view. ([Firefox bug 2029099](https://bugzil.la/2029099))
-- {{WebExtAPIRef("tab.move")}} now correctly moves a split view to the right when a call includes one of the split view's tabs. Previously, a call moved a split view only to the left or to the end of the tab list. ([Firefox bug 2027855](https://bugzil.la/2027855))
+- {{WebExtAPIRef("tabs.group()")}} and {{WebExtAPIRef("tabs.ungroup()")}} now correctly add and remove a split view when a call includes one of the split view's tabs. Previously, a call would fail or close the split view. ([Firefox bug 2029099](https://bugzil.la/2029099))
+- {{WebExtAPIRef("tabs.move()")}} now correctly moves a split view to the right when a call includes one of the split view's tabs. Previously, a call moved a split view only to the left or to the end of the tab list. ([Firefox bug 2027855](https://bugzil.la/2027855))
 
 <!-- ### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -72,6 +72,9 @@ Firefox 151 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
+- {{WebExtAPIRef("tab.group")}} and {{WebExtAPIRef("tab.ungroup")}} now correctly add and remove a split view when a call includes one of the split view's tabs. Previously, a call would fail or close the split view. ([Firefox bug 2029099](https://bugzil.la/2029099))
+- {{WebExtAPIRef("tab.move")}} now correctly moves a split view to the right when a call includes one of the split view's tabs. Previously, a call moved a split view only to the left or to the end of the tab list. ([Firefox bug 2027855](https://bugzil.la/2027855))
+
 <!-- ### Removals -->
 
 <!-- ### Other -->

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -72,7 +72,7 @@ Firefox 151 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
-- {{WebExtAPIRef("tabs.group()")}} and {{WebExtAPIRef("tabs.ungroup()")}} now correctly add and remove a split view when a call includes one of the split view's tabs. Previously, a call would fail or close the split view. ([Firefox bug 2029099](https://bugzil.la/2029099))
+- {{WebExtAPIRef("tabs.group()")}} and {{WebExtAPIRef("tabs.ungroup()")}} now correctly add and remove a split view when a call includes one of the split view's tabs. Previously, a call would fail or separate the split view. ([Firefox bug 2029099](https://bugzil.la/2029099))
 - {{WebExtAPIRef("tabs.move()")}} now correctly moves a split view to the right when a call includes one of the split view's tabs. Previously, a call moved a split view only to the left or to the end of the tab list. ([Firefox bug 2027855](https://bugzil.la/2027855))
 
 <!-- ### Removals -->


### PR DESCRIPTION
### Description

Updates to provide documentation for:

- [Bug 2029099](https://bugzilla.mozilla.org/show_bug.cgi?id=2029099) tabs.group() does not work with split views
- [Bug 2027855](https://bugzilla.mozilla.org/show_bug.cgi?id=2027855) Unexpected position of split view tabs after tabs.move()

Including a release note and clarification in `tabs.group` and `tabs.ungroup` regarding split views.