### PR TITLE
Add note about function call args limit for using spread syntax to concatenate arrays

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -85,7 +85,9 @@ vegetables.push(...moreVegs);
 console.log(vegetables); // ['parsnip', 'potato', 'celery', 'beetroot']
 ```
 
-Merging two arrays can also be done with the {{jsxref("Array/concat", "concat()")}} method.
+Merging two arrays can also be done with the {{jsxref("Array/concat", "concat()")}} method, which will make a new combined array instead of adding to the original.
+
+Note: using spread syntax will only work if the number of elements in the array is less than the maximum number of function parameters. Use {{jsxref("Array/concat", "concat()")}} if you're not sure that the array you're trying to merge will be short enough.
 
 ### Calling push() on non-array objects
 

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -85,9 +85,7 @@ vegetables.push(...moreVegs);
 console.log(vegetables); // ['parsnip', 'potato', 'celery', 'beetroot']
 ```
 
-Merging two arrays can also be done with the {{jsxref("Array/concat", "concat()")}} method, which will make a new combined array instead of adding to the original.
-
-Note: using spread syntax will only work if the number of elements in the array is less than the maximum number of function parameters. Use {{jsxref("Array/concat", "concat()")}} if you're not sure that the array you're trying to merge will be short enough.
+Merging two arrays can also be done with the {{jsxref("Array/concat", "concat()")}} method, which will make a new combined array instead of adding to the original. The spread syntax only works if the number of elements in the array is less than the maximum number of function arguments allowed by the engine. For longer arrays, use `concat()` or call `push()` multiple times in a loop.
 
 ### Calling push() on non-array objects
 


### PR DESCRIPTION
### Description

The Array.push documentation gives an example of using spread syntax to concatenate arrays. However, it doesn't mention the limitation which applies in this case: the array being concatenated needs to be short enough that it doesn't go beyond the limit on the number of arguments to a function call. This adds a note about that to the section with that example, and suggests using Array.concat instead in that case (Array.concat was already linked there as an alternative). It also mentions that Array.concat makes a copy so people who don't follow the link will get a hint about how Array.concat is different from Array.push(...).

### Motivation

It's easy in testing to see that Array.push(...x) works if you're testing with a small array x, including in unit tests you might set up. However, in production when x grows larger than the limits on function call parameters (which is pretty easy) this will break. So this is a hidden sharp edge to the suggested concatenation method in the docs. Since Array.concat always makes a copy which is not always desirable due to time/memory overhead, there's an extra incentive to use the push(...) method (and the existing docs don't highlight this distinction on the Array.push side). Adding a note will hopefully help some people avoid a headache.
