### PR TITLE
Add missing `PlatformArch` values

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -12,12 +12,22 @@ The machine's processor architecture.
 
 Values of this type are strings. Possible values are:
 
+- `"aarch64"`
+  - : The platform is based on the ARM 64-bit architecture.
 - `"arm"`
-  - : The platform is based on arm architecture.
+  - : The platform is based on the ARM 32-bit architecture.
+- `"arm64"`
+  - : The platform is based on the ARM 64-bit architecture.
+- `"mips"`
+  - : The platform is based on the 32-bit MIPS instruction set architecture (ISA).
+- `"mips64"`
+  - : The platform is based on the 64-bit MIPS instruction set architecture (ISA).
+- `"riscv64"`
+  - : The platform is based on the 64-bit implementation of the RISC-V open-standard instruction set architecture (ISA). 
 - `"x86-32"`
-  - : The platform is based on x86 32-bit architecture.
+  - : The platform is based on the x86 32-bit architecture.
 - `"x86-64"`
-  - : The platform is based on x86 64-bit architecture.
+  - : The platform is based on the x86 64-bit architecture.
 
 {{WebExtExamples}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -29,6 +29,9 @@ Values of this type are strings. Possible values are:
 - `"x86-64"`
   - : The platform is based on the x86 64-bit architecture.
 
+> [!NOTE]
+> This list may be incomplete. In particular, it may not reflect unofficial builds for other platforms.
+
 {{WebExtExamples}}
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -23,7 +23,7 @@ Values of this type are strings. Possible values are:
 - `"mips64"`
   - : The platform is based on the 64-bit MIPS instruction set architecture (ISA).
 - `"riscv64"`
-  - : The platform is based on the 64-bit implementation of the RISC-V open-standard instruction set architecture (ISA). 
+  - : The platform is based on the 64-bit implementation of the RISC-V open-standard instruction set architecture (ISA).
 - `"x86-32"`
   - : The platform is based on the x86 32-bit architecture.
 - `"x86-64"`

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformarch/index.md
@@ -15,7 +15,7 @@ Values of this type are strings. Possible values are:
 - `"aarch64"`
   - : The platform is based on the ARM 64-bit architecture.
 - `"arm"`
-  - : The platform is based on the ARM 32-bit architecture.
+  - : The platform is based on the ARM 32-bit architecture. Safari returns this value for the 64-bit architecture.
 - `"arm64"`
   - : The platform is based on the ARM 64-bit architecture.
 - `"mips"`

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformnaclarch/index.md
@@ -14,15 +14,15 @@ The enumerated value representing the CPU instruction set architecture of Google
 ## Type
 
 - `ARM`
-  - : The string literal `"arm"`. Represents all versions of the ARM ISA, including all 32-bit and 64-bit variants. Equivalent to [`PlatformArch.arm`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#arm) (32-bit variant) and `PlatformArch.arm64` combined into one value.
+  - : The string literal `"arm"`. Represents all versions of the ARM ISA, including all 32-bit and 64-bit variants. Equivalent to [`PlatformArch.arm`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#arm) (32-bit variant) and [`PlatformArch.arm64`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#arm64) combined into one value.
 - `X86_32`
   - : The string literal `"x86-32"`. Represents the 32-bit variant of the x86 architecture. Equivalent to [`PlatformArch.x86_32`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#x86-32).
 - `X86_64`
   - : The string literal `"x86-64"`. Represents the 64-bit variant of the x86 architecture. Equivalent to [`PlatformArch.X86_64`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#x86-64).
 - `MIPS`
-  - : The string literal `"mips"`. Represents the 32-bit variant of the MIPS ISA, which was never supported by official releases. Equivalent to `PlatformArch.mips`.
+  - : The string literal `"mips"`. Represents the 32-bit variant of the MIPS ISA, which was never supported by official releases. Equivalent to [`PlatformArch.mips`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#mips).
 - `MIPS64`
-  - : The string literal `"mips64"`. Represents the 64-bit variant of the MIPS ISA, which was never supported by official releases. Equivalent to `PlatformArch.mips64`.
+  - : The string literal `"mips64"`. Represents the 64-bit variant of the MIPS ISA, which was never supported by official releases. Equivalent to [`PlatformArch.mips64`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformArch#xmips64).
 
 {{WebExtExamples}}
 


### PR DESCRIPTION
### Description

As a result of [[WebExtensions] Deprecate runtime.PlatformInfo.nacl_arch](https://github.com/mdn/content/pull/43799#top) #43799, it was identified that a number of the `PlatformArch` values are missing. This PR adds those values.

### Related issues and pull requests

BCD changes in https://github.com/mdn/browser-compat-data/pull/29512
