### PR TITLE
docs: fix 'scrset' and 'LUNDDUN' typos flagged by the weekly spelling check

### DIFF
--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -198,7 +198,7 @@ It also allows you to see the effect of changing the size of a container on the 
 
 #### HTML
 
-The HTML is similar to that in the previous example, except that it defines three near-identical {{htmlelement("img")}} elements, each with a `scrset` indicating 3 images that are `600px`, `400px`, and `200px` wide, and with a `sizes` value of `auto`.
+The HTML is similar to that in the previous example, except that it defines three near-identical {{htmlelement("img")}} elements, each with a `srcset` indicating 3 images that are `600px`, `400px`, and `200px` wide, and with a `sizes` value of `auto`.
 These are constrained within containers that are sized to select the different images.
 
 ```html

--- a/files/en-us/web/security/threat_modeling/index.md
+++ b/files/en-us/web/security/threat_modeling/index.md
@@ -12,7 +12,7 @@ Depending on your goal, threat modeling can be more involved than described here
 This page describes the overall threat modeling process. For threat model frameworks and resources, see:
 
 - [Threat modeling frameworks and tools](/en-US/docs/Web/Security/Threat_modeling/Frameworks)
-  - : Overview of the STRIDE and LUNDDUN frameworks that provide structure for threat modeling processes, and additional threat modeling tools.
+  - : Overview of the STRIDE and LINDDUN frameworks that provide structure for threat modeling processes, and additional threat modeling tools.
 
 For an example threat model, see:
 
@@ -210,7 +210,7 @@ You can revisit the issues you filed and the documentation you've written in the
 
 We provide an [example threat model](/en-US/docs/Web/Security/Threat_modeling/Example_threat_model) for inspiration. Threat model documents don't get published very often and aren't shared broadly unfortunately; they are often an internal resource. Although it is good practice to publish your threat model, both to demonstrate trustworthiness and to solicit additional feedback.
 
-In our threat modeling above, we focus on the four key questions as defined in the [Threat Modeling Manifesto](https://www.threatmodelingmanifesto.org). Frameworks exist, including STRIDE and LUNDDUN, that provide structure for threat modeling processes. See the [threat modeling frameworks and resources](/en-US/docs/Web/Security/Threat_modeling/Frameworks) guide for a list of privacy and security threats, along with example questions that may help guide you in your own threat model development.
+In our threat modeling above, we focus on the four key questions as defined in the [Threat Modeling Manifesto](https://www.threatmodelingmanifesto.org). Frameworks exist, including STRIDE and LINDDUN, that provide structure for threat modeling processes. See the [threat modeling frameworks and resources](/en-US/docs/Web/Security/Threat_modeling/Frameworks) guide for a list of privacy and security threats, along with example questions that may help guide you in your own threat model development.
 
 ## See also
 


### PR DESCRIPTION
## Summary
Fixes three spelling typos surfaced by the automated weekly spelling check:

- `scrset` → `srcset` in `web/api/htmlimageelement/sizes` (one occurrence).
- `LUNDDUN` → `LINDDUN` in `web/security/threat_modeling` (two occurrences). The same page — and the related `web/security/threat_modeling/frameworks` page — already use `LINDDUN` correctly, which matches the framework's canonical name.

## Issue
Refs #43850

## Changes
- `files/en-us/web/api/htmlimageelement/sizes/index.md`
- `files/en-us/web/security/threat_modeling/index.md`

## Testing
- Content-only change; no build config or example code touched. Prose renders unchanged apart from the corrected spellings.