### PR TITLE
Permissions-Policy-Report-Only and Reporting API updates

### DIFF
--- a/files/en-us/web/api/crashreport/index.md
+++ b/files/en-us/web/api/crashreport/index.md
@@ -30,7 +30,7 @@ The `CrashReport` dictionary of the [Reporting API](/en-US/docs/Web/API/Reportin
     - `is_top_level` {{experimental_inline}}
       - : A boolean indicating whether the crashed document was a top-level document (`true`) or an embedded document (`false`).
     - `reason` {{experimental_inline}} {{optional_inline}}
-      - : A string indicating the specfic reason why the crash occurred, if known. Possible values are:
+      - : A string indicating the specific reason why the crash occurred, if known. Possible values are:
         - `oom`
           - : The page ran out of memory.
         - `unresponsive`

--- a/files/en-us/web/api/crashreportcontext/index.md
+++ b/files/en-us/web/api/crashreportcontext/index.md
@@ -69,7 +69,7 @@ async function fetchURL(url) {
 }
 ```
 
-This also prevents key-value pairs that identify the same issue occuring at different times or places from overwriting one another. In this case, we differentiate crash report data set in the top-level document versus data set in embeded documents.
+This also prevents key-value pairs that identify the same issue occuring at different times or places from overwriting one another. In this case, we differentiate crash report data set in the top-level document versus data set in embedded documents.
 
 ## Specifications
 

--- a/files/en-us/web/api/permissionspolicyviolationreport/index.md
+++ b/files/en-us/web/api/permissionspolicyviolationreport/index.md
@@ -11,7 +11,7 @@ browser-compat: api.ReportingObserver.ReportingObserver.options_parameter.types_
 
 The `PermissionsPolicyViolationReport` dictionary of the [Reporting API](/en-US/docs/Web/API/Reporting_API) represents a report that is generated when a document violates its [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy).
 
-Reports of this type can be observed from within a page using a {{domxref("ReportingObserver")}}, and a serialized version can be sent to a reporting endpoint server.
+Reports of this type can be observed from within a page using a {{domxref("ReportingObserver")}}, and a serialized version can be sent to a reporting server endpoint.
 
 ## Instance properties
 
@@ -52,7 +52,7 @@ Violations of the policy may also be reported but not enforced using the {{httph
 You can monitor for Permissions-Policy violation reports within the page that sets the policy using the [Reporting API](/en-US/docs/Web/API/Reporting_API).
 To do this you create a {{domxref("ReportingObserver")}} object to listen for reports, passing a callback method and an (optional) `options` property specifying the types of reports that you want to report on.
 The callback method is then called with reports of the requested types, passing a report object.
-For `Permissions-Policy` or `Permissions-Policy-Report-Only` violations, the object will be a `PermissionsPolicyViolationReport` instance with `PermissionsPolicyViolationReport.type == "permissions-policy-violation"`.
+For `Permissions-Policy` or `Permissions-Policy-Report-Only` violations, the object will be a `PermissionsPolicyViolationReport` instance with `PermissionsPolicyViolationReport.type === "permissions-policy-violation"`.
 
 The structure of a typical in-page report is shown below.
 Note that we can see the URL of the page that had its policy violated (`url`), and from `body.featureId` we can see which feature was blocked.
@@ -167,7 +167,7 @@ Note that the `type` is `"permissions-policy-violation"` and `body.featureId` id
 This example shows how to configure reporting of `Permissions-Policy` violations to a server endpoint.
 
 The response headers below block geolocation and define the reporting endpoint name for the feature as "geo_endpoint".
-The {{HTTPHeader("Reporting-Endpoints")}} HTTP response header is used to define URL of this endpoint name.
+The {{HTTPHeader("Reporting-Endpoints")}} HTTP response header is used to define the URL of this endpoint name.
 
 ```http
 Reporting-Endpoints: geo_endpoint="https://example.com/reports"

--- a/files/en-us/web/api/permissionspolicyviolationreport/index.md
+++ b/files/en-us/web/api/permissionspolicyviolationreport/index.md
@@ -73,7 +73,7 @@ The `body.disposition` field shows that the violation was enforced or only repor
 }
 ```
 
-Violation reports may also be sent as a JSON object in a {{httpmethod("POST")}} request to the [reporting server endpoint](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) indicated by name in a per-directive `report-to` parameter, or otherwise to the [`default` reporting server endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint).
+Violation reports may also be sent as a JSON object in a {{httpmethod("POST")}} request to the [reporting server endpoint](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) indicated by name in a per-directive `report-to` parameter, with fallback to the [`default` reporting server endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint) (if defined).
 The reporting server endpoint and its mapping to a particular URL are set using the {{httpheader("Reporting-Endpoints")}} response header.
 
 The structure of the server report is almost exactly the same as `PermissionsPolicyViolationReport`, except that it additionally includes `age` and `user_agent` fields.

--- a/files/en-us/web/api/permissionspolicyviolationreport/index.md
+++ b/files/en-us/web/api/permissionspolicyviolationreport/index.md
@@ -11,7 +11,7 @@ browser-compat: api.ReportingObserver.ReportingObserver.options_parameter.types_
 
 The `PermissionsPolicyViolationReport` dictionary of the [Reporting API](/en-US/docs/Web/API/Reporting_API) represents a report that is generated when a document violates its [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy).
 
-Reports of this type can be observed from within a page using a {{domxref("ReportingObserver")}}, and a serialized version can be sent to the [default reporting server endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint).
+Reports of this type can be observed from within a page using a {{domxref("ReportingObserver")}}, and a serialized version can be sent to a reporting endpoint server.
 
 ## Instance properties
 
@@ -47,15 +47,16 @@ Reports of this type can be observed from within a page using a {{domxref("Repor
 
 Permissions Policy violations are reported when a document attempts to use a browser feature that is blocked by its [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy).
 The policy is set using the {{httpheader("Permissions-Policy")}} HTTP header, or a `<meta http-equiv="permissions-policy">` element.
+Violations of the policy may also be reported but not enforced using the {{httpheader("Permissions-Policy-Report-Only")}} HTTP header, or a `<meta http-equiv="permissions-policy-report-only">` element.
 
 You can monitor for Permissions-Policy violation reports within the page that sets the policy using the [Reporting API](/en-US/docs/Web/API/Reporting_API).
 To do this you create a {{domxref("ReportingObserver")}} object to listen for reports, passing a callback method and an (optional) `options` property specifying the types of reports that you want to report on.
 The callback method is then called with reports of the requested types, passing a report object.
-For `Permissions-Policy` violations, the object will be a `PermissionsPolicyViolationReport` instance with `PermissionsPolicyViolationReport.type == "permissions-policy-violation"`.
+For `Permissions-Policy` or `Permissions-Policy-Report-Only` violations, the object will be a `PermissionsPolicyViolationReport` instance with `PermissionsPolicyViolationReport.type == "permissions-policy-violation"`.
 
 The structure of a typical in-page report is shown below.
 Note that we can see the URL of the page that had its policy violated (`url`), and from `body.featureId` we can see which feature was blocked.
-The `body.disposition` field shows that the violation was enforced.
+The `body.disposition` field shows that the violation was enforced or only reported.
 
 ```json
 {
@@ -66,14 +67,14 @@ The `body.disposition` field shows that the violation was enforced.
     "lineNumber": 44,
     "columnNumber": 29,
     "featureId": "geolocation",
-    "disposition": "enforce",
+    "disposition": "enforce", // Policy was enforced!
     "message": "Permissions policy violation: geolocation access has been blocked because of a permissions policy applied to the current document."
   }
 }
 ```
 
-Violation reports may also be sent as a JSON object in a {{httpmethod("POST")}} request to the [reporting server endpoint](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) named `"default"`, if one is defined.
-The reporting server endpoint and its mapping to a particular URL are set using the {{httpheader("Reporting-Endpoints")}} header.
+Violation reports may also be sent as a JSON object in a {{httpmethod("POST")}} request to the [reporting server endpoint](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) indicated by name in a per-directive `report-to` parameter, or otherwise to the [`default` reporting server endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint).
+The reporting server endpoint and its mapping to a particular URL are set using the {{httpheader("Reporting-Endpoints")}} response header.
 
 The structure of the server report is almost exactly the same as `PermissionsPolicyViolationReport`, except that it additionally includes `age` and `user_agent` fields.
 
@@ -163,12 +164,23 @@ Note that the `type` is `"permissions-policy-violation"` and `body.featureId` id
 
 ### Sending a Permissions Policy violation report to a reporting endpoint
 
-Here we define the define reporting endpoint named `"default"` using the {{httpheader("Reporting-Endpoints")}} response header, and set the `Permissions-Policy` header to block use of the `geolocation` feature.
+This example shows how to configure reporting of `Permissions-Policy` violations to a server endpoint.
+
+The response headers below block geolocation and define the reporting endpoint name for the feature as "geo_endpoint".
+The {{HTTPHeader("Reporting-Endpoints")}} HTTP response header is used to define URL of this endpoint name.
 
 ```http
-Reporting-Endpoints: default="https://example.com/reports"
-Permissions-Policy: geolocation=()
+Reporting-Endpoints: geo_endpoint="https://example.com/reports"
+Permissions-Policy: geolocation=();report-to=geo_endpoint
 ```
+
+> [!NOTE]
+> To send all violation reports to the same endpoint we might instead define the [`"default"` reporting endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint):
+>
+> ```http
+> Reporting-Endpoints: default="https://example.com/reports"
+> Permissions-Policy: geolocation=()
+> ```
 
 As before, a violation is triggered by attempting to use a blocked feature:
 
@@ -214,6 +226,7 @@ Note that the `type` is `"permissions-policy-violation"` and the `body` property
 
 - {{domxref("ReportingObserver")}}
 - {{httpheader("Permissions-Policy")}}
+- {{httpheader("Permissions-Policy-Report-Only")}}
 - {{httpheader("Reporting-Endpoints")}}
 - [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy)
 - [Reporting API](/en-US/docs/Web/API/Reporting_API)

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -72,24 +72,37 @@ The {{httpheader("Reporting-Endpoints")}} HTTP header is used to specify the nam
 The endpoints can then be specified within particular HTTP response headers to indicate the endpoint (or in some cases, endpoints) that associated reports will be delivered to.
 Report types that don't have an associated HTTP header, such as `crash`, `deprecation`, and `intervention` reports, will usually send reports to the [`"default"` reporting endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint) (this is just an endpoint named "default" specified using the `Reporting-Endpoints` header).
 
-The mechanism to specify server endpoints for each report is listed below.
+The mechanisms to specify server endpoints for each report type are listed below:
 
-- `coep`
-  - `report-to` parameter on {{HTTPHeader("Cross-Origin-Embedder-Policy")}} or {{HTTPHeader("Cross-Origin-Embedder-Policy-Report-Only")}}
-- `csp-violation`
-  - {{CSP("report-to")}} directive on {{HTTPHeader("Content-Security-Policy")}} or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
-- `integrity-violation`
-  - [`endpoints`](/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy#endpoints) field in {{httpheader("Integrity-Policy")}} or {{httpheader("Integrity-Policy-Report-Only")}}
-- `permissions-policy-violation`
-  - `report-to` parameter on {{HTTPHeader("Permissions-Policy")}} or {{HTTPHeader("Permissions-Policy-Report-Only")}}
-  - [`"default"` endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint)
-- `crash`
-  - `crash-reporting` endpoint
-  - `default` endpoint.
-- `deprecation`
-  - `default` endpoint.
-- `intervention`
-  - `default` endpoint.
+`coep`
+
+- `report-to` parameter on {{HTTPHeader("Cross-Origin-Embedder-Policy")}} or {{HTTPHeader("Cross-Origin-Embedder-Policy-Report-Only")}}
+
+`csp-violation`
+
+- {{CSP("report-to")}} directive on {{HTTPHeader("Content-Security-Policy")}} or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
+
+`integrity-violation`
+
+- [`endpoints`](/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy#endpoints) field in {{httpheader("Integrity-Policy")}} or {{httpheader("Integrity-Policy-Report-Only")}}
+
+`permissions-policy-violation`
+
+- `report-to` parameter on {{HTTPHeader("Permissions-Policy")}} or {{HTTPHeader("Permissions-Policy-Report-Only")}}
+- [`"default"` endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint)
+
+`crash`
+
+- `crash-reporting` endpoint
+- `default` endpoint.
+
+`deprecation`
+
+- `default` endpoint.
+
+`intervention`
+
+- `default` endpoint.
 
 ### Generating reports via WebDriver
 

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -29,41 +29,10 @@ There are several different features and problems on the web platform that gener
 - Occurrence of crashes.
 - Occurrence of user-agent interventions (when the browser blocks something your code is trying to do because it is deemed a security risk for example, or just plain annoying, like auto-playing audio).
 
-The purpose of the Reporting API is to provide a consistent reporting mechanism that can be used to make such information available to developers in the form of reports represented by JavaScript objects. There are a few ways to use it, which are detailed in the sections below.
+The purpose of the Reporting API is to provide a consistent reporting mechanism that can be used to make such information available to developers in the form of reports represented by JavaScript objects.
 
-### Reporting server endpoints
-
-Each unique origin you want to get reports for can be given a series of "endpoints", which are named URLs (or groups of URLs) that can be sent reports from a user agent.
-A reporting server at these endpoints can collect the reports, and process and present them as needed by your application.
-
-The {{httpheader("Reporting-Endpoints")}} HTTP header is used to specify details about the different endpoints that a user-agent has available to it for delivering reports.
-The endpoints can then be used on particular HTTP response headers to indicate the specific endpoint (or in some cases endpoints) that will be used for the associated report.
-The directive or parameter used to specify an endpoint depends on the header.
-For example, the CSP {{CSP("report-to")}} directive can be used on the {{HTTPHeader("Content-Security-Policy")}} or {{HTTPHeader("Content-Security-Policy-Report-Only")}} HTTP headers to specify the endpoint that CSP violation reports should be sent to, while the [`endpoints`](/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy#endpoints) field is used on {{httpheader("Integrity-Policy")}} or {{httpheader("Integrity-Policy-Report-Only")}} to specify where to send integrity-policy violation reports.
-
-Report types that don't have an associated HTTP header, such as `crash`, `deprecation`, and `intervention` reports, will usually send reports to the "default reporting endpoint".
-This is just an endpoint named "default" specified using the `Reporting-Endpoints` header.
-
-> [!NOTE]
-> There is no absolute guarantee of report delivery — a report could still fail to be collected if a serious error occurs.
-
-The reports themselves are sent to the target endpoint by the user agent in a `POST` operation with a {{HTTPHeader("Content-Type")}} of `application/reports+json`.
-They are serializations of the corresponding dictionary for each [report type](#report_types).
-For example, CSP violation reports are a serialization of a {{domxref("CSPViolationReport")}} object.
-
-Reports sent to endpoints can be retrieved independently of the running of the websites they relate to, which is useful — a crash for example could bring down a website and stop anything running, but a report could still be obtained to give the developer some clues as to why it happened.
-
-### Reporting observers
-
-Reports can also be obtained via {{domxref("ReportingObserver")}} objects created via JavaScript inside the website you are aiming to get reports on.
-This method is not as failsafe as sending reports to the server because any page crash could stop you retrieving the reports — but it is easier to set up, and more flexible.
-
-A `ReportingObserver` object is created using the {{domxref("ReportingObserver.ReportingObserver", "ReportingObserver()")}} constructor, which is passed two parameters:
-
-- A callback function with two parameters — an array of the reports available in the observer's report queue and a copy of the same `ReportingObserver` object, which allows observation to be controlled directly from inside the callback. The callback runs when observation starts.
-- An options dictionary that allows you to specify the [types](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) of reports to collect, and whether reports generated before the observer was created should be observable (`buffered: true`).
-
-Methods are then available on the observer to start collecting reports ({{domxref("ReportingObserver.observe()")}}), retrieve the reports currently in the report queue ({{domxref("ReportingObserver.takeRecords()")}}), and disconnect the observer so it can no longer collect records ({{domxref("ReportingObserver.disconnect()")}}).
+Reports can be obtained within a page using JavaScript via reporting observers, or can be sent to a remote server endpoint.
+The types of reports and the two reporting approaches are detailed in the sections below.
 
 ### Report types
 
@@ -75,6 +44,52 @@ Reports sent to reporting endpoints and reporting observers are essentially the 
 The only difference is that server reports are JSON serializations of the objects that have additional `user_agent` and `age` fields.
 
 A list of documented report types and their corresponding report dictionary are given in the [`options.types`](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) parameter passed to the `ReportingObserver()` constructor.
+
+### Reporting observers
+
+Reports can be obtained via {{domxref("ReportingObserver")}} objects created via JavaScript inside the website you are aiming to get reports on.
+This method is not as failsafe as sending reports to the server because any page crash could stop you retrieving the reports — but it is easier to set up, and more flexible.
+
+A `ReportingObserver` object is created using the {{domxref("ReportingObserver.ReportingObserver", "ReportingObserver()")}} constructor, which is passed two parameters:
+
+- A callback function with two parameters — an array of the reports available in the observer's report queue and a copy of the same `ReportingObserver` object, which allows observation to be controlled directly from inside the callback. The callback runs when observation starts.
+- An options dictionary that allows you to specify the [types](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) of reports to collect, and whether reports generated before the observer was created should be observable (`buffered: true`).
+
+Methods are then available on the observer to start collecting reports ({{domxref("ReportingObserver.observe()")}}), retrieve the reports currently in the report queue ({{domxref("ReportingObserver.takeRecords()")}}), and disconnect the observer so it can no longer collect records ({{domxref("ReportingObserver.disconnect()")}}).
+
+### Reporting server endpoints
+
+Reports can also be sent to remote _server endpoints_ by the user agent in a `POST` operation with a {{HTTPHeader("Content-Type")}} of `application/reports+json`.
+They are serializations of the corresponding dictionary for each [report type](#report_types).
+For example, CSP violation reports are a serialization of a {{domxref("CSPViolationReport")}} object.
+
+Reports sent to endpoints can be retrieved independently of the running of the websites they relate to, which is useful — a crash for example could bring down a website and stop anything running, but a report could still be obtained to give the developer some clues as to why it happened.
+
+> [!NOTE]
+> There is no absolute guarantee of report delivery — a report could still fail to be collected if a serious error occurs.
+
+The {{httpheader("Reporting-Endpoints")}} HTTP header is used to specify the name and URL for different endpoints that a user-agent has available to it for delivering reports.
+The endpoints can then be used on particular HTTP response headers to indicate the specific endpoint (or in some cases endpoints) that will be used for the associated report.
+Report types that don't have an associated HTTP header, such as `crash`, `deprecation`, and `intervention` reports, will usually send reports to the [`"default"` reporting endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint) (this is just an endpoint named "default" specified using the `Reporting-Endpoints` header).
+
+The mechanism to specify server endpoint for each report is listed below.
+
+- `coep`
+  - `report-to` parameter on {{HTTPHeader("Cross-Origin-Embedder-Policy")}} or {{HTTPHeader("Cross-Origin-Embedder-Policy-Report-Only")}}
+- `csp-violation`
+  - {{CSP("report-to")}} directive on {{HTTPHeader("Content-Security-Policy")}} or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
+- `integrity-violation`
+  - [`endpoints`](/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy#endpoints) field in {{httpheader("Integrity-Policy")}} or {{httpheader("Integrity-Policy-Report-Only")}}
+- `permissions-policy-violation`
+  - `report-to` parameter on {{HTTPHeader("Permissions-Policy")}} or {{HTTPHeader("Permissions-Policy-Report-Only")}}
+  - [`"default"` endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint)
+- `crash`
+  - `crash-reporting` endpoint
+  - `default` endpoint.
+- `deprecation`
+  - `default` endpoint.
+- `intervention`
+  - `default` endpoint.
 
 ### Generating reports via WebDriver
 
@@ -121,18 +136,6 @@ These HTTP response headers define the endpoints where reports are sent.
     These endpoints can be used in the `report-to` directive, which may be used with a number of HTTP headers including {{httpheader("Content-Security-Policy")}} or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
 - {{HTTPHeader("Report-To")}} {{deprecated_inline}}
   - : No longer part of the Reporting API but still supported by some browsers. This sets the name and URL of reporting endpoint groups, which may be used with a number of HTTP headers especially for [Network Error Logging](/en-US/docs/Web/HTTP/Guides/Network_Error_Logging) that has not yet been updated to support `Reporting-Endpoints`. Other Reporting API reports should use `Reporting-Endpoints` instead for better future support.
-
-Report endpoints can be set for the following reports using the {{CSP("report-to")}} directive or parameter on the corresponding headers:
-
-- COEP violations
-  - : {{HTTPHeader("Cross-Origin-Embedder-Policy")}} or {{HTTPHeader("Cross-Origin-Embedder-Policy-Report-Only")}}.
-- CSP violations
-  - : {{HTTPHeader("Content-Security-Policy")}} or {{HTTPHeader("Content-Security-Policy-Report-Only")}}.
-
-Report endpoints can be set for the following reports using the [`endpoints`](/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy#endpoints) field in a structured dictionary on the corresponding headers:
-
-- Integrity-Policy violations
-  - : {{httpheader("Integrity-Policy")}} or {{httpheader("Integrity-Policy-Report-Only")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -36,14 +36,27 @@ The types of reports and the two reporting approaches are detailed in the sectio
 
 ### Report types
 
-Reports sent to reporting observers are instances of dictionary objects, such as {{domxref("COEPViolationReport")}}, {{domxref("CrashReport")}}, {{domxref("DeprecationReport")}}, {{domxref("IntegrityViolationReport")}}, {{domxref("InterventionReport")}}, {{domxref("CSPViolationReport")}}, and {{domxref("PermissionsPolicyViolationReport")}}.
-These all have an origin `url`, a `type`, and a `body` that is specific to the report type.
-The type of report can be determined from its `type` property, which for the reports above would be `coep`, `crash`, `deprecation`, `integrity-violation`, `intervention`, `csp-violation`, and `permissions-policy-violation`.
+Reports sent to reporting observers are instances of dictionary objects.
+These all have `type`, `url`, and `body` properties, where the `type` indicates the type of report, and the `body` is specific to the report type.
 
-Reports sent to reporting endpoints and reporting observers are essentially the same.
+Reports sent to reporting endpoints are essentially the same.
 The only difference is that server reports are JSON serializations of the objects that have additional `user_agent` and `age` fields.
 
-A list of documented report types and their corresponding report dictionaries is given in the [`options.types`](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) parameter passed to the `ReportingObserver()` constructor.
+The following table lists the documented report types, their corresponding report dictionaries, and notes on the violation.
+Note that except for `crash` reports, which can't be observed in JavaScript (because the observing page has crashed), all the listed reports are visible in both observers and can be sent to server endpoints.
+
+| Type                           | Report object                                   | Notes                                                                                      |
+| ------------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `coep`                         | {{domxref("COEPViolationReport")}}              | {{httpheader("Cross-Origin-Embedder-Policy")}} (COEP) violations                           |
+| `coop`                         | `COOPViolationReport`                           | {{httpheader("Cross-Origin-Opener-Policy")}} (COOP) violations                             |
+| `crash`                        | {{domxref("CrashReport")}}                      | Browser crash reports                                                                      |
+| `csp-violation`                | {{domxref("CSPViolationReport")}}               | [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/Guides/CSP) violations                |
+| `deprecation`                  | {{domxref("DeprecationReport")}}                | Deprecated features used by the site.                                                      |
+| `integrity-violation`          | {{domxref("IntegrityViolationReport")}}         | {{httpheader("Integrity-Policy")}} violations                                              |
+| `intervention`                 | {{domxref("InterventionReport")}}               | Features blocked by the user agent, such as ads that significantly impact page performance |
+| `permissions-policy-violation` | {{domxref("PermissionsPolicyViolationReport")}} | {{httpheader("Permissions-Policy")}} violations                                            |
+
+A list of the types is also is given in the [`options.types`](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) parameter passed to the `ReportingObserver()` constructor.
 
 ### Reporting observers
 

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -43,7 +43,7 @@ Reports sent to reporting endpoints are essentially the same.
 The only difference is that server reports are JSON serializations of the objects that have additional `user_agent` and `age` fields.
 
 The following table lists the documented report types, their corresponding report dictionaries, and notes on the violation.
-Note that except for `crash` reports, which can't be observed in JavaScript (because the observing page has crashed), all the listed reports are visible in both observers and can be sent to server endpoints.
+Note that, except for `crash` reports, which can't be observed in JavaScript (because the observing page has crashed), all the listed reports are visible in observers and can be sent to server endpoints.
 
 | Type                           | Report object                                   | Notes                                                                                      |
 | ------------------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------ |

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -31,7 +31,7 @@ There are several different features and problems on the web platform that gener
 
 The purpose of the Reporting API is to provide a consistent reporting mechanism that can be used to make such information available to developers in the form of reports represented by JavaScript objects.
 
-Reports can be obtained within a page using JavaScript via reporting observers, or can be sent to a remote server endpoint.
+Reports can be retrieved via JavaScript reporting observers or sent to a remote server endpoint.
 The types of reports and the two reporting approaches are detailed in the sections below.
 
 ### Report types
@@ -43,12 +43,12 @@ The type of report can be determined from its `type` property, which for the rep
 Reports sent to reporting endpoints and reporting observers are essentially the same.
 The only difference is that server reports are JSON serializations of the objects that have additional `user_agent` and `age` fields.
 
-A list of documented report types and their corresponding report dictionary are given in the [`options.types`](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) parameter passed to the `ReportingObserver()` constructor.
+A list of documented report types and their corresponding report dictionaries is given in the [`options.types`](/en-US/docs/Web/API/ReportingObserver/ReportingObserver#types) parameter passed to the `ReportingObserver()` constructor.
 
 ### Reporting observers
 
 Reports can be obtained via {{domxref("ReportingObserver")}} objects created via JavaScript inside the website you are aiming to get reports on.
-This method is not as failsafe as sending reports to the server because any page crash could stop you retrieving the reports — but it is easier to set up, and more flexible.
+This method is not as failsafe as sending reports to the server because any page crash could stop you from retrieving the reports; it is, however, easier to set up, and more flexible.
 
 A `ReportingObserver` object is created using the {{domxref("ReportingObserver.ReportingObserver", "ReportingObserver()")}} constructor, which is passed two parameters:
 
@@ -69,10 +69,10 @@ Reports sent to endpoints can be retrieved independently of the running of the w
 > There is no absolute guarantee of report delivery — a report could still fail to be collected if a serious error occurs.
 
 The {{httpheader("Reporting-Endpoints")}} HTTP header is used to specify the name and URL for different endpoints that a user-agent has available to it for delivering reports.
-The endpoints can then be used on particular HTTP response headers to indicate the specific endpoint (or in some cases endpoints) that will be used for the associated report.
+The endpoints can then be specified within particular HTTP response headers to indicate the endpoint (or in some cases, endpoints) that associated reports will be delivered to.
 Report types that don't have an associated HTTP header, such as `crash`, `deprecation`, and `intervention` reports, will usually send reports to the [`"default"` reporting endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint) (this is just an endpoint named "default" specified using the `Reporting-Endpoints` header).
 
-The mechanism to specify server endpoint for each report is listed below.
+The mechanism to specify server endpoints for each report is listed below.
 
 - `coep`
   - `report-to` parameter on {{HTTPHeader("Cross-Origin-Embedder-Policy")}} or {{HTTPHeader("Cross-Origin-Embedder-Policy-Report-Only")}}

--- a/files/en-us/web/http/reference/headers/permissions-policy-report-only/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy-report-only/index.md
@@ -1,0 +1,114 @@
+---
+title: Permissions-Policy-Report-Only header
+short-title: Permissions-Policy-Report-Only
+slug: Web/HTTP/Reference/Headers/Permissions-Policy-Report-Only
+page-type: http-header
+status:
+  - experimental
+browser-compat: http.headers.Permissions-Policy-Report-Only
+sidebar: http
+---
+
+{{SeeCompatTable}}
+
+The HTTP **`Permissions-Policy-Report-Only`** {{Glossary("response header")}} provides a mechanism for website administrators to report on violations of a {{HTTPHeader("Permissions-Policy")}} without enforcing them.
+This allows testing and fixing of a [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) issues before a policy is deployed.
+
+The syntax and behavior is exactly the same as for `Permissions-Policy` except:
+
+- The policy is not enforced.
+- Policy violation report objects ({{domxref("PermissionsPolicyViolationReport")}}) have the value `body.disposition="report"` (instead of `"enforce"`).
+
+See {{HTTPHeader("Permissions-Policy")}} for more information (most of its content has not been duplicated below).
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Response header")}}</td>
+    </tr>
+  </tbody>
+</table>
+
+## Syntax
+
+```http
+# Single directive
+Permissions-Policy-Report-Only: <directive>=<allowlist>
+
+# Single directive with reporting endpoint
+Permissions-Policy-Report-Only: <directive>=<allowlist>;report-to=<endpoint>
+
+# Multiple directives, with and without server reporting endpoints
+Permissions-Policy-Report-Only: <directive>=<allowlist>, <directive>=<allowlist>;report-to=<endpoint>, ...
+```
+
+## Examples
+
+### Basic usage
+
+SecureCorp Inc. wants to disable the {{domxref("Geolocation")}} API in its application.
+Before rolling out the policy using `Permissions-Policy`, it adds the `Permissions-Policy-Report-Only` and {{HTTPHeader("Reporting-Endpoints")}} headers as shown below:
+
+```http
+Reporting-Endpoints: geo_endpoint="https://example.com/reports"
+Permissions-Policy-Report-Only: geolocation=();report-to=geo_endpoint
+```
+
+By specifying `geolocation=()` for the origin list, it is violation to access geolocation for all browsing contexts (this includes all `<iframe>`s), regardless of their origin.
+The `report-to` parameter indicates that reports will be sent to the endpoint named `geo_endpoint`.
+The mapping between `geo_endpoint` and the URL where reports are to be sent is provided in `Reporting-Endpoints`.
+
+A violation occurs when a page attempts to use the blocked feature, for example:
+
+```js
+navigator.geolocation.getCurrentPosition(
+  () => {},
+  () => {},
+);
+```
+
+The [report payload](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) sent to the endpoint might look like the JSON below.
+This is the same as a report for `Permissions-Policy` except for the value of `body.disposition`.
+
+```json
+[
+  {
+    "age": 48512,
+    "body": {
+      "columnNumber": 29,
+      "disposition": "report", // A violation that is reported and not enforced
+      "lineNumber": 44,
+      "message": "Permissions policy violation: geolocation access has been blocked because of a permissions policy applied to the current document.",
+      "featureId": "geolocation",
+      "sourceFile": "https://example.com/"
+    },
+    "type": "permissions-policy-violation",
+    "url": "https://example.com/",
+    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+  }
+]
+```
+
+> [!NOTE]
+> Chrome's server-side serialization of violation reports uses `policyId` rather than [`featureId`](/en-US/docs/Web/API/PermissionsPolicyViolationReport#featureid) for the feature name in the `body` of a server report.
+> The {{domxref("PermissionsPolicyViolationReport")}} returned by a [`ReportingObserver`](/en-US/docs/Web/API/ReportingObserver) follows the specification.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy)
+- {{DOMxRef("Document.featurePolicy")}} and {{DOMxRef("FeaturePolicy")}}
+- {{HTTPHeader("Content-Security-Policy")}}
+- {{HTTPHeader("Referrer-Policy")}}
+- {{HTTPHeader("Reporting-Endpoints")}}
+- {{domxref("PermissionsPolicyViolationReport")}}
+- {{domxref("ReportingObserver")}}
+- [Reporting API](/en-US/docs/Web/API/Reporting_API)

--- a/files/en-us/web/http/reference/headers/permissions-policy-report-only/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy-report-only/index.md
@@ -12,12 +12,12 @@ sidebar: http
 {{SeeCompatTable}}
 
 The HTTP **`Permissions-Policy-Report-Only`** {{Glossary("response header")}} provides a mechanism for website administrators to report on violations of a {{HTTPHeader("Permissions-Policy")}} without enforcing them.
-This allows testing and fixing of a [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) issues before a policy is deployed.
+This allows testing and fixing of [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) issues before a policy is deployed.
 
 The syntax and behavior is exactly the same as for `Permissions-Policy` except:
 
 - The policy is not enforced.
-- Policy violation report objects ({{domxref("PermissionsPolicyViolationReport")}}) have the value `body.disposition="report"` (instead of `"enforce"`).
+- Policy violation report objects ({{domxref("PermissionsPolicyViolationReport")}}) have a `body.disposition` value of `"report"` instead of `"enforce"`.
 
 See {{HTTPHeader("Permissions-Policy")}} for more information (most of its content has not been duplicated below).
 
@@ -55,7 +55,7 @@ Reporting-Endpoints: geo_endpoint="https://example.com/reports"
 Permissions-Policy-Report-Only: geolocation=();report-to=geo_endpoint
 ```
 
-By specifying `geolocation=()` for the origin list, it is violation to access geolocation for all browsing contexts (this includes all `<iframe>`s), regardless of their origin.
+By specifying `geolocation=()` for the origin list, it is a violation for any browsing context to access geolocation (this includes `<iframe>`s), regardless of origin.
 The `report-to` parameter indicates that reports will be sent to the endpoint named `geo_endpoint`.
 The mapping between `geo_endpoint` and the URL where reports are to be sent is provided in `Reporting-Endpoints`.
 
@@ -68,7 +68,7 @@ navigator.geolocation.getCurrentPosition(
 );
 ```
 
-The [report payload](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) sent to the endpoint might look like the JSON below.
+The [report payload](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoints) sent to the endpoint will have the same structure as the JSON sample shown below.
 This is the same as a report for `Permissions-Policy` except for the value of `body.disposition`.
 
 ```json
@@ -77,7 +77,7 @@ This is the same as a report for `Permissions-Policy` except for the value of `b
     "age": 48512,
     "body": {
       "columnNumber": 29,
-      "disposition": "report", // A violation that is reported and not enforced
+      "disposition": "report", // A violation that is reported but not enforced
       "lineNumber": 44,
       "message": "Permissions policy violation: geolocation access has been blocked because of a permissions policy applied to the current document.",
       "featureId": "geolocation",

--- a/files/en-us/web/http/reference/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/index.md
@@ -13,8 +13,8 @@ sidebar: http
 
 The HTTP **`Permissions-Policy`** {{Glossary("response header")}} provides a mechanism to allow and deny the use of browser features in a document or within any {{HTMLElement("iframe")}} elements in the document.
 
-Violations of a policy may be reported using the [Reporting API](/en-US/docs/Web/API/Reporting_API).
-Reports are automatically sent to the server endpoint named `"default"`, if one is defined in a {{HTTPHeader("Reporting-Endpoints")}} HTTP response header.
+Violations of a policy can be reported using the [Reporting API](/en-US/docs/Web/API/Reporting_API).
+Reports may be sent to a server indicated by name in a per-directive `report-to` parameter, or otherwise to the server endpoint named `"default"` (the mapping between server endpoint names and URLs is set using the {{HTTPHeader("Reporting-Endpoints")}} HTTP response header).
 Reports can also be observed in the page for which the policy is being enforced using a [`ReportingObserver`](/en-US/docs/Web/API/ReportingObserver).
 The format of the report and additional detail is provided in {{domxref("PermissionsPolicyViolationReport")}}.
 
@@ -32,8 +32,18 @@ For more information, see the main [Permissions Policy](/en-US/docs/Web/HTTP/Gui
 ## Syntax
 
 ```http
+# Single directive
 Permissions-Policy: <directive>=<allowlist>
+
+# Single directive with reporting endpoint
+Permissions-Policy: <directive>=<allowlist>;report-to=<endpoint>
+
+# Multiple directives, with and without server reporting endpoints
+Permissions-Policy: <directive>=<allowlist>, <directive>=<allowlist>;report-to=<endpoint>, ...
 ```
+
+The header can be used to set the allowlists for one or more directives, and optionally a per-directive `report-to` parameter indicating the server endpoint for reporting violations of the policy.
+The entries for each directive are comma separated.
 
 - `<directive>`
   - : The Permissions Policy directive to apply the `allowlist` to. See [Directives](#directives) below for a list of the permitted directive names.
@@ -56,7 +66,15 @@ Permissions-Policy: <directive>=<allowlist>
     > Directives have a default allowlist, which is always one of `*`, `self`, or `none` for the `Permissions-Policy` HTTP header, and governs the default behavior if they are not explicitly listed in a policy.
     > These are specified on the individual [directive reference pages](#directives). For `<iframe>` `allow` attributes, the default behavior is always `src`.
 
-Where supported, you can include wildcards in Permissions Policy origins. This means that instead of having to explicitly specify several different subdomains in an allowlist, you can specify them all in a single origin with a wildcard.
+- `report-to=<endpoint>` {{optional_inline}}
+  - : The `report-to` parameter can be used to indicate the name of a reporting endpoint where reports will be sent if there is a policy violation for the associated directive.
+    The endpoint name and its associated URL must be specified in a separate {{HTTPHeader("Reporting-Endpoints")}} HTTP response header.
+
+    If omitted, reports will be send to the [`default` reporting endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint) if one has been defined.
+    See [Reporting API](/en-US/docs/Web/API/Reporting_API) for more information.
+
+Where supported, you can include wildcards in Permissions Policy origins.
+This means that instead of having to explicitly specify several different subdomains in an allowlist, you can specify them all in a single origin with a wildcard.
 
 So instead of:
 
@@ -314,15 +332,23 @@ If a different origin ended up getting loaded into `<iframe>`, it would not have
 
 ### Reporting violations
 
-This example shows how to configure reporting of Permissions Policy violations to a server endpoint.
+This example shows how to configure reporting of `Permissions-Policy` violations to a server endpoint.
 
-The response headers below block geolocation and define a [`"default"` reporting endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint) using the {{HTTPHeader("Reporting-Endpoints")}} HTTP response header.
-Permissions Policy violation reports are automatically sent to this endpoint.
+The response headers below block geolocation and define the reporting endpoint name for the feature as "geo_endpoint".
+The {{HTTPHeader("Reporting-Endpoints")}} HTTP response header is used to define URL of this endpoint name.
 
 ```http
-Reporting-Endpoints: default="https://example.com/reports"
-Permissions-Policy: geolocation=()
+Reporting-Endpoints: geo_endpoint="https://example.com/reports"
+Permissions-Policy: geolocation=();report-to=geo_endpoint
 ```
+
+> [!NOTE]
+> To send all violation reports to the same endpoint we might instead define the [`"default"` reporting endpoint](/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints#default_reporting_endpoint):
+>
+> ```http
+> Reporting-Endpoints: default="https://example.com/reports"
+> Permissions-Policy: geolocation=()
+> ```
 
 A violation occurs when a page attempts to use the blocked feature, for example:
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/index.md
@@ -335,7 +335,7 @@ If a different origin ended up getting loaded into `<iframe>`, it would not have
 This example shows how to configure reporting of `Permissions-Policy` violations to a server endpoint.
 
 The response headers below block geolocation and define the reporting endpoint name for the feature as "geo_endpoint".
-The {{HTTPHeader("Reporting-Endpoints")}} HTTP response header is used to define URL of this endpoint name.
+The {{HTTPHeader("Reporting-Endpoints")}} HTTP response header is used to define the URL of this endpoint name.
 
 ```http
 Reporting-Endpoints: geo_endpoint="https://example.com/reports"

--- a/files/en-us/web/http/reference/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/index.md
@@ -395,6 +395,7 @@ The [report payload](/en-US/docs/Web/API/Reporting_API#reporting_server_endpoint
 ## See also
 
 - [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy)
+- {{HTTPHeader("Permissions-Policy-Report-Only")}}
 - {{DOMxRef("Document.featurePolicy")}} and {{DOMxRef("FeaturePolicy")}}
 - {{HTTPHeader("Content-Security-Policy")}}
 - {{HTTPHeader("Referrer-Policy")}}

--- a/files/en-us/web/http/reference/headers/permissions-policy/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/index.md
@@ -42,7 +42,7 @@ Permissions-Policy: <directive>=<allowlist>;report-to=<endpoint>
 Permissions-Policy: <directive>=<allowlist>, <directive>=<allowlist>;report-to=<endpoint>, ...
 ```
 
-The header can be used to set the allowlists for one or more directives, and optionally a per-directive `report-to` parameter indicating the server endpoint for reporting violations of the policy.
+The header can be used to set the allowlists for one or more directives, and optionally a per-directive `report-to` parameter indicating the server endpoint to send policy violation reports to.
 The entries for each directive are comma separated.
 
 - `<directive>`


### PR DESCRIPTION
This PR does a number of things:

1. adds the `Permissions-Policy-Report-Only` HTTP header, to complement the  `Permissions-Policy` header. The headers are the same really, the only difference being that the report version does not enforce the policy and has a different `disposition` in reports. 
   - Given that it doesn't make sense to redocument everything, especially in his case which has so much content.
   - I think this is a better model that what we did for the other policy docs - suggest we copy it for the other too (? for reviewer)
2. This then requires and update to cross link to Permissions-Policy and to the reporting object.
3. Then I updated the Reporting API. The main change is a restructure to put the Reporting Types first. I will be turning that into a table in #43782
4. I also added a specific list in server endpoints of how you set the endpoint (moved out of the HTTP inteface section, as it is more general than that). This is useful as it shows how "diverse" the mechanisms are.

@chrisdavidmills I haven't checked this yet. Will take review, but might do a little tidy tomorrow.