### PR TITLE
uniformity of no-support banner 

### DIFF
--- a/files/en-us/web/css/guides/anchor_positioning/anchored_container_queries/index.md
+++ b/files/en-us/web/css/guides/anchor_positioning/anchored_container_queries/index.md
@@ -167,10 +167,8 @@ p {
 @supports not (container-type: anchored) {
   body::before {
     content: "Your browser does not support anchored container queries.";
-    color: black;
-    background-color: #ffcd33;
+    background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }
@@ -277,10 +275,8 @@ p {
 @supports not (container-type: anchored) {
   body::before {
     content: "Your browser does not support anchored container queries.";
-    color: black;
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }

--- a/files/en-us/web/css/guides/anchor_positioning/anchored_container_queries/index.md
+++ b/files/en-us/web/css/guides/anchor_positioning/anchored_container_queries/index.md
@@ -174,16 +174,6 @@ p {
     text-align: center;
     padding: 1rem 0;
   }
-
-  body {
-    width: 100%;
-    max-width: 100%;
-    margin: 0;
-  }
-
-  body > * {
-    display: none;
-  }
 }
 ```
 
@@ -288,15 +278,11 @@ p {
   body::before {
     content: "Your browser does not support anchored container queries.";
     color: black;
-    background-color: #ffcd33;
+    background-color: wheat;
     display: block;
     width: 100%;
     text-align: center;
     padding: 1rem 0;
-  }
-
-  body > * {
-    display: none;
   }
 }
 ```

--- a/files/en-us/web/css/guides/scroll-driven_animations/index.md
+++ b/files/en-us/web/css/guides/scroll-driven_animations/index.md
@@ -97,6 +97,7 @@ div::after {
       background-color: wheat;
       display: block;
       text-align: center;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/guides/scroll-driven_animations/timeline_range_names/index.md
+++ b/files/en-us/web/css/guides/scroll-driven_animations/timeline_range_names/index.md
@@ -162,12 +162,16 @@ body::before {
 
 @layer no-support {
   @supports not (animation-timeline: view()) {
-    body::before {
+    body::after {
       content: "Your browser doesn't support view progress scrolling.";
       background-color: wheat;
       display: block;
       text-align: center;
       padding: 1rem 0;
+
+      position: absolute;
+      inset: 0;
+      bottom: auto;
     }
   }
 }

--- a/files/en-us/web/css/guides/scroll-driven_animations/timeline_range_names/index.md
+++ b/files/en-us/web/css/guides/scroll-driven_animations/timeline_range_names/index.md
@@ -167,6 +167,7 @@ body::before {
       background-color: wheat;
       display: block;
       text-align: center;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/animation-timeline/index.md
+++ b/files/en-us/web/css/reference/properties/animation-timeline/index.md
@@ -170,7 +170,7 @@ The only difference is the `animation-timeline` declaration (or lack thereof in 
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1rem 0;
     }
   }
 }
@@ -256,7 +256,7 @@ The CSS below defines a square that rotates in alternate directions according to
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1rem 0;
     }
   }
 }
@@ -290,7 +290,7 @@ We include all the CSS from the previous example, only setting the `animation-ti
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/animation-timeline/scroll/index.md
+++ b/files/en-us/web/css/reference/properties/animation-timeline/scroll/index.md
@@ -143,7 +143,7 @@ These two together ensure that the container has a vertical scrollbar, which all
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/animation-timeline/view/index.md
+++ b/files/en-us/web/css/reference/properties/animation-timeline/view/index.md
@@ -190,12 +190,16 @@ An important point to remember is that the animation lasts only as long as the `
 ```css hidden
 @layer no-support {
   @supports not (animation-timeline: view()) {
-    body::before {
+    body::after {
       content: "Your browser doesn't support the CSS `view()` function.";
       background-color: wheat;
       display: block;
       text-align: center;
       padding: 1rem 0;
+
+      position: absolute;
+      inset: 0;
+      bottom: auto;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/animation-timeline/view/index.md
+++ b/files/en-us/web/css/reference/properties/animation-timeline/view/index.md
@@ -195,7 +195,7 @@ An important point to remember is that the animation lasts only as long as the `
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/background-repeat-x/index.md
+++ b/files/en-us/web/css/reference/properties/background-repeat-x/index.md
@@ -167,8 +167,8 @@ div {
       content: "Your browser doesn't support the `background-repeat-x` property.";
       background-color: wheat;
       display: block;
-      padding: 1em;
       text-align: center;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/background-repeat-y/index.md
+++ b/files/en-us/web/css/reference/properties/background-repeat-y/index.md
@@ -167,8 +167,8 @@ div {
       content: "Your browser doesn't support the `background-repeat-y` property.";
       background-color: wheat;
       display: block;
-      padding: 1em;
       text-align: center;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/baseline-shift/index.md
+++ b/files/en-us/web/css/reference/properties/baseline-shift/index.md
@@ -145,9 +145,8 @@ svg {
     content: "Your browser doesn't support the `baseline-shift` property.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
-    padding: 0.5em;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/baseline-shift/index.md
+++ b/files/en-us/web/css/reference/properties/baseline-shift/index.md
@@ -104,19 +104,6 @@ We define an SVG with two SVG {{SVGElement("text")}} elements, each containing a
     une pipe sub!
   </text>
 </svg>
-<p><code>baseline-shift: top;</code></p>
-<svg viewBox="0 0 500 120" xmlns="http://www.w3.org/2000/svg">
-  <text x="10" y="50">
-    Ceci
-    <tspan baseline-shift="super">n'est pas</tspan>
-    une pipe super!
-  </text>
-  <text x="10" y="90">
-    Ceci
-    <tspan baseline-shift="sub">n'est pas</tspan>
-    une pipe sub!
-  </text>
-</svg>
 ```
 
 The SVG is repeated three times; we've only shown one copy for the sake of brevity.
@@ -145,9 +132,6 @@ svg:nth-of-type(2) tspan {
 svg:nth-of-type(3) tspan {
   baseline-shift: super;
 }
-svg:nth-of-type(4) tspan {
-  baseline-shift: top;
-}
 ```
 
 ```css hidden
@@ -156,9 +140,9 @@ svg {
   width: 15em;
   margin-bottom: 10px;
 }
-@supports not (baseline-shift: top) {
+@supports not (baseline-shift: sub) {
   body::before {
-    content: "Your browser doesn't support all the `baseline-shift` property values.";
+    content: "Your browser doesn't support the `baseline-shift` property.";
     background-color: wheat;
     display: block;
     text-align: center;
@@ -169,7 +153,7 @@ svg {
 
 #### Results
 
-{{EmbedLiveSample("Using keyword values", "300", "500")}}
+{{EmbedLiveSample("Using keyword values", "300", "370")}}
 
 The SVG `baseline-shift` attribute values are used in the first SVG. In the second and third SVGs, the CSS `baseline-shift` values override the attribute values.
 

--- a/files/en-us/web/css/reference/properties/baseline-shift/index.md
+++ b/files/en-us/web/css/reference/properties/baseline-shift/index.md
@@ -140,9 +140,9 @@ svg {
   width: 15em;
   margin-bottom: 10px;
 }
-@supports not (baseline-shift: sub) {
+@supports not (baseline-shift: top) {
   body::before {
-    content: "Your browser doesn't support the `baseline-shift` property.";
+    content: "Your browser doesn't support all the `baseline-shift` property values.";
     background-color: wheat;
     display: block;
     text-align: center;

--- a/files/en-us/web/css/reference/properties/baseline-shift/index.md
+++ b/files/en-us/web/css/reference/properties/baseline-shift/index.md
@@ -104,6 +104,19 @@ We define an SVG with two SVG {{SVGElement("text")}} elements, each containing a
     une pipe sub!
   </text>
 </svg>
+<p><code>baseline-shift: top;</code></p>
+<svg viewBox="0 0 500 120" xmlns="http://www.w3.org/2000/svg">
+  <text x="10" y="50">
+    Ceci
+    <tspan baseline-shift="super">n'est pas</tspan>
+    une pipe super!
+  </text>
+  <text x="10" y="90">
+    Ceci
+    <tspan baseline-shift="sub">n'est pas</tspan>
+    une pipe sub!
+  </text>
+</svg>
 ```
 
 The SVG is repeated three times; we've only shown one copy for the sake of brevity.
@@ -132,6 +145,9 @@ svg:nth-of-type(2) tspan {
 svg:nth-of-type(3) tspan {
   baseline-shift: super;
 }
+svg:nth-of-type(4) tspan {
+  baseline-shift: top;
+}
 ```
 
 ```css hidden
@@ -153,7 +169,7 @@ svg {
 
 #### Results
 
-{{EmbedLiveSample("Using keyword values", "300", "370")}}
+{{EmbedLiveSample("Using keyword values", "300", "500")}}
 
 The SVG `baseline-shift` attribute values are used in the first SVG. In the second and third SVGs, the CSS `baseline-shift` values override the attribute values.
 

--- a/files/en-us/web/css/reference/properties/corner-shape/index.md
+++ b/files/en-us/web/css/reference/properties/corner-shape/index.md
@@ -188,10 +188,6 @@ div {
     text-align: center;
     padding: 1rem 0;
   }
-
-  body > * {
-    display: none;
-  }
 }
 ```
 
@@ -272,10 +268,6 @@ div {
     width: 100%;
     text-align: center;
     padding: 1rem 0;
-  }
-
-  body > * {
-    display: none;
   }
 }
 ```
@@ -398,22 +390,12 @@ section {
 }
 
 @supports not (corner-shape: scoop) {
-  body {
-    all: unset !important;
-  }
-
   body::before {
     content: "Your browser does not support the 'corner-shape' property.";
-    color: black;
-    background-color: #ffcd33;
+    background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
-  }
-
-  body > * {
-    display: none;
   }
 }
 ```
@@ -536,10 +518,6 @@ section {
     text-align: center;
     padding: 1rem 0;
   }
-
-  body > * {
-    display: none;
-  }
 }
 ```
 
@@ -613,22 +591,13 @@ div {
 }
 
 @supports not (corner-shape: square) {
-  body {
-    all: unset !important;
-  }
-
   body::before {
     content: "Your browser does not support the 'corner-shape' property.";
-    color: black;
-    background-color: #ffcd33;
+    background-color: wheat;
     display: block;
     width: 100%;
     text-align: center;
     padding: 1rem 0;
-  }
-
-  body > * {
-    display: none;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/corner-shape/index.md
+++ b/files/en-us/web/css/reference/properties/corner-shape/index.md
@@ -256,16 +256,11 @@ div {
 }
 
 @supports not (corner-shape: scoop notch) {
-  body {
-    all: unset !important;
-  }
-
-  body::before {
+  :root::before {
     content: "Your browser does not support the 'corner-shape' property.";
     color: black;
-    background-color: #ffcd33;
+    background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }
@@ -390,7 +385,7 @@ section {
 }
 
 @supports not (corner-shape: scoop) {
-  body::before {
+  :root::before {
     content: "Your browser does not support the 'corner-shape' property.";
     background-color: wheat;
     display: block;
@@ -505,16 +500,10 @@ section {
 }
 
 @supports not (corner-shape: superellipse(0)) {
-  body {
-    all: unset !important;
-  }
-
-  body::before {
+  :root::before {
     content: "Your browser does not support the 'corner-shape' property.";
-    color: black;
-    background-color: #ffcd33;
+    background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }
@@ -591,11 +580,10 @@ div {
 }
 
 @supports not (corner-shape: square) {
-  body::before {
+  :root::before {
     content: "Your browser does not support the 'corner-shape' property.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }

--- a/files/en-us/web/css/reference/properties/counter-reset/index.md
+++ b/files/en-us/web/css/reference/properties/counter-reset/index.md
@@ -205,7 +205,7 @@ In the following example, we've declared a reversed counter named 'priority'. Th
 ```css hidden
 @supports not (counter-reset: reversed(priority)) {
   body::before {
-    content: "Your browser doesn't support the reversed counters yet.";
+    content: "Your browser doesn't support the reversed() function.";
     background-color: wheat;
     display: block;
     text-align: center;

--- a/files/en-us/web/css/reference/properties/counter-reset/index.md
+++ b/files/en-us/web/css/reference/properties/counter-reset/index.md
@@ -204,11 +204,12 @@ In the following example, we've declared a reversed counter named 'priority'. Th
 
 ```css hidden
 @supports not (counter-reset: reversed(priority)) {
-  .stack {
-    display: none;
-  }
-  body::after {
+  body::before {
     content: "Your browser doesn't support the reversed counters yet.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/font-synthesis-style/index.md
+++ b/files/en-us/web/css/reference/properties/font-synthesis-style/index.md
@@ -121,10 +121,10 @@ p {
 @supports not (font-synthesis-style: oblique-only) {
   body::before {
     content: "Your browser doesn't support the 'oblique-only' value.";
-    background-color: #ffcd33;
+    background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/height/index.md
+++ b/files/en-us/web/css/reference/properties/height/index.md
@@ -177,12 +177,12 @@ div {
 
 ```css hidden
 @supports not (height: stretch) {
-  .parent {
-    display: none !important;
-  }
-
-  body::after {
+  body::before {
     content: "Your browser doesn't support the `stretch` value yet.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/scroll-initial-target/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-initial-target/index.md
@@ -183,9 +183,8 @@ p {
     content: "Your browser doesn't support the scroll-initial-target property.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
-    padding: 1em;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/scroll-initial-target/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-initial-target/index.md
@@ -179,7 +179,7 @@ p {
 }
 
 @supports not (scroll-initial-target: nearest) {
-  body::before {
+  :root::before {
     content: "Your browser doesn't support the scroll-initial-target property.";
     background-color: wheat;
     display: block;

--- a/files/en-us/web/css/reference/properties/scroll-timeline-axis/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-timeline-axis/index.md
@@ -132,6 +132,7 @@ body {
       display: block;
       width: 100%;
       text-align: center;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/scroll-timeline-axis/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-timeline-axis/index.md
@@ -130,7 +130,6 @@ body {
       content: "Your browser doesn't support the `scroll-timeline-axis` property.";
       background-color: wheat;
       display: block;
-      width: 100%;
       text-align: center;
       padding: 1rem 0;
     }

--- a/files/en-us/web/css/reference/properties/scroll-timeline/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-timeline/index.md
@@ -141,7 +141,7 @@ Without content that overflows the container, there would be no scrollbar, and h
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1em 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/scroll-timeline/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-timeline/index.md
@@ -141,7 +141,7 @@ Without content that overflows the container, there would be no scrollbar, and h
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em 0;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/text-decoration-inset/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-inset/index.md
@@ -140,9 +140,9 @@ li {
     content: "Your browser doesn't support the text-decoration-inset property.";
     background-color: wheat;
     display: block;
-    padding: 10px 0;
     width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 }
 ```
@@ -199,9 +199,9 @@ u {
     content: "Your browser doesn't support the text-decoration-inset property.";
     background-color: wheat;
     display: block;
-    padding: 10px 0;
     width: 100%;
     text-align: center;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/text-decoration-inset/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-inset/index.md
@@ -140,7 +140,6 @@ li {
     content: "Your browser doesn't support the text-decoration-inset property.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }
@@ -199,7 +198,6 @@ u {
     content: "Your browser doesn't support the text-decoration-inset property.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }

--- a/files/en-us/web/css/reference/properties/view-timeline-axis/index.md
+++ b/files/en-us/web/css/reference/properties/view-timeline-axis/index.md
@@ -164,7 +164,7 @@ p {
   body::before {
     display: block;
     text-align: center;
-    padding: 1em;
+    padding: 1rem 0;
   }
   @supports not (view-timeline-axis: inherit) {
     body::before {

--- a/files/en-us/web/css/reference/properties/view-timeline-name/index.md
+++ b/files/en-us/web/css/reference/properties/view-timeline-name/index.md
@@ -166,7 +166,7 @@ Last, an animation is specified on the element that animates its opacity and sca
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em 0;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/view-timeline-name/index.md
+++ b/files/en-us/web/css/reference/properties/view-timeline-name/index.md
@@ -166,7 +166,7 @@ Last, an animation is specified on the element that animates its opacity and sca
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1em 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/view-timeline/index.md
+++ b/files/en-us/web/css/reference/properties/view-timeline/index.md
@@ -186,7 +186,7 @@ Lastly, an animation is specified on the element that animates its opacity and s
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em 0;
+      padding: 1rem 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/view-timeline/index.md
+++ b/files/en-us/web/css/reference/properties/view-timeline/index.md
@@ -186,7 +186,7 @@ Lastly, an animation is specified on the element that animates its opacity and s
       background-color: wheat;
       display: block;
       text-align: center;
-      padding: 1em;
+      padding: 1em 0;
     }
   }
 }

--- a/files/en-us/web/css/reference/properties/width/index.md
+++ b/files/en-us/web/css/reference/properties/width/index.md
@@ -275,7 +275,7 @@ p.min-pink {
     background-color: wheat;
     display: block;
     text-align: center;
-    padding: 1em;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/width/index.md
+++ b/files/en-us/web/css/reference/properties/width/index.md
@@ -324,7 +324,7 @@ We use the {{cssxref("display")}} property to make the parent a flex container, 
 
 ```css hidden
 @supports not (width: stretch) {
-  body::after {
+  body::before {
     content: "Your browser doesn't support the stretch value yet.";
     background-color: wheat;
     display: block;
@@ -391,6 +391,16 @@ We declare the `anchor` `<div>` as an anchor element by giving it an {{cssxref("
 ```css hidden
 body {
   padding: 5em;
+}
+
+@supports not (width: anchor-size(width)) {
+  body::before {
+    content: "Your browser doesn't support the anchor-size() function value.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1rem 0;
+  }
 }
 ```
 

--- a/files/en-us/web/css/reference/properties/width/index.md
+++ b/files/en-us/web/css/reference/properties/width/index.md
@@ -329,7 +329,7 @@ We use the {{cssxref("display")}} property to make the parent a flex container, 
     background-color: wheat;
     display: block;
     text-align: center;
-    padding: 1em;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/properties/width/index.md
+++ b/files/en-us/web/css/reference/properties/width/index.md
@@ -270,7 +270,7 @@ p.min-pink {
 
 ```css hidden
 @supports not (width: calc-size(min-content, size * 2)) {
-  body::after {
+  body::before {
     content: "Your browser doesn't support the calc-size() function yet.";
     background-color: wheat;
     display: block;

--- a/files/en-us/web/css/reference/selectors/_colon_autofill/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_autofill/index.md
@@ -120,9 +120,8 @@ input:autofill {
     content: "Your browser doesn't support the :autofill selector.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
-    padding: 5px;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/selectors/_colon_open/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_open/index.md
@@ -55,10 +55,7 @@ details:open > summary {
     display: block;
     width: 100%;
     text-align: center;
-  }
-
-  body > * {
-    display: none;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/selectors/_colon_open/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_open/index.md
@@ -53,7 +53,6 @@ details:open > summary {
     content: "Your browser doesn't support :open selector.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }

--- a/files/en-us/web/css/reference/selectors/_colon_open/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_open/index.md
@@ -50,7 +50,7 @@ details:open > summary {
 ```css hidden
 @supports not selector(:open) {
   body::before {
-    content: "Your browser doesn't support :open selector.";
+    content: "Your browser doesn't support the :open selector.";
     background-color: wheat;
     display: block;
     text-align: center;

--- a/files/en-us/web/css/reference/values/basic-shape/shape/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/shape/index.md
@@ -213,11 +213,12 @@ body {
 }
 
 @supports not (offset-path: shape(from 0 0, move to 0 0)) {
-  .container {
-    display: none;
-  }
   body::after {
     content: "Your browser doesn't support the `shape()` function yet.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```
@@ -299,11 +300,12 @@ body {
 }
 
 @supports not (clip-path: shape(from 0 0, move to 0 0)) {
-  .container {
-    display: none;
-  }
   body::after {
     content: "Your browser doesn't support the `shape()` function yet.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```
@@ -378,11 +380,12 @@ The first shape (`shape1`) draws two cubic Bézier curves.
       close
     )
 ) {
-  .container {
-    display: none;
-  }
   body::after {
     content: "Your browser doesn't support `shape()` relative control points.";
+    background-color: wheat;
+    display: block;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/values/color_value/contrast-color/index.md
+++ b/files/en-us/web/css/reference/values/color_value/contrast-color/index.md
@@ -80,12 +80,8 @@ button {
     content: "Your browser doesn't support the contrast-color() function.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
-  }
-
-  body > * {
-    display: none;
+    padding: 1rem 0;
   }
 }
 ```
@@ -150,16 +146,8 @@ pre {
     content: "Your browser doesn't support the contrast-color() function.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
-  }
-
-  body {
-    background-color: white;
-  }
-
-  body > * {
-    display: none;
+    padding: 1rem 0;
   }
 }
 ```

--- a/files/en-us/web/css/reference/values/random/index.md
+++ b/files/en-us/web/css/reference/values/random/index.md
@@ -237,7 +237,6 @@ We render the five badges as circles. We use the `random()` function within an {
     content: "Your browser doesn't support the random() function.";
     background-color: wheat;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }
@@ -291,7 +290,6 @@ body {
     content: "Your browser doesn't support the random() function.";
     color: white;
     display: block;
-    width: 100%;
     text-align: center;
     padding: 1rem 0;
   }

--- a/files/en-us/web/css/reference/values/random/index.md
+++ b/files/en-us/web/css/reference/values/random/index.md
@@ -231,7 +231,9 @@ We render the five badges as circles. We use the `random()` function within an {
 .badge.unique {
   background: hsl(random(0, 360) 50% 50%);
 }
+```
 
+```css hidden
 @supports not (order: random(1, 2)) {
   body::before {
     content: "Your browser doesn't support the random() function.";

--- a/files/en-us/web/css/reference/values/random/index.md
+++ b/files/en-us/web/css/reference/values/random/index.md
@@ -233,8 +233,13 @@ We render the five badges as circles. We use the `random()` function within an {
 }
 
 @supports not (order: random(1, 2)) {
-  :root::after {
+  body::before {
     content: "Your browser doesn't support the random() function.";
+    background-color: wheat;
+    display: block;
+    width: 100%;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```
@@ -283,8 +288,12 @@ body {
 ```css hidden
 @supports not (order: random(1, 2)) {
   body::before {
-    color: white;
     content: "Your browser doesn't support the random() function.";
+    color: white;
+    display: block;
+    width: 100%;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```


### PR DESCRIPTION
- Made all the "Your browser doesn't support this feature" banners in the CSS section (mostly) uniform.
- Made the content visible even if feature is not supported as our readers should know what happens when the feature is used in a non-supporting browser

- Some examples overflow (scroll) when the banner shows.
- A few pages had bodies with flex layout, so those are set to `:root`
- some pages had semi-transparent wheat boxes overlaying the page, so positioned non-support absolutely with inset on those pages (we could create an issue to do that to all)

if we decide wheat isn't the right color, or the padding isn't right, when uniform, it will be easier to change them all at once.

Not part of this PR:
- positioning all the banners absolutely
- fixing the non-showing banner on autofill
- expanding baseline-shift to include new values.
