### PR TITLE
docs(firefox-release): Finalize release notes for Fx150 release

### DIFF
--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -1,8 +1,8 @@
 ---
-title: Firefox 149 release notes for developers (Stable)
-short-title: Firefox 149 (Stable)
+title: Firefox 149 release notes for developers
+short-title: Firefox 149
 slug: Mozilla/Firefox/Releases/149
-page-type: firefox-release-notes-active
+page-type: firefox-release-notes
 sidebar: firefox
 ---
 

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -1,18 +1,13 @@
 ---
-title: Firefox 150 release notes for developers (Beta)
-short-title: Firefox 150 (Beta)
+title: Firefox 150 release notes for developers (Stable)
+short-title: Firefox 150 (Stable)
 slug: Mozilla/Firefox/Releases/150
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
 This article provides information about the changes in Firefox 150 that affect developers.
-Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [April 21, 2026](https://whattrainisitnow.com/release/?version=150).
-
-> [!NOTE]
-> The release notes for this Firefox version are still a work in progress.
-
-<!-- Authors: Please uncomment any headings you are writing notes for -->
+Firefox 150 was released on [April 21, 2026](https://whattrainisitnow.com/release/?version=150).
 
 ## Changes for web developers
 
@@ -29,18 +24,6 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
   This is simpler that specifying media conditions and their associated sizes in the attribute, which likely duplicates behavior that is already captured in CSS media queries.
   ([Firefox bug 1819581](https://bugzil.la/1819581)).
 
-<!-- No notable changes. -->
-
-<!-- #### Removals -->
-
-<!-- ### MathML -->
-
-<!-- #### Removals -->
-
-<!-- ### SVG -->
-
-<!-- #### Removals -->
-
 ### CSS
 
 - The [`color-mix()`](/en-US/docs/Web/CSS/Reference/Values/color_value/color-mix) CSS function now accepts multiple [`<color>`](/en-US/docs/Web/CSS/Reference/Values/color_value) values, rather than just two. This allows you to mix any number of colors. ([Firefox bug 2024171](https://bugzil.la/2024171)).
@@ -56,21 +39,9 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - The {{cssxref("overscroll-behavior")}} CSS property (and its longhand properties {{cssxref("overscroll-behavior-x")}}, {{cssxref("overscroll-behavior-y")}}, {{cssxref("overscroll-behavior-block")}}, and {{cssxref("overscroll-behavior-inline")}}) now correctly apply to scroll containers that have no scrollable overflow, such as elements with `overflow: hidden`. Previously, the property was ignored on such elements. ([Firefox bug 1837436](https://bugzil.la/1837436)).
 
-<!-- #### Removals -->
+### JavaScript
 
-<!-- ### JavaScript -->
-
-<!-- No notable changes. -->
-
-<!-- #### Removals -->
-
-<!-- ### HTTP -->
-
-<!-- #### Removals -->
-
-<!-- ### Security -->
-
-<!-- #### Removals -->
+No notable changes.
 
 ### APIs
 
@@ -90,14 +61,6 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The `ariaNotify()` method is now supported on {{domxref("Document/ariaNotify","Document")}} and {{domxref("Element/ariaNotify","Element")}}.
   This queues a string of text to be announced by a {{glossary("screen reader")}}, providing a more ergonomic and reliable alternative to [ARIA live regions](/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
   ([Firefox bug 2018095](https://bugzil.la/2018095)).
-
-<!-- #### Media, WebRTC, and Web Audio -->
-
-<!-- #### Removals -->
-
-<!-- ### WebAssembly -->
-
-<!-- #### Removals -->
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -124,10 +87,6 @@ Firefox 150 is the current [Beta version of Firefox](https://www.firefox.com/en-
   - The order of tabs in a split view can be swapped. ([Firefox bug 2016762](https://bugzil.la/2016762))
   - When the list of tabs includes both split view tabs and places one or more tabs between them, the tabs are moved apart and the split view closed. ([Firefox bug 2022549](https://bugzil.la/2022549))
 - Resolved an issue with some JavaScript [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) calls failing to import CSS. ([Firefox bug 2016369](https://bugzil.la/2016369))
-
-<!-- ### Removals -->
-
-<!-- ### Other -->
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -1,13 +1,13 @@
 ---
-title: Firefox 151 release notes for developers (Beta)
-short-title: Firefox 151 (Beta)
-slug: Mozilla/Firefox/Releases/151
+title: Firefox 152 release notes for developers (Nightly)
+short-title: Firefox 152 (Nightly)
+slug: Mozilla/Firefox/Releases/152
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
-This article provides information about the changes in Firefox 151 that affect developers.
-Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [May 19, 2026](https://whattrainisitnow.com/release/?version=151).
+This article provides information about the changes in Firefox 152 that affect developers.
+Firefox 152 is the current [Nightly version of Firefox](https://www.firefox.com/en-US/channel/desktop/#nightly) and ships on [June 16, 2026](https://whattrainisitnow.com/release/?version=152).
 
 > [!NOTE]
 > The release notes for this Firefox version are still a work in progress.
@@ -78,6 +78,6 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Experimental web features
 
-These features are shipping in Firefox 151 but are disabled by default.
+These features are shipping in Firefox 152 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
### Description

This PR updates pages for Firefox 150 (release date: April 21, 2026).
Ran: `node scripts/content/release-firefox.js 149`
Output:

```
✅ Removed active status from Firefox 149
✅ Updated Firefox 150 to (Stable)
✅ Updated Firefox 151 to (Beta)
✅ Created new Nightly page for Firefox 152
```