### PR TITLE
fix(css sidebar): Add code styling to sidebar items

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -313,6 +313,7 @@ sidebar:
     link: /Web/CSS/Reference/Properties
     title: Properties
     details: closed
+    code: true
   - type: listSubPages
     path: /Web/CSS/Reference/Selectors
     tags: css-selector
@@ -331,30 +332,35 @@ sidebar:
     link: /Web/CSS/Reference/Selectors/Pseudo-classes
     title: Pseudo-classes
     details: closed
+    code: true
   - type: listSubPagesGrouped
     path: /Web/CSS/Reference/Selectors
     tags: css-pseudo-element
     link: /Web/CSS/Reference/Selectors/Pseudo-elements
     title: Pseudo-elements
     details: closed
+    code: true
   - type: listSubPages
     path: /Web/CSS/Reference/At-rules
     tags: css-at-rule
     link: /Web/CSS/Reference/At-rules
     title: At-rules
     details: closed
+    code: true
   - type: listSubPages
     path: /Web/CSS/Reference/Values
     tags: css-keyword
     link: /Web/CSS/Reference/Values
     title: Values
     details: closed
+    code: true
   - type: listSubPages
     path: /Web/CSS/Reference/Values
     tags: css-type
     link: /Web/CSS/Reference/Values/Data_types
     title: Types
     details: closed
+    code: true
   - type: listSubPages
     path: /Web/CSS/Reference/Values
     tags: css-function
@@ -362,6 +368,7 @@ sidebar:
     link: /Web/CSS/Reference/Values/Functions
     title: Functions
     details: closed
+    code: true
 l10n:
   de:
     Guides: Leitfäden


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR adds `code: true` to the following categories in `cssref.yaml` so that the sidebar items under them render with code formatting:
- Properties
- Pseudo-classes
- Pseudo-elements
- At-rules
- Values
- Types
- Functions

### Related issues and pull requests

- https://github.com/mdn/mdn/issues/811
- https://github.com/mdn/content/pull/43830

