### PR TITLE
Fix small typos in web docs ("the the", "withing")

### DIFF
--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -178,7 +178,7 @@ The example is best {{LiveSampleLink('Selecting an image to fit window width', '
    The label at the bottom of the image shows the current container width.
 2. Resize the window — you should see the image change at the `sizes` attribute's media query break points.
 
-   Note that the the selected image may be larger than the container width alone suggests.
+   Note that the selected image may be larger than the container width alone suggests.
    Many displays, if not most, have a [device pixel ratio (DPR)](/en-US/docs/Web/API/Window/devicePixelRatio) greater than one.
    In order to render a sharp image at the physical pixel density of the display, a browser will multiply the matched `sizes` hint by the DPR before selecting from `srcset`.
    For example, on a 2× display with a viewport of ~500px, the matched hint is `600px`, but the browser looks for a ~1200px image and selects `1200.png` as the closest available size and then scales it to fit in the available space.

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -48,7 +48,7 @@ To only provide an `endMark`, you need to provide an empty `measureOptions` obje
             - `track` {{optional_inline}} {{experimental_inline}}
               - : String of the name of the custom track (required for `track-entry`)
             - `trackGroup` {{optional_inline}} {{experimental_inline}}
-              - : String of the name of the grouping withing a custom track (required for `track-entry`)
+              - : String of the name of the grouping within a custom track (required for `track-entry`)
             - `properties` {{optional_inline}} {{experimental_inline}}
               - : Array of key-value pairs. Values can be any JSON-compatible type.
             - `tooltipText` {{optional_inline}} {{experimental_inline}}

--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -433,7 +433,7 @@ All HTML and SVG elements support event handler attributes defined on the [`Glob
 
 While event handler attributes, like {{domxref("Element/blur_event", "onblur")}} and {{domxref("Element/auxclick_event", "onauxclick")}}, apply to all elements, they may not have any effect. For example, the {{domxref("HTMLTrackElement/cuechange_event", "oncuechange")}} attribute can be applied to any element, but it is only relevant to the {{htmlelement("track")}} element.
 
-Event handler attributes are discouraged, considered unsafe, and may be blocked by [content security policies (CSP)](/en-US/docs/Web/Security/Practical_implementation_guides/CSP). Use the event name withing an {{domxref("EventTarget.addEventListener", "addEventListener()")}} method instead.
+Event handler attributes are discouraged, considered unsafe, and may be blocked by [content security policies (CSP)](/en-US/docs/Web/Security/Practical_implementation_guides/CSP). Use the event name within an {{domxref("EventTarget.addEventListener", "addEventListener()")}} method instead.
 
 ## See also
 


### PR DESCRIPTION

**Repo:** mdn/content (⭐ 9100)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fixes three typographical errors in MDN documentation:
- `files/en-us/web/api/htmlimageelement/sizes/index.md`: duplicate word "the the" → "the".
- `files/en-us/web/svg/reference/attribute/index.md`: misspelling "withing" → "within".
- `files/en-us/web/api/performance/measure/index.md`: misspelling "withing" → "within".

## Why
Small editorial fixes that improve readability of public-facing documentation. Errors were found by grepping the `files/en-us` tree for common duplicate-word and misspelling patterns; these three were the only genuine prose typos surfaced (other matches were intentional code samples like CSS grid `"a a a"` templates or JS `using of of []` examples).

## Testing
Visual diff inspection. The changes are pure prose corrections inside Markdown body text — no front-matter, KumaScript macros, or code blocks are touched, so no rendering or build changes are expected.

## Risk
Low — three single-word edits in prose, no structural or semantic content changed.
