### PR TITLE
FF151 Relnote: DocumentPictureInPicture API

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -562,21 +562,6 @@ In Firefox 149, the previous C++ [JPEG XL](https://jpeg.org/jpegxl/) image decod
 - `image.jxl.enabled`
   - : Set to `true` to enable.
 
-#### Document Picture-in-Picture API
-
-The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) makes it possible to open an always-on-top window that can be populated with arbitrary HTML content such as a video with custom controls or a set of streams showing the participants of a video conference call.
-See [Firefox bug 1858562](https://bugzil.la/1858562) for more details.
-
-| Release channel   | Version added | Enabled by default? |
-| ----------------- | ------------- | ------------------- |
-| Nightly           | 148           | Yes                 |
-| Developer Edition | 148           | No                  |
-| Beta              | 148           | No                  |
-| Release           | 148           | No                  |
-
-- `dom.documentpip.enabled`
-  - : Set to `true` to enable.
-
 ### WebVR API (Disabled)
 
 The deprecated [WebVR API](/en-US/docs/Web/API/WebVR_API) is on the path for removal.

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -50,7 +50,12 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
+
+- The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) is now supported on desktop platforms.
+  This makes it possible to open an always-on-top popup window that can be populated with arbitrary HTML content.
+  It can be used to display any content that a user might want to view separate from the launching page (or even the browser), such as a set of streams showing the participants of a video conference call, a stock ticker, or a countdown timer.
+  ([Firefox bug 2006594](https://bugzil.la/2006594)).
 
 <!-- #### DOM -->
 

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -53,7 +53,7 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 ### APIs
 
 - The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) is now supported on desktop platforms.
-  This makes it possible to open an always-on-top popup window that can be populated with arbitrary HTML content.
+  This makes it possible to open an [always-on-top window](/en-US/docs/Web/API/Document_Picture-in-Picture_API#how_does_it_work) that can be populated with arbitrary HTML content.
   It can be used to display any content that a user might want to view separate from the launching page (or even the browser), such as a set of streams showing the participants of a video conference call, a stock ticker, or a countdown timer.
   ([Firefox bug 2006594](https://bugzil.la/2006594)).
 


### PR DESCRIPTION
FF151 adds support for the [Document Picture in Picture API](https://developer.mozilla.org/en-US/docs/Web/API/Document_Picture-in-Picture_API) on desktop in https://bugzilla.mozilla.org/show_bug.cgi?id=2006594 (not android, which I believe is a spec thing)

This adds reo release note and removes from experimental features.

Related docs work can be tracked in #43861