### PR TITLE
FF151 Relnote: shadowrootslotassignment

### DIFF
--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -18,7 +18,11 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- ### Developer Tools -->
 
-<!-- ### HTML -->
+### HTML
+
+- The [`shadowrootslotassignment` attribute](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootslotassignment) is now supported on {{htmleelement("template")}} elements, allowing declarative definition of slot assignment behavior for shadow roots.
+  The attribute is reflected in JavaScript by {{domxref("ShadowRoot.slotAssignment")}} or {{domxref("HTMLTemplateElement.shadowRootSlotAssignment")}}
+  ([Firefox bug 2031295](https://bugzil.la/2031295), [Firefox bug 2023824](https://bugzil.la/2023824)).
 
 <!-- No notable changes. -->
 

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -20,7 +20,7 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### HTML
 
-- The [`shadowrootslotassignment` attribute](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootslotassignment) is now supported on {{htmleelement("template")}} elements, allowing declarative definition of slot assignment behavior for shadow roots.
+- The [`shadowrootslotassignment` attribute](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootslotassignment) is now supported on {{htmlelement("template")}} elements, allowing declarative definition of slot assignment behavior for shadow roots.
   The attribute is reflected in JavaScript by {{domxref("ShadowRoot.slotAssignment")}} or {{domxref("HTMLTemplateElement.shadowRootSlotAssignment")}}
   ([Firefox bug 2031295](https://bugzil.la/2031295), [Firefox bug 2023824](https://bugzil.la/2023824)).
 


### PR DESCRIPTION
FF152 added support for declarative slot assignment using the `shadowrootslotassignment` attribute on `<template>` in https://bugzilla.mozilla.org/show_bug.cgi?id=2023824

This adds the release note.

Related docs work can be tracked in #43866