### PR TITLE
FF151 Relnote: keyboardLock option for Element.requestFullScreen()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -58,6 +58,9 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
   This makes it possible to open an [always-on-top window](/en-US/docs/Web/API/Document_Picture-in-Picture_API#how_does_it_work) that can be populated with arbitrary HTML content.
   It can be used to display any content that a user might want to view separate from the launching page (or even the browser), such as a set of streams showing the participants of a video conference call, a stock ticker, or a countdown timer.
   ([Firefox bug 2006594](https://bugzil.la/2006594)).
+- The [`options.keyboardLock`](/en-US/docs/Web/API/Element/requestFullscreen#keyboardlock) property can now be passed as an option to {{domxref("Element.requestFullscreen()")}}, allowing websites to request keyboard lock when the element is displayed in fullscreen mode.
+  This prevents the <kbd>Esc</kbd> key from causing the element to leave fullscreen (instead, a long-press is required), and some formerly-reserved browser hotkeys are allowed to be default-prevented.
+  ([Firefox bug 2032302](https://bugzil.la/2032302)).
 
 <!-- #### DOM -->
 

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -59,7 +59,7 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
   It can be used to display any content that a user might want to view separate from the launching page (or even the browser), such as a set of streams showing the participants of a video conference call, a stock ticker, or a countdown timer.
   ([Firefox bug 2006594](https://bugzil.la/2006594)).
 - The [`options.keyboardLock`](/en-US/docs/Web/API/Element/requestFullscreen#keyboardlock) property can now be passed as an option to {{domxref("Element.requestFullscreen()")}}, allowing websites to request keyboard lock when the element is displayed in fullscreen mode.
-  This prevents the <kbd>Esc</kbd> key from causing the element to leave fullscreen (instead, a long-press is required), and some formerly-reserved browser hotkeys are allowed to be default-prevented.
+  This stops the <kbd>Esc</kbd> key from causing the element to leave fullscreen (a long-press is required instead), and some formerly-reserved browser hotkeys can now be intercepted and their default action prevented.
   ([Firefox bug 2032302](https://bugzil.la/2032302)).
 
 <!-- #### DOM -->


### PR DESCRIPTION
FF151 adds support for the `options.keyboardlock` property to be passed in the options object to `Element.requestFullScreen()` in https://bugzilla.mozilla.org/show_bug.cgi?id=2032302.
This allows use cases such as games to use the Esc key (say) without exiting full screen mode.

This PR adds the release note.

Related docs work can be tracked in #43868
