### PR TITLE
Fix HTMLSelectElement item equivalent method

### DIFF
--- a/files/en-us/web/api/htmlselectelement/item/index.md
+++ b/files/en-us/web/api/htmlselectelement/item/index.md
@@ -15,7 +15,7 @@ position in the options list corresponds to the index given in the parameter, or
 
 In JavaScript, using the array bracket syntax with an `unsigned long`, like
 `selectElt[index]` is equivalent to
-`selectElt.namedItem(index)`.
+`selectElt.item(index)`.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Fixes the `HTMLSelectElement.item()` page so the bracket access example points to `item(index)` instead of `namedItem(index)`.

### Motivation

The page is describing array-index access with an `unsigned long`, which is equivalent to `item(index)`.

Fixes #43885

### Additional details

Checks:
- `git diff --check`