### PR TITLE
Update xsl:message page to remove ancient Netscape (NS) abbreviation

### DIFF
--- a/files/en-us/web/xml/xslt/reference/element/message/index.md
+++ b/files/en-us/web/xml/xslt/reference/element/message/index.md
@@ -5,7 +5,7 @@ page-type: xslt-element
 sidebar: xmlsidebar
 ---
 
-The `<xsl:message>` element outputs a message (to the JavaScript Console in NS) and optionally terminates execution of the stylesheet. It can be useful for debugging.
+The `<xsl:message>` element outputs a message (to the JavaScript Console in the browser) and optionally terminates execution of the stylesheet. It can be useful for debugging.
 
 ## Syntax
 


### PR DESCRIPTION
I assume in the context that NS does mean Netscape. This might be confusing for the reader, since NS could also be taken to mean namespace in an XML / XSLT context. If so, changing "NS" to "the browser" is much less ambiguous and relevant since all the popular modern browsers have a console.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Change "NS" to "the browser".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I assume in the context that NS does mean Netscape. This might be confusing for the reader, since NS could also be taken to mean namespace in an XML / XSLT context. If so, changing "NS" to "the browser" is much less ambiguous and relevant since all the popular modern browsers have a console.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
