### PR TITLE
Corrected SC 1.4.4 link

### DIFF
--- a/files/en-us/web/css/reference/values/calc/index.md
+++ b/files/en-us/web/css/reference/values/calc/index.md
@@ -141,7 +141,7 @@ h1 {
 This ensures that text size will scale if the page is zoomed.
 
 - [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
-- [Understanding Success Criterion 1.4.4 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html)
+[Understanding Success Criterion 1.4.4: Resize Text | WAI | W3C](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
 
 ## Examples
 

--- a/files/en-us/web/css/reference/values/calc/index.md
+++ b/files/en-us/web/css/reference/values/calc/index.md
@@ -141,7 +141,7 @@ h1 {
 This ensures that text size will scale if the page is zoomed.
 
 - [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
-  [Understanding Success Criterion 1.4.4: Resize Text | WAI | W3C](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+- [Understanding Success Criterion 1.4.4: Resize Text | WAI | W3C](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
 
 ## Examples
 

--- a/files/en-us/web/css/reference/values/calc/index.md
+++ b/files/en-us/web/css/reference/values/calc/index.md
@@ -141,7 +141,7 @@ h1 {
 This ensures that text size will scale if the page is zoomed.
 
 - [MDN Understanding WCAG, Guideline 1.4 explanations](/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable#guideline_1.4_make_it_easier_for_users_to_see_and_hear_content_including_separating_foreground_from_background)
-[Understanding Success Criterion 1.4.4: Resize Text | WAI | W3C](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
+  [Understanding Success Criterion 1.4.4: Resize Text | WAI | W3C](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html)
 
 ## Examples
 


### PR DESCRIPTION
It pointed to unmaintained WCAG 2.0 version.
