### PR TITLE
Update window.open on document / window creation and load behavior

### DIFF
--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -89,7 +89,8 @@ If the {{httpheader("Cross-Origin-Opener-Policy")}} HTTP header is being used, a
 
 ## Description
 
-The [`Window`](/en-US/docs/Web/API/Window) interface's `open()` method takes a URL as a parameter, and loads the resource it identifies into a new or existing tab or window. The `target` parameter determines which window or tab to load the resource into, and the `windowFeatures` parameter can be used to control to open a new popup with minimal UI features and control its size and position.
+The [`Window`](/en-US/docs/Web/API/Window) interface's `open()` method takes a URL as a parameter, and loads the resource it identifies into a new or existing tab or window.
+The `target` parameter determines which window or tab to load the resource into, and the `windowFeatures` parameter can be used to control the features of the new window, such as whether it is a tab or a popup with minimal UI features, its size and position, and so on.
 
 When `window.open()` returns, the new window always contains `about:blank`. If a different URL was provided, it is loaded asynchronously. The global object is reused for this initial load, so properties set on it may persist.
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -90,7 +90,7 @@ If the {{httpheader("Cross-Origin-Opener-Policy")}} HTTP header is being used, a
 ## Description
 
 The [`Window`](/en-US/docs/Web/API/Window) interface's `open()` method takes a URL as a parameter, and loads the resource it identifies into a new or existing browsing context.
-The `target` parameter determines which window or tab to load the resource into, and the `windowFeatures` parameter can be used to control the features of the new window, such as whether it is a tab or a popup with minimal UI features, its size and position, and so on.
+The `target` parameter determines which window, tab, or frame, to load the resource into, and the `windowFeatures` parameter can be used to control the features of the new window, such as whether it is a tab or a popup with minimal UI features, its size and position, and so on.
 
 When `window.open()` returns, the new window always contains `about:blank`. If a different URL was provided, it is loaded asynchronously. The global object is reused for this initial load, so properties set on it may persist.
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -91,7 +91,7 @@ If the {{httpheader("Cross-Origin-Opener-Policy")}} HTTP header is being used, a
 
 The [`Window`](/en-US/docs/Web/API/Window) interface's `open()` method takes a URL as a parameter, and loads the resource it identifies into a new or existing tab or window. The `target` parameter determines which window or tab to load the resource into, and the `windowFeatures` parameter can be used to control to open a new popup with minimal UI features and control its size and position.
 
-Remote URLs won't load immediately. When `window.open()` returns, the window always contains `about:blank`. The actual fetching of the URL is deferred and starts after the current script block finishes executing. The window creation and the loading of the referenced resource are done asynchronously.
+When `window.open()` returns, the new window always contains `about:blank`. If a different URL was provided, it is loaded asynchronously. The global object is reused for this initial load, so properties set on it may persist.
 
 Modern browsers have strict popup blocker policies. Popup windows must be opened in direct response to user input, and a separate user gesture event is required for each `Window.open()` call. This prevents sites from spamming users with lots of windows. However, this poses an issue for multi-window applications. To work around this limitation, you can design your applications to:
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -89,7 +89,7 @@ If the {{httpheader("Cross-Origin-Opener-Policy")}} HTTP header is being used, a
 
 ## Description
 
-The [`Window`](/en-US/docs/Web/API/Window) interface's `open()` method takes a URL as a parameter, and loads the resource it identifies into a new or existing tab or window.
+The [`Window`](/en-US/docs/Web/API/Window) interface's `open()` method takes a URL as a parameter, and loads the resource it identifies into a new or existing browsing context.
 The `target` parameter determines which window or tab to load the resource into, and the `windowFeatures` parameter can be used to control the features of the new window, such as whether it is a tab or a popup with minimal UI features, its size and position, and so on.
 
 When `window.open()` returns, the new window always contains `about:blank`. If a different URL was provided, it is loaded asynchronously. The global object is reused for this initial load, so properties set on it may persist.

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -92,7 +92,9 @@ If the {{httpheader("Cross-Origin-Opener-Policy")}} HTTP header is being used, a
 The [`Window`](/en-US/docs/Web/API/Window) interface's `open()` method takes a URL as a parameter, and loads the resource it identifies into a new or existing browsing context.
 The `target` parameter determines which window, tab, or frame, to load the resource into, and the `windowFeatures` parameter can be used to control the features of the new window, such as whether it is a tab or a popup with minimal UI features, its size and position, and so on.
 
-When `window.open()` returns, the new window always contains `about:blank`. If a different URL was provided, it is loaded asynchronously. The global object is reused for this initial load, so properties set on it may persist.
+When `window.open()` creates a new browsing context (i.e., when no existing window with that name is found), the window initially contains `about:blank`.
+If a different URL was provided, it is loaded asynchronously, and the global object is reused for that navigation if it is same-origin — so any properties set on the window before the load may persist.
+If target refers to an existing navigable (`_self`, `_parent`, `_top`, or a known window name), no `about:blank` phase occurs — the browser navigates the existing context directly.
 
 Modern browsers have strict popup blocker policies. Popup windows must be opened in direct response to user input, and a separate user gesture event is required for each `Window.open()` call. This prevents sites from spamming users with lots of windows. However, this poses an issue for multi-window applications. To work around this limitation, you can design your applications to:
 


### PR DESCRIPTION

### Motivation

I have multiple issues with the existing paragraph.
- What does remote mean? I think that could be mistaken as non-local or cross origin.
- The window isn't created asynchronously, only the navigation occurs async.
- "current script block" is imprecise and probably incorrect.

If we think of this paragraph as being about how `window.open()` creates the document and window, I also think it's important to mention that the global is reused and thus `window.open(...).onload` works even though we start on `about:blank`.

### Additional details

- https://html.spec.whatwg.org/#window-open-steps
- https://html.spec.whatwg.org/#windows:is-initial-about:blank
- https://bugzilla.mozilla.org/show_bug.cgi?id=543435#c224