### PR TITLE
Clarify HSTS preload max-age example

### DIFF
--- a/files/en-us/web/http/reference/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/reference/headers/strict-transport-security/index.md
@@ -152,7 +152,7 @@ This blocks access to pages or subdomains that can only be served over HTTP.
 Strict-Transport-Security: max-age=31536000; includeSubDomains
 ```
 
-Although a `max-age` of 1 year is acceptable for a domain, two years is the recommended value as explained on https://hstspreload.org.
+A `max-age` of 1 year is the minimum value accepted for HSTS preloading. The following example uses 2 years, which is the value shown in the example header on https://hstspreload.org.
 
 In the following example, `max-age` is set to 2 years, and is suffixed with `preload`, which is necessary for inclusion in all major web browsers' HSTS preload lists, like Chromium, Edge, and Firefox.
 


### PR DESCRIPTION
### Description

Clarifies the HSTS example text so it no longer states that a 2-year `max-age` is a recommended value from hstspreload.org.

### Motivation

The previous wording implied that hstspreload.org recommends a 2-year `max-age`, but the site actually documents a 1-year minimum requirement for HSTS preloading and shows a 2-year header as an example.

### Additional details

This change updates the wording to say that 1 year is the minimum value accepted for HSTS preloading, and that the following 2-year header matches the example shown on hstspreload.org.

### Related issues and pull requests

Fixes #43877
