### PR TITLE
[Editorial review] BiDi - Add pages for input module commands and event

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
@@ -1,5 +1,5 @@
 ---
-title: input.fileDialogOpened event
+title: "`input.fileDialogOpened` event"
 short-title: fileDialogOpened
 slug: Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened
 page-type: webdriver-event

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
@@ -1,0 +1,64 @@
+---
+title: input.fileDialogOpened event
+short-title: fileDialogOpened
+slug: Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened
+page-type: webdriver-event
+browser-compat: webdriver.bidi.input.fileDialogOpened_event
+sidebar: webdriver
+---
+
+The `input.fileDialogOpened` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`input`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input) module fires when a file picker dialog opens in a context, for example when [`click()`](/en-US/docs/Web/API/HTMLElement/click) or [`showPicker()`](/en-US/docs/Web/API/HTMLInputElement/showPicker) is called on an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element.
+
+## Event data
+
+The `params` field in the event notification is an object with the following fields:
+
+- `context`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context in which the file picker dialog was triggered.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `element` {{optional_inline}}
+  - : An object containing the ID that uniquely identifies the [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) DOM element that triggered the file picker dialog.
+    This field is included when the file picker dialog is opened by a file `<input>` element.
+- `multiple`
+  - : A boolean that indicates whether the file picker dialog allows multiple file paths.
+    - `true`: The file picker dialog accepts multiple files (the associated `<input>` element has the [`multiple`](/en-US/docs/Web/HTML/Reference/Elements/input/file#multiple) attribute).
+    - `false`: The file picker dialog accepts only a single file path.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the file picker dialog was triggered.
+
+## Examples
+
+### Receiving an event when a file picker dialog opens
+
+Consider a scenario where a page has an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element that accepts a single file and your script calls [`click()`](/en-US/docs/Web/API/HTMLElement/click) on it. With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `input.fileDialogOpened` active, the browser sends a notification when the file picker dialog opens:
+
+```json
+{
+  "type": "event",
+  "method": "input.fileDialogOpened",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "element": {
+      "sharedId": "3be28343-afd3-4dea-a2b6-a863fbbb80e1"
+    },
+    "multiple": false
+  }
+}
+```
+
+You can then call [`input.setFiles`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/setFiles) with the `element.sharedId` from the notification to simulate file upload.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command
+- [`input.setFiles`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/setFiles) command
+- [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) command
+- [`input.releaseActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/releaseActions) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/index.md
@@ -7,7 +7,17 @@ browser-compat: webdriver.bidi.input
 sidebar: webdriver
 ---
 
-The **`input`** module contains commands for simulating user input actions.
+The **`input`** module contains commands for simulating user input actions such as key presses, mouse clicks, scrolling, and file selection.
+
+## Commands
+
+- [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions)
+- [`input.releaseActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/releaseActions)
+- [`input.setFiles`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/setFiles)
+
+## Events
+
+- [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened)
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/index.md
@@ -1,5 +1,5 @@
 ---
-title: input module
+title: "`input` module"
 short-title: input
 slug: Web/WebDriver/Reference/BiDi/Modules/input
 page-type: listing-page
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.input
 sidebar: webdriver
 ---
 
-The **`input`** module contains commands for simulating user input actions such as key presses, mouse clicks, scrolling, and file selection.
+The **`input`** module provides commands and an event for simulating and observing user input actions such as key presses, mouse clicks, scrolling, and file selection.
 
 ## Commands
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -1,0 +1,255 @@
+---
+title: "`input.performActions` command"
+short-title: performActions
+slug: Web/WebDriver/Reference/BiDi/Modules/input/performActions
+page-type: webdriver-command
+browser-compat: webdriver.bidi.input.performActions
+sidebar: webdriver
+---
+
+The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`input`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input) module simulates user input actions in a given context to interact with elements on the page. After performing actions, call [`input.releaseActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/releaseActions) to release any inputs left in an intermediate state.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "input.performActions",
+  "params": {
+    "context": "<contextId>",
+    "actions": [
+      {
+        "type": "<inputSourceType>",
+        "id": "<sourceId>",
+        "actions": [
+          {
+            "type": "<actionType>",
+            ...
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context in which to perform the actions. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `actions`
+  - : An array of objects, each representing an input source (`"key"`, `"pointer"`, or `"wheel"`) and the actions to perform for that source.
+    All input sources are processed in parallel.
+    This allows combining input sources, for example, holding <kbd>Shift</kbd> while clicking.
+
+    Each `actions` object has the following fields:
+    - `id`
+      - : A string that uniquely identifies this input source within the action sequence, for example, `"mouse1"` or `"keyboard1"`.
+    - `type`
+      - : A string that identifies the type of input source. Accepted values are `"none"`, `"key"`, `"pointer"`, and `"wheel"`.
+    - `actions`
+      - : An array of objects, each representing an action for the input source specified in the [`type`](#type) field.
+
+        Each object has a `type` field that specifies the type of operation and additional fields that depend on the value of this `type`. The `type` field accepts the following values:
+        - `"pause"`: Waits for the given duration before the next step.
+        - `"keyDown"`: Simulates pressing a key.
+        - `"keyUp"`: Simulates releasing a key.
+        - `"pointerDown"`: Simulates pressing a pointer button.
+        - `"pointerUp"`: Simulates releasing a pointer button.
+        - `"pointerMove"`: Simulates moving the pointer.
+        - `"scroll"`: Simulates a mouse wheel scroll.
+
+        The following table shows, for each input source `type` value, the `type` values valid inside the nested `actions` array:
+
+        | Input source `type` values | Accepted operation `type` values                           |
+        | -------------------------- | ---------------------------------------------------------- |
+        | `"none"`                   | `"pause"`                                                  |
+        | `"key"`                    | `"pause"`, `"keyDown"`, `"keyUp"`                          |
+        | `"pointer"`                | `"pause"`, `"pointerDown"`, `"pointerUp"`, `"pointerMove"` |
+        | `"wheel"`                  | `"pause"`, `"scroll"`                                      |
+
+        The following table shows the additional fields in the `actions` object for each operation type:
+
+        | Operation `type` values | Fields available with this `type` value                                                                              |
+        | ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
+        | `"pause"`               | [`duration`](#duration)                                                                                              |
+        | `"keyDown"`, `"keyUp"`  | [`value`](#value)                                                                                                    |
+        | `"pointerDown"`         | [`button`](#button), [pointer properties](#common_pointer_properties)                                                |
+        | `"pointerUp"`           | [`button`](#button)                                                                                                  |
+        | `"pointerMove"`         | [`x`](#x), [`y`](#y), [`duration`](#duration), [`origin`](#origin), [pointer properties](#common_pointer_properties) |
+        | `"scroll"`              | [`x`](#x), [`y`](#y), [`deltaX`](#deltax), [`deltaY`](#deltay), [`duration`](#duration), [`origin`](#origin)         |
+
+    - `parameters` {{optional_inline}}
+      - : An object with a `pointerType` field that specifies the pointer device type. Accepted values are `"mouse"` (default), `"pen"`, or `"touch"`. This field is valid only when the input source [`type`](#type) is `"pointer"`.
+
+The following fields are supported depending on the value of the operation `type`:
+
+- `button`
+  - : A non-negative integer that identifies the pointer button (`0` = primary, `1` = middle, `2` = secondary).
+    Specify this when the `type` field value is `"pointerDown"` or `"pointerUp"`.
+- `deltaX`
+  - : An integer that specifies the horizontal scroll delta in CSS pixels.
+    Specify this when the `type` field value is `"scroll"`.
+- `deltaY`
+  - : An integer that specifies the vertical scroll delta in CSS pixels.
+    Specify this when the `type` field value is `"scroll"`.
+- `duration` {{optional_inline}}
+  - : A non-negative integer that specifies the time in milliseconds.
+    Specify this when the `type` field value is `"pause"`, `"pointerMove"`, or `"scroll"`.
+- `origin` {{optional_inline}}
+  - : A string or an object that specifies the origin for the move or scroll. Accepted string values are `"viewport"` and `"pointer"`. For an object, include the following fields:
+    - `type`
+      - : A string set to `"element"`.
+    - `element`
+      - : An object containing the ID that uniquely identifies the DOM element to use as the origin. The ID is returned by the browser when you locate the element using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
+
+    Specify this when the `type` field value is `"pointerMove"` or `"scroll"`. For `"scroll"`, `"viewport"` is the default if this field is omitted.
+
+- `value`
+  - : A string that contains the key value, such as <kbd>a</kbd>, <kbd>Enter</kbd>, or <kbd>Shift</kbd>.
+    Specify this when the `type` field value is `"keyDown"` or `"keyUp"`.
+- Common pointer properties
+  - : The following optional fields describe the physical characteristics of the pointer device, such as a mouse, stylus, or touchscreen. Specify these when the `type` field value is `"pointerDown"` or `"pointerMove"`.
+    - `width` {{optional_inline}}
+      - : A non-negative integer that specifies the width, in CSS pixels, of the pointer contact area. See {{domxref("PointerEvent.width")}}.
+    - `height` {{optional_inline}}
+      - : A non-negative integer that specifies the height, in CSS pixels, of the pointer contact area. See {{domxref("PointerEvent.height")}}.
+    - `pressure` {{optional_inline}}
+      - : A float that specifies the normalized pressure of the pointer in the range `0.0`–`1.0`. See {{domxref("PointerEvent.pressure")}}.
+    - `tangentialPressure` {{optional_inline}}
+      - : A float that specifies the normalized tangential pressure in the range `-1.0`–`1.0`. See {{domxref("PointerEvent.tangentialPressure")}}.
+    - `twist` {{optional_inline}}
+      - : An integer that specifies the clockwise rotation, in degrees, of the pointer in the range `0`–`359`. See {{domxref("PointerEvent.twist")}}.
+    - `altitudeAngle` {{optional_inline}}
+      - : A float that specifies the altitude angle, in radians, of the pointer in the range `0.0`–`1.5707963267948966`. See {{domxref("PointerEvent.altitudeAngle")}}.
+    - `azimuthAngle` {{optional_inline}}
+      - : A float that specifies the azimuth angle, in radians, of the pointer in the range `0.0`–`6.283185307179586`. See {{domxref("PointerEvent.azimuthAngle")}}.
+- `x`
+  - : A number (for `"pointerMove"`) or an integer (for `"scroll"`) that specifies the x-coordinate.
+    Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
+- `y`
+  - : A number (for `"pointerMove"`) or an integer (for `"scroll"`) that specifies the y-coordinate.
+    Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : The action sequence is malformed; for example, if a required field is missing or a field value is of the wrong type.
+
+## Examples
+
+### Clicking an element
+
+Consider a scenario where you want to simulate a mouse click on an element.
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) and the element identifier using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate).
+Send the following message that uses three sequential steps: moving (`pointerMove`) the pointer to the center of the element (`x: 0, y: 0` relative to the element), pressing (`pointerDown`) the primary mouse button (`0`), and then releasing (`pointerUp`) it.
+
+```json
+{
+  "id": 1,
+  "method": "input.performActions",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "actions": [
+      {
+        "type": "pointer",
+        "id": "mouse1",
+        "parameters": {
+          "pointerType": "mouse"
+        },
+        "actions": [
+          {
+            "type": "pointerMove",
+            "x": 0,
+            "y": 0,
+            "origin": {
+              "type": "element",
+              "element": {
+                "sharedId": "3be28343-afd3-4dea-a2b6-a863fbbb80e1"
+              }
+            }
+          },
+          {
+            "type": "pointerDown",
+            "button": 0
+          },
+          {
+            "type": "pointerUp",
+            "button": 0
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+### Scrolling the page
+
+Consider a scenario where you want to simulate scrolling a page down.
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+Send the following message that scrolls from the top-left of the viewport (`x: 0, y: 0`) by `300` CSS pixels downward (`deltaY: 300`) with no horizontal scrolling (`deltaX: 0`).
+
+```json
+{
+  "id": 2,
+  "method": "input.performActions",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "actions": [
+      {
+        "type": "wheel",
+        "id": "wheel1",
+        "actions": [
+          {
+            "type": "scroll",
+            "x": 0,
+            "y": 0,
+            "deltaX": 0,
+            "deltaY": 300
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {}
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`input.releaseActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/releaseActions) command
+- [`input.setFiles`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/setFiles) command
+- [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -125,6 +125,7 @@ The following fields are available in each inner `actions` object, depending on 
 
 - `value`
   - : A string that contains the key value, such as <kbd>a</kbd>, <kbd>Enter</kbd>, or <kbd>Shift</kbd>.
+    See [Key values for keyboard events](/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values) for the full list of valid values.
     Specify this when the inner `type` field value is `"keyDown"` or `"keyUp"`.
 - Pointer properties
   - : The following fields are part of the inner `actions` object and describe the physical characteristics of the pointer device, such as a mouse, stylus, or touchscreen.

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -175,13 +175,13 @@ The `result` field in the response is an empty object (`{}`).
 Consider a scenario where you want to hold the <kbd>Shift</kbd> key while clicking an element, for example to extend a text selection.
 
 With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) and the element identifier using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes).
-Send the following message with two outer `actions` objects — a `"key"` source and a `"pointer"` source — running in parallel across the following three ticks:
+Send the following message with two outer `actions` objects — a `"key"` source and a `"pointer"` source — each with an outer `type` and an inner `actions` array, running in parallel across the following three ticks:
 
 - Tick 1: The keyboard presses <kbd>Shift</kbd> while the pointer moves to the element. Since the `duration` of `pointerMove` is specified as `300`, the tick lasts `300 ms`, which is the longest `duration` in this tick.
 - Tick 2: The keyboard pauses while the pointer button is pressed (`pointerDown`). This tick lasts for `0 ms`.
 - Tick 3: The <kbd>Shift</kbd> key is released (`keyUp`) and the pointer button is released (`pointerUp`) simultaneously. This tick also lasts for `0 ms`.
 
-```json
+```json-nolint
 {
   "id": 1,
   "method": "input.performActions",
@@ -193,14 +193,14 @@ Send the following message with two outer `actions` objects — a `"key"` source
         "id": "keyboard1",
         "actions": [
           {
-            "type": "keyDown",
+            "type": "keyDown", // Tick 1: Shift key down (0 ms)
             "value": "\uE008"
           },
           {
-            "type": "pause"
+            "type": "pause"    // Tick 2: Keyboard pause (0 ms)
           },
           {
-            "type": "keyUp",
+            "type": "keyUp",   // Tick 3: Shift key up (0 ms)
             "value": "\uE008"
           }
         ]
@@ -213,7 +213,7 @@ Send the following message with two outer `actions` objects — a `"key"` source
         },
         "actions": [
           {
-            "type": "pointerMove",
+            "type": "pointerMove", // Tick 1: Move to element (300 ms)
             "x": 0,
             "y": 0,
             "duration": 300,
@@ -225,11 +225,11 @@ Send the following message with two outer `actions` objects — a `"key"` source
             }
           },
           {
-            "type": "pointerDown",
+            "type": "pointerDown", // Tick 2: Press button (0 ms)
             "button": 0
           },
           {
-            "type": "pointerUp",
+            "type": "pointerUp",   // Tick 3: Release button (0 ms)
             "button": 0
           }
         ]

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -69,7 +69,7 @@ The `params` field contains:
         | `"pointer"`                | `"pause"`, `"pointerDown"`, `"pointerUp"`, `"pointerMove"` |
         | `"wheel"`                  | `"pause"`, `"scroll"`                                      |
 
-        The following table shows the additional fields in the `actions` object for each operation type:
+        The following table shows the additional fields in the nested `actions` object for each operation type:
 
         | Operation `type` values | Fields available with this `type` value                                                                              |
         | ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -80,10 +80,11 @@ The `params` field contains:
         | `"pointerMove"`         | [`x`](#x), [`y`](#y), [`duration`](#duration), [`origin`](#origin), [pointer properties](#common_pointer_properties) |
         | `"scroll"`              | [`x`](#x), [`y`](#y), [`deltaX`](#deltax), [`deltaY`](#deltay), [`duration`](#duration), [`origin`](#origin)         |
 
+    The outer `actions` object also supports the following optional field:
     - `parameters` {{optional_inline}}
       - : An object with a `pointerType` field that specifies the pointer device type. Accepted values are `"mouse"` (default), `"pen"`, or `"touch"`. This field is valid only when the input source [`type`](#type) is `"pointer"`.
 
-The following fields are supported depending on the value of the operation `type`:
+The following fields are available in each nested `actions` object, depending on the operation `type`:
 
 - `button`
   - : A non-negative integer that identifies the pointer button (`0` = primary, `1` = middle, `2` = secondary).
@@ -98,13 +99,17 @@ The following fields are supported depending on the value of the operation `type
   - : A non-negative integer that specifies the time in milliseconds.
     Specify this when the `type` field value is `"pause"`, `"pointerMove"`, or `"scroll"`.
 - `origin` {{optional_inline}}
-  - : A string or an object that specifies the origin for the move or scroll. Accepted string values are `"viewport"` and `"pointer"`. For an object, include the following fields:
+  - : A string or an object that specifies the origin for the move or scroll. Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
+
+    If a string, accepted values are:
+    - `"viewport"`: Indicates that the x and y coordinates are relative to the viewport's top-left corner. Use this for absolute positioning within the page. This is the default value for `"scroll"` if `origin` is omitted.
+    - `"pointer"`: Indicates that the x and y coordinates are relative to the current pointer position. Use this for relative moves from where the pointer currently is.
+
+    If an object, include the following fields:
     - `type`
       - : A string set to `"element"`.
     - `element`
-      - : An object containing the ID that uniquely identifies the DOM element to use as the origin. The ID is returned by the browser when you locate the element using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
-
-    Specify this when the `type` field value is `"pointerMove"` or `"scroll"`. For `"scroll"`, `"viewport"` is the default if this field is omitted.
+      - : An object containing the ID that uniquely identifies the DOM element to use as the origin. The ID is returned by the browser when you locate the element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes), [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
 
 - `value`
   - : A string that contains the key value, such as <kbd>a</kbd>, <kbd>Enter</kbd>, or <kbd>Shift</kbd>.
@@ -122,9 +127,9 @@ The following fields are supported depending on the value of the operation `type
     - `twist` {{optional_inline}}
       - : An integer that specifies the clockwise rotation, in degrees, of the pointer in the range `0`–`359`. See {{domxref("PointerEvent.twist")}}.
     - `altitudeAngle` {{optional_inline}}
-      - : A float that specifies the altitude angle, in radians, of the pointer in the range `0.0`–`1.5707963267948966`. See {{domxref("PointerEvent.altitudeAngle")}}.
+      - : A float that specifies the altitude angle, in radians, of the pointer in the range `0.0`–`π/2`. See {{domxref("PointerEvent.altitudeAngle")}}.
     - `azimuthAngle` {{optional_inline}}
-      - : A float that specifies the azimuth angle, in radians, of the pointer in the range `0.0`–`6.283185307179586`. See {{domxref("PointerEvent.azimuthAngle")}}.
+      - : A float that specifies the azimuth angle, in radians, of the pointer in the range `0.0`–`2π`. See {{domxref("PointerEvent.azimuthAngle")}}.
 - `x`
   - : A number (for `"pointerMove"`) or an integer (for `"scroll"`) that specifies the x-coordinate.
     Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
@@ -146,7 +151,7 @@ The `result` field in the response is an empty object (`{}`).
 ### Clicking an element
 
 Consider a scenario where you want to simulate a mouse click on an element.
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) and the element identifier using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate).
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) and the element identifier using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes).
 Send the following message that uses three sequential steps: moving (`pointerMove`) the pointer to the center of the element (`x: 0, y: 0` relative to the element), pressing (`pointerDown`) the primary mouse button (`0`), and then releasing (`pointerUp`) it.
 
 ```json
@@ -202,7 +207,7 @@ The browser responds as follows:
 ### Scrolling the page
 
 Consider a scenario where you want to simulate scrolling a page down.
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 Send the following message that scrolls from the top-left of the viewport (`x: 0, y: 0`) by `300` CSS pixels downward (`deltaY: 300`) with no horizontal scrolling (`deltaX: 0`).
 
 ```json

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -41,6 +41,7 @@ The `params` field contains:
 - `actions`
   - : An array of objects, each representing an input source (`"key"`, `"pointer"`, or `"wheel"`) and the actions to perform for that source.
     All input sources are processed in parallel.
+    In each tick (step), every input source performs one action simultaneously or does nothing if assigned a `"pause"` action.
     This allows combining input sources, for example, holding <kbd>Shift</kbd> while clicking.
 
     Each `actions` object has the following fields:
@@ -97,7 +98,8 @@ The following fields are available in each nested `actions` object, depending on
     Specify this when the `type` field value is `"scroll"`.
 - `duration` {{optional_inline}}
   - : A non-negative integer that specifies the time in milliseconds.
-    Specify this when the `type` field value is `"pause"`, `"pointerMove"`, or `"scroll"`.
+    This value determines the number of ticks into which the action is divided; for example, a `"pointerMove"` with a 100 ms duration gets split across multiple ticks, each tick moving the pointer a fraction of the distance.
+    Specify `duration` when the `type` field value is `"pause"`, `"pointerMove"`, or `"scroll"`.
 - `origin` {{optional_inline}}
   - : A string or an object that specifies the origin for the move or scroll. Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
 
@@ -144,7 +146,7 @@ The `result` field in the response is an empty object (`{}`).
 ### Errors
 
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
-  - : The action sequence is malformed; for example, if a required field is missing or a field value is of the wrong type.
+  - : The action sequence is malformed; for example, if a required field is missing, a field value is of the wrong type, or an input source `type` value is not `"none"`, `"key"`, `"pointer"`, or `"wheel"`.
 - `no such frame`
   - : No context with the given context ID is found.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -39,20 +39,24 @@ The `params` field contains:
 - `context`
   - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context in which to perform the actions. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `actions`
-  - : An array of objects, each representing an input source (`"key"`, `"pointer"`, or `"wheel"`) and the actions to perform for that source.
+  - : An array of objects, each representing an input source and the actions to perform for that source.
+    Each such object represents the outer `actions` object, which in turn, contains an outer `type` (input source type can be `"key"`, `"pointer"`, or `"wheel"`) and an inner `actions` array.
+    Each object in the inner `actions` array has its own inner `type` and additional fields that depend on it.
+
     All input sources are processed in parallel.
     In each tick (step), every input source performs one action simultaneously or does nothing if assigned a `"pause"` action.
     This allows combining input sources, for example, holding <kbd>Shift</kbd> while clicking.
 
-    Each `actions` object has the following fields:
+    Each outer `actions` object has the following fields:
     - `id`
       - : A string that uniquely identifies this input source within the action sequence, for example, `"mouse1"` or `"keyboard1"`.
     - `type`
-      - : A string that identifies the type of input source. Accepted values are `"none"`, `"key"`, `"pointer"`, and `"wheel"`.
+      - : A string (the outer `type`) that identifies the type of input source. Accepted values are `"none"`, `"key"`, `"pointer"`, and `"wheel"`.
     - `actions`
-      - : An array of objects, each representing an action for the input source specified in the [`type`](#type) field.
+      - : An array of objects (the inner `actions`), each representing an action for the input source specified in the outer [`type`](#type) field.
 
-        Each object has a `type` field that specifies the type of operation and additional fields that depend on the value of this `type`. The `type` field accepts the following values:
+        Each inner `actions` object has an inner `type` field that specifies the operation to perform and additional fields that depend on it.
+        The inner `type` accepts the following values:
         - `"pause"`: Waits for the given duration before the next step.
         - `"keyDown"`: Simulates pressing a key.
         - `"keyUp"`: Simulates releasing a key.
@@ -61,83 +65,97 @@ The `params` field contains:
         - `"pointerMove"`: Simulates moving the pointer.
         - `"scroll"`: Simulates a mouse wheel scroll.
 
-        The following table shows, for each input source `type` value, the `type` values valid inside the nested `actions` array:
+        The following table shows, for each outer `type` value, the valid values for the inner `type`:
 
-        | Input source `type` values | Accepted operation `type` values                           |
-        | -------------------------- | ---------------------------------------------------------- |
-        | `"none"`                   | `"pause"`                                                  |
-        | `"key"`                    | `"pause"`, `"keyDown"`, `"keyUp"`                          |
-        | `"pointer"`                | `"pause"`, `"pointerDown"`, `"pointerUp"`, `"pointerMove"` |
-        | `"wheel"`                  | `"pause"`, `"scroll"`                                      |
+        | Outer `type` values | Accepted inner `type` values                               |
+        | ------------------- | ---------------------------------------------------------- |
+        | `"none"`            | `"pause"`                                                  |
+        | `"key"`             | `"pause"`, `"keyDown"`, `"keyUp"`                          |
+        | `"pointer"`         | `"pause"`, `"pointerDown"`, `"pointerUp"`, `"pointerMove"` |
+        | `"wheel"`           | `"pause"`, `"scroll"`                                      |
 
-        The following table shows the additional fields in the nested `actions` object for each operation type:
+        The following table shows, for each inner `type` value, the fields available in the inner `actions` object:
 
-        | Operation `type` values | Fields available with this `type` value                                                                              |
-        | ----------------------- | -------------------------------------------------------------------------------------------------------------------- |
-        | `"pause"`               | [`duration`](#duration)                                                                                              |
-        | `"keyDown"`, `"keyUp"`  | [`value`](#value)                                                                                                    |
-        | `"pointerDown"`         | [`button`](#button), [pointer properties](#common_pointer_properties)                                                |
-        | `"pointerUp"`           | [`button`](#button)                                                                                                  |
-        | `"pointerMove"`         | [`x`](#x), [`y`](#y), [`duration`](#duration), [`origin`](#origin), [pointer properties](#common_pointer_properties) |
-        | `"scroll"`              | [`x`](#x), [`y`](#y), [`deltaX`](#deltax), [`deltaY`](#deltay), [`duration`](#duration), [`origin`](#origin)         |
+        | Inner `type` values    | Fields available in the inner `actions` object                                                                |
+        | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+        | `"pause"`              | [`duration`](#duration)                                                                                       |
+        | `"keyDown"`, `"keyUp"` | [`value`](#value)                                                                                             |
+        | `"pointerDown"`        | [`button`](#button), [pointer properties](#pointer_properties)                                                |
+        | `"pointerUp"`          | [`button`](#button)                                                                                           |
+        | `"pointerMove"`        | [`x`](#x), [`y`](#y), [`duration`](#duration), [`origin`](#origin), [pointer properties](#pointer_properties) |
+        | `"scroll"`             | [`x`](#x), [`y`](#y), [`deltaX`](#deltax), [`deltaY`](#deltay), [`duration`](#duration), [`origin`](#origin)  |
 
-    The outer `actions` object also supports the following optional field:
+    The outer `actions` object also supports the following field:
     - `parameters` {{optional_inline}}
-      - : An object with a `pointerType` field that specifies the pointer device type. Accepted values are `"mouse"` (default), `"pen"`, or `"touch"`. This field is valid only when the input source [`type`](#type) is `"pointer"`.
+      - : An object with a `pointerType` field that specifies the pointer device type. Accepted values are `"mouse"` (default), `"pen"`, or `"touch"`. This field is valid only when the outer [`type`](#type) is `"pointer"`.
 
-The following fields are available in each nested `actions` object, depending on the operation `type`:
+The following fields are available in each inner `actions` object, depending on the inner `type`:
 
 - `button`
   - : A non-negative integer that identifies the pointer button (`0` = primary, `1` = middle, `2` = secondary).
-    Specify this when the `type` field value is `"pointerDown"` or `"pointerUp"`.
+    Specify this when the inner `type` field value is `"pointerDown"` or `"pointerUp"`.
 - `deltaX`
   - : An integer that specifies the horizontal scroll delta in CSS pixels.
-    Specify this when the `type` field value is `"scroll"`.
+    Specify this when the inner `type` field value is `"scroll"`.
 - `deltaY`
   - : An integer that specifies the vertical scroll delta in CSS pixels.
-    Specify this when the `type` field value is `"scroll"`.
+    Specify this when the inner `type` field value is `"scroll"`.
 - `duration` {{optional_inline}}
-  - : A non-negative integer that specifies the time in milliseconds.
-    This value determines the number of ticks into which the action is divided; for example, a `"pointerMove"` with a 100 ms duration gets split across multiple ticks, each tick moving the pointer a fraction of the distance.
-    Specify `duration` when the `type` field value is `"pause"`, `"pointerMove"`, or `"scroll"`.
+  - : A non-negative integer that specifies the time in milliseconds over which the action is performed.
+    Specify this when the inner `type` field value is `"pause"`, `"pointerMove"`, or `"scroll"`.
+    For `"pointerMove"` and `"scroll"`, the overall movement occurs as a series of small movements over this period at a browser-defined rate (for example, one step per animation frame).
+    When multiple outer `actions` objects run in parallel, the tick lasts as long as the longest `duration` value in that tick.
 - `origin` {{optional_inline}}
-  - : A string or an object that specifies the origin for the move or scroll. Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
+  - : A string or an object that specifies the origin for the move or scroll.
+    Specify this when the inner `type` field value is `"pointerMove"` or `"scroll"`.
 
-    If a string, accepted values are:
-    - `"viewport"`: Indicates that the x and y coordinates are relative to the viewport's top-left corner. Use this for absolute positioning within the page. This is the default value for `"scroll"` if `origin` is omitted.
-    - `"pointer"`: Indicates that the x and y coordinates are relative to the current pointer position. Use this for relative moves from where the pointer currently is.
+    If `origin` is a string, accepted values are:
+    - `"viewport"`: Indicates that the x and y coordinates are relative to the viewport's top-left corner.
+      Use this for absolute positioning within the page.
+      This is the default value for `"scroll"` if `origin` is omitted.
+    - `"pointer"`: Indicates that the x and y coordinates are relative to the current pointer position.
+      Use this for relative moves from where the pointer currently is.
 
-    If an object, include the following fields:
+    If `origin` is an object, include the following fields:
     - `type`
       - : A string set to `"element"`.
     - `element`
-      - : An object containing the ID that uniquely identifies the DOM element to use as the origin. The ID is returned by the browser when you locate the element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes), [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
+      - : An object containing the ID that uniquely identifies the DOM element to use as the origin.
+        The ID is returned by the browser when you locate the element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes), [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
 
 - `value`
   - : A string that contains the key value, such as <kbd>a</kbd>, <kbd>Enter</kbd>, or <kbd>Shift</kbd>.
-    Specify this when the `type` field value is `"keyDown"` or `"keyUp"`.
-- Common pointer properties
-  - : The following optional fields describe the physical characteristics of the pointer device, such as a mouse, stylus, or touchscreen. Specify these when the `type` field value is `"pointerDown"` or `"pointerMove"`.
+    Specify this when the inner `type` field value is `"keyDown"` or `"keyUp"`.
+- Pointer properties
+  - : The following fields are part of the inner `actions` object and describe the physical characteristics of the pointer device, such as a mouse, stylus, or touchscreen.
+    Specify these when the inner `type` is `"pointerDown"` or `"pointerMove"`.
     - `width` {{optional_inline}}
-      - : A non-negative integer that specifies the width, in CSS pixels, of the pointer contact area. See {{domxref("PointerEvent.width")}}.
+      - : A non-negative integer that specifies the width, in CSS pixels, of the pointer contact area.
+        See {{domxref("PointerEvent.width")}}.
     - `height` {{optional_inline}}
-      - : A non-negative integer that specifies the height, in CSS pixels, of the pointer contact area. See {{domxref("PointerEvent.height")}}.
+      - : A non-negative integer that specifies the height, in CSS pixels, of the pointer contact area.
+        See {{domxref("PointerEvent.height")}}.
     - `pressure` {{optional_inline}}
-      - : A float that specifies the normalized pressure of the pointer in the range `0.0`–`1.0`. See {{domxref("PointerEvent.pressure")}}.
+      - : A float that specifies the normalized pressure of the pointer in the range `0.0`–`1.0`.
+        See {{domxref("PointerEvent.pressure")}}.
     - `tangentialPressure` {{optional_inline}}
-      - : A float that specifies the normalized tangential pressure in the range `-1.0`–`1.0`. See {{domxref("PointerEvent.tangentialPressure")}}.
+      - : A float that specifies the normalized tangential pressure in the range `-1.0`–`1.0`.
+        See {{domxref("PointerEvent.tangentialPressure")}}.
     - `twist` {{optional_inline}}
-      - : An integer that specifies the clockwise rotation, in degrees, of the pointer in the range `0`–`359`. See {{domxref("PointerEvent.twist")}}.
+      - : An integer that specifies the clockwise rotation, in degrees, of the pointer in the range `0`–`359`.
+        See {{domxref("PointerEvent.twist")}}.
     - `altitudeAngle` {{optional_inline}}
-      - : A float that specifies the altitude angle, in radians, of the pointer in the range `0.0`–`π/2`. See {{domxref("PointerEvent.altitudeAngle")}}.
+      - : A float that specifies the altitude angle, in radians, of the pointer in the range `0.0`–`π/2`.
+        See {{domxref("PointerEvent.altitudeAngle")}}.
     - `azimuthAngle` {{optional_inline}}
-      - : A float that specifies the azimuth angle, in radians, of the pointer in the range `0.0`–`2π`. See {{domxref("PointerEvent.azimuthAngle")}}.
+      - : A float that specifies the azimuth angle, in radians, of the pointer in the range `0.0`–`2π`.
+        See {{domxref("PointerEvent.azimuthAngle")}}.
 - `x`
   - : A number (for `"pointerMove"`) or an integer (for `"scroll"`) that specifies the x-coordinate.
-    Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
+    Specify this when the inner `type` field value is `"pointerMove"` or `"scroll"`.
 - `y`
   - : A number (for `"pointerMove"`) or an integer (for `"scroll"`) that specifies the y-coordinate.
-    Specify this when the `type` field value is `"pointerMove"` or `"scroll"`.
+    Specify this when the inner `type` field value is `"pointerMove"` or `"scroll"`.
 
 ### Return value
 
@@ -146,17 +164,22 @@ The `result` field in the response is an empty object (`{}`).
 ### Errors
 
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
-  - : The action sequence is malformed; for example, if a required field is missing, a field value is of the wrong type, or an input source `type` value is not `"none"`, `"key"`, `"pointer"`, or `"wheel"`.
+  - : The action sequence is malformed; for example, if a required field is missing, a field value is of the wrong type, or an outer `type` value is not `"none"`, `"key"`, `"pointer"`, or `"wheel"`.
 - `no such frame`
   - : No context with the given context ID is found.
 
 ## Examples
 
-### Clicking an element
+### Holding Shift while clicking an element
 
-Consider a scenario where you want to simulate a mouse click on an element.
+Consider a scenario where you want to hold the <kbd>Shift</kbd> key while clicking an element, for example to extend a text selection.
+
 With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) and the element identifier using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes).
-Send the following message that uses three sequential steps: moving (`pointerMove`) the pointer to the center of the element (`x: 0, y: 0` relative to the element), pressing (`pointerDown`) the primary mouse button (`0`), and then releasing (`pointerUp`) it.
+Send the following message with two outer `actions` objects — a `"key"` source and a `"pointer"` source — running in parallel across the following three ticks:
+
+- Tick 1: The keyboard presses <kbd>Shift</kbd> while the pointer moves to the element. Since the `duration` of `pointerMove` is specified as `300`, the tick lasts `300 ms`, which is the longest `duration` in this tick.
+- Tick 2: The keyboard pauses while the pointer button is pressed (`pointerDown`). This tick lasts for `0 ms`.
+- Tick 3: The <kbd>Shift</kbd> key is released (`keyUp`) and the pointer button is released (`pointerUp`) simultaneously. This tick also lasts for `0 ms`.
 
 ```json
 {
@@ -165,6 +188,23 @@ Send the following message that uses three sequential steps: moving (`pointerMov
   "params": {
     "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
     "actions": [
+      {
+        "type": "key",
+        "id": "keyboard1",
+        "actions": [
+          {
+            "type": "keyDown",
+            "value": "\uE008"
+          },
+          {
+            "type": "pause"
+          },
+          {
+            "type": "keyUp",
+            "value": "\uE008"
+          }
+        ]
+      },
       {
         "type": "pointer",
         "id": "mouse1",
@@ -176,6 +216,7 @@ Send the following message that uses three sequential steps: moving (`pointerMov
             "type": "pointerMove",
             "x": 0,
             "y": 0,
+            "duration": 300,
             "origin": {
               "type": "element",
               "element": {
@@ -211,6 +252,7 @@ The browser responds as follows:
 ### Scrolling the page
 
 Consider a scenario where you want to simulate scrolling a page down.
+
 With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 Send the following message that scrolls from the top-left of the viewport (`x: 0, y: 0`) by `300` CSS pixels downward (`deltaY: 300`) with no horizontal scrolling (`deltaX: 0`).
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -124,9 +124,9 @@ The following fields are available in each inner `actions` object, depending on 
         The ID is returned by the browser when you locate the element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes), [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
 
 - `value`
-  - : A string that contains the key value, such as <kbd>a</kbd>, <kbd>Enter</kbd>, or <kbd>Shift</kbd>.
-    See [Key values for keyboard events](/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values) for the full list of valid values.
+  - : A string that contains the key value.
     Specify this when the inner `type` field value is `"keyDown"` or `"keyUp"`.
+    For special keys such as <kbd>Shift</kbd> or <kbd>Enter</kbd>, use the Unicode code points defined in the [WebDriver keyboard actions](https://w3c.github.io/webdriver/#keyboard-actions) table (for example, `"\uE008"` for the <kbd>Shift</kbd> key). For printable characters, use the character directly (for example, `"a"`).
 - Pointer properties
   - : The following fields are part of the inner `actions` object and describe the physical characteristics of the pointer device, such as a mouse, stylus, or touchscreen.
     Specify these when the inner `type` is `"pointerDown"` or `"pointerMove"`.
@@ -178,9 +178,9 @@ Consider a scenario where you want to hold the <kbd>Shift</kbd> key while clicki
 With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) and the element identifier using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes).
 Send the following message with two outer `actions` objects — a `"key"` source and a `"pointer"` source — each with an outer `type` and an inner `actions` array, running in parallel across the following three ticks:
 
-- Tick 1: The keyboard presses <kbd>Shift</kbd> while the pointer moves to the element. Since the `duration` of `pointerMove` is specified as `300`, the tick lasts `300 ms`, which is the longest `duration` in this tick.
-- Tick 2: The keyboard pauses while the pointer button is pressed (`pointerDown`). This tick lasts for `0 ms`.
-- Tick 3: The <kbd>Shift</kbd> key is released (`keyUp`) and the pointer button is released (`pointerUp`) simultaneously. This tick also lasts for `0 ms`.
+- Tick 1: The keyboard presses <kbd>Shift</kbd> while the pointer moves to the element. Since the `duration` of `pointerMove` is specified as `300`, the tick lasts 300 ms, which is the longest `duration` in this tick.
+- Tick 2: The keyboard pauses while the pointer button is pressed (`pointerDown`). This tick lasts for 0 ms.
+- Tick 3: The <kbd>Shift</kbd> key is released (`keyUp`) and the pointer button is released (`pointerUp`) simultaneously. This tick also lasts for 0 ms.
 
 ```json-nolint
 {
@@ -198,10 +198,10 @@ Send the following message with two outer `actions` objects — a `"key"` source
             "value": "\uE008"
           },
           {
-            "type": "pause"    // Tick 2: Keyboard pause (0 ms)
+            "type": "pause" // Tick 2: Keyboard pause (0 ms)
           },
           {
-            "type": "keyUp",   // Tick 3: Shift key up (0 ms)
+            "type": "keyUp", // Tick 3: Shift key up (0 ms)
             "value": "\uE008"
           }
         ]
@@ -230,7 +230,7 @@ Send the following message with two outer `actions` objects — a `"key"` source
             "button": 0
           },
           {
-            "type": "pointerUp",   // Tick 3: Release button (0 ms)
+            "type": "pointerUp", // Tick 3: Release button (0 ms)
             "button": 0
           }
         ]

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -18,11 +18,11 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
     "context": "<contextId>",
     "actions": [
       {
-        "type": "<inputSourceType>",
+        "type": "<outerType>",
         "id": "<sourceId>",
         "actions": [
           {
-            "type": "<actionType>",
+            "type": "<innerType>",
             ...
           }
         ]

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -145,6 +145,8 @@ The `result` field in the response is an empty object (`{}`).
 
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
   - : The action sequence is malformed; for example, if a required field is missing or a field value is of the wrong type.
+- `no such frame`
+  - : No context with the given context ID is found.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
@@ -1,0 +1,72 @@
+---
+title: "`input.releaseActions` command"
+short-title: releaseActions
+slug: Web/WebDriver/Reference/BiDi/Modules/input/releaseActions
+page-type: webdriver-command
+browser-compat: webdriver.bidi.input.releaseActions
+sidebar: webdriver
+---
+
+The `input.releaseActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`input`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input) module releases any held keys or pressed pointer buttons for a given context and resets the session's input state. Call it after [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) to clean up any inputs left in an intermediate state.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "input.releaseActions",
+  "params": {
+    "context": "<contextId>"
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID of the context for which to release inputs.
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+## Examples
+
+### Releasing all active inputs
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, send the following message after [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) to release all held keys and pointer buttons and reset the input state:
+
+```json
+{
+  "id": 1,
+  "method": "input.releaseActions",
+  "params": {
+    "context": "6B3D5B3A-6571-432B-8E96-E53B5C2ECBB5"
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) command
+- [`input.setFiles`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/setFiles) command
+- [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.input.releaseActions
 sidebar: webdriver
 ---
 
-The `input.releaseActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`input`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input) module releases any held keys or pressed pointer buttons for a given context and resets the session's input state. Call it after [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) to clean up any inputs left in an intermediate state.
+The `input.releaseActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`input`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input) module releases any held keys or pressed pointer buttons for a given context and resets the input state for that context. Call it after [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) to clean up any inputs left in an intermediate state.
 
 ## Syntax
 
@@ -25,7 +25,7 @@ The `input.releaseActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 The `params` field contains:
 
 - `context`
-  - : A string that contains the ID of the context for which to release inputs.
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context for which to release inputs. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
 ### Return value
 
@@ -35,7 +35,7 @@ The `result` field in the response is an empty object (`{}`).
 
 ### Releasing all active inputs
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, send the following message after [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) to release all held keys and pointer buttons and reset the input state:
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), send the following message after [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) to release all held keys and pointer buttons and reset the input state:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
@@ -31,6 +31,13 @@ The `params` field contains:
 
 The `result` field in the response is an empty object (`{}`).
 
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
+- `no such frame`
+  - : No context with the given context ID is found.
+
 ## Examples
 
 ### Releasing all active inputs

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
@@ -1,0 +1,124 @@
+---
+title: "`input.setFiles` command"
+short-title: setFiles
+slug: Web/WebDriver/Reference/BiDi/Modules/input/setFiles
+page-type: webdriver-command
+browser-compat: webdriver.bidi.input.setFiles
+sidebar: webdriver
+---
+
+The `input.setFiles` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`input`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input) module simulates a file picker dialog by setting the file selection of an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element in a given context to the specified file paths.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "input.setFiles",
+  "params": {
+    "context": "<contextId>",
+    "element": "<elementId>",
+    "files": ["<filePath>", ...]
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context with the target [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `element`
+  - : An object containing the ID that uniquely identifies the `<input type="file">` DOM element to use for file selection.
+    The ID is returned by the browser when you locate the element using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
+- `files`
+  - : An array of strings, where each string is the absolute file path of a file to select.
+    This command overrides any previously selected files. You can pass an empty array to clear the selection.
+    If the array contains more than one file path, ensure that the `<input type="file">` element has the [`multiple`](/en-US/docs/Web/HTML/Reference/Elements/input/file#multiple) attribute.
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+### Errors
+
+- `no such element`
+  - : The element reference cannot be resolved to a valid DOM element in the given context.
+- `unable to set file input`
+  - : The element is not an `<input>` element with `type="file"`, the element is disabled, or more than one file path is provided without the `multiple` attribute.
+- `unsupported operation`
+  - : The browser is unable to set the selected files to the provided paths; for example, if any of the specified files do not exist on the filesystem.
+
+## Examples
+
+### Setting a file on a file input
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, first obtain a shared reference to a `<input type="file">` element, then send the following message to set its selected file:
+
+```json
+{
+  "id": 1,
+  "method": "input.setFiles",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "element": {
+      "sharedId": "3be28343-afd3-4dea-a2b6-a863fbbb80e1"
+    },
+    "files": ["/home/user/documents/test-upload.txt"]
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+### Clearing the file selection
+
+To clear all previously selected files, pass an empty array:
+
+```json
+{
+  "id": 2,
+  "method": "input.setFiles",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "element": {
+      "sharedId": "3be28343-afd3-4dea-a2b6-a863fbbb80e1"
+    },
+    "files": []
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {}
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`input.performActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/performActions) command
+- [`input.releaseActions`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/releaseActions) command
+- [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event
+- [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
@@ -31,7 +31,7 @@ The `params` field contains:
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `element`
   - : An object containing the ID that uniquely identifies the `<input type="file">` DOM element to use for file selection.
-    The ID is returned by the browser when you locate the element using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
+    The ID is returned by the browser when you locate the element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes), [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), or [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction).
 - `files`
   - : An array of strings, where each string is the absolute file path of a file to select.
     This command overrides any previously selected files. You can pass an empty array to clear the selection.
@@ -54,7 +54,7 @@ The `result` field in the response is an empty object (`{}`).
 
 ### Setting a file on a file input
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, first obtain the `sharedId` of a `<input type="file">` element using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction), or an [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event, then send the following message to set its selected file:
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), first obtain the `sharedId` of a `<input type="file">` element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes) or an [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event, then send the following message to set its selected file:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
@@ -54,7 +54,7 @@ The `result` field in the response is an empty object (`{}`).
 
 ### Setting a file on a file input
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, first obtain a shared reference to a `<input type="file">` element, then send the following message to set its selected file:
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an active session, first obtain the `sharedId` of a `<input type="file">` element using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction), or an [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event, then send the following message to set its selected file:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
@@ -43,8 +43,12 @@ The `result` field in the response is an empty object (`{}`).
 
 ### Errors
 
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
 - `no such element`
   - : The element reference cannot be resolved to a valid DOM element in the given context.
+- `no such frame`
+  - : No context with the given context ID is found.
 - `unable to set file input`
   - : The element is not an `<input>` element with `type="file"`, the element is disabled, or more than one file path is provided without the `multiple` attribute.
 - `unsupported operation`

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
@@ -58,7 +58,7 @@ The `result` field in the response is an empty object (`{}`).
 
 ### Setting a file on a file input
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), first obtain the `sharedId` of a `<input type="file">` element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes) or an [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event, then send the following message to set its selected file:
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), first obtain the `sharedId` of an `<input type="file">` element using [`browsingContext.locateNodes`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/locateNodes) or an [`input.fileDialogOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened) event, then send the following message to set its selected file:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
@@ -28,13 +28,15 @@ The `params` field contains:
   - : An array of one or more event name strings. Use a module name (for example, `"log"`) to subscribe to all events in that module or a specific event name (for example, `"log.entryAdded"`) to subscribe to only that event.
 - `contexts` {{optional_inline}}
   - : An array of one or more context IDs ([UUIDs](/en-US/docs/Glossary/UUID)), each corresponding to a tab or frame.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
     If specified, events are received only for those contexts and their descendants.
     If the context ID corresponds to a frame, the subscription is created for the top-level context (tab) that owns the frame.
 
     This field cannot be used if `userContexts` is also specified.
 
 - `userContexts` {{optional_inline}}
-  - : An array of one or more user context IDs, each corresponding to a browser context or container.
+  - : An array of one or more user context IDs ([UUIDs](/en-US/docs/Glossary/UUID)), each corresponding to a browser context or container.
+    User context IDs are returned by commands such as [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts).
     If specified, events are received only for those user contexts.
 
     This field cannot be used if `contexts` is also specified.

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -24,7 +24,10 @@ sidebar:
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true
-      - link: /Web/WebDriver/Reference/BiDi/Modules/input
+      - type: listSubPages
+        path: /Web/WebDriver/Reference/BiDi/Modules/input
+        link: /Web/WebDriver/Reference/BiDi/Modules/input
+        details: closed
         code: true
       - type: listSubPages
         path: /Web/WebDriver/Reference/BiDi/Modules/log

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -38,7 +38,10 @@ sidebar:
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true
-      - link: /Web/WebDriver/Reference/BiDi/Modules/input
+      - type: listSubPages
+        path: /Web/WebDriver/Reference/BiDi/Modules/input
+        link: /Web/WebDriver/Reference/BiDi/Modules/input
+        details: closed
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/log
         details: closed

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -38,11 +38,24 @@ sidebar:
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true
-      - type: listSubPages
-        path: /Web/WebDriver/Reference/BiDi/Modules/input
-        link: /Web/WebDriver/Reference/BiDi/Modules/input
+      - link: /Web/WebDriver/Reference/BiDi/Modules/input
         details: closed
         code: true
+        children:
+          - type: section
+            link: /Web/WebDriver/Reference/BiDi/Modules/input#commands
+            title: Commands
+          - link: /Web/WebDriver/Reference/BiDi/Modules/input/performActions
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/input/releaseActions
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/input/setFiles
+            code: true
+          - type: section
+            link: /Web/WebDriver/Reference/BiDi/Modules/input#events
+            title: Events
+          - link: /Web/WebDriver/Reference/BiDi/Modules/input/fileDialogOpened
+            code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/log
         details: closed
         code: true


### PR DESCRIPTION
### Description

This PR adds the following pages:
  - `input.performActions`
  - `input.releaseActions`
  - `input.setFiles`
  - `input.fileDialogOpened`

**Quick note about short-titles in front matter**: In this module, I've used shorter short-titles (eg, performActions instead of input.performActions) - this only affects command (and event) names in the sidebar and breadcrumb. I'll update the short-titles in the already published `session`, `browser`, and `log` modules in a follow-up PR.

### Spec links

- https://w3c.github.io/webdriver-bidi/#command-input-performActions
- https://w3c.github.io/webdriver-bidi/#command-input-releaseActions
- https://w3c.github.io/webdriver-bidi/#command-input-setFiles

### Related issue

Doc issue: mdn/mdn#339