### PR TITLE
Correction of solution

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
@@ -279,7 +279,7 @@ Your finished HTML should look like this:
         Birdwatching
         <img
           src="https://mdn.github.io/shared-assets/images/examples/learn/birds/dove.png"
-          alt="a simple dove logo" />
+          alt="" />
       </h1>
 
       <nav>


### PR DESCRIPTION
In the [Challenge: Structuring a page of content (Bird watching site)](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Structuring_a_page_of_content) instructions, we are told to
'Give it (the dove logo) a blank alternative text ("").'
The included solution however, specifies
'alt="a simple dove logo".'

In the next section of the course (HTML images), it is even specified that
'if you must use HTML, add a blank alt="". If the image isn't part of the content, a screen reader shouldn't waste time reading it.'
to explain why we shouldn't add an alt description to such an image.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Solution updated to make it comply with the given directions and fall in line with the best practice proposed in the subsequent lesson "HTML images".

### Motivation

To increase the consistency of the course.

### Additional details

Best practice in regards to not providing an alt description to non-content logos quoted from
https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_images

### Related issues and pull requests

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
