### PR TITLE
Fix incorrectly formatted link in Fx 146 relnotes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/146/index.md
+++ b/files/en-us/mozilla/firefox/releases/146/index.md
@@ -74,7 +74,7 @@ No notable changes.
 ## Changes for add-on developers
 
 - {{WebExtAPIRef("browsingData.removeLocalStorage")}} and {{WebExtAPIRef("browsingData.remove")}} (when `localStorage` is set in {{WebExtAPIRef("browsingData.DataTypeSet")}}) now delete objects from [`sessionStorage`](/en-US/docs/Web/API/Window/sessionStorage). ([Firefox bug 1886894](https://bugzil.la/1886894))
-- The {{WebExtAPIRef("proxy.onRequest")}} API adds support for MASQUE proxies (proxy tunnel over QUIC) in the {{WebExtAPIRef("proxy.ProxyInfo")}} return type. ([Firefox bug 1988988](https://bugzil.la/1988988) and Firefox bug 1998894](https://bugzil.la/1998894))
+- The {{WebExtAPIRef("proxy.onRequest")}} API adds support for MASQUE proxies (proxy tunnel over QUIC) in the {{WebExtAPIRef("proxy.ProxyInfo")}} return type. ([Firefox bug 1988988](https://bugzil.la/1988988) and [Firefox bug 1998894](https://bugzil.la/1998894))
 
 ## Experimental web features
 


### PR DESCRIPTION
### Description

Add missing `[` that caused a link to be formatted incorrectly in the Firefox 146 release notes.

### Motivation

I spotted a weirdly formatted link at https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/146#changes_for_add-on_developers due to a markdown error.

### Additional details

### Related issues and pull requests
