### PR TITLE
Fix several issues in webext storage docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -6,11 +6,10 @@ browser-compat: webextensions.api.storage.onChanged
 sidebar: addonsidebar
 ---
 
-Fires when one or more items in any of the {{WebExtAPIRef('storage.StorageArea', 'storage areas'}} changes, with details for the keys that changed.
+Fires when one or more items in any of the {{WebExtAPIRef('storage.StorageArea', 'storage areas'}} changes.
 If you only need to listen for changes in one storage area, use {{WebExtAPIRef('storage.StorageArea.onChanged')}} instead.
 
 Fired when {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}}, {{WebExtAPIRef('storage.StorageArea.remove','storageArea.remove')}}, or {{WebExtAPIRef('storage.StorageArea.clear','storageArea.clear')}} executes against any of the {{WebExtAPIRef('storage.StorageArea', 'storage areas'}}.
-The listener is called with details of the changed keys.
 
 > [!NOTE]
 > In Firefox, the listener receives all the keys from a storage area where {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} executes. The listener may be invoked when there is no change to the data. To find details of the changed items, examine each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -13,7 +13,7 @@ Fired when {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}}, {{WebE
 The listener is called with details of the changed keys.
 
 > [!NOTE]
-> In Firefox, the listener receives all keys within the storage area {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} ran against whether they changed or not. The listener may be invoked when there is no change to the underlying data. Details of the changed items are found by examining each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
+> In Firefox, the listener receives all the keys from a storage area where {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} executes. The listener may be invoked when there is no change to the data. To find details of the changed items, examine each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
 
 > [!NOTE]
 > Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup (from the [JSON manifest (native manifest) file](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty)).

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -7,7 +7,7 @@ sidebar: addonsidebar
 ---
 
 Fires when one or more items in any of the {{WebExtAPIRef('storage.StorageArea', 'storage areas'}} changes, with details for the keys that changed.
-To listen for changes in a specific storage area instead of all, use {{WebExtAPIRef('storage.StorageArea.onChanged')}} instead.
+If you only need to listen for changes in one storage area, use {{WebExtAPIRef('storage.StorageArea.onChanged')}} instead.
 
 Fired when {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}}, {{WebExtAPIRef('storage.StorageArea.remove','storageArea.remove')}}, or {{WebExtAPIRef('storage.StorageArea.clear','storageArea.clear')}} executes against any of the {{WebExtAPIRef('storage.StorageArea', 'storage areas'}}.
 The listener is called with details of the changed keys.

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -6,10 +6,17 @@ browser-compat: webextensions.api.storage.onChanged
 sidebar: addonsidebar
 ---
 
-Fired when {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}}, {{WebExtAPIRef('storage.StorageArea.remove','storageArea.remove')}}, or {{WebExtAPIRef('storage.StorageArea.clear','storageArea.clear')}} executes against a storage area, returning details of only changed keys. A callback is called only when there are changes to the underlying data.
+Fires when one or more items in any of the {{WebExtAPIRef('storage.StorageArea', 'storage areas'}} changes, with details for the keys that changed.
+To listen for changes in a specific storage area instead of all, use {{WebExtAPIRef('storage.StorageArea.onChanged')}} instead.
+
+Fired when {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}}, {{WebExtAPIRef('storage.StorageArea.remove','storageArea.remove')}}, or {{WebExtAPIRef('storage.StorageArea.clear','storageArea.clear')}} executes against any of the {{WebExtAPIRef('storage.StorageArea', 'storage areas'}}.
+The listener is called with details of the changed keys.
 
 > [!NOTE]
-> In Firefox, the information returned includes all keys within the storage area {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} ran against whether they changed or not. Also, a callback may be invoked when there is no change to the underlying data. Details of the changed items are found by examining each returned key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
+> In Firefox, the listener receives all keys within the storage area {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} ran against whether they changed or not. The listener may be invoked when there is no change to the underlying data. Details of the changed items are found by examining each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
+
+> [!NOTE]
+> Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup (from the [JSON manifest (native manifest) file](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty)).
 
 ## Syntax
 
@@ -37,7 +44,7 @@ Events have three functions:
     - `changes`
       - : `object`. Object describing the change. The name of each property is the name of each key. The value of each key is a {{WebExtAPIRef('storage.StorageChange')}} object describing the change to that item.
     - `areaName`
-      - : `string`. The name of the storage area (`"sync"`, `"local"`, or `"managed"`) to which the changes were made.
+      - : `string`. The name of the storage area (`"local"`, `"managed"`, `"session"`, or `"sync"`) to which the changes were made.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -6,14 +6,14 @@ browser-compat: webextensions.api.storage.StorageArea
 sidebar: addonsidebar
 ---
 
-StorageArea is an object representing a storage area. This documentation describes the common interface of the following concrete implementations:
+StorageArea is an object representing a storage area. This documentation describes the common interface of these concrete implementations:
 
 - {{WebExtAPIRef("storage.local")}}
 - {{WebExtAPIRef("storage.managed")}}
 - {{WebExtAPIRef("storage.session")}}
 - {{WebExtAPIRef("storage.sync")}}
 
-`storage.StorageArea` is not an actual API object, it is merely a mechanism to describe the above APIs.
+`storage.StorageArea` is not an API object; it is a mechanism for describing the concrete APIs.
 
 ## Type
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/index.md
@@ -6,7 +6,14 @@ browser-compat: webextensions.api.storage.StorageArea
 sidebar: addonsidebar
 ---
 
-StorageArea is an object representing a storage area.
+StorageArea is an object representing a storage area. This documentation describes the common interface of the following concrete implementations:
+
+- {{WebExtAPIRef("storage.local")}}
+- {{WebExtAPIRef("storage.managed")}}
+- {{WebExtAPIRef("storage.session")}}
+- {{WebExtAPIRef("storage.sync")}}
+
+`storage.StorageArea` is not an actual API object, it is merely a mechanism to describe the above APIs.
 
 ## Type
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -6,12 +6,13 @@ browser-compat: webextensions.api.storage.StorageArea.onChanged
 sidebar: addonsidebar
 ---
 
-Fires when one or more items in a storage area change, returning details for the keys that changed. Compared to {{WebExtAPIRef("storage.onChanged")}}, this event enables you to listen for changes in one of the storage areas: `local`, `managed`, `session`, and `sync`.
+Fires when one or more items in a storage area change, with details for the keys that changed. Compared to {{WebExtAPIRef("storage.onChanged")}}, this event enables you to listen for changes in one of the storage areas: `local`, `managed`, `session`, and `sync`.
 
 > [!NOTE]
-> In Firefox, the information returned includes all keys within the storage area. Also, the callback may be invoked when there is no change to the underlying data. Details of the changed items are found by examining each returned key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
->
-> Firefox only loads changes to managed storage content (from the [JSON manifest (native manifest) file](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty)), when it restarts. Therefore, this event never triggers in Firefox.
+> In Firefox, the listener receives all keys within the storage area {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} ran against whether they changed or not. The listener may be invoked when there is no change to the underlying data. Details of the changed items are found by examining each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
+
+> [!NOTE]
+> Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup (from the [JSON manifest (native manifest) file](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty)).
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.storage.StorageArea.onChanged
 sidebar: addonsidebar
 ---
 
-Fires when one or more items in a storage area change, with details for the keys that changed. Compared to {{WebExtAPIRef("storage.onChanged")}}, this event enables you to listen for changes in one of the storage areas: `local`, `managed`, `session`, and `sync`.
+Fires when one or more items in a storage area change. Compared to {{WebExtAPIRef("storage.onChanged")}}, this event enables you to listen for changes in one of the storage areas: `local`, `managed`, `session`, or `sync`.
 
 > [!NOTE]
 > In Firefox, the listener receives all the keys from a storage area where {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} executes. The listener may also be invoked when there is no change to the data. To find details of the changed items, examine each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -9,7 +9,7 @@ sidebar: addonsidebar
 Fires when one or more items in a storage area change, with details for the keys that changed. Compared to {{WebExtAPIRef("storage.onChanged")}}, this event enables you to listen for changes in one of the storage areas: `local`, `managed`, `session`, and `sync`.
 
 > [!NOTE]
-> In Firefox, the listener receives all keys within the storage area {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} ran against whether they changed or not. The listener may be invoked when there is no change to the underlying data. Details of the changed items are found by examining each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
+> In Firefox, the listener receives all the keys from a storage area where {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} executes. The listener may also be invoked when there is no change to the data. To find details of the changed items, examine each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
 
 > [!NOTE]
 > Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup (from the [JSON manifest (native manifest) file](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty)).

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
@@ -21,7 +21,7 @@ await browser.storage.<storageType>.setAccessLevel(
 )
 ```
 
-Where `<storageType>` is any of the storage types — {{WebExtAPIRef("storage.local")}}, {{WebExtAPIRef("storage.managed")}}, {{WebExtAPIRef("storage.session")}}, or {{WebExtAPIRef("storage.sync")}}.
+Where `<storageType>` is any of the storage types: {{WebExtAPIRef("storage.local")}}, {{WebExtAPIRef("storage.managed")}}, {{WebExtAPIRef("storage.session")}}, or {{WebExtAPIRef("storage.sync")}}.
 
 ### Parameters
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
@@ -9,6 +9,7 @@ sidebar: addonsidebar
 Sets the access level for the storage area.
 
 Use this method to:
+
 - Expose the `session` storage area to content scripts. Unlike other storage areas, by default, `storage.session` is only available to privileged (trusted) extension contexts by default.
 - Restrict content scripts' access to `local`, `managed`, and `sync` storage areas. By default, these storage areas are exposed to all extension contexts, including content scripts.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
@@ -8,11 +8,9 @@ sidebar: addonsidebar
 
 Sets the access level for the storage area.
 
-Unlike other storage areas, `storage.session` is only available to privileged (trusted) extension contexts. This `setAccessLevel` method is used to expose the session storage area to content scripts too.
-
-By default, all other storage areas are exposed to all extension contexts, including content scripts. This `setAccessLevel` method can be used to restrict access of these storage areas in content scripts.
-
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+Use this method to:
+- Expose the `session` storage area to content scripts. Unlike other storage areas, by default, `storage.session` is only available to privileged (trusted) extension contexts by default.
+- Restrict content scripts' access to `local`, `managed`, and `sync` storage areas. By default, these storage areas are exposed to all extension contexts, including content scripts.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/setaccesslevel/index.md
@@ -8,9 +8,9 @@ sidebar: addonsidebar
 
 Sets the access level for the storage area.
 
-This method is only supported for the `storage.session` StorageArea.
+Unlike other storage areas, `storage.session` is only available to privileged (trusted) extension contexts. This `setAccessLevel` method is used to expose the session storage area to content scripts too.
 
-Unlike other storage areas, `storage.session` is only available to privileged (trusted) extension contexts. This `setAccessLevel` method is used to expose the session storage area to content scripts too. By default, all other storage areas are exposed to all extension contexts, including content scripts.
+By default, all other storage areas are exposed to all extension contexts, including content scripts. This `setAccessLevel` method can be used to restrict access of these storage areas in content scripts.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
@@ -22,7 +22,7 @@ await browser.storage.<storageType>.setAccessLevel(
 )
 ```
 
-Where `<storageType>` is the {{WebExtAPIRef("storage.session")}} storage type.
+Where `<storageType>` is any of the storage types — {{WebExtAPIRef("storage.local")}}, {{WebExtAPIRef("storage.managed")}}, {{WebExtAPIRef("storage.session")}}, or {{WebExtAPIRef("storage.sync")}}.
 
 ### Parameters
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -7,7 +7,7 @@ sidebar: addonsidebar
 ---
 
 `StorageChange` is an object representing a change to a storage area.
-These objects are received by listeners to the {{WebExtAPIRef("storage.onChanged")}} or {{WebExtAPIRef("storage.StorageArea.onChanged")}} events.
+Objects of this type are received by {{WebExtAPIRef("storage.onChanged")}} and {{WebExtAPIRef("storage.StorageArea.onChanged")}} event listeners.
 
 ## Type
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -7,6 +7,7 @@ sidebar: addonsidebar
 ---
 
 `StorageChange` is an object representing a change to a storage area.
+These objects are received by listeners to the {{WebExtAPIRef("storage.onChanged")}} or {{WebExtAPIRef("storage.StorageArea.onChanged")}} events.
 
 ## Type
 


### PR DESCRIPTION
### Description

storage/onchanged:
- Mention storage.StorageArea.onChanged in storage.onChanged.
- Change "return" terminology to "listener" / "receive" in onChanged.
- Add missing "session" to storage.onChanged's areaName parameter.
- Include mention of `storage.managed` behavior that was already mentioned in the storage.StorageArea.onChanged docs.

storage/storagearea:
- Clarify that `StorageArea` is an abstract type and explicitly mention the concrete APIs it applies to.

storage/onchanged:
- Change "return" terminology to "listener" / "receive" in onChanged.
- Fix very confusing description of managed storage.

storage/setaccesslevel:
- Drop mention of it supporting session only. It expanded to all storage areas in Chrome 140 (https://issues.chromium.org/issues/40949182).

storage/storagechange:
- Mention the events this type relates to.

### Motivation

Documentation was inaccurate, misleading or confusing.

### Additional details

### Related issues and pull requests

