### PR TITLE
Remove statement that default_icon is mandatory

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/page_actions/index.md
@@ -64,8 +64,6 @@ You define the page action's properties using the [`page_action`](/en-US/docs/Mo
 }
 ```
 
-The only mandatory key is `default_icon`.
-
 There are two ways to specify a page action: with or without a [popup](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups).
 
 - **Without a popup:** When the user clicks the button, an event is dispatched to the extension, which the extension listens for using [`pageAction.onClicked`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked):


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

default_icon is not mandatory.

### Motivation

Statement is incorrect

### Additional details

It is noted as optional on the dedicated documentation page: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#default_icon

Firefox shows the default puzzle piece icon when default_icon is omitted. Tested in 149.0.2 (64-bit) on NixOS.

### Related issues and pull requests

N.A.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
