### PR TITLE
[WebExtensions] Chrome 150 plans to limit alarm name lengths

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -29,6 +29,8 @@ browser.alarms.create(
 
     Alarm names are unique within the scope of a single extension. If an alarm with an identical name exists, the existing alarm will be cleared and the alarm being created will replace it.
 
+    From Chrome 150, alarms with names longer than 1024 bytes are rejected. This limit may be implemented on other browsers. See [Proposal: Limits on lengths of strings passed to WebExtension APIs](https://github.com/w3c/webextensions/issues/935) for more information.
+
 - `alarmInfo` {{optional_inline}}
   - : `object`. You can use this to specify when the alarm will initially fire, either as an absolute value (`when`), or as a delay from the time the alarm is set (`delayInMinutes`). To make the alarm recur, specify `periodInMinutes`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Add note stating upcoming limit for extension alarm names in Google Chrome 150.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Chrome 148 introduced a console warning for alarm names longer than 1024 bytes.[1] Safari devs believe "1024 is a good limit".[2] Firefox will likely "take a wait and see approach".[3]


<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Sources:
[1] https://github.com/chromium/chromium/commit/432c30e3e1dcd03cecb869a1e23162d8ea1b9af2
[2] https://github.com/w3c/webextensions/issues/935#issuecomment-4047692973
[3] https://github.com/w3c/webextensions/blob/main/_minutes/2026-03-12-wecg.md


<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

https://github.com/w3c/webextensions/issues/422
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
