### PR TITLE
Narrow ReadableStreamBYOBRequest.view to Uint8Array

### DIFF
--- a/files/en-us/web/api/readablestreambyobrequest/view/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/view/index.md
@@ -12,7 +12,7 @@ The **`view`** getter property of the {{domxref("ReadableStreamBYOBRequest")}} i
 
 ## Value
 
-A [typed array](/en-US/docs/Web/JavaScript/Guide/Typed_arrays) representing the destination region to which the controller can write generated data.
+A [`Uint8Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) [typed array](/en-US/docs/Web/JavaScript/Guide/Typed_arrays) representing the destination region to which the controller can write generated data.
 
 `null` if the request has already been responded to, by calling {{domxref("ReadableStreamBYOBRequest.respond()")}} or {{domxref("ReadableStreamBYOBRequest.respondWithNewView()")}}.
 


### PR DESCRIPTION
### Description

The Streams specification has been updated to clarify that `ReadableStreamBYOBRequest.view` always returns a `Uint8Array` typed array.

### Motivation

By making the type of `view` more precise, readers can be confident that they don't need to check for other kinds of typed arrays when they make use of this API in their code.

### Additional details

The specification change is in https://github.com/whatwg/streams/pull/1367. All supporting browsers and runtimes already implement this correctly today.