### PR TITLE
List all OscillatorNode waveform types in Web Audio API overview

### DIFF
--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -80,7 +80,7 @@ Interfaces that define audio sources for use in the Web Audio API.
 - {{domxref("AudioScheduledSourceNode")}}
   - : The **`AudioScheduledSourceNode`** is a parent interface for several types of audio source node interfaces. It is an {{domxref("AudioNode")}}.
 - {{domxref("OscillatorNode")}}
-  - : The **`OscillatorNode`** interface represents a periodic waveform, such as a sine or triangle wave. It is an {{domxref("AudioNode")}} audio-processing module that causes a given _frequency_ of wave to be created.
+  - : The **`OscillatorNode`** interface represents a periodic waveform — sine, square, sawtooth, triangle, or a custom shape. It is an {{domxref("AudioNode")}} audio-processing module that causes a given _frequency_ of wave to be created.
 - {{domxref("AudioBuffer")}}
   - : The **`AudioBuffer`** interface represents a short audio asset residing in memory, created from an audio file using the {{ domxref("BaseAudioContext.decodeAudioData") }} method, or created with raw data using {{ domxref("BaseAudioContext.createBuffer") }}. Once decoded into this form, the audio can then be put into an {{ domxref("AudioBufferSourceNode") }}.
 - {{domxref("AudioBufferSourceNode")}}

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -80,7 +80,7 @@ Interfaces that define audio sources for use in the Web Audio API.
 - {{domxref("AudioScheduledSourceNode")}}
   - : The **`AudioScheduledSourceNode`** is a parent interface for several types of audio source node interfaces. It is an {{domxref("AudioNode")}}.
 - {{domxref("OscillatorNode")}}
-  - : The **`OscillatorNode`** interface represents a periodic waveform — sine, square, sawtooth, triangle, or a custom shape. It is an {{domxref("AudioNode")}} audio-processing module that causes a given _frequency_ of wave to be created.
+  - : The **`OscillatorNode`** interface represents a periodic waveform, which can be sine, square, sawtooth, triangle, or custom. It is an {{domxref("AudioNode")}} audio-processing module that causes a given _frequency_ of wave to be created.
 - {{domxref("AudioBuffer")}}
   - : The **`AudioBuffer`** interface represents a short audio asset residing in memory, created from an audio file using the {{ domxref("BaseAudioContext.decodeAudioData") }} method, or created with raw data using {{ domxref("BaseAudioContext.createBuffer") }}. Once decoded into this form, the audio can then be put into an {{ domxref("AudioBufferSourceNode") }}.
 - {{domxref("AudioBufferSourceNode")}}


### PR DESCRIPTION
### Description

The current text reads "represents a periodic waveform, such as a sine or triangle wave," giving readers only two of the five supported shapes. Listing the full set (sine, square, sawtooth, triangle, custom) matches the [OscillatorNode.type](https://developer.mozilla.org/en-US/docs/Web/API/OscillatorNode/type) page and gives readers unfamiliar with waveform names a better chance of recognizing one.

### Motivation

Replaced "such as" with an em dash since the list is now complete rather than illustrative. Recognizing even one of the listed shapes can help readers anchor the rest of the description.

### Additional details

Reference: [OscillatorNode.type](https://developer.mozilla.org/en-US/docs/Web/API/OscillatorNode/type) 

### Related issues and pull requests

Fixes #43925


