### PR TITLE
FF118 keyboard value for Window Event tidy

### DIFF
--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -198,24 +198,18 @@ _Modifiers_ are special keys which are used to generate special characters or ca
     <tr>
       <td><code>"Meta"</code> [1]</td>
       <td>
-        The <kbd>Meta</kbd> key. Allows issuing special command inputs. This is
-        the <kbd>Windows</kbd> logo key, or the <kbd>Command</kbd> or
-        <kbd>⌘</kbd> key on Mac keyboards.
+        The <kbd>Meta</kbd> key. Allows issuing special command inputs.
+        This is the <kbd>Windows</kbd> logo key, or the <kbd>Command</kbd> or <kbd>⌘</kbd> key on Mac keyboards.
       </td>
       <td><code>VK_LWIN</code> (0x5B)<br /><code>VK_RWIN</code> (0x5C)</td>
       <td>
-        <code>kVK_Command</code> (0x37)<br /><code>kVK_RightCommand</code>
-        (0x36)
+        <code>kVK_Command</code> (0x37)<br /><code>kVK_RightCommand</code> (0x36)
       </td>
       <td>
-        <code>GDK_KEY_Meta_L</code> (0xFFE7)<br /><code>GDK_KEY_Meta_R</code>
-        (0xFFE8)<br /><code>Qt::Key_Meta</code> (0x01000022)
+        <code>GDK_KEY_Meta_L</code> (0xFFE7)<br /><code>GDK_KEY_Meta_R</code> (0xFFE8)<br /><code>Qt::Key_Meta</code> (0x01000022)
       </td>
       <td>
-        <code>KEYCODE_META_LEFT</code> (117)<br /><code
-          >KEYCODE_META_RIGHT</code
-        >
-        (118)
+        <code>KEYCODE_META_LEFT</code> (117)<br /><code>KEYCODE_META_RIGHT</code> (118)
       </td>
     </tr>
     <tr>
@@ -308,7 +302,7 @@ _Modifiers_ are special keys which are used to generate special characters or ca
   </tbody>
 </table>
 
-\[1] In Firefox, the <kbd>Windows</kbd> key is reported as `"OS"` instead of as `"Meta"`. This will be changed in Firefox per [Firefox bug 1232918](https://bugzil.la/1232918). Until that's fixed, these keys are returned as `"OS"` by Firefox: `VK_LWIN` (0x5B) and `VK_RWIN` (0x5C) on Windows, and `GDK_KEY_Super_L` (0xFFEB), `GDK_KEY_Super_R` (0xFFEC), `GDK_KEY_Hyper_L` (0xFFED), and `GDK_KEY_Hyper_R` (0xFFEE) on Linux.
+\[1] Firefox 118 and later correctly report the <kbd>Windows</kbd> key as `"Meta"` (earlier versions reported the key as `"OS"`).
 
 \[2] Firefox did not add support for the <kbd>Symbol</kbd> key until Firefox 37.
 


### PR DESCRIPTION
FF118 fixed a bug on the returned key when pressing the Windows key. This tidies up the note to make it clear the version that the issue was fixed.

Fixes #43940
