### PR TITLE
Add hsl interpolation to color wheel conic-gradient example

### DIFF
--- a/files/en-us/web/css/reference/values/gradient/conic-gradient/index.md
+++ b/files/en-us/web/css/reference/values/gradient/conic-gradient/index.md
@@ -71,19 +71,6 @@ conic-gradient(from 90deg at 0 0, blue, red)
 /* Interpolation in polar color space
   with longer hue interpolation method */
 conic-gradient(in hsl longer hue, red, blue, green, red)
-
-/* Color wheel */
-conic-gradient(
-  hsl(360 100% 50%),
-  hsl(315 100% 50%),
-  hsl(270 100% 50%),
-  hsl(225 100% 50%),
-  hsl(180 100% 50%),
-  hsl(135 100% 50%),
-  hsl(90 100% 50%),
-  hsl(45 100% 50%),
-  hsl(0 100% 50%)
-)
 ```
 
 ### Values
@@ -310,6 +297,32 @@ In this example for interpolation [hsl](/en-US/docs/Web/CSS/Reference/Values/col
 The box on the left uses [shorter interpolation](/en-US/docs/Web/CSS/Reference/Values/hue-interpolation-method#shorter), meaning color goes straight from red to blue using the shorter arc on the [color wheel](/en-US/docs/Glossary/Color_wheel). The box on the right uses [longer interpolation](/en-US/docs/Web/CSS/Reference/Values/hue-interpolation-method#longer), meaning the color goes from red to blue using the longer arc, traversing through greens, yellows, and oranges.
 
 {{EmbedLiveSample("Interpolating with hue", 240, 200)}}
+
+### Color Wheel
+
+```html hidden
+<div></div>
+```
+
+```css hidden
+div {
+  width: 100px;
+  height: 100px;
+  border-radius: 50px;
+}
+```
+
+```css
+div {
+  background-image: conic-gradient(
+    in hsl longer hue,
+    hsl(360 100% 50%),
+    hsl(0 100% 50%)
+  );
+}
+```
+
+{{EmbedLiveSample("Color Wheel", 100, 100)}}
 
 ### More conic-gradient examples
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

* Move the color wheel syntax example from syntax to example section.
* Add hsl interpolation.
* Remove superfluous intermediate points now that we have proper interpolation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The color wheel syntax example in `conic-gradient()` page was not a real color wheel because the interpolation was done in `sRGB` notation and not hue (while the gradient stops themselves were defined in hsl syntax which caused confusion).

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Fixes #43905 

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
