### PR TITLE
fix(html): remove extra apostrophe in input/file selected files

### DIFF
--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -125,7 +125,7 @@ Including the [`multiple`](#multiple) attribute, as shown above, specifies that 
 
 ### Getting information on selected files
 
-The selected files' are returned by the element's `HTMLInputElement.files` property, which is a {{domxref("FileList")}} object containing a list of {{domxref("File")}} objects. The `FileList` behaves like an array, so you can check its `length` property to get the number of selected files.
+The selected files are returned by the element's `HTMLInputElement.files` property, which is a {{domxref("FileList")}} object containing a list of {{domxref("File")}} objects. The `FileList` behaves like an array, so you can check its `length` property to get the number of selected files.
 
 Each `File` object contains the following information:
 


### PR DESCRIPTION
## Summary
Removes an extra apostrophe after "files" in the "Getting information on selected files" section of the `<input type="file">` reference page.

## Issue
Fixes #43947

## Changes
- `files/en-us/web/html/reference/elements/input/file/index.md`: change `The selected files' are returned…` to `The selected files are returned…`