### PR TITLE
fix(css): remove container-type from containing block list

### DIFF
--- a/files/en-us/web/css/guides/display/block_formatting_context/index.md
+++ b/files/en-us/web/css/guides/display/block_formatting_context/index.md
@@ -22,6 +22,7 @@ A block formatting context is created by at least one of the following:
 - Grid items (direct children of the element with {{cssxref("display", "display: grid")}} or `inline-grid`) if they are neither [flex](/en-US/docs/Glossary/Flex_Container) nor [grid](/en-US/docs/Glossary/Grid_Container) nor [table](/en-US/docs/Web/CSS/Guides/Table) containers themselves.
 - Block elements where {{ cssxref("overflow") }} has a value other than `visible` and `clip`.
 - Elements with {{cssxref("contain", "contain: layout")}}, `content`, or `paint`.
+- Query containers (elements where {{cssxref("container-type")}} isn't `normal`).
 - Multicol containers (elements where {{ cssxref("column-count") }} or {{ cssxref("column-width") }} isn't `auto`, including elements with `column-count: 1`).
 - {{cssxref("column-span", "column-span: all")}}, even when the `column-span: all` element isn't contained by a multicol container.
 

--- a/files/en-us/web/css/guides/display/containing_block/index.md
+++ b/files/en-us/web/css/guides/display/containing_block/index.md
@@ -34,7 +34,6 @@ The process for identifying the containing block depends entirely on the value o
 4. If the `position` property is **`absolute`** or **`fixed`**, the containing block may also be formed by the edge of the _padding box_ of the nearest ancestor element that has any of the following:
    - A {{cssxref("filter")}}, {{cssxref("backdrop-filter")}}, {{cssxref("transform")}}, {{cssxref("perspective")}}, {{cssxref("rotate")}}, {{cssxref("scale")}}, or {{cssxref("translate")}} value other than `none`.
    - A {{cssxref("contain")}} value of `layout`, `paint`, `strict` or `content` (e.g., `contain: paint;`).
-   - A {{cssxref("container-type")}} value other than `normal`.
    - A {{cssxref("will-change")}} value containing a property for which a non-initial value would form a containing block (e.g., `filter` or `transform`).
    - A {{cssxref("content-visibility")}} value of `auto`.
 

--- a/files/en-us/web/css/guides/display/formatting_contexts/index.md
+++ b/files/en-us/web/css/guides/display/formatting_contexts/index.md
@@ -28,6 +28,7 @@ A new BFC is created in the following situations:
 - block elements where `overflow` has a value other than `visible`
 - elements with `display: flow-root` or `display: flow-root list-item`
 - elements with {{cssxref("contain", "contain: layout", "#layout")}}, `content`, or `strict`
+- query containers (elements where {{cssxref("container-type")}} isn't `normal`)
 - {{Glossary("flex item", "flex items")}}
 - grid items
 - [multicol containers](/en-US/docs/Web/CSS/Guides/Multicol_layout/Basic_concepts)


### PR DESCRIPTION
## Summary
Removes the `container-type` bullet from the list of declarations that cause an element to form a containing block for absolutely/fixed positioned descendants. The CSSWG resolved that `container-type` no longer forces layout containment — it only establishes an independent formatting context — and this change has shipped in Chrome, Firefox, and Safari.

## Issue
Fixes #43405

## Changes
- `files/en-us/web/css/guides/display/containing_block/index.md`: drop the `container-type` bullet under item 4 of "Identifying the containing block".

## References
- [CSSWG resolution](https://github.com/w3c/csswg-drafts/issues/10544)
- [CSSWG Minutes Telecon 2024-07-24](https://lists.w3.org/Archives/Public/www-style/2024Jul/0010.html)