### PR TITLE
Issue-33315 debug hint in native msg guide

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -195,7 +195,6 @@ browser.browserAction.onClicked.addListener(() => {
 > [!CALLOUT]
 > To learn about debugging background scripts and viewing console output, see [Debugging background scripts](https://extensionworkshop.com/documentation/develop/debugging/#debugging-background-scripts) on Extension Workshop.
 
-
 #### Connectionless messaging
 
 With this pattern you call {{WebExtAPIRef("runtime.sendNativeMessage()")}}, passing it:

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -192,6 +192,10 @@ browser.browserAction.onClicked.addListener(() => {
 });
 ```
 
+> [!CALLOUT]
+> To learn about debugging background scripts and viewing console output, see [Debugging background scripts](https://extensionworkshop.com/documentation/develop/debugging/#debugging-background-scripts) on Extension Workshop.
+
+
 #### Connectionless messaging
 
 With this pattern you call {{WebExtAPIRef("runtime.sendNativeMessage()")}}, passing it:


### PR DESCRIPTION
### Description

Adds a hint and link to the Extension Workshop article on debugging background scripts after the first background script code snippet to help readers who may not know how to view the console output in the example.

### Related issues and pull requests

Fixes #33315
