### PR TITLE
[Editorial review] BiDi - Add page for browser.setDownloadBehavior command

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/close/index.md
@@ -1,6 +1,6 @@
 ---
-title: browser.close command
-short-title: browser.close
+title: "`browser.close` command"
+short-title: close
 slug: Web/WebDriver/Reference/BiDi/Modules/browser/close
 page-type: webdriver-command
 browser-compat: webdriver.bidi.browser.close

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -41,6 +41,8 @@ The following field in the `result` object of the response describes the created
 
 ### Errors
 
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
 - `unsupported operation`
   - : `acceptInsecureCerts` is `true` but the browser does not support accepting insecure TLS connections, or `proxy` is specified but the browser cannot configure proxy settings for this user context or cannot apply the given proxy configuration.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -1,6 +1,6 @@
 ---
-title: browser.createUserContext command
-short-title: browser.createUserContext
+title: "`browser.createUserContext` command"
+short-title: createUserContext
 slug: Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext
 page-type: webdriver-command
 browser-compat: webdriver.bidi.browser.createUserContext

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -37,7 +37,7 @@ Set `params` to an empty object (`{}`) or include any of the following optional 
 The following field in the `result` object of the response describes the created user context:
 
 - `userContext`
-  - : A string that uniquely identifies the created user context.
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) that uniquely identifies the created user context.
 
 ### Errors
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getclientwindows/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getclientwindows/index.md
@@ -1,6 +1,6 @@
 ---
-title: browser.getClientWindows command
-short-title: browser.getClientWindows
+title: "`browser.getClientWindows` command"
+short-title: getClientWindows
 slug: Web/WebDriver/Reference/BiDi/Modules/browser/getClientWindows
 page-type: webdriver-command
 browser-compat: webdriver.bidi.browser.getClientWindows

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
@@ -30,7 +30,7 @@ The following field in the `result` object of the response describes the user co
   - : An array of one or more objects, each representing a user context.
     Each object has the following field:
     - `userContext`
-      - : A string that uniquely identifies the user context.
+      - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) that uniquely identifies the user context.
         The default user context has the value `"default"`; it always exists and cannot be removed, so the array is never empty.
 
 ## Examples

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
@@ -1,6 +1,6 @@
 ---
-title: browser.getUserContexts command
-short-title: browser.getUserContexts
+title: "`browser.getUserContexts` command"
+short-title: getUserContexts
 slug: Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts
 page-type: webdriver-command
 browser-compat: webdriver.bidi.browser.getUserContexts

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
@@ -1,5 +1,5 @@
 ---
-title: browser module
+title: "`browser` module"
 short-title: browser
 slug: Web/WebDriver/Reference/BiDi/Modules/browser
 page-type: listing-page
@@ -35,7 +35,13 @@ User contexts can be created using [`browser.createUserContext`](/en-US/docs/Web
 
 ## Commands
 
-{{ListSubPages}}
+- [`browser.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/close)
+- [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext)
+- [`browser.getClientWindows`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getClientWindows)
+- [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts)
+- [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext)
+- [`browser.setClientWindowState`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setClientWindowState)
+- [`browser.setDownloadBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setDownloadBehavior)
 
 ## Events
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -28,7 +28,7 @@ The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/Bi
 The `params` field contains:
 
 - `userContext`
-  - : A string that specifies the ID of the user context to remove.
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the user context to remove.
     The default user context (`"default"`) cannot be removed.
 
 ### Return value

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -29,6 +29,7 @@ The `params` field contains:
 
 - `userContext`
   - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the user context to remove.
+    User context IDs are returned by commands such as [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts).
     The default user context (`"default"`) cannot be removed.
 
 ### Return value

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -1,6 +1,6 @@
 ---
-title: browser.removeUserContext command
-short-title: browser.removeUserContext
+title: "`browser.removeUserContext` command"
+short-title: removeUserContext
 slug: Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext
 page-type: webdriver-command
 browser-compat: webdriver.bidi.browser.removeUserContext

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -1,0 +1,174 @@
+---
+title: "`browser.setDownloadBehavior` command"
+short-title: setDownloadBehavior
+slug: Web/WebDriver/Reference/BiDi/Modules/browser/setDownloadBehavior
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browser.setDownloadBehavior
+sidebar: webdriver
+---
+
+The `browser.setDownloadBehavior` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module allows file downloads to a specified folder, or blocks file downloads entirely. The behavior can be configured for all or some [user contexts](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts).
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": {}
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `downloadBehavior`
+  - : An object with the following fields, or `null` to reset to the browser's default download behavior:
+    - `type`
+      - : A string that specifies whether downloads are allowed or blocked. Valid values are:
+        - `"allowed"`: Indicates that downloads are permitted. When this value is set, the `destinationFolder` field is required.
+        - `"denied"`: Indicates that downloads are blocked.
+    - `destinationFolder`
+      - : A string that specifies the path to the folder where downloaded files are saved.
+        This field is required when `type` is `"allowed"`.
+- `userContexts` {{optional_inline}}
+  - : An array of strings where each string is the ID ([UUID](/en-US/docs/Glossary/UUID)) of a [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) to apply the download behavior to.
+    - If included, the specified download behavior is applied to each listed user context. If `downloadBehavior` is `null`, the per-context override is reset for each listed user context.
+    - If not included, the specified download behavior is applied as a global default to all user contexts.
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+### Errors
+
+- `unsupported operation`
+  - : The browser does not support the specified download behavior.
+- `no such user context`
+  - : No user context with the given user context ID is found.
+
+## Examples
+
+### Allowing downloads to a specific folder
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), send the following message to set the global download behavior and direct downloads to a specific folder:
+
+```json
+{
+  "id": 1,
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": {
+      "type": "allowed",
+      "destinationFolder": "/home/user/downloads"
+    }
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+### Allowing downloads in multiple user contexts
+
+To allow downloads in multiple user contexts, get the user context IDs using [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts), and then send the following message to direct downloads to a specified folder:
+
+```json
+{
+  "id": 2,
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": {
+      "type": "allowed",
+      "destinationFolder": "/home/user/downloads/user-context"
+    },
+    "userContexts": [
+      "4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f",
+      "9c2d8e45-fb12-4a67-bc34-567890abcdef"
+    ]
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {}
+}
+```
+
+### Blocking downloads in a specific user context
+
+To block downloads in a specific user context, first obtain the user context ID using [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts). Then send the following message:
+
+```json
+{
+  "id": 3,
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": {
+      "type": "denied"
+    },
+    "userContexts": ["4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"]
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 3,
+  "type": "success",
+  "result": {}
+}
+```
+
+### Resetting download behavior to the browser default
+
+Send the following message to reset the global download behavior back to the browser's default:
+
+```json
+{
+  "id": 4,
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": null
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 4,
+  "type": "success",
+  "result": {}
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) command
+- [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -45,6 +45,8 @@ The `result` field in the response is an empty object (`{}`).
 
 ### Errors
 
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
 - `unsupported operation`
   - : The browser does not support the specified download behavior.
 - `no such user context`

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -35,6 +35,7 @@ The `params` field contains:
         This field is required when `type` is `"allowed"`.
 - `userContexts` {{optional_inline}}
   - : An array of strings where each string is the ID ([UUID](/en-US/docs/Glossary/UUID)) of a [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) to apply the download behavior to.
+    User context IDs are returned by commands such as [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts).
     - If included, the specified download behavior is applied to each listed user context. If `downloadBehavior` is `null`, the per-context override is reset for each listed user context.
     - If not included, the specified download behavior is applied as a global default to all user contexts.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browser.setDownloadBehavior
 sidebar: webdriver
 ---
 
-The `browser.setDownloadBehavior` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module allows file downloads to a specified folder, or blocks file downloads entirely. The behavior can be configured for all or some [user contexts](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts).
+The `browser.setDownloadBehavior` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browser`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser) module allows file downloads to a specified folder, blocks file downloads entirely, or resets the behavior to the browser's default. The behavior can be configured for all or some [user contexts](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts).
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This is a follow up to https://github.com/mdn/content/pull/43518 to add one more browser module command page.

While here, I've also updated the front matter in other browser command pages to:
- Include backticks around keywords in `title` (they now render as inline code on MDN).
- Make `short-title`s shorter (e.g., `short-title: close` instead of `short-title: browser.close`).

### Spec link

https://w3c.github.io/webdriver-bidi/#command-browser-setDownloadBehavior

### Related issue

Doc issue: https://github.com/mdn/mdn/issues/339
