### PR TITLE
Clarify dispatchEvent synchronous handler wording

### DIFF
--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -19,10 +19,7 @@ should have already been created and initialized using an {{domxref("Event/Event
 > [!NOTE]
 > When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
 
-Unlike "native" events, which are fired by the browser and dispatched
-asynchronously via the [event loop](/en-US/docs/Web/JavaScript/Reference/Execution_model),
-`dispatchEvent()` invokes event handlers _synchronously_. All applicable event
-handlers are called and return before `dispatchEvent()` returns.
+Unlike "native" events, which the browser fires by queuing a task on the [event loop](/en-US/docs/Web/JavaScript/Reference/Execution_model), `dispatchEvent()` invokes all applicable event handlers _synchronously_ before returning.
 
 ## Syntax
 

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -19,7 +19,7 @@ should have already been created and initialized using an {{domxref("Event/Event
 > [!NOTE]
 > When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
 
-Unlike "native" events, which are fired by the browser and invoke event handlers
+Unlike "native" events, which are fired by the browser and dispatched
 asynchronously via the [event loop](/en-US/docs/Web/JavaScript/Reference/Execution_model),
 `dispatchEvent()` invokes event handlers _synchronously_. All applicable event
 handlers are called and return before `dispatchEvent()` returns.


### PR DESCRIPTION
### Summary

- Clarifies that browser-fired native events are dispatched asynchronously via the event loop
- Keeps the existing contrast that `dispatchEvent()` invokes applicable handlers synchronously

### Issue

Fixes #43519

### Checks

- `npx --yes prettier -c files/en-us/web/api/eventtarget/dispatchevent/index.md`
- `git diff --check`

Note: a standalone `markdownlint-cli2` run without the full repo lint config reported pre-existing line-length findings in this page.