### PR TITLE
Fixes Float64Array example in Object.freeze documentation

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/freeze/index.md
@@ -70,7 +70,7 @@ Object.freeze(new Uint8Array(1)); // Has elements
 Object.freeze(new DataView(new ArrayBuffer(32))); // No elements
 // DataView {}
 
-Object.freeze(new Float64Array(new ArrayBuffer(64), 63, 0)); // No elements
+Object.freeze(new Float64Array(new ArrayBuffer(64), 32, 0)); // No elements
 // Float64Array []
 
 Object.freeze(new Float64Array(new ArrayBuffer(64), 32, 2)); // Has elements


### PR DESCRIPTION
### Description

The sample aimed to demonstrate the freezing of an empty ``Float64Array`` has been throwing ``RangeError: start offset of Float64Array should be a multiple of 8``. This fix updates the start offset value to make the code behave the expected way

