### PR TITLE
feat(jsondata): add `external_link` translation key

### DIFF
--- a/files/jsondata/L10n-Template.json
+++ b/files/jsondata/L10n-Template.json
@@ -482,7 +482,7 @@
     "zh-TW": "來源："
   },
   "external_link": {
-    "de": "Externer Link (wird in neuem Tab geöffnet)",
+    "de": "Externer Link (öffnet in neuem Tab)",
     "en-US": "External link (opens in new tab)",
     "es": "Enlace externo (se abre en una nueva pestaña)",
     "fr": "Lien externe (ouvre un nouvel onglet)",

--- a/files/jsondata/L10n-Template.json
+++ b/files/jsondata/L10n-Template.json
@@ -481,6 +481,18 @@
     "zh-CN": "来源：",
     "zh-TW": "來源："
   },
+  "external_link": {
+    "de": "Externer Link (wird in neuem Tab geöffnet)",
+    "en-US": "External link (opens in new tab)",
+    "es": "Enlace externo (se abre en una nueva pestaña)",
+    "fr": "Lien externe (ouvre un nouvel onglet)",
+    "ja": "外部リンク（新しいタブで開きます）",
+    "ko": "외부 링크 (새 탭에서 열림)",
+    "pt-BR": "Link externo (abre em uma nova aba)",
+    "ru": "Внешняя ссылка (открывается в новой вкладке)",
+    "zh-CN": "外部链接（在新标签页中打开）",
+    "zh-TW": "外部連結（在新分頁開啟）"
+  },
   "formal_syntax_footer": {
     "de": "Diese Syntax spiegelt den neuesten Standard gemäß { $specs } wider. Möglicherweise haben nicht alle Browser jeden Teil implementiert. Siehe <a href=\"#browser-kompatibilität\">Browserkompatibilität</a> für Informationen zur Unterstützung.",
     "en-US": "This syntax reflects the latest standard as per { $specs }. Not all browsers may have implemented every part. See <a href=\"#browser_compatibility\">Browser compatibility</a> for support information.",


### PR DESCRIPTION
## Summary

Adds a new `external_link` key to `L10n-Template.json`, used by rari to set a localized `title` attribute on external links for accessibility.

Companion PR: mdn/rari#658 (resolving mdn/rari#266)

English value: `External link (opens in new tab)`.

## Translations

Translations are provided as starting drafts and need review by L10n maintainers for each locale (de, es, fr, ja, ko, pt-BR, ru, zh-CN, zh-TW).

## Test plan

- [x] JSON validates
- [ ] L10n maintainers review translations