### PR TITLE
Fix missing variable declarations in object example

### DIFF
--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -522,11 +522,11 @@ Together, these also bring object literals and class declarations closer togethe
 // "theProtoObj is not defined" or "handler is not defined"
 
 const theProtoObj = {
-    /*The proto Object*/
+  /*The proto Object*/
 };
 const handler = {
-    /*Handler*/
-}
+  /*Handler*/
+};
 const obj = {
   // __proto__
   __proto__: theProtoObj,

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -517,10 +517,8 @@ Object literals support a range of shorthand syntaxes that include setting the p
 Together, these also bring object literals and class declarations closer together, and allow object-based design to benefit from some of the same conveniences.
 
 ```js
-const theProtoObj = {
-};
-const handler = {
-};
+const theProtoObj = {};
+const handler = {};
 const obj = {
   // __proto__
   __proto__: theProtoObj,

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -517,6 +517,16 @@ Object literals support a range of shorthand syntaxes that include setting the p
 Together, these also bring object literals and class declarations closer together, and allow object-based design to benefit from some of the same conveniences.
 
 ```js
+// If `theProtoObj` and `handler` are not declared,
+// the code will throw a ReferenceError:
+// "theProtoObj is not defined" or "handler is not defined"
+
+const theProtoObj = {
+    /*The proto Object*/
+};
+const handler = {
+    /*Handler*/
+}
 const obj = {
   // __proto__
   __proto__: theProtoObj,

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -517,10 +517,6 @@ Object literals support a range of shorthand syntaxes that include setting the p
 Together, these also bring object literals and class declarations closer together, and allow object-based design to benefit from some of the same conveniences.
 
 ```js
-// If `theProtoObj` and `handler` are not declared,
-// the code will throw a ReferenceError:
-// "theProtoObj is not defined" or "handler is not defined"
-
 const theProtoObj = {
   /*The proto Object*/
 };

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -518,10 +518,8 @@ Together, these also bring object literals and class declarations closer togethe
 
 ```js
 const theProtoObj = {
-  /*The proto Object*/
 };
 const handler = {
-  /*Handler*/
 };
 const obj = {
   // __proto__


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Explain that the example uses theProtoObj and handler without declaring them, which may lead to a ReferenceError when copied directly. Add explicit variable declarations to make the example self-contained and runnable.

### Motivation

The current example may confuse readers, especially beginners, because it assumes the existence of variables that are not defined in the snippet. Making the example self-contained improves clarity and ensures it works when copied and tested directly.



<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
