### PR TITLE
Fix ambiguous "current domain" wording in Set-Cookie Domain attribute

### DIFF
--- a/files/en-us/web/http/reference/headers/set-cookie/index.md
+++ b/files/en-us/web/http/reference/headers/set-cookie/index.md
@@ -72,7 +72,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 - `Domain=<domain-value>` {{optional_inline}}
   - : Defines the host to which the cookie will be sent.
 
-    Only the current domain can be set as the value, or a domain of a higher order, unless it is a public suffix. Setting the domain will make the cookie available to it, as well as to all its subdomains.
+    Only the domain of the server that set the cookie (the origin of the HTTP response) can be used as the value, or a higher-level domain (for example, `example.com` instead of `sub.example.com`), unless it is a public suffix. Setting the domain will make the cookie available to it, as well as to all its subdomains.
 
     If omitted, the cookie is returned only to the host that sent them (i.e., it becomes a "host-only cookie").
     This is more restrictive than setting the host name, as the cookie is not made available to subdomains of the host.


### PR DESCRIPTION
docs: clarify domain definition in Set-Cookie header

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Clarifies the meaning of "current domain" in the Set-Cookie Domain attribute by replacing it with a more precise explanation referring to the server origin.

### Motivation

The phrase "current domain" is ambiguous and may confuse readers about whether it refers to the client or server domain. This change improves clarity by explicitly stating that the domain is based on the server that sets the cookie.


### Additional details

This aligns with existing MDN documentation on cookie behavior:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#define_where_cookies_are_sent

### Related issues and pull requests

Fixes #43871
