### PR TITLE
Update description of Array.length property

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.length
 sidebar: jsref
 ---
 
-The **`length`** data property of an {{jsxref("Array")}} instance represents the number of slots in that array (this may be different to the number of elements as it may be a sparse array - with 'holes'). The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array.
+The **`length`** data property of an {{jsxref("Array")}} instance represents the number of slots in that array. The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array. It may be greater than the number of elements if the array is [sparse](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array_methods_and_empty_slots).
 
 {{InteractiveExample("JavaScript Demo: Array: length", "shorter")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/array/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/length/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Array.length
 sidebar: jsref
 ---
 
-The **`length`** data property of an {{jsxref("Array")}} instance represents the number of elements in that array. The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array.
+The **`length`** data property of an {{jsxref("Array")}} instance represents the number of slots in that array (this may be different to the number of elements as it may be a sparse array - with 'holes'). The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array.
 
 {{InteractiveExample("JavaScript Demo: Array: length", "shorter")}}
 


### PR DESCRIPTION
Clarified the definition of the 'length' property to indicate it represents the number of slots in the array, accounting for sparse arrays.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
