### PR TITLE
Element.setHTML(): add mXSS warning about re-parsing sanitized HTML

### DIFF
--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -68,7 +68,7 @@ Note that since this method always sanitizes input strings of XSS-unsafe entitie
 
 ## Re-parsing and mutated XSS (mXSS)
 
-Sanitizing HTML with the Sanitizer API or using `Element.prototype.setHTML()` helps remove unsafe nodes and attributes, but it does not eliminate the risk of mutated XSS (mXSS) when the sanitized HTML is serialized and later re-parsed. If sanitized HTML is serialized (for example via `innerHTML`) and later re-parsed by the browser, parsing-time transformations can re-introduce executable content or attributes that the sanitizer did not anticipate.
+Sanitizing HTML with the Sanitizer API or using `setHTML()` helps remove unsafe nodes and attributes, but it does not eliminate the risk of mutated XSS (mXSS) when the sanitized HTML is serialized and later re-parsed. If sanitized HTML is serialized (for example via `innerHTML`) and later re-parsed by the browser, parsing-time transformations can re-introduce executable content or attributes that the sanitizer did not anticipate.
 
 Example — unsafe flow
 

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -66,24 +66,32 @@ It should also be used instead of {{domxref("Element.setHTMLUnsafe()")}}, unless
 
 Note that since this method always sanitizes input strings of XSS-unsafe entities, it is not secured or validated using the [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API).
 
-## Re-parsing and mutated XSS (mXSS)
+### Re-parsing and mutated XSS (mXSS)
 
-Sanitizing HTML with the Sanitizer API or using `setHTML()` helps remove unsafe nodes and attributes, but it does not eliminate the risk of mutated XSS (mXSS) when the sanitized HTML is serialized and later re-parsed. If sanitized HTML is serialized (for example via `innerHTML`) and later re-parsed by the browser, parsing-time transformations can re-introduce executable content or attributes that the sanitizer did not anticipate.
+Even after sanitizing HTML input with `setHTML()`, it is still not safe to serialize the HTML and reparse it using `innerHTML`.
+For example, the following code is unsafe.
 
-Example — unsafe flow
-
-```js
-// `code` comes from an untrusted source
-div.setHTML(code); // Sanitizer runs here
-other_div.innerHTML = div.innerHTML; // Re-parsing `innerHTML` — can trigger mXSS
+```js example-bad
+div.setHTML(unsafeString); //Safe
+const serializedHTML = div.innerHTML; //No longer sanitized!
+other_element.innerHTML = serializedHTML;
 ```
 
-Recommendations
+The reason for this is that sanitization is context-aware.
+When you call `setHTML()` on a particular element the unsafe elements and attributes for that context are removed.
+If you serialize the code and use it directly in another element, it may still contain elements that are unsafe in that element.
 
-- Avoid round-tripping sanitized `innerHTML` as a string. If you must persist markup, re-sanitize on every parse before insertion.
-- Prefer structured, safe representations (for example, store content as sanitized fragments or a safe data model) instead of raw HTML strings.
-- Use defensive headers and policies: Content Security Policy (CSP), Trusted Types, and server-side validation.
-- See also the WICG discussion on mutated XSS: https://wicg.github.io/sanitizer-api/#mutated-xss
+This would be safe (if pointless):
+
+```js example-good
+div.setHTML(unsafeString); // Safe
+const serializedHTML = div.innerHTML; //No longer sanitized!
+// This is safe
+other_div.innerHTML = setHTML(serializedHTML);
+```
+
+There is a class of attacks that take advantage of this flaw, referred to as [mutated XSS](https://wicg.github.io/sanitizer-api/#mutated-xss).
+The simple rule to avoid this problem is to only ever inject HTML strings using safe methods such as `setHTML()`.
 
 ## Examples
 

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -66,6 +66,25 @@ It should also be used instead of {{domxref("Element.setHTMLUnsafe()")}}, unless
 
 Note that since this method always sanitizes input strings of XSS-unsafe entities, it is not secured or validated using the [Trusted Types API](/en-US/docs/Web/API/Trusted_Types_API).
 
+## Re-parsing and mutated XSS (mXSS)
+
+Sanitizing HTML with the Sanitizer API or using `Element.prototype.setHTML()` helps remove unsafe nodes and attributes, but it does not eliminate the risk of mutated XSS (mXSS) when the sanitized HTML is serialized and later re-parsed. If sanitized HTML is serialized (for example via `innerHTML`) and later re-parsed by the browser, parsing-time transformations can re-introduce executable content or attributes that the sanitizer did not anticipate.
+
+Example — unsafe flow
+
+```js
+// `code` comes from an untrusted source
+div.setHTML(code);             // Sanitizer runs here
+other_div.innerHTML = div.innerHTML; // Re-parsing `innerHTML` — can trigger mXSS
+```
+
+Recommendations
+
+- Avoid round-tripping sanitized `innerHTML` as a string. If you must persist markup, re-sanitize on every parse before insertion.
+- Prefer structured, safe representations (for example, store content as sanitized fragments or a safe data model) instead of raw HTML strings.
+- Use defensive headers and policies: Content Security Policy (CSP), Trusted Types, and server-side validation.
+- See also the WICG discussion on mutated XSS: https://wicg.github.io/sanitizer-api/#mutated-xss
+
 ## Examples
 
 ### Basic usage

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -68,26 +68,25 @@ Note that since this method always sanitizes input strings of XSS-unsafe entitie
 
 ### Re-parsing and mutated XSS (mXSS)
 
-Even after sanitizing HTML input with `setHTML()`, it is still not safe to serialize the HTML and reparse it using `innerHTML`.
+Even after sanitizing HTML input with `setHTML()`, it is still not safe to serialize the HTML and re-parse it using `innerHTML`.
 For example, the following code is unsafe.
 
 ```js example-bad
-div.setHTML(unsafeString); //Safe
-const serializedHTML = div.innerHTML; //No longer sanitized!
+div.setHTML(unsafeString); // Safe
+const serializedHTML = div.innerHTML; // No longer sanitized!
 other_element.innerHTML = serializedHTML;
 ```
 
 The reason for this is that sanitization is context-aware.
-When you call `setHTML()` on a particular element the unsafe elements and attributes for that context are removed.
-If you serialize the code and use it directly in another element, it may still contain elements that are unsafe in that element.
+When you call `setHTML()` on a particular element, the unsafe elements and attributes for that context are removed.
+If you serialize the HTML and use it directly in another element, it may still contain elements that are unsafe in that element.
 
 This would be safe (if pointless):
 
 ```js example-good
 div.setHTML(unsafeString); // Safe
-const serializedHTML = div.innerHTML; //No longer sanitized!
-// This is safe
-other_div.innerHTML = setHTML(serializedHTML);
+const serializedHTML = div.innerHTML; // Serialized as a plain string
+other_div.setHTML(serializedHTML); // Safe — re-sanitized by setHTML()
 ```
 
 There is a class of attacks that take advantage of this flaw, referred to as [mutated XSS](https://wicg.github.io/sanitizer-api/#mutated-xss).

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -74,7 +74,7 @@ Example — unsafe flow
 
 ```js
 // `code` comes from an untrusted source
-div.setHTML(code);             // Sanitizer runs here
+div.setHTML(code); // Sanitizer runs here
 other_div.innerHTML = div.innerHTML; // Re-parsing `innerHTML` — can trigger mXSS
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Re-parsing and mutated XSS (mXSS) security section explaining innerHTML round-trip risk, example unsafe flow, mitigation recommendations along with reference 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? --> Make readers to avoid risk and stay updated

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" --> Fixes #43386
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
