### PR TITLE
Clarify AudioSession intro

### DIFF
--- a/files/en-us/web/api/audiosession/index.md
+++ b/files/en-us/web/api/audiosession/index.md
@@ -9,9 +9,9 @@ browser-compat: api.AudioSession
 
 {{APIRef("Audio Session API")}}{{SeeCompatTable}}
 
-The **`AudioSession`** interface of the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) allows developers to specify how audio from a web application interacts with other audio playing on a device.
+The **`AudioSession`** interface of the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) lets a web page declare the purpose of the audio it is producing — for example music playback, a video call, or a short notification. The platform uses that declaration to decide what should happen to audio from other apps and browser tabs — whether to pause it, duck it (lower its volume), or let it play alongside.
 
-An audio session represents the aggregated audio output from a web page. It allows web pages to express the general nature of their audio output, such as playback, recording, or transient sounds like notifications. The platform can then use this information to determine how web-based audio should interact with other applications on the device, for example, whether web audio should pause other audio or play alongside it.
+An audio session is the spec's term for the per-page object that holds this declaration; see the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) overview for the underlying model.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/audiosession/index.md
+++ b/files/en-us/web/api/audiosession/index.md
@@ -9,9 +9,7 @@ browser-compat: api.AudioSession
 
 {{APIRef("Audio Session API")}}{{SeeCompatTable}}
 
-The **`AudioSession`** interface of the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) lets a web page declare the purpose of the audio it is producing — for example music playback, a video call, or a short notification. The platform uses that declaration to decide what should happen to audio from other apps and browser tabs — whether to pause it, duck it (lower its volume), or let it play alongside.
-
-An audio session is the spec's term for the per-page object that holds this declaration; see the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) overview for the underlying model.
+The **`AudioSession`** interface of the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) lets a web page declare the type of audio it is producing — for example music playback, a video call, or a short notification. The platform uses that declaration to decide how the page's audio and audio from other applications and tabs should coexist — whether to pause, duck (lower the volume), or play in parallel.
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
### Description

Rewrites the `AudioSession` intro paragraph for clarity and removes the redundant second paragraph.

### Motivation

The original first sentence said the API "allows developers to specify how audio from a web application interacts with other audio." The API only exposes a `type` property, though — the developer declares a type, and the platform decides how the page's audio coexists with other audio. The rewrite makes that distinction explicit and uses concrete examples (music playback, a video call, a short notification) instead of abstract phrasing. The original second paragraph duplicated material already covered on the parent `Audio_Session_API` landing page and is removed; the interface page is now in line with the API reference page template ("one or two short sentences").

### Additional details

Spec: https://w3c.github.io/audio-session/#audiosession

### Related issues and pull requests

—