### PR TITLE
Issue-22534 native manifest reference improvement

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -42,7 +42,7 @@ Most probably, the user or device administrator would install the `PKCS #11` mod
 
 However, the module and manifest can't be installed as part of the extension's own installation process.
 
-For details about the manifest file's contents and location, see [Native manifests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests).
+For details about the manifest file's contents and location, see [PKCS #11 manifests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#pkcs_11_manifests).
 
 ## Functions
 

--- a/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
@@ -42,7 +42,7 @@ There are three types of native manifest:
   </tbody>
 </table>
 
-For all native manifests, you need to store the file so the browser can find it. The section on [manifest location](#manifest_location) describes how to do this. On Linux and macOS, the files are in a fixed location, on Windows the file location is written to the Windows Registry.
+For all native manifests, you need to store the file so the browser can find it. On Linux and macOS, you need to store the manifest in a particular place. On Windows, you need to create a registry key that points to the manifest's location.
 
 ## Native messaging manifests
 
@@ -156,6 +156,33 @@ For example, here's the content of the `ping_pong.json` manifest file for the `p
 
 This allows the extension with the ID `ping_pong@example.org` to connect by passing the name `ping_pong` into the relevant {{WebExtAPIRef("runtime")}} API function. The native application is at `/path/to/native-messaging/app/ping_pong.py`.
 
+## Native messaging manifest locations
+
+In the examples, `<name>` is the value of the `name` property in the native manifest.
+
+### Windows
+
+For global visibility, create a registry key named `HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\NativeMessagingHosts\<name>` with a single default value, which is the path to the manifest.
+
+> [!WARNING]
+> As of Firefox 64, the 32-bit registry view [Wow6432Node](https://en.wikipedia.org/wiki/WoW64#Registry_and_file_system) is checked first for these keys, followed by the "native" registry view. Use whichever is appropriate for your application.
+>
+> **For Firefox 63 and older:** This key should _not_ be created under [Wow6432Node](https://en.wikipedia.org/wiki/WoW64#Registry_and_file_system), even if the app is 32-bit. Previous versions of the browser always look for the key under the "native" view of the registry, not the 32-bit emulation. To ensure that the key is created in the "native" view, you can pass the `KEY_WOW64_64KEY` or `KEY_WOW64_32KEY` flags into `RegCreateKeyEx`. See [Accessing an Alternate Registry View](https://learn.microsoft.com/en-us/windows/win32/winprog64/accessing-an-alternate-registry-view).
+
+For per-user visibility, create a registry key named `HKEY_CURRENT_USER\SOFTWARE\Mozilla\NativeMessagingHosts\<name>` with a single default value, which is the path to the manifest.
+
+### macOS
+
+For global visibility, store the manifest in `/Library/Application Support/Mozilla/NativeMessagingHosts/<name>.json`.
+
+For per-user visibility, store the manifest in `~/Library/Application Support/Mozilla/NativeMessagingHosts/<name>.json`.
+
+### Linux
+
+For global visibility, store the manifest in `/usr/lib/mozilla/native-messaging-hosts/<name>.json` or `/usr/lib64/mozilla/native-messaging-hosts/<name>.json`.
+
+For per-user visibility, store the manifest in `~/.mozilla/native-messaging-hosts/<name>.json`.
+
 ## Managed storage manifests
 
 The managed storage manifest is a file with a name that matches the ID specified in the extension's [browser_specific_settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key with the `.json` extension. It contains a JSON object with these properties:
@@ -237,6 +264,28 @@ storageItem.then((res) => {
   console.log(`Managed color is: ${res.color}`);
 });
 ```
+
+## Managed storage manifest locations
+
+In these examples, `<name>` is the value of the name property in the native manifest.
+
+### Windows
+
+For global visibility, create a registry key named `HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\ManagedStorage\<name>` with a single default value, which is the path to the manifest.
+
+For per-user visibility, create a registry key named `HKEY_CURRENT_USER\SOFTWARE\Mozilla\ManagedStorage\<name>` with a single default value, which is the path to the manifest.
+
+### macOS
+
+For global visibility, store the manifest in `/Library/Application Support/Mozilla/ManagedStorage/<name>.json`.
+
+For per-user visibility, store the manifest in `~/Library/Application Support/Mozilla/ManagedStorage/<name>.json`.
+
+### Linux
+
+For global visibility, store the manifest in `/usr/lib/mozilla/managed-storage/<name>.json` or `/usr/lib64/mozilla/managed-storage/<name>.json`.
+
+For per-user visibility, store the manifest in `~/.mozilla/managed-storage/<name>.json`.
 
 ## PKCS #11 manifests
 
@@ -345,121 +394,24 @@ Given this JSON manifest, saved as `my_module.json`, the `my-extension@mozilla.o
 browser.pkcs11.installModule("my_module");
 ```
 
-## Manifest location
+## PKCS #11 manifest locations
 
-On Linux and macOS, you need to store the manifest in a particular place. On Windows, you need to create a registry key that points to the manifest's location.
-
-The detailed rules are the same for all the manifest types, except that the penultimate component of the path identifies the type of manifest. The examples below show the form for each of the three different types. In all the examples, `<name>` is the value of the name property in the native manifest.
+In these examples, `<name>` is the value of the name property in the native manifest.
 
 ### Windows
 
-For global visibility, create a registry key with the following name:
+For global visibility, create a registry key named `HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\PKCS11Modules\<name>` with a single default value, which is the path to the manifest.
 
-```plain
-HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\NativeMessagingHosts\<name>
-```
-
-```plain
-HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\ManagedStorage\<name>
-```
-
-```plain
-HKEY_LOCAL_MACHINE\SOFTWARE\Mozilla\PKCS11Modules\<name>
-```
-
-The key should have a single default value, which is the path to the manifest.
-
-> [!WARNING]
-> As of Firefox 64, the 32-bit registry view [Wow6432Node](https://en.wikipedia.org/wiki/WoW64#Registry_and_file_system) will be checked first for these keys, followed by the "native" registry view. Use whichever is appropriate for your application.
->
-> **For Firefox 63 and older:** This key should _not_ be created under [Wow6432Node](https://en.wikipedia.org/wiki/WoW64#Registry_and_file_system), even if the app is 32-bit. Previous versions of the browser will always look for the key under the "native" view of the registry, not the 32-bit emulation. To ensure that the key is created in the "native" view, you can pass the `KEY_WOW64_64KEY` or `KEY_WOW64_32KEY` flags into `RegCreateKeyEx`. See [Accessing an Alternate Registry View](https://learn.microsoft.com/en-us/windows/win32/winprog64/accessing-an-alternate-registry-view).
-
-For per-user visibility, create a registry key with the following name:
-
-```plain
-HKEY_CURRENT_USER\SOFTWARE\Mozilla\NativeMessagingHosts\<name>
-```
-
-```plain
-HKEY_CURRENT_USER\SOFTWARE\Mozilla\ManagedStorage\<name>
-```
-
-```plain
-HKEY_CURRENT_USER\SOFTWARE\Mozilla\PKCS11Modules\<name>
-```
-
-The key should have a single default value, which is the path to the manifest.
+For per-user visibility, create a registry key named `HKEY_CURRENT_USER\SOFTWARE\Mozilla\PKCS11Modules\<name>` with a single default value, which is the path to the manifest.
 
 ### macOS
 
-For global visibility, store the manifest in:
+For global visibility, store the manifest in `/Library/Application Support/Mozilla/PKCS11Modules/<name>.json`.
 
-```plain
-/Library/Application Support/Mozilla/NativeMessagingHosts/<name>.json
-```
-
-```plain
-/Library/Application Support/Mozilla/ManagedStorage/<name>.json
-```
-
-```plain
-/Library/Application Support/Mozilla/PKCS11Modules/<name>.json
-```
-
-For per-user visibility, store the manifest in:
-
-```plain
-~/Library/Application Support/Mozilla/NativeMessagingHosts/<name>.json
-```
-
-```plain
-~/Library/Application Support/Mozilla/ManagedStorage/<name>.json
-```
-
-```plain
-~/Library/Application Support/Mozilla/PKCS11Modules/<name>.json
-```
+For per-user visibility, store the manifest in `~/Library/Application Support/Mozilla/PKCS11Modules/<name>.json`.
 
 ### Linux
 
-For global visibility, store the manifest in either:
+For global visibility, store the manifest in `/usr/lib/mozilla/pkcs11-modules/<name>.json` or `/usr/lib64/mozilla/pkcs11-modules/<name>.json`.
 
-```plain
-/usr/lib/mozilla/native-messaging-hosts/<name>.json
-```
-
-```plain
-/usr/lib/mozilla/managed-storage/<name>.json
-```
-
-```plain
-/usr/lib/mozilla/pkcs11-modules/<name>.json
-```
-
-or:
-
-```plain
-/usr/lib64/mozilla/native-messaging-hosts/<name>.json
-```
-
-```plain
-/usr/lib64/mozilla/managed-storage/<name>.json
-```
-
-```plain
-/usr/lib64/mozilla/pkcs11-modules/<name>.json
-```
-
-For per-user visibility, store the manifest in:
-
-```plain
-~/.mozilla/native-messaging-hosts/<name>.json
-```
-
-```plain
-~/.mozilla/managed-storage/<name>.json
-```
-
-```plain
-~/.mozilla/pkcs11-modules/<name>.json
-```
+For per-user visibility, store the manifest in `~/.mozilla/pkcs11-modules/<name>.json`.

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -127,7 +127,7 @@ python -u "c:\\path\\to\\native-messaging\\app\\ping_pong.py"
 
 #### Registry
 
-The browser finds the extension based on registry keys which are located in a specific location. You need to add them either programmatically with your final application or manually if you are using the example from GitHub. For more details, refer to [Manifest location](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#manifest_location).
+The browser finds the extension based on registry keys which are located in a specific location. You need to add them either programmatically with your final application or manually if you are using the example from GitHub. For more details, refer to [Manifest location](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#native_messaging_manifest_locations).
 
 Following with the `ping_pong` example, if using Firefox (see [this page for Chrome](https://developer.chrome.com/docs/apps/nativeMessaging/#native-messaging-host-location)), one of the two registry entries should be created for the messaging to work:
 
@@ -395,8 +395,8 @@ If you haven't managed to run the application, you should see an error message g
 
 - Check that the name passed to `runtime.connectNative()` matches the name in the app manifest
 - macOS/Linux: check that name of the app manifest is `<name>.json`.
-- macOS/Linux: check the native application's manifest file location as mentioned [in the native manifests reference](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#macos).
-- Windows: check that the registry key is in the correct place, and that its name matches the name in the app manifest.
+- macOS/Linux: check the native application's manifest file location. For details see [Managed storage manifest locations, macOS/Linux](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#macos).
+- Windows: check that the registry key is in the correct place, and that its name matches the name in the app manifest. For details see [Managed storage manifest locations, Windows](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#windows).
 - Windows: check that the path given in the registry key points to the app manifest.
 
   ```plain


### PR DESCRIPTION
### Description

The structure of the guide to native manifests made it difficult to reference location information for a specific manifest. This change moves the location information into sections immediately after each manifest description. This enables linking to location details and makes it easier for the reader to find location information for a manifest.

### Related issues and pull requests

Fixes #22534