### PR TITLE
FF151 Relnote CanvasRenderingContext2D.lang

### DIFF
--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -58,6 +58,9 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
   This makes it possible to open an [always-on-top window](/en-US/docs/Web/API/Document_Picture-in-Picture_API#how_does_it_work) that can be populated with arbitrary HTML content.
   It can be used to display any content that a user might want to view separate from the launching page (or even the browser), such as a set of streams showing the participants of a video conference call, a stock ticker, or a countdown timer.
   ([Firefox bug 2006594](https://bugzil.la/2006594)).
+- The {{domxref("CanvasRenderingContext2D.lang")}} property is supported for setting the language of the canvas drawing context.
+  While a DOM canvas can inherit this context from the `lang` attribute of its associated {{htmlelement("canvas")}} element, this is useful for setting the context for an offscreen canvas, which may be rendered before being associated with a `<canvas>`.
+  ([Firefox bug 1943070](https://bugzil.la/1943070)).
 - The [`options.keyboardLock`](/en-US/docs/Web/API/Element/requestFullscreen#keyboardlock) property can now be passed as an option to {{domxref("Element.requestFullscreen()")}}, allowing websites to request keyboard lock when the element is displayed in fullscreen mode.
   This stops the <kbd>Esc</kbd> key from causing the element to leave fullscreen (a long-press is required instead), and some formerly-reserved browser hotkeys can now be intercepted and their default action prevented.
   ([Firefox bug 2032302](https://bugzil.la/2032302)).


### PR DESCRIPTION
FF151 adds support for [`CanvasRenderingContext2D.lang`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lang) in https://bugzilla.mozilla.org/show_bug.cgi?id=1943070

This adds a release note.

Related docs work can be tracked in #43865