### PR TITLE
Correct incorrect filename on learn assessment

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/splash_page/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/splash_page/index.md
@@ -349,7 +349,7 @@ Later on, you will need to include the following URLs in your page.
 - `bee.jpg`: [Image for the "Bees, Wasps, Ants (Hymenoptera)" section](https://mdn.github.io/shared-assets/images/examples/learn/crawlies/bee.jpg).
 - `beetle.png`: [Image for the "Beetles (Coleoptera)" section](https://mdn.github.io/shared-assets/images/examples/learn/crawlies/beetle.png).
 - `butterfly.jpg`: [Image for the "Butterflies & Moths (Lepidoptera)" section](https://mdn.github.io/shared-assets/images/examples/learn/crawlies/butterfly.jpg).
-- `mosquito.jpg`: [Image for the "Flies & Mosquitoes (Diptera)" section](https://mdn.github.io/shared-assets/images/examples/learn/crawlies/mosquito.jpg).
+- `fly.jpg`: [Image for the "Flies & Mosquitoes (Diptera)" section](https://mdn.github.io/shared-assets/images/examples/learn/crawlies/fly.jpg).
 - `spider.jpg`: [Image for the "Spiders (Araneae)" section](https://mdn.github.io/shared-assets/images/examples/learn/crawlies/spider.jpg).
 - `true_bug.jpg`: [Image for the "True Bugs (Hemiptera)" section](https://mdn.github.io/shared-assets/images/examples/learn/crawlies/true_bug.jpg).
 - `bug_video_640.mp4`: [header video](https://mdn.github.io/shared-assets/videos/learn/bug_video_640.mp4).
@@ -561,11 +561,11 @@ Your finished HTML should look something like this:
 
         <figure>
           <img
-            src="https://mdn.github.io/shared-assets/images/examples/learn/crawlies/mosquito.jpg"
+            src="https://mdn.github.io/shared-assets/images/examples/learn/crawlies/fly.jpg"
             alt="A hairy flying insect with long legs"
             width="250"
             height="180" />
-          <figcaption>A mosquito.</figcaption>
+          <figcaption>A fly.</figcaption>
         </figure>
 
         <p>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

As per https://github.com/mdn/content/issues/43950, the learn assessment asset `mosquito.jpg` is incorrectly named, as it is a type of fly. 

https://github.com/mdn/shared-assets/pull/97 renames the asset itself; this PR changes `mosquito.jpg` references in the content to `fly.jpg`, and alters the associated `<figcaption>` content to reference the correct type of bug.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

Fixes https://github.com/mdn/content/issues/43950

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
