### PR TITLE
Reference HTML forms assessment features not covered in the tutorial

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
@@ -208,7 +208,9 @@ In the case of radio buttons, you generally need to provide the value that would
 
 #### Specialized text field inputs
 
-The second exercise above raises an interesting point. The second input field specifically expects an email address and validates entered values as such. If you look at the form code again, you'll see why — the second `<input>` has a `type` of `email`. There are several specialized text field input types designed to handle specific types of data — [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number), [`<input type="password">`](/en-US/docs/Web/HTML/Reference/Elements/input/password), [`<input type="tel">`](/en-US/docs/Web/HTML/Reference/Elements/input/tel), etc.
+The second exercise above raises an interesting point. The second input field specifically expects an email address and validates entered values as such. If you look at the form code again, you'll see why — the second `<input>` has a `type` of `email`.
+
+There are several specialized text field input types designed to handle specific types of data — [`<input type="color">`](/en-US/docs/Web/HTML/Reference/Elements/input/color), [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number), [`<input type="password">`](/en-US/docs/Web/HTML/Reference/Elements/input/password), [`<input type="tel">`](/en-US/docs/Web/HTML/Reference/Elements/input/tel), [`<input type="url">`](/en-US/docs/Web/HTML/Reference/Elements/input/url), etc.
 
 Follow some of the links above to find out what these input types are used for. Have a look around our [`<input>`](/en-US/docs/Web/HTML/Reference/Elements/input) reference and see if you can find any more specialized text field input types.
 
@@ -462,6 +464,9 @@ Each possible value for the data item is represented by an `<option>` element, n
 
 > [!NOTE]
 > If you want to have a specific option selected on page load, you can add a `selected` attribute to the relevant `<option>` element.
+
+> [!NOTE]
+> It is possible to split the options inside a `<select>` drop-down menu into multiple subgroups using the {{htmlelement("optgroup")}} element. Have a look at this element's reference page to find out how it works!
 
 ### Multi-line text input fields
 

--- a/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
@@ -210,7 +210,7 @@ In the case of radio buttons, you generally need to provide the value that would
 
 The second exercise above raises an interesting point. The second input field specifically expects an email address and validates entered values as such. If you look at the form code again, you'll see why — the second `<input>` has a `type` of `email`.
 
-There are several specialized text field input types designed to handle specific types of data — [`<input type="color">`](/en-US/docs/Web/HTML/Reference/Elements/input/color), [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number), [`<input type="password">`](/en-US/docs/Web/HTML/Reference/Elements/input/password), [`<input type="tel">`](/en-US/docs/Web/HTML/Reference/Elements/input/tel), [`<input type="url">`](/en-US/docs/Web/HTML/Reference/Elements/input/url), etc.
+There are several specialized text field input types designed to handle specific types of data such as [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number), [`<input type="password">`](/en-US/docs/Web/HTML/Reference/Elements/input/password), [`<input type="tel">`](/en-US/docs/Web/HTML/Reference/Elements/input/tel), [`<input type="url">`](/en-US/docs/Web/HTML/Reference/Elements/input/url), and so on.
 
 Follow some of the links above to find out what these input types are used for. Have a look around our [`<input>`](/en-US/docs/Web/HTML/Reference/Elements/input) reference and see if you can find any more specialized text field input types.
 

--- a/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/html_forms/index.md
@@ -462,11 +462,10 @@ The `<select>` element wraps all the different value choices. It is where you se
 
 Each possible value for the data item is represented by an `<option>` element, nested inside the `<select>` element. Each `<option>` element can take a `value` attribute, which specifies the value to be submitted if that option is chosen from the drop-down list. If you don't specify a `value`, the text inside the `<option></option>` tags is used as the value.
 
-> [!NOTE]
-> If you want to have a specific option selected on page load, you can add a `selected` attribute to the relevant `<option>` element.
+You can also split the options inside a `<select>` drop-down menu into multiple subgroups using the {{htmlelement("optgroup")}} element. Take a look at this element's reference page to find out how.
 
 > [!NOTE]
-> It is possible to split the options inside a `<select>` drop-down menu into multiple subgroups using the {{htmlelement("optgroup")}} element. Have a look at this element's reference page to find out how it works!
+> If you want to have a specific option selected on page load, you can add a `selected` attribute to the relevant `<option>` element.
 
 ### Multi-line text input fields
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

As per https://github.com/mdn/content/issues/43974, there are some features required for the [HTML forms assessment](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/Test_your_skills/Forms_and_buttons) solutions that are not covered in the [related tutorial](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_forms).

I've decided to fix this by making sure the required features are all referenced in the tutorial.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/43974

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
