### PR TITLE
Add constituent properties section to background-repeat

### DIFF
--- a/files/en-us/web/css/reference/properties/background-repeat/index.md
+++ b/files/en-us/web/css/reference/properties/background-repeat/index.md
@@ -56,6 +56,7 @@ This property is a shorthand for the following CSS properties:
 
 - {{cssxref("background-repeat-x")}}
 - {{cssxref("background-repeat-y")}}
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/reference/properties/background-repeat/index.md
+++ b/files/en-us/web/css/reference/properties/background-repeat/index.md
@@ -50,6 +50,16 @@ background-repeat: space repeat;
 }
 ```
 
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{cssxref("background-repeat-x")}}
+- {{cssxref("background-repeat-y")}}
+
+> [!WARNING]
+> {{cssxref("background-repeat-x")}} and {{cssxref("background-repeat-y")}} have very low browser support compared to `background-repeat`.
+
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/reference/properties/background-repeat/index.md
+++ b/files/en-us/web/css/reference/properties/background-repeat/index.md
@@ -56,10 +56,6 @@ This property is a shorthand for the following CSS properties:
 
 - {{cssxref("background-repeat-x")}}
 - {{cssxref("background-repeat-y")}}
-
-> [!WARNING]
-> {{cssxref("background-repeat-x")}} and {{cssxref("background-repeat-y")}} have very low browser support compared to `background-repeat`.
-
 ## Syntax
 
 ```css


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Add a "Constituent properties" section to the `background-repeat` page linking to `background-repeat-x` and `background-repeat-y`.

> [!NOTE]
> I added a warning because from my understanding `background-repeat-x` and `background-repeat-y` were only ever supported in Safari from versions 5 to 10.1 and I couldn't find any statement about intent to implement it in any major browser. See discussion in #43512 for more info.
> As this is time sensitive information I tried to phrase it in the most general way.
> Of course feel free to rephrase, edit or remove this warning as you see fit.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

A CSS property being a shorthand for other properties is interesting information.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

The  `background-repeat-x` and `background-repeat-y` pages were added in #42184.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->

Closes #43512 