### PR TITLE
Fix PreviousMenuNext on Django Forms page

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
@@ -7,6 +7,7 @@ sidebar: learnsidebar
 ---
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Sessions", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Authentication", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
 
 In this tutorial, we'll show you how to work with HTML Forms in Django, and, in particular, the easiest way to write forms to create, update, and delete model instances. As part of this demonstration, we'll extend the [LocalLibrary](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) website so that librarians can renew books, and create, update, and delete authors using our own forms (rather than using the admin application).
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
@@ -834,4 +834,5 @@ There is a lot more that can be done with forms (check out our [See also](#see_a
 - [Creating forms from models](https://docs.djangoproject.com/en/5.0/topics/forms/modelforms/) (Django docs)
 - [Generic editing views](https://docs.djangoproject.com/en/5.0/ref/class-based-views/generic-editing/) (Django docs)
 
-{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/authentication_and_sessions", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Sessions", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
+

--- a/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
@@ -835,4 +835,4 @@ There is a lot more that can be done with forms (check out our [See also](#see_a
 - [Creating forms from models](https://docs.djangoproject.com/en/5.0/topics/forms/modelforms/) (Django docs)
 - [Generic editing views](https://docs.djangoproject.com/en/5.0/ref/class-based-views/generic-editing/) (Django docs)
 
-{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Sessions", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Authentication", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}

--- a/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
@@ -835,4 +835,3 @@ There is a lot more that can be done with forms (check out our [See also](#see_a
 - [Generic editing views](https://docs.djangoproject.com/en/5.0/ref/class-based-views/generic-editing/) (Django docs)
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Sessions", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
-


### PR DESCRIPTION
### Description

Fixes `PreviousMenuNext` parameter on Django Forms page.

### Motivation

Resolve a Rari issue that was propagated to other locales.

### Additional details

The top/bottom invocations were out of sync, with
the bottom one pointing to a non-existing page.


### Related issues and pull requests


Part of https://github.com/mdn/fred/issues/1462.