### PR TITLE
Add missing commas between domxref params

### DIFF
--- a/files/en-us/web/api/preferenceobject/clearoverride/index.md
+++ b/files/en-us/web/api/preferenceobject/clearoverride/index.md
@@ -11,7 +11,7 @@ spec-urls: https://drafts.csswg.org/mediaqueries-5/#clear-override-method
 
 {{APIRef("User Preferences API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`clearOverride`** method of the {{domxref("PreferenceObject")}} interface resets the {{domxref("PreferenceObject.override" "override")}} value.
+The **`clearOverride`** method of the {{domxref("PreferenceObject")}} interface resets the {{domxref("PreferenceObject.override", "override")}} value.
 
 ## Syntax
 
@@ -31,7 +31,7 @@ None ({{jsxref("undefined")}}).
 
 ### Basic usage
 
-The following example clears the override of the {{domxref("PreferenceObject.colorScheme" "color scheme")}}.
+The following example clears the override of the {{domxref("PreferenceObject.colorScheme", "color scheme")}}.
 
 ```js
 navigator.preferences.colorScheme.clearOverride();

--- a/files/en-us/web/api/preferenceobject/index.md
+++ b/files/en-us/web/api/preferenceobject/index.md
@@ -30,9 +30,9 @@ The `PreferenceManager` interface inherits from {{domxref("EventTarget")}}.
 ## Instance methods
 
 - {{domxref("PreferenceObject.clearOverride()")}} {{Experimental_Inline}}
-  - : Resets any previously set override to `null` and fires the {{domxref("PreferenceObject.change_event" "change")}} event.
+  - : Resets any previously set override to `null` and fires the {{domxref("PreferenceObject.change_event", "change")}} event.
 - {{domxref("PreferenceObject.requestOverride()")}} {{Experimental_Inline}}
-  - : Requests an override of the preference and fires the {{domxref("PreferenceObject.change_event" "change")}} event on success.
+  - : Requests an override of the preference and fires the {{domxref("PreferenceObject.change_event", "change")}} event on success.
 
 ## Events
 

--- a/files/en-us/web/api/preferenceobject/requestoverride/index.md
+++ b/files/en-us/web/api/preferenceobject/requestoverride/index.md
@@ -11,7 +11,7 @@ spec-urls: https://drafts.csswg.org/mediaqueries-5/#request-override-method
 
 {{APIRef("User Preferences API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-The **`requestOverride`** method of the {{domxref("PreferenceObject")}} interface sets an {{domxref("PreferenceObject.override" "override")}} value for a particular preference.
+The **`requestOverride`** method of the {{domxref("PreferenceObject")}} interface sets an {{domxref("PreferenceObject.override", "override")}} value for a particular preference.
 
 ## Syntax
 
@@ -37,7 +37,7 @@ A {{jsxref("Promise")}} which resolves to {{jsxref("undefined")}} on success, or
 
 ### Basic usage
 
-The following example requests an override of the {{domxref("PreferenceObject.colorScheme" "colorScheme")}}.
+The following example requests an override of the {{domxref("PreferenceObject.colorScheme", "colorScheme")}}.
 
 ```js
 await navigator.preferences.colorScheme.requestOverride("dark");


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Add missing commas between domxref params

### Motivation

These were causing "must be provided" Rari issues.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests


Part of https://github.com/mdn/fred/issues/1462.