### PR TITLE
Remove `{{HTTPMethod("TRACK")}}`

### DIFF
--- a/files/en-us/glossary/forbidden_request_header/index.md
+++ b/files/en-us/glossary/forbidden_request_header/index.md
@@ -43,7 +43,7 @@ Forbidden headers are one of the following:
 - {{HTTPHeader("Transfer-Encoding")}}
 - {{HTTPHeader("Upgrade")}}
 - {{HTTPHeader("Via")}}
-- `X-HTTP-Method`, but only when it contains a forbidden method name ({{HTTPMethod("CONNECT")}}, {{HTTPMethod("TRACE")}}, {{HTTPMethod("TRACK")}})
+- `X-HTTP-Method`, but only when it contains a forbidden method name ({{HTTPMethod("CONNECT")}}, {{HTTPMethod("TRACE")}}, `TRACK`)
 - `X-HTTP-Method-Override`, but only when it contains a forbidden method name
 - `X-Method-Override`, but only when it contains a forbidden method name
 


### PR DESCRIPTION
### Description

Remove `{{HTTPMethod("TRACK")}}`.

### Motivation

The `TRACK` HTTP method page no longer exists, so it causes a Rari issue ("flaw").

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.