### PR TITLE
RTCError and RTCErrorEvent docs

### DIFF
--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -72,6 +72,8 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The [`options.keyboardLock`](/en-US/docs/Web/API/Element/requestFullscreen#keyboardlock) property can now be passed as an option to {{domxref("Element.requestFullscreen()")}}, allowing websites to request keyboard lock when the element is displayed in fullscreen mode.
   This stops the <kbd>Esc</kbd> key from causing the element to leave fullscreen (a long-press is required instead), and some formerly-reserved browser hotkeys can now be intercepted and their default action prevented.
   ([Firefox bug 2032302](https://bugzil.la/2032302)).
+- The {{domxref("CanvasRenderingContext2D.lang")}} property is now supported, allowing the rendering language of an offscreen canvas to be explicitly specified and changed after the rendering context is created.
+  ([Firefox bug 1943070](https://bugzil.la/1943070)).
 
 <!-- #### DOM -->
 

--- a/files/en-us/web/api/rtcerror/errordetail/index.md
+++ b/files/en-us/web/api/rtcerror/errordetail/index.md
@@ -8,47 +8,34 @@ browser-compat: api.RTCError.errorDetail
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCError")}} interface's read-only
-**`errorDetail`** property is a string indicating the [WebRTC](/en-US/docs/Web/API/WebRTC_API)-specific error code that occurred.
+The **`errorDetail`** read-only property of the {{domxref("RTCError")}} interface is a string indicating the [WebRTC](/en-US/docs/Web/API/WebRTC_API)-specific error code that occurred.
 
 ## Value
 
-A read-only string whose value indicates the type of WebRTC-specific error that
-occurred on an {{domxref("RTCPeerConnection")}}. The possible values are:
+A read-only string whose value indicates the type of WebRTC-specific error that occurred on an {{domxref("RTCPeerConnection")}}.
+The possible values are:
 
 - `data-channel-failure`
   - : The connection's {{domxref("RTCDataChannel")}} has failed.
 - `dtls-failure`
-  - : The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was
-    terminated with a fatal error. The error's {{domxref("DOMException.message", "message")}}
-    contains details about the nature of the error. If a fatal error is _received_,
-    the error object's {{domxref("RTCError.receivedAlert", "receivedAlert")}} property is
-    set to the value of the DTLSL alert received. If, on the other hand, a fatal error was
-    _sent_, the {{domxref("RTCError.sentAlert", "sentAlert")}} is set to the
-    alert's value.
+  - : The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was terminated with a fatal error.
+    The error's {{domxref("DOMException.message", "message")}} contains details about the nature of the error.
+    If a fatal error is _received_, the error object's {{domxref("RTCError.receivedAlert", "receivedAlert")}} property is set to the value of the DTLSL alert received.
+    If, on the other hand, a fatal error was _sent_, the {{domxref("RTCError.sentAlert", "sentAlert")}} is set to the alert's value.
 - `fingerprint-failure`
-  - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of
-    the fingerprints listed in the SDP. If the remote peer can't match the local
-    certificate against the provided fingerprints, this error doesn't occur, though this
-    situation may result instead in a `dtls-failure` error.
+  - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the SDP.
+    If the remote peer can't match the local certificate against the provided fingerprints, this error doesn't occur, though this situation may result instead in a `dtls-failure` error.
 - `hardware-encoder-error`
   - : The hardware encoder doesn't support the given configuration parameters.
 - `hardware-encoder-not-available`
-  - : The hardware encoder resources required to accomplish the requested operation aren't
-    available.
+  - : The hardware encoder resources required to accomplish the requested operation aren't available.
 - `sctp-failure`
-  - : The {{Glossary("SCTP")}} negotiation has failed, or the connection has terminated
-    with a fatal error. The SCTP cause code can be found in the `RTCError`
-    object's {{domxref("RTCError.sctpCauseCode", "sctpCauseCode")}}. SCTP error cause
-    codes 1-13 are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
+  - : The {{Glossary("SCTP")}} negotiation has failed, or the connection has terminated with a fatal error.
+    The SCTP cause code can be found in the `RTCError` object's {{domxref("RTCError.sctpCauseCode", "sctpCauseCode")}}.
+    SCTP error cause codes 1-13 are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
 - `sdp-syntax-error`
-  - : The SDP syntax is invalid. The error's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}}
-    property indicates the line number within the SDP at which the
-    error was detected.
-
-## Examples
-
-tbd
+  - : The SDP syntax is invalid.
+    The error's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} property indicates the line number within the SDP at which the error was detected.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerror/errordetail/index.md
+++ b/files/en-us/web/api/rtcerror/errordetail/index.md
@@ -20,10 +20,10 @@ The possible values are:
 - `dtls-failure`
   - : The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was terminated with a fatal error.
     The error's {{domxref("DOMException.message", "message")}} contains details about the nature of the error.
-    If a fatal error is _received_, the error object's {{domxref("RTCError.receivedAlert", "receivedAlert")}} property is set to the value of the DTLSL alert received.
-    If, on the other hand, a fatal error was _sent_, the {{domxref("RTCError.sentAlert", "sentAlert")}} is set to the alert's value.
+    If a fatal error is _received_, the error object's {{domxref("RTCError.receivedAlert", "receivedAlert")}} property is set to the value of the DTLS alert received.
+    If, on the other hand, a fatal error was _sent_, the {{domxref("RTCError.sentAlert", "sentAlert")}} property is set to the alert's value.
 - `fingerprint-failure`
-  - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the SDP.
+  - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the {{Glossary("SDP")}}.
     If the remote peer can't match the local certificate against the provided fingerprints, this error doesn't occur, though this situation may result instead in a `dtls-failure` error.
 - `hardware-encoder-error`
   - : The hardware encoder doesn't support the given configuration parameters.
@@ -31,11 +31,11 @@ The possible values are:
   - : The hardware encoder resources required to accomplish the requested operation aren't available.
 - `sctp-failure`
   - : The {{Glossary("SCTP")}} negotiation has failed, or the connection has terminated with a fatal error.
-    The SCTP cause code can be found in the `RTCError` object's {{domxref("RTCError.sctpCauseCode", "sctpCauseCode")}}.
+    The SCTP cause code can be found in the `RTCError` object's {{domxref("RTCError.sctpCauseCode", "sctpCauseCode")}} property.
     SCTP error cause codes 1-13 are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
 - `sdp-syntax-error`
   - : The SDP syntax is invalid.
-    The error's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} property indicates the line number within the SDP at which the error was detected.
+    The error's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} property indicates the SDP message line number where the error was detected.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/index.md
@@ -15,16 +15,16 @@ It's based upon the standard {{domxref("DOMException")}} interface that describe
 ## Constructor
 
 - {{domxref("RTCError.RTCError", "RTCError()")}}
-  - : Creates and returns a new `RTCError` object initialized with the different parameters and, optionally, a string to use as the value of the error's {{domxref("DOMException.message", "message")}} property.
+  - : Creates and returns a new `RTCError` object instance.
 
 ## Instance properties
 
-_Also inherits properties from its parent interface, {{DOMxRef("DOMException")}}_
+_Also inherits properties from its parent interface, {{DOMxRef("DOMException")}}._
 
 - {{domxref("RTCError.errorDetail", "errorDetail")}} {{ReadOnlyInline}}
   - : A string specifying the WebRTC-specific error code identifying the type of error that occurred.
 - {{domxref("RTCError.receivedAlert", "receivedAlert")}} {{ReadOnlyInline}}
-  - : A positive integer value indicating the fatal {{Glossary("DTLS")}} error which was received from the network.
+  - : A positive integer value indicating the fatal {{Glossary("DTLS")}} error received from the network.
     Only valid if the `errorDetail` string is `dtls-failure`.
     If `null`, no DTLS error was received.
 - {{domxref("RTCError.sctpCauseCode", "sctpCauseCode")}} {{ReadOnlyInline}}
@@ -65,7 +65,7 @@ dataChannel.addEventListener("error", (event) => {
 });
 ```
 
-If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail", "errorDetail")}} property being `sdp-syntax-error`—, a message string is constructed to present the error message and the line number within the SDP at which the error occurred.
+If the error is an SDP syntax error—as indicated by the {{domxref("RTCError.errorDetail", "errorDetail")}} property being set to `sdp-syntax-error`— a message string is constructed to present the error message and line number within the SDP message where the error occurred.
 This message is then displayed using a function called `showMyAlertMessage()`, which stands in for whatever output mechanism this code might use.
 
 Any other error is treated as terminal, causing a `terminateMyConnection()` function to be called.

--- a/files/en-us/web/api/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/index.md
@@ -19,7 +19,7 @@ It's based upon the standard {{domxref("DOMException")}} interface that describe
 
 ## Instance properties
 
-_Also inherits properties from its parent interface, {{DOMxRef("DOMException")}}._
+_Also inherits properties from its parent interface, {{domxref("DOMException")}}._
 
 - {{domxref("RTCError.errorDetail", "errorDetail")}} {{ReadOnlyInline}}
   - : A string specifying the WebRTC-specific error code identifying the type of error that occurred.

--- a/files/en-us/web/api/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/index.md
@@ -7,7 +7,8 @@ browser-compat: api.RTCError
 
 {{APIRef("WebRTC")}}
 
-The **`RTCError`** interface describes an error which has occurred while handling [WebRTC](/en-US/docs/Web/API/WebRTC_API) operations. It's based upon the standard {{domxref("DOMException")}} interface that describes general DOM errors.
+The **`RTCError`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error which has occurred while handling RTC operations.
+It's based upon the standard {{domxref("DOMException")}} interface that describes general DOM errors.
 
 {{InheritanceDiagram}}
 
@@ -18,26 +19,35 @@ The **`RTCError`** interface describes an error which has occurred while handlin
 
 ## Instance properties
 
-_In addition to the properties defined by the parent interface, {{domxref("DOMException")}}, `RTCError` includes the following properties:_
+_Also inherits properties from its parent interface, {{DOMxRef("DOMException")}}_
 
 - {{domxref("RTCError.errorDetail", "errorDetail")}} {{ReadOnlyInline}}
   - : A string specifying the WebRTC-specific error code identifying the type of error that occurred.
 - {{domxref("RTCError.receivedAlert", "receivedAlert")}} {{ReadOnlyInline}}
-  - : An unsigned long integer value indicating the fatal {{Glossary("DTLS")}} error which was received from the network. Only valid if the `errorDetail` string is `dtls-failure`. If `null`, no DTLS error was received.
+  - : A positive integer value indicating the fatal {{Glossary("DTLS")}} error which was received from the network.
+    Only valid if the `errorDetail` string is `dtls-failure`.
+    If `null`, no DTLS error was received.
 - {{domxref("RTCError.sctpCauseCode", "sctpCauseCode")}} {{ReadOnlyInline}}
-  - : If `errorDetail` is `sctp-failure`, this property is a long integer specifying the {{Glossary("SCTP")}} cause code indicating the cause of the failed SCTP negotiation. `null` if the error isn't an SCTP error.
+  - : An integer specifying the {{Glossary("SCTP")}} cause code indicating the cause of the failed SCTP negotiation.
+    Set if `errorDetail` is `sctp-failure`.
+    `null` if the error isn't an SCTP error.
 - {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} {{ReadOnlyInline}}
-  - : If `errorDetail` is `sdp-syntax-error`, this property is a long integer identifying the line number of the {{Glossary("SDP")}} on which the syntax error occurred. `null` if the error isn't an SDP syntax error.
+  - : An integer identifying the line number of the {{Glossary("SDP")}} on which the syntax error occurred.
+    Set if `errorDetail` is `sdp-syntax-error`.
+    `null` if the error isn't an SDP syntax error.
 - {{domxref("RTCError.sentAlert", "sentAlert")}} {{ReadOnlyInline}}
-  - : If `errorDetail` is `dtls-failure`, this property is an unsigned long integer indicating the fatal DTLS error that was sent out by this device. If `null`, no DTLS error was transmitted.
+  - : A positive integer indicating the fatal DTLS error that was sent out by this device.
+    Set if `errorDetail` is `dtls-failure`.
+    If `null`, no DTLS error was transmitted.
 
 > [!NOTE]
 > All `RTCError` objects have their {{domxref("DOMException.name", "name")}} set to `OperationError`.
 
 ## Examples
 
-In this example, a handler is established for an {{domxref("RTCDataChannel")}}'s
-{{domxref("RTCDataChannel.error_event", "error")}} event.
+### Basic usage
+
+In this example, a handler is established for an {{domxref("RTCDataChannel")}}'s {{domxref("RTCDataChannel.error_event", "error")}} event.
 
 ```js
 dataChannel.addEventListener("error", (event) => {
@@ -55,19 +65,13 @@ dataChannel.addEventListener("error", (event) => {
 });
 ```
 
-If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail", "errorDetail")}}
-property being `sdp-syntax-error`—, a message string is
-constructed to present the error message and the line number within the SDP at which the
-error occurred. This message is then displayed using a function called
-`showMyAlertMessage()`, which stands in for whatever output mechanism this
-code might use.
+If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail", "errorDetail")}} property being `sdp-syntax-error`—, a message string is constructed to present the error message and the line number within the SDP at which the error occurred.
+This message is then displayed using a function called `showMyAlertMessage()`, which stands in for whatever output mechanism this code might use.
 
-Any other error is treated as terminal, causing a `terminateMyConnection()`
-function to be called.
+Any other error is treated as terminal, causing a `terminateMyConnection()` function to be called.
 
-The above example uses {{domxref("EventTarget.addEventListener", "addEventListener()")}}
-to add the handler for `error` events. You can also use the `RTCDataChannel` object's
-{{domxref("RTCDataChannel.error_event", "onerror")}} event handler property, like this:
+The above example uses {{domxref("EventTarget.addEventListener", "addEventListener()")}} to add the handler for `error` events.
+You can also use the `RTCDataChannel` object's {{domxref("RTCDataChannel.error_event", "onerror")}} event handler property, like this:
 
 ```js
 dataChannel.onerror = (event) => {

--- a/files/en-us/web/api/rtcerror/receivedalert/index.md
+++ b/files/en-us/web/api/rtcerror/receivedalert/index.md
@@ -8,19 +8,14 @@ browser-compat: api.RTCError.receivedAlert
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCError")}} read-only property
-**`receivedAlert`** specifies the fatal {{Glossary("DTLS")}}
-error which resulted in an alert being received from the remote peer.
+The **`receivedAlert`** read-only property of the {{domxref("RTCError")}} interface specifies the fatal {{Glossary("DTLS")}} error which resulted in an alert being received from the remote peer.
 
 ## Value
 
-An unsigned long integer value specifying the fatal {{Glossary("DTLS")}} error which
-resulted in an alert being received from the remote peer.
+A positive integer value specifying the fatal {{Glossary("DTLS")}} error which resulted in an alert being received from the remote peer.
 
 > [!NOTE]
-> This property is `null` if the `RTCError` doesn't represent a
-> DTLS error (with {{domxref("RTCError.errorDetail", "errorDetail")}} set to
-> `dtls-failure`).
+> This property is `null` if the `RTCError` doesn't represent a DTLS error (with {{domxref("RTCError.errorDetail", "errorDetail")}} set to `dtls-failure`).
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerror/receivedalert/index.md
+++ b/files/en-us/web/api/rtcerror/receivedalert/index.md
@@ -12,10 +12,11 @@ The **`receivedAlert`** read-only property of the {{domxref("RTCError")}} interf
 
 ## Value
 
-A positive integer value specifying the fatal {{Glossary("DTLS")}} error which resulted in an alert being received from the remote peer.
+A positive integer value.
 
 > [!NOTE]
-> This property is `null` if the `RTCError` doesn't represent a DTLS error (with {{domxref("RTCError.errorDetail", "errorDetail")}} set to `dtls-failure`).
+> This property is `null` if the `RTCError` doesn't represent a DTLS error.
+> DTLS errors are indicated by the {{domxref("RTCError.errorDetail", "errorDetail")}} property being set to `dtls-failure`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerror/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/rtcerror/index.md
@@ -1,0 +1,84 @@
+---
+title: "RTCError: RTCError() constructor"
+short-title: RTCError()
+slug: Web/API/RTCError/RTCError
+page-type: web-api-constructor
+browser-compat: api.RTCError.RTCError
+---
+
+{{APIRef("WebRTC")}}
+
+The **`RTCError()`** constructor creates and returns a new {{domxref("RTCError")}} object initialized with the different parameters and, optionally, a string to use as the value of the error's message property.
+
+## Syntax
+
+```js-nolint
+new RTCError(options)
+new RTCError(options, message)
+```
+
+### Parameters
+
+- `options`
+  - : An object that can be provided to set the details of the specific error in an RTCErrorEvent.
+    The object has the following properties:
+    - `errorDetail`
+      - : A string specifying the WebRTC-specific error code identifying the type of error that occurred.
+        This will be one of:
+        - `data-channel-failure`
+          - : The connection's {{domxref("RTCDataChannel")}} has failed.
+        - `dtls-failure`
+          - : The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was terminated with a fatal error.
+            The error's {{domxref("DOMException.message", "message")}} contains details about the nature of the error.
+            - If a fatal error is _received_, set [`receivedAlert`](#receivedalert) to the value of the received DTLSL alert.
+            - If a fatal error was _sent_, set [`sentAlert`](#sentalert) to the alert's value.
+        - `fingerprint-failure`
+          - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the SDP.
+            If the remote peer can't match the local certificate against the provided fingerprints, this error doesn't occur, though this situation may result instead in a `dtls-failure` error.
+        - `hardware-encoder-error`
+          - : The hardware encoder doesn't support the given configuration parameters.
+        - `hardware-encoder-not-available`
+          - : The hardware encoder resources required to accomplish the requested operation aren't available.
+        - `sctp-failure`
+          - : The {{Glossary("SCTP")}} negotiation has failed, or the connection has terminated with a fatal error.
+            The SCTP cause code should be set in [`sctpCauseCode`](#sctpcausecode).
+            SCTP error cause codes 1-13 are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
+        - `sdp-syntax-error`
+          - : The SDP syntax is invalid.
+            The line number within the SDP at which the error was detected should be set in [`sdpLineNumber`](#sdplinenumber).
+
+    - `receivedAlert` {{optional_inline}}
+      - : A positive integer value indicating a fatal {{Glossary("DTLS")}} error that was received from the network.
+        Only set if the `errorDetail` string is `dtls-failure`.
+
+    - `sctpCauseCode` {{optional_inline}}
+      - : An integer specifying the {{Glossary("SCTP")}} cause code that indicates the cause of the failed SCTP negotiation.
+        This should only be set if `errorDetail` is `sctp-failure`.
+
+    - `sdpLineNumber` {{optional_inline}}
+      - : An integer identifying the line number of the {{Glossary("SDP")}} on which a syntax error occurred.
+        Only set if `errorDetail` is `sdp-syntax-error`.
+    - `sentAlert` {{optional_inline}}
+      - : A positive integer indicating s fatal DTLS error that was sent out by this device.
+        Only set is `errorDetail` is `dtls-failure`.
+
+- `message` {{optional_inline}}
+  - : A string for the error message.
+    Defaults to the empty string (`""`).
+
+### Return value
+
+A newly-created {{domxref("RTCError")}} object.
+The properties of the object are set to the values passed in the [`options`](#options) parameter, or otherwise `null`.
+
+## Usage notes
+
+This constructor does not do complete validation of the specified `candidateInfo` object or string.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcerror/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/rtcerror/index.md
@@ -30,10 +30,10 @@ new RTCError(options, message)
         - `dtls-failure`
           - : The negotiation of the {{Glossary("DTLS")}} connection failed, or the connection was terminated with a fatal error.
             The error's {{domxref("DOMException.message", "message")}} contains details about the nature of the error.
-            - If a fatal error is _received_, set [`receivedAlert`](#receivedalert) to the value of the received DTLSL alert.
+            - If a fatal error is _received_, set [`receivedAlert`](#receivedalert) to the value of the received DTLS alert.
             - If a fatal error was _sent_, set [`sentAlert`](#sentalert) to the alert's value.
         - `fingerprint-failure`
-          - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the SDP.
+          - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the {{Glossary("SDP")}} message.
             If the remote peer can't match the local certificate against the provided fingerprints, this error doesn't occur, though this situation may result instead in a `dtls-failure` error.
         - `hardware-encoder-error`
           - : The hardware encoder doesn't support the given configuration parameters.
@@ -45,7 +45,7 @@ new RTCError(options, message)
             SCTP error cause codes 1-13 are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
         - `sdp-syntax-error`
           - : The SDP syntax is invalid.
-            The line number within the SDP at which the error was detected should be set in [`sdpLineNumber`](#sdplinenumber).
+            The SDP message line number at which the error was detected should be set in [`sdpLineNumber`](#sdplinenumber).
 
     - `receivedAlert` {{optional_inline}}
       - : A positive integer value indicating a fatal {{Glossary("DTLS")}} error that was received from the network.
@@ -56,7 +56,7 @@ new RTCError(options, message)
         This should only be set if `errorDetail` is `sctp-failure`.
 
     - `sdpLineNumber` {{optional_inline}}
-      - : An integer identifying the line number of the {{Glossary("SDP")}} on which a syntax error occurred.
+      - : An integer identifying the {{Glossary("SDP")}} message line number at which a syntax error occurred.
         Only set if `errorDetail` is `sdp-syntax-error`.
     - `sentAlert` {{optional_inline}}
       - : A positive integer indicating s fatal DTLS error that was sent out by this device.
@@ -68,8 +68,7 @@ new RTCError(options, message)
 
 ### Return value
 
-A newly-created {{domxref("RTCError")}} object.
-The properties of the object are set to the values passed in the [`options`](#options) parameter, or otherwise `null`.
+A newly-created {{domxref("RTCError")}} object instance.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcerror/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/rtcerror/index.md
@@ -59,8 +59,8 @@ new RTCError(options, message)
       - : An integer identifying the {{Glossary("SDP")}} message line number at which a syntax error occurred.
         Only set if `errorDetail` is `sdp-syntax-error`.
     - `sentAlert` {{optional_inline}}
-      - : A positive integer indicating s fatal DTLS error that was sent out by this device.
-        Only set is `errorDetail` is `dtls-failure`.
+      - : A positive integer indicating a fatal DTLS error that was sent out by this device.
+        Only set if `errorDetail` is `dtls-failure`.
 
 - `message` {{optional_inline}}
   - : A string for the error message.

--- a/files/en-us/web/api/rtcerror/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/rtcerror/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCError.RTCError
 
 {{APIRef("WebRTC")}}
 
-The **`RTCError()`** constructor creates and returns a new {{domxref("RTCError")}} object initialized with the different parameters and, optionally, a string to use as the value of the error's message property.
+The **`RTCError()`** constructor creates and returns a new {{domxref("RTCError")}} object instance.
 
 ## Syntax
 
@@ -20,7 +20,7 @@ new RTCError(options, message)
 ### Parameters
 
 - `options`
-  - : An object that can be provided to set the details of the specific error in an RTCErrorEvent.
+  - : An object providing the details of the specific error in an `RTCErrorEvent`.
     The object has the following properties:
     - `errorDetail`
       - : A string specifying the WebRTC-specific error code identifying the type of error that occurred.

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.md
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.md
@@ -8,19 +8,14 @@ browser-compat: api.RTCError.sctpCauseCode
 
 {{APIRef("WebRTC")}}
 
-The read-only **`sctpCauseCode`** property in an
-{{domxref("RTCError")}} object provides the {{Glossary("SCTP")}} cause code explaining
-why the SCTP negotiation failed, if the `RTCError` represents an SCTP error.
+The **`sctpCauseCode`** read-only property of the {{domxref("RTCError")}} interface provides the {{Glossary("SCTP")}} cause code explaining why the SCTP negotiation failed, if the `RTCError` represents an SCTP error.
 
 ## Value
 
-An unsigned long integer value specifying SCTP cause code explaining why the error
-occurred. This property is `null` if the error isn't an SCTP error, with its
-{{domxref("RTCError.errorDetail", "errorDetail")}} property set to
-`sctp-failure`.
+An unsigned long integer value specifying SCTP cause code explaining why the error occurred.
+This property is `null` if the error isn't an SCTP error, with its {{domxref("RTCError.errorDetail", "errorDetail")}} property set to `sctp-failure`.
 
-The standard SCTP error cause codes, numbered 1-13, are defined in the SCTP
-specification: {{RFC(4960, "", "3.3.10")}}.
+The standard SCTP error cause codes, numbered 1-13, are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.md
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.md
@@ -12,8 +12,8 @@ The **`sctpCauseCode`** read-only property of the {{domxref("RTCError")}} interf
 
 ## Value
 
-An unsigned long integer value specifying SCTP cause code explaining why the error occurred.
-This property is `null` if the error isn't an SCTP error, with its {{domxref("RTCError.errorDetail", "errorDetail")}} property set to `sctp-failure`.
+A positive integer specifying the SCTP cause code explaining why the error occurred.
+This property is `null` if the error isn't an SCTP error, indicated by the {{domxref("RTCError.errorDetail", "errorDetail")}} property being set to `sctp-failure`.
 
 The standard SCTP error cause codes, numbered 1-13, are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
 

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.md
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.md
@@ -13,7 +13,7 @@ The **`sctpCauseCode`** read-only property of the {{domxref("RTCError")}} interf
 ## Value
 
 A positive integer specifying the SCTP cause code explaining why the error occurred.
-This property is `null` if the error isn't an SCTP error, indicated by the {{domxref("RTCError.errorDetail", "errorDetail")}} property being set to `sctp-failure`.
+This property must only be set if {{domxref("RTCError.errorDetail", "errorDetail")}} is `sctp-failure`, and is otherwise `null`.
 
 The standard SCTP error cause codes, numbered 1-13, are defined in the SCTP specification: {{RFC(4960, "", "3.3.10")}}.
 

--- a/files/en-us/web/api/rtcerror/sdplinenumber/index.md
+++ b/files/en-us/web/api/rtcerror/sdplinenumber/index.md
@@ -8,11 +8,11 @@ browser-compat: api.RTCError.sdpLineNumber
 
 {{APIRef("WebRTC")}}
 
-The **`sdpLineNumber`** read-only property of the {{domxref("RTCError")}} interface specifies the line number within the {{Glossary("SDP")}} at which a syntax error occurred while parsing it.
+The **`sdpLineNumber`** read-only property of the {{domxref("RTCError")}} interface specifies the {{Glossary("SDP")}} message line number where a syntax error occurred.
 
 ## Value
 
-An integer value indicating the line within the SDP at which the syntax error described by the `RTCError` object occurred.
+An integer value indicating the SDP message line number where the syntax error described by the `RTCError` object occurred.
 The lines are numbered starting with line 1.
 
 This property is `null` unless the value of {{domxref("RTCError.errorDetail", "errorDetail")}} is `sdp-syntax-error`.

--- a/files/en-us/web/api/rtcerror/sdplinenumber/index.md
+++ b/files/en-us/web/api/rtcerror/sdplinenumber/index.md
@@ -8,18 +8,14 @@ browser-compat: api.RTCError.sdpLineNumber
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCError")}} interface's read-only property
-**`sdpLineNumber`** specifies the line number within the
-{{Glossary("SDP")}} at which a syntax error occurred while parsing it.
+The **`sdpLineNumber`** read-only property of the {{domxref("RTCError")}} interface specifies the line number within the {{Glossary("SDP")}} at which a syntax error occurred while parsing it.
 
 ## Value
 
-An unsigned integer value indicating the line within the SDP at which the syntax error
-described by the `RTCError` object occurred. The lines are numbered starting
-with line 1.
+An integer value indicating the line within the SDP at which the syntax error described by the `RTCError` object occurred.
+The lines are numbered starting with line 1.
 
-This property is `null` unless the value of
-{{domxref("RTCError.errorDetail", "errorDetail")}} is `sdp-syntax-error`.
+This property is `null` unless the value of {{domxref("RTCError.errorDetail", "errorDetail")}} is `sdp-syntax-error`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerror/sentalert/index.md
+++ b/files/en-us/web/api/rtcerror/sentalert/index.md
@@ -8,16 +8,12 @@ browser-compat: api.RTCError.sentAlert
 
 {{APIRef("WebRTC")}}
 
-The read-only **`sentAlert`** property in an
-{{domxref("RTCError")}} object specifies the {{Glossary("DTLS")}} alert number occurred
-while sending data to the remote peer, if the error represents an outbound DTLS error.
+The **`sentAlert`** read-only property of the {{domxref("RTCError")}} interface specifies the {{Glossary("DTLS")}} alert number occurred while sending data to the remote peer, if the error represents an outbound DTLS error.
 
 ## Value
 
-An unsigned integer value providing the DTLS alert number corresponding to the DTLS
-error which was sent to the remote peer, as represented by this `RTCError`
-object. This property is `null` if {{domxref("RTCError.errorDetail", "errorDetail")}}
-isn't `dtls-failure`.
+A positive integer value providing the DTLS alert number corresponding to the DTLS error which was sent to the remote peer, as represented by this `RTCError` object.
+This property is `null` if {{domxref("RTCError.errorDetail", "errorDetail")}} isn't `dtls-failure`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerror/sentalert/index.md
+++ b/files/en-us/web/api/rtcerror/sentalert/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCError.sentAlert
 
 {{APIRef("WebRTC")}}
 
-The **`sentAlert`** read-only property of the {{domxref("RTCError")}} interface specifies the {{Glossary("DTLS")}} alert number occurred while sending data to the remote peer, if the error represents an outbound DTLS error.
+The **`sentAlert`** read-only property of the {{domxref("RTCError")}} interface specifies the {{Glossary("DTLS")}} alert number sent to the remote peer, if the error represents an outbound DTLS error.
 
 ## Value
 

--- a/files/en-us/web/api/rtcerrorevent/error/index.md
+++ b/files/en-us/web/api/rtcerrorevent/error/index.md
@@ -8,29 +8,27 @@ browser-compat: api.RTCErrorEvent.error
 
 {{APIRef("WebRTC")}}
 
-The read-only {{domxref("RTCErrorEvent")}} property **`error`**
-contains an {{domxref("RTCError")}} object describing the details of the error which the
-event is announcing.
+The **`error`** read-only property of the {{domxref("RTCErrorEvent")}} interface contains an {{domxref("RTCError")}} object that describes the {{Glossary("WebRTC")}}-specific details of the error.
 
 ## Value
 
-An {{domxref("RTCError")}} object whose properties provide details about the error
-which has occurred in the context of a {{Glossary("WebRTC")}} operation.
+An {{domxref("RTCError")}} object whose properties provide RTC-specific details about the error.
 
 ## Examples
 
-In this example, a handler is established for an {{domxref("RTCDataChannel")}}'s
-{{domxref("RTCDataChannel.error_event", "error")}} event.
+### Basic usage
+
+In this example, a handler is established for an {{domxref("RTCDataChannel")}}'s {{domxref("RTCDataChannel.error_event", "error")}} event.
 
 ```js
 dataChannel.addEventListener("error", (event) => {
   let error = event.error;
 
   if (error.errorDetail === "sdp-syntax-error") {
-    let errLine = error.sdpLineNumber;
-    let errMessage = error.message;
+    const errLine = error.sdpLineNumber;
+    const errMessage = error.message;
 
-    let alertMessage = `A syntax error occurred interpreting line ${errLine} of the SDP: ${errMessage}`;
+    const alertMessage = `A syntax error occurred interpreting line ${errLine} of the SDP: ${errMessage}`;
     showMyAlertMessage("Data Channel Error", alertMessage);
   } else {
     terminateMyConnection();
@@ -38,19 +36,13 @@ dataChannel.addEventListener("error", (event) => {
 });
 ```
 
-If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail", "errorDetail")}}
-property being `sdp-syntax-error`—, a message string is
-constructed to present the error message and the line number within the SDP at which the
-error occurred. This message is then displayed using a function called
-`showMyAlertMessage()`, which stands in for whatever output mechanism this
-code might use.
+If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail", "errorDetail")}} property being `sdp-syntax-error`— a message string is constructed to present the error message and the line number within the SDP at which the error occurred.
+This message is then displayed using a function called `showMyAlertMessage()`, which stands in for whatever output mechanism this code might use.
 
-Any other error is treated as terminal, causing a `terminateMyConnection()`
-function to be called.
+Any other error is treated as terminal, causing a `terminateMyConnection()` function to be called.
 
-The above example uses {{domxref("EventTarget.addEventListener", "addEventListener()")}}
-to add the handler for `error` events. You can also use the `RTCDataChannel` object's
-{{domxref("RTCDataChannel.error_event", "onerror")}} event handler property, like this:
+The above example uses {{domxref("EventTarget.addEventListener", "addEventListener()")}} to add the handler for `error` events.
+You can also use the `RTCDataChannel` object's {{domxref("RTCDataChannel.error_event", "onerror")}} event handler property, like this:
 
 ```js
 dataChannel.onerror = (event) => {

--- a/files/en-us/web/api/rtcerrorevent/error/index.md
+++ b/files/en-us/web/api/rtcerrorevent/error/index.md
@@ -12,7 +12,7 @@ The **`error`** read-only property of the {{domxref("RTCErrorEvent")}} interface
 
 ## Value
 
-An {{domxref("RTCError")}} object whose properties provide RTC-specific details about the error.
+An {{domxref("RTCError")}} object.
 
 ## Examples
 
@@ -36,7 +36,7 @@ dataChannel.addEventListener("error", (event) => {
 });
 ```
 
-If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail", "errorDetail")}} property being `sdp-syntax-error`— a message string is constructed to present the error message and the line number within the SDP at which the error occurred.
+If the error is an SDP syntax error—indicated by its {{domxref("RTCError.errorDetail", "errorDetail")}} property being `sdp-syntax-error`— a message string is constructed to present the error message and the SDP message line number where the error occurred.
 This message is then displayed using a function called `showMyAlertMessage()`, which stands in for whatever output mechanism this code might use.
 
 Any other error is treated as terminal, causing a `terminateMyConnection()` function to be called.

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -10,7 +10,9 @@ browser-compat: api.RTCErrorEvent
 The **`RTCErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) represents an error event sent to a WebRTC object.
 
 It inherits from the standard {{domxref("Event")}} interface, adding RTC-specific information describing the error.
-Note that WebRTC defines other error event interfaces, which are used for errors that have other special information sharing requirements.
+
+> [!NOTE]
+> WebRTC defines other error event interfaces, such as {{domxref("RTCPeerConnectionIceErrorEvent")}}, which are used for errors that have other special information sharing requirements.
 
 {{InheritanceDiagram}}
 
@@ -25,16 +27,16 @@ _Also inherits properties from its parent interface, {{domxref("Event")}}._
 
 - {{domxref("RTCErrorEvent.error", "error")}} {{ReadOnlyInline}}
   - : An {{domxref("RTCError")}} object specifying RTC-specific information about the error.
-    This includes information such as the type/cause of the error and the location that triggered the error.
+    This includes information such as the error type and cause, and the location that triggered the error.
 
 ## Instance methods
 
-_Only inherits properties from its parent interface, {{domxref("Event")}}._
+_Only inherits methods from its parent interface, {{domxref("Event")}}._
 
 ## Events
 
 - {{domxref("RTCDataChannel.error_event", "error")}}
-  - : An error that occurred on the{{domxref("RTCDataChannel")}}.
+  - : An error that occurred on the {{domxref("RTCDataChannel")}}.
 - {{domxref("RTCDtlsTransport.error_event", "error")}}
   - : An error that occurred on the {{domxref("RTCDtlsTransport")}}.
 

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -7,7 +7,10 @@ browser-compat: api.RTCErrorEvent
 
 {{APIRef("WebRTC")}}
 
-The WebRTC API's **`RTCErrorEvent`** interface represents an error sent to a WebRTC object. It's based on the standard {{domxref("Event")}} interface, but adds RTC-specific information describing the error, as shown below.
+The **`RTCErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) represents an error event sent to a WebRTC object.
+
+It inherits from the standard {{domxref("Event")}} interface, adding RTC-specific information describing the error.
+Note that WebRTC defines other error event interfaces, which are used for errors that have other special information sharing requirements.
 
 {{InheritanceDiagram}}
 
@@ -18,18 +21,22 @@ The WebRTC API's **`RTCErrorEvent`** interface represents an error sent to a Web
 
 ## Instance properties
 
-_In addition to the standard properties available on the {{domxref("Event")}} interface, `RTCErrorEvent` also includes the following:_
+_Also inherits properties from its parent interface, {{domxref("Event")}}_
 
 - {{domxref("RTCErrorEvent.error", "error")}} {{ReadOnlyInline}}
-  - : An {{domxref("RTCError")}} object specifying the error which occurred; this object includes the type of error that occurred, information about where the error occurred (such as which line number in the {{Glossary("SDP")}} or what {{Glossary("SCTP")}} cause code was at issue).
+  - : An {{domxref("RTCError")}} object specifying RTC-specific information about the error.
+    This includes information such as the type/cause of the error and the location that triggered the error.
 
 ## Instance methods
 
-_No additional methods are provided beyond any found on the parent interface, {{domxref("Event")}}._
+_Only inherits properties from its parent interface, {{domxref("Event")}}_
 
-## Description
+## Events
 
-There are other data types used for error events in WebRTC, as needed for errors with special information sharing requirements. The most common of these is probably {{domxref("RTCPeerConnectionIceErrorEvent")}}, used by the {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} event, which signals an error that has occurred while gathering ICE candidates during connection negotiation.
+- {{domxref("RTCDataChannel.error_event", "error")}}
+  - : An error that occurred on the{{domxref("RTCDataChannel")}}.
+- {{domxref("RTCDtlsTransport.error_event", "error")}}
+  - : An error that occurred on the {{domxref("RTCDtlsTransport")}}.
 
 ## Specifications
 
@@ -41,7 +48,4 @@ There are other data types used for error events in WebRTC, as needed for errors
 
 ## See also
 
-- WebRTC API
-- {{domxref("RTCError")}}
-- The `error` event occurs on the following interfaces: {{domxref("RTCDataChannel")}} and {{domxref("RTCDtlsTransport")}}
 - {{domxref("RTCPeerConnectionIceErrorEvent")}}

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -21,7 +21,7 @@ Note that WebRTC defines other error event interfaces, which are used for errors
 
 ## Instance properties
 
-_Also inherits properties from its parent interface, {{domxref("Event")}}_
+_Also inherits properties from its parent interface, {{domxref("Event")}}._
 
 - {{domxref("RTCErrorEvent.error", "error")}} {{ReadOnlyInline}}
   - : An {{domxref("RTCError")}} object specifying RTC-specific information about the error.
@@ -29,7 +29,7 @@ _Also inherits properties from its parent interface, {{domxref("Event")}}_
 
 ## Instance methods
 
-_Only inherits properties from its parent interface, {{domxref("Event")}}_
+_Only inherits properties from its parent interface, {{domxref("Event")}}._
 
 ## Events
 

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -8,8 +8,9 @@ browser-compat: api.RTCErrorEvent
 {{APIRef("WebRTC")}}
 
 The **`RTCErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) represents an error event sent to a WebRTC object.
-
 It inherits from the standard {{domxref("Event")}} interface, adding RTC-specific information describing the error.
+
+The `error` events fired at {{domxref("RTCDataChannel.error_event", "RTCDataChannel")}} and {{domxref("RTCDtlsTransport.error_event", "RTCDtlsTransport")}} are instances of this object.
 
 > [!NOTE]
 > WebRTC defines other error event interfaces, such as {{domxref("RTCPeerConnectionIceErrorEvent")}}, which are used for errors that have other special information sharing requirements.
@@ -32,13 +33,6 @@ _Also inherits properties from its parent interface, {{domxref("Event")}}._
 ## Instance methods
 
 _Only inherits methods from its parent interface, {{domxref("Event")}}._
-
-## Events
-
-- {{domxref("RTCDataChannel.error_event", "error")}}
-  - : An error that occurred on the {{domxref("RTCDataChannel")}}.
-- {{domxref("RTCDtlsTransport.error_event", "error")}}
-  - : An error that occurred on the {{domxref("RTCDtlsTransport")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
@@ -10,7 +10,7 @@ browser-compat: api.RTCErrorEvent.RTCErrorEvent
 
 The **`RTCErrorEvent()`** constructor creates a new {{domxref("RTCErrorEvent")}} object.
 
-This is called by the browser to create the RTC events.
+Note that you will not normally create an object of this type yourself.
 
 ## Syntax
 

--- a/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.RTCErrorEvent.RTCErrorEvent
 ---
 
-{{APIRef("Reporting API")}}{{AvailableInWorkers}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers}}
 
 The **`RTCErrorEvent()`** constructor creates a new {{domxref("RTCErrorEvent")}} object.
 
@@ -25,7 +25,7 @@ new RTCErrorEvent(type, options)
 - `options`
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `error`
-      - : A {{domxref("RTCError")}} describing the type (cause) and location of the error.
+      - : A {{domxref("RTCError")}} describing the cause and the location of the error.
 
 ### Return value
 

--- a/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
@@ -22,8 +22,9 @@ new RTCErrorEvent(type, options)
 
 - `type`
   - : A string with the name of the event.
+    This is usually `"error"`.
 - `options`
-  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `error`
       - : A {{domxref("RTCError")}} describing the cause and the location of the error.
 

--- a/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
@@ -1,0 +1,64 @@
+---
+title: "RTCErrorEvent: RTCErrorEvent() constructor"
+short-title: RTCErrorEvent()
+slug: Web/API/RTCErrorEvent/RTCErrorEvent
+page-type: web-api-constructor
+browser-compat: api.RTCErrorEvent.RTCErrorEvent
+---
+
+{{APIRef("Reporting API")}}{{AvailableInWorkers}}
+
+The **`RTCErrorEvent()`** constructor creates a new {{domxref("RTCErrorEvent")}} object.
+
+This is called by the browser to create the RTC events.
+
+## Syntax
+
+```js-nolint
+new RTCErrorEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+- `options`
+  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+    - `error`
+      - : A {{domxref("RTCError")}} describing the type (cause) and location of the error.
+
+### Return value
+
+A new `RTCErrorEvent` object.
+
+## Examples
+
+### Basic usage
+
+This example shows how you might create an `RTCErrorEvent` instance.
+
+```js
+// Construct an RTCError (used to initialize the event)
+const rtcError = new RTCError(
+  {
+    errorDetail: "sdp-syntax-error",
+    sdpLineNumber: 42,
+  },
+  "SDP syntax error on line 42",
+);
+
+// Construct the RTCErrorEvent, passing the RTCError
+const event = new RTCErrorEvent("error", {
+  error: rtcError, // required
+  bubbles: true, // Optional (inherited from Event)
+  cancelable: false, // Optional (inherited from Event)
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
FF150 adds support for   [`RTCErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/RTCErrorEvent) and [`RTCError`](https://developer.mozilla.org/en-US/docs/Web/API/RTCError). 

This updates the docs for those interfaces to match the current API templates, fixes weird layout, adds missing constructors.

This should all be at least as correct as it was before I started.

Related docs work can be tracked in #43970