### PR TITLE
Fix mistake and grammar in CSS `quotes` property docs

### DIFF
--- a/files/en-us/web/css/reference/properties/quotes/index.md
+++ b/files/en-us/web/css/reference/properties/quotes/index.md
@@ -228,7 +228,7 @@ In this example, instead of using the `<q>` element, we are adding quotation mar
 
 ### Text as quotes and empty quotes
 
-This example demonstrates using something other than quotation marks as the `<string>` values. The open-quote indicates the speaker and, as there is no opening quotation mark, the close-quote is the empty. (Mixing a `<string>` with an enumerated keyword to create a pair is not supported). We set `auto` for the nested quotes. These nested quotes will be book-ended by whatever the language dictates is normal for nested quotes.
+This example demonstrates using something other than quotation marks as the `<string>` values. The open-quote indicates the speaker and, as there is no opening quotation mark, the close-quote is empty. (Mixing a `<string>` with an enumerated keyword to create a pair is not supported). We set `auto` for the nested quotes. These nested quotes will be book-ended by whatever the language dictates is normal for nested quotes.
 
 #### HTML
 

--- a/files/en-us/web/css/reference/properties/quotes/index.md
+++ b/files/en-us/web/css/reference/properties/quotes/index.md
@@ -81,7 +81,7 @@ quotes: unset;
     Which pair of quotes is used depends on the depth, or nesting level, of quotes: the number of occurrences of `<q>` quotes or `open-quote` (or `no-open-quote`) in all generated text before the current occurrence, minus the number of occurrences of closing quotes, either as `</q>`, `close-quote`, or `no-close-quote`. If the depth is 0, the first pair is used, if the depth is 1, the second pair is used, etc.
 
 > [!NOTE]
-> The CSS `content` property value `open-quote` increments and `no-close-quote` decrements the quoting level, but does not insert a quotation marks.
+> The CSS `content` property value `no-open-quote` increments and `no-close-quote` decrements the quoting level, but they do not insert quotation marks.
 
 ## Formal definition
 
@@ -95,7 +95,7 @@ quotes: unset;
 
 ### Default quotes and overrides
 
-This examples compares the default quotes provided by the semantic HTML `<q>` element to those we define using the CSS `quotes` property.
+This example compares the default quotes provided by the semantic HTML `<q>` element to those we define using the CSS `quotes` property.
 
 The default value of `quotes` is [`auto`](#auto). In this example, the first list item has `quotes: auto` set, so gets the default quotes for the language specified; the same as if no `quotes` property was set. The second list item defines which quotation marks to use for quotes and nested quotes; these quotation marks will be used for descendants of an element with `specialQuotes` class regardless of the language (like any [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute values set).
 
@@ -228,7 +228,7 @@ In this example, instead of using the `<q>` element, we are adding quotation mar
 
 ### Text as quotes and empty quotes
 
-This example demonstrates using something other than quotation marks as the `<string>` values. The open-quote indicates the speaker and, as there is not opening quotation mark, the close-quote is the empty. (Mixing a `<string>` with an enumerated keyword to create a pair is not supported). We set `auto` for the nested quotes. These nested quotes will be book-ended by whatever the language dictates is normal for nested quotes.
+This example demonstrates using something other than quotation marks as the `<string>` values. The open-quote indicates the speaker and, as there is no opening quotation mark, the close-quote is the empty. (Mixing a `<string>` with an enumerated keyword to create a pair is not supported). We set `auto` for the nested quotes. These nested quotes will be book-ended by whatever the language dictates is normal for nested quotes.
 
 #### HTML
 


### PR DESCRIPTION
### Description

I fixed the property value mentioned in a note in the docs for the `quotes` CSS property, as well as several grammatical mistakes.

### Motivation

The mention of  the `open-quote` property value rather than `no-open-quote` is, to the best of my understanding, wrong. Apart from that, grammatical mistakes detract from the reading experience and may create unneeded confusion.

### Additional details

None.

### Related issues and pull requests

None.
