### PR TITLE
docs(wasm): add document Memory address option

### DIFF
--- a/files/en-us/webassembly/reference/javascript_interface/memory/grow/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/memory/grow/index.md
@@ -18,10 +18,12 @@ grow(delta)
 
 - `delta`
   - : The number of WebAssembly pages you want to grow the memory by (each one is 64KiB in size).
+    For memories with an address type of `"i64"`, this must be a {{jsxref("BigInt")}} value.
 
 ### Return value
 
 The previous size of the memory, in units of WebAssembly pages.
+For memories with an address type of `"i64"`, this is returned as a {{jsxref("BigInt")}} value.
 
 ### Exceptions
 
@@ -50,6 +52,20 @@ console.log(memory.buffer.byteLength / bytesPerPage); // "2"
 ```
 
 Note the return value of `grow()` here is the previous number of WebAssembly pages.
+
+### Growing a 64-bit memory
+
+For memories with an address type of `"i64"`, pass a {{jsxref("BigInt")}} value to `grow()`:
+
+```js
+const memory = new WebAssembly.Memory({
+  address: "i64",
+  initial: 1n,
+  maximum: 10n,
+});
+
+console.log(memory.grow(1n)); // 1n
+```
 
 ### Detachment upon growing
 

--- a/files/en-us/webassembly/reference/javascript_interface/memory/grow/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/memory/grow/index.md
@@ -23,7 +23,7 @@ grow(delta)
 ### Return value
 
 The previous size of the memory, in units of WebAssembly pages.
-For memories with an address type of `"i64"`, this is returned as a {{jsxref("BigInt")}} value.
+For memories with an address type of `"i64"`, this is a {{jsxref("BigInt")}} value.
 
 ### Exceptions
 

--- a/files/en-us/webassembly/reference/javascript_interface/memory/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/memory/index.md
@@ -48,6 +48,17 @@ const memory = new WebAssembly.Memory({
 });
 ```
 
+The following snippet creates a new WebAssembly Memory instance with a 64-bit address type.
+The size values are {{jsxref("BigInt")}} values:
+
+```js
+const memory = new WebAssembly.Memory({
+  address: "i64",
+  initial: 1n,
+  maximum: 10n,
+});
+```
+
 The following example (see [memory.html](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/memory.html) on GitHub, and [view it live also](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)) fetches and instantiates the loaded "memory.wasm" bytecode using the [`WebAssembly.instantiateStreaming()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static) function, while importing the memory created in the line above. It then stores some values in that memory, exports a function, and uses the exported function to sum those values. Note the use of {{jsxref("DataView")}} to access the memory so we always use little-endian format.
 
 ```js

--- a/files/en-us/webassembly/reference/javascript_interface/memory/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/memory/index.md
@@ -48,17 +48,6 @@ const memory = new WebAssembly.Memory({
 });
 ```
 
-The following snippet creates a new WebAssembly Memory instance with a 64-bit address type.
-The size values are {{jsxref("BigInt")}} values:
-
-```js
-const memory = new WebAssembly.Memory({
-  address: "i64",
-  initial: 1n,
-  maximum: 10n,
-});
-```
-
 The following example (see [memory.html](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/memory.html) on GitHub, and [view it live also](https://mdn.github.io/webassembly-examples/js-api-examples/memory.html)) fetches and instantiates the loaded "memory.wasm" bytecode using the [`WebAssembly.instantiateStreaming()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/instantiateStreaming_static) function, while importing the memory created in the line above. It then stores some values in that memory, exports a function, and uses the exported function to sum those values. Note the use of {{jsxref("DataView")}} to access the memory so we always use little-endian format.
 
 ```js
@@ -101,6 +90,19 @@ const memory = new WebAssembly.Memory({
 ```
 
 This memory's `buffer` property will return a {{jsxref("SharedArrayBuffer")}}.
+
+### Using a 64-bit address
+
+The following snippet creates a new WebAssembly Memory instance with a 64-bit address type.
+The `initial` and `maximum` values must be {{jsxref("BigInt")}} values:
+
+```js
+const memory = new WebAssembly.Memory({
+  address: "i64",
+  initial: 1n,
+  maximum: 10n,
+});
+```
 
 ## Specifications
 

--- a/files/en-us/webassembly/reference/javascript_interface/memory/memory/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/memory/memory/index.md
@@ -30,6 +30,10 @@ new WebAssembly.Memory(memoryDescriptor)
         to the engine to reserve memory up front. However, the engine may ignore or clamp
         this reservation request. Unshared WebAssembly memories don't need to set a
         `maximum`, but shared memories do.
+    - `address` {{optional_inline}}
+      - : A string value that specifies the address type of the memory. This can be
+        `"i32"` or `"i64"`. The default is `"i32"`.
+        If `address` is `"i64"`, `initial` and `maximum`, if present, must be {{jsxref("BigInt")}} values.
     - `shared` {{optional_inline}}
       - : A boolean value that defines whether the memory is a shared memory or not. If
         set to `true`, it is a shared memory. The default is `false`.
@@ -47,7 +51,7 @@ new WebAssembly.Memory(memoryDescriptor)
 - {{jsxref("RangeError")}}
   - : Thrown if at least one of these conditions is met:
     - `maximum` is specified and is smaller than `initial`.
-    - `initial` exceeds 65,536 (2^16). 2^16 pages is 2^16 \* 64KiB = 4GiB bytes, which is the maximum range that a Wasm module can address, as Wasm currently only allows 32-bit addressing.
+    - `address` is `"i32"` or omitted, and `initial` exceeds 65,536 (2^16). 2^16 pages is 2^16 \* 64KiB = 4GiB bytes, which is the maximum range that a Wasm module can address with 32-bit addressing.
     - Allocation fails. This may occur due to attempting to allocate too much at once, or if the User Agent is otherwise out of memory.
 
 ## Examples
@@ -73,6 +77,19 @@ WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
   }
   const sum = obj.instance.exports.accumulate(0, 10);
   console.log(sum);
+});
+```
+
+### Creating a 64-bit memory
+
+To create a memory with a 64-bit address type, pass `address: "i64"`.
+The `initial` and `maximum` values must be {{jsxref("BigInt")}} values:
+
+```js
+const memory = new WebAssembly.Memory({
+  address: "i64",
+  initial: 1n,
+  maximum: 10n,
 });
 ```
 

--- a/files/en-us/webassembly/reference/javascript_interface/memory/memory/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/memory/memory/index.md
@@ -51,7 +51,7 @@ new WebAssembly.Memory(memoryDescriptor)
 - {{jsxref("RangeError")}}
   - : Thrown if at least one of these conditions is met:
     - `maximum` is specified and is smaller than `initial`.
-    - `address` is `"i32"` or omitted, and `initial` exceeds 65,536 (2^16). 2^16 pages is 2^16 \* 64KiB = 4GiB bytes, which is the maximum range that a Wasm module can address with 32-bit addressing.
+    - `address` is set to `"i32"` or omitted, and `initial` exceeds `65,536` (2^16). 2^16 pages is equivalent to 4GiB (2^16 \* 64KiB), which is the maximum range that a Wasm module can address with 32-bit addressing.
     - Allocation fails. This may occur due to attempting to allocate too much at once, or if the User Agent is otherwise out of memory.
 
 ## Examples

--- a/files/en-us/webassembly/reference/javascript_interface/memory/memory/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/memory/memory/index.md
@@ -22,6 +22,10 @@ new WebAssembly.Memory(memoryDescriptor)
 
 - `memoryDescriptor`
   - : An object that can contain the following members:
+    - `address` {{optional_inline}}
+      - : A string value that specifies the address type of the memory. This can be
+        `"i32"` or `"i64"`. The default is `"i32"`.
+        If `address` is `"i64"`, `initial` and `maximum`, if present, must be {{jsxref("BigInt")}} values.
     - `initial`
       - : The initial size of the WebAssembly Memory, in units of WebAssembly pages.
     - `maximum` {{optional_inline}}
@@ -30,10 +34,6 @@ new WebAssembly.Memory(memoryDescriptor)
         to the engine to reserve memory up front. However, the engine may ignore or clamp
         this reservation request. Unshared WebAssembly memories don't need to set a
         `maximum`, but shared memories do.
-    - `address` {{optional_inline}}
-      - : A string value that specifies the address type of the memory. This can be
-        `"i32"` or `"i64"`. The default is `"i32"`.
-        If `address` is `"i64"`, `initial` and `maximum`, if present, must be {{jsxref("BigInt")}} values.
     - `shared` {{optional_inline}}
       - : A boolean value that defines whether the memory is a shared memory or not. If
         set to `true`, it is a shared memory. The default is `false`.
@@ -80,19 +80,6 @@ WebAssembly.instantiateStreaming(fetch("memory.wasm"), {
 });
 ```
 
-### Creating a 64-bit memory
-
-To create a memory with a 64-bit address type, pass `address: "i64"`.
-The `initial` and `maximum` values must be {{jsxref("BigInt")}} values:
-
-```js
-const memory = new WebAssembly.Memory({
-  address: "i64",
-  initial: 1n,
-  maximum: 10n,
-});
-```
-
 ### Creating a shared memory
 
 By default, WebAssembly memories are unshared.
@@ -108,6 +95,19 @@ const memory = new WebAssembly.Memory({
 ```
 
 This memory's `buffer` property will return a {{jsxref("SharedArrayBuffer")}}.
+
+### Using a 64-bit address
+
+To create a memory with a 64-bit address type, pass `address: "i64"`.
+The `initial` and `maximum` values must be {{jsxref("BigInt")}} values:
+
+```js
+const memory = new WebAssembly.Memory({
+  address: "i64",
+  initial: 1n,
+  maximum: 10n,
+});
+```
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Document the `address` option for `WebAssembly.Memory()`, including the `"i32"` and `"i64"` address types. This also clarifies the BigInt requirements for `"i64"` memories and updates `Memory.prototype.grow()` to describe its BigInt behavior for `"i64"` memories.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The `address` option is currently missing from the MDN documentation for `WebAssembly.Memory()`. Adding it helps readers understand how to create Memory64 memories from JavaScript and avoid using Number values where BigInt values are required.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

This is defined in the WebAssembly JavaScript Interface:

- `AddressType` is defined as `"i32"` or `"i64"`.
- `MemoryDescriptor` includes an `address` member.
- The `Memory(descriptor)` constructor defaults `address` to `"i32"` when omitted, and converts `initial` and `maximum` using the selected address type.
- `grow(delta)` also converts `delta` using the memory's address type and returns the previous size using the same address type.

Spec references:

- https://www.w3.org/TR/wasm-js-api-2/#enumdef-addresstype
- https://www.w3.org/TR/wasm-js-api-2/#dom-memorydescriptor-address
- https://www.w3.org/TR/wasm-js-api-2/#dom-memory-memory
- https://www.w3.org/TR/wasm-js-api-2/#dom-memory-grow

### Related issues and pull requests

Fixes #43904 

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
