### PR TITLE
Fix compilation command in "Compiling an existing C module to WebAssembly" guide.

### DIFF
--- a/files/en-us/webassembly/guides/existing_c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/existing_c_to_wasm/index.md
@@ -34,6 +34,7 @@ To compile this program, you need to tell the compiler where it can find libwebp
 ```bash
 emcc -O3 -s WASM=1 -s EXPORTED_RUNTIME_METHODS='["cwrap"]' \
     -I libwebp \
+    -I libwebp/src \
     webp.c \
     libwebp/src/{dec,dsp,demux,enc,mux,utils}/*.c \
     libwebp/sharpyuv/*.c

--- a/files/en-us/webassembly/guides/existing_c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/existing_c_to_wasm/index.md
@@ -32,7 +32,7 @@ This is a good simple program to test whether you can get the source code of lib
 To compile this program, you need to tell the compiler where it can find libwebp's header files using the `-I` flag and also pass it all the C files of libwebp that it needs. A useful strategy is to just give it **all** the C files and rely on the compiler to strip out everything that is unnecessary. It seems to work brilliantly for this library:
 
 ```bash
-emcc -O3 -s WASM=1 -s EXPORTED_RUNTIME_METHODS='["cwrap"]' \
+emcc -O3 -s WASM=1 -s EXPORTED_RUNTIME_METHODS='["cwrap", "HEAP8"]' \
     -I libwebp \
     -I libwebp/src \
     webp.c \


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix the `emcc` compilation command in the `existing_c_to_wasm` example.

#### Missing include path
Specify `-I libwebp/src` as an include path.

Without this, some include files aren't found:

```shell
% emcc -O3 -s WASM=1 -s EXPORTED_RUNTIME_METHODS='["cwrap"]' \
    -I libwebp \
    webp.c \
    libwebp/src/{dec,dsp,demux,enc,mux,utils}/*.c \
    libwebp/sharpyuv/*.c
In file included from libwebp/sharpyuv/sharpyuv.c:23:
libwebp/sharpyuv/./sharpyuv_dsp.h:16:10: fatal error: 'webp/types.h' file not found
   16 | #include "webp/types.h"
      |          ^~~~~~~~~~~~~~
1 error generated.
```

The `types.h` file is located at `libwebp/src/webp/types.h`
#### `Module.HEAP8` was undefined

Export HEAP8 in compilation example.

Without this, the sample javascript fails here:

```javascript
   const image = await loadImage("./image.jpg");
   const p = api.create_buffer(image.width, image.height);
   Module.HEAP8.set(image.data, p); // <--- Fails here
```

With this error:

    TypeError: Cannot read properties of undefined (reading 'set')

I had a doubt about the fix for this one. `HEAP8` doesn't appear to be a "method", and the correction is to include it in `EXPORTED_RUNTIME_METHODS`. But this fix works 😅 


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Without these changes, it's not possible to test the example in the "Compiling an existing C module to WebAssembly" guide.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

Not sure if this google groups discussion is related: https://groups.google.com/g/emscripten-discuss/c/Qlob7yyD94U

I used NotebookLM to debug and find the fix for `HEAP8`. But other than that, I tested it by hand, and this PR has been opened by a human, not an agent ^^. My motivation is to learn about web assembly. Thanks for your time, maintainers!

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->
Didn't find any related issues or PRs.

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
