### PR TITLE
Fix typo in tech stacks acronyms description

### DIFF
--- a/files/en-us/learn_web_development/getting_started/soft_skills/workflows_and_processes/index.md
+++ b/files/en-us/learn_web_development/getting_started/soft_skills/workflows_and_processes/index.md
@@ -57,7 +57,7 @@ Your own, built around a server product such as Apache, or a service like Netlif
 ```
 
 > [!NOTE]
-> You will often see acronyms that refer to poplar tech stacks, such as [MEAN](https://www.mongodb.com/resources/languages/mean-stack) (MongoDB, Express, Angular, Node) or [LAMP](<https://en.wikipedia.org/wiki/LAMP_(software_bundle)>) (Linux, Apache, MySQL, PHP or Python).
+> You will often see acronyms that refer to popular tech stacks, such as [MEAN](https://www.mongodb.com/resources/languages/mean-stack) (MongoDB, Express, Angular, Node) or [LAMP](<https://en.wikipedia.org/wiki/LAMP_(software_bundle)>) (Linux, Apache, MySQL, PHP or Python).
 
 On MDN, we are mainly concerned with the front-end part, but even that can be broken down into lots of different pieces. Take the front-end for example:
 


### PR DESCRIPTION
### Description

Corrected a typo in the documentation page by changing “poplar” to “popular”.

### Motivation

This improves readability and prevents confusion for readers.

### Additional details

Minor documentation typo fix. No functional changes.

### Related issues and pull requests

None.
