### PR TITLE
Mention :nth-child of-syntax in :nth-of-type

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
@@ -100,7 +100,7 @@ p.fancy:nth-of-type(2n + 1) {
 {{EmbedLiveSample('Basic_example', 250, 250)}}
 
 > [!NOTE]
-> There is no way to select the nth-of-class using this selector. The selector looks at the type only when creating the list of matches. You can however apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the example above. You can use the newer [`:nth-of-child`'s `of` syntax](/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#syntax:~:text=The%20of%20%3Cselector%3E%20syntax) to achieve a "nth-of-class" behavior.
+> There is no way to select the "nth-of-class" using this selector. The `:nth-of-type` selector looks at the type only when creating the list of matches. You can however use the [`:nth-of-child` selector `of` syntax](/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#the_of_selector_syntax) to achieve a "nth-of-class" behavior. You can also apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the previous example. 
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
@@ -100,7 +100,7 @@ p.fancy:nth-of-type(2n + 1) {
 {{EmbedLiveSample('Basic_example', 250, 250)}}
 
 > [!NOTE]
-> There is no way to select the "nth-of-class" using this selector. The `:nth-of-type` selector looks at the type only when creating the list of matches. You can however use the [`:nth-of-child` selector `of` syntax](/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#the_of_selector_syntax) to achieve a "nth-of-class" behavior. You can also apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the previous example.
+> There is no way to select the "nth-of-class" using this selector. The `:nth-of-type` selector looks at the type only when creating the list of matches. You can however use the [`:nth-of-child` selector `of` syntax](/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#the_of_selector_syntax) to achieve an "nth-of-class" behavior. You can also apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the previous example.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
@@ -100,7 +100,7 @@ p.fancy:nth-of-type(2n + 1) {
 {{EmbedLiveSample('Basic_example', 250, 250)}}
 
 > [!NOTE]
-> There is no way to select the "nth-of-class" using this selector. The `:nth-of-type` selector looks at the type only when creating the list of matches. You can however use the [`:nth-of-child` selector `of` syntax](/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#the_of_selector_syntax) to achieve a "nth-of-class" behavior. You can also apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the previous example. 
+> There is no way to select the "nth-of-class" using this selector. The `:nth-of-type` selector looks at the type only when creating the list of matches. You can however use the [`:nth-of-child` selector `of` syntax](/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#the_of_selector_syntax) to achieve a "nth-of-class" behavior. You can also apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the previous example.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_nth-of-type/index.md
@@ -100,7 +100,7 @@ p.fancy:nth-of-type(2n + 1) {
 {{EmbedLiveSample('Basic_example', 250, 250)}}
 
 > [!NOTE]
-> There is no way to select the nth-of-class using this selector. The selector looks at the type only when creating the list of matches. You can however apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the example above.
+> There is no way to select the nth-of-class using this selector. The selector looks at the type only when creating the list of matches. You can however apply CSS to an element based on `:nth-of-type` location **and** a class, as shown in the example above. You can use the newer [`:nth-of-child`'s `of` syntax](/en-US/docs/Web/CSS/Reference/Selectors/:nth-child#syntax:~:text=The%20of%20%3Cselector%3E%20syntax) to achieve a "nth-of-class" behavior.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

`:nth-child`'s `of` syntax reached Baseline Widely Available some time ago, so I added it as a way to achieve a "nth-of-class" selector in the callout that specifies it's not something :nth-of-type can do.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

They might think nth-of-class is just plainly not possible, even though it *is* now !

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://web-platform-dx.github.io/web-features-explorer/features/nth-child-of/

Note: I used a text fragment link because the heading in the nth-child article seems too nested to have its own anchor

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
