### PR TITLE
RTCPeerConnectionIceErrorEvent docs

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCPeerConnection.icecandidateerror_event
 
 {{APIRef("WebRTC")}}
 
-The [WebRTC API](/en-US/docs/Web/API/WebRTC_API) event **`icecandidateerror`** is sent to an {{domxref("RTCPeerConnection")}} if an error occurs while performing ICE negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server. The event object is of type {{domxref("RTCPeerConnectionIceErrorEvent")}}, and contains information describing the error in some amount of detail.
+The **`icecandidateerror`** event is sent to an {{domxref("RTCPeerConnection")}} if an error occurs while performing ICE negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
 
 This event is not cancelable and does not bubble.
 
@@ -35,23 +35,25 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 - {{domxref("RTCPeerConnectionIceErrorEvent.address", "address")}} {{ReadOnlyInline}}
   - : A string providing the local IP address used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server being used to negotiate the connection, or `null` if the local IP address has not yet been exposed as part of a local ICE candidate.
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} {{ReadOnlyInline}}
-  - : An unsigned integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server. If no host candidate can reach the server, this property is set to the number 701, which is outside the range of valid STUN error codes. The 701 error is fired only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
+  - : A positive integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server. If no host candidate can reach the server, this property is set to the number 701, which is outside the range of valid STUN error codes. The 701 error is fired only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} {{ReadOnlyInline}}
   - : A string containing the STUN reason text returned by the STUN or TURN server. If communication with the STUN or TURN server couldn't be established at all, this string will be a browser-specific string explaining the error.
 - {{domxref("RTCPeerConnectionIceErrorEvent.port", "port")}} {{ReadOnlyInline}}
-  - : An unsigned integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`. `null` if the connection hasn't been established (that is, if `address` is `null`).
+  - : A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`. `null` if the connection hasn't been established (that is, if `address` is `null`).
 - {{domxref("RTCPeerConnectionIceErrorEvent.url", "url")}} {{ReadOnlyInline}}
   - : A string indicating the URL of the STUN or TURN server with which the error occurred.
 
 ## Description
 
-The error object's {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} property is one of the numeric STUN error codes. There is one additional, WebRTC-specific, error which lies outside the valid STUN error code range: 701. Error 701 indicates that none of the ICE candidates were able to successfully make contact with the STUN or TURN server.
+The error object's {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} property is one of the numeric STUN error codes. There is one additional WebRTC-specific error that lies outside the valid STUN error code range: 701. Error 701 indicates that none of the ICE candidates were able to successfully make contact with the STUN or TURN server.
 
 The 701 error is fired only once per server URL from the list of available STUN or TURN servers provided when creating the {{domxref("RTCPeerConnection")}}. These errors occur only when the connection's [ICE gathering state](/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState) is `gathering`.
 
-## Example
+## Examples
 
-The following example establishes a handler for `icecandidateerror`s that occur on the {{domxref("RTCPeerConnection")}} `pc`. This handler looks specifically for 701 errors that indicate that candidates couldn't reach the STUN or TURN server.
+### Basic usage
+
+The following example establishes a handler for `icecandidateerror` events that occur on the {{domxref("RTCPeerConnection")}} `pc`. This handler looks specifically for 701 errors that indicate that candidates couldn't reach the STUN or TURN server.
 
 When this happens, the server URL and the error message are passed to a function called `reportConnectFail()` to log or output the connection failure.
 
@@ -72,3 +74,7 @@ Note that if multiple STUN and/or TURN servers are provided when creating the co
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [WebRTC API](/en-US/docs/Web/API/WebRTC_API)

--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.RTCPeerConnection.icecandidateerror_event
 
 {{APIRef("WebRTC")}}
 
-The **`icecandidateerror`** event is sent to an {{domxref("RTCPeerConnection")}} if an error occurs while performing ICE negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
+The **`icecandidateerror`** event is sent to an {{domxref("RTCPeerConnection")}} if an error occurs while performing ICE negotiation through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
 
 This event is not cancelable and does not bubble.
 
@@ -35,7 +35,7 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 - {{domxref("RTCPeerConnectionIceErrorEvent.address", "address")}} {{ReadOnlyInline}}
   - : A string providing the local IP address used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server being used to negotiate the connection, or `null` if the local IP address has not yet been exposed as part of a local ICE candidate.
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} {{ReadOnlyInline}}
-  - : A positive integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server. If no host candidate can reach the server, this property is set to the number 701, which is outside the range of valid STUN error codes. The 701 error is fired only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
+  - : A positive integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server. If no host candidate can reach the server, this property is set to the number 701, which is outside the range of valid STUN error codes. This value is reported only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} {{ReadOnlyInline}}
   - : A string containing the STUN reason text returned by the STUN or TURN server. If communication with the STUN or TURN server couldn't be established at all, this string will be a browser-specific string explaining the error.
 - {{domxref("RTCPeerConnectionIceErrorEvent.port", "port")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
@@ -39,7 +39,8 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} {{ReadOnlyInline}}
   - : A string containing the STUN reason text returned by the STUN or TURN server. If communication with the STUN or TURN server couldn't be established at all, this string will be a browser-specific string explaining the error.
 - {{domxref("RTCPeerConnectionIceErrorEvent.port", "port")}} {{ReadOnlyInline}}
-  - : A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`. `null` if the connection hasn't been established (that is, if `address` is `null`).
+  - : A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in [`address`](#address).
+  This is `null` if the connection hasn't been established (that is, if `address` is `null`).
 - {{domxref("RTCPeerConnectionIceErrorEvent.url", "url")}} {{ReadOnlyInline}}
   - : A string indicating the URL of the STUN or TURN server with which the error occurred.
 

--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
@@ -40,15 +40,9 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
   - : A string containing the STUN reason text returned by the STUN or TURN server. If communication with the STUN or TURN server couldn't be established at all, this string will be a browser-specific string explaining the error.
 - {{domxref("RTCPeerConnectionIceErrorEvent.port", "port")}} {{ReadOnlyInline}}
   - : A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in [`address`](#address).
-  This is `null` if the connection hasn't been established (that is, if `address` is `null`).
+    This is `null` if the connection hasn't been established (that is, if `address` is `null`).
 - {{domxref("RTCPeerConnectionIceErrorEvent.url", "url")}} {{ReadOnlyInline}}
   - : A string indicating the URL of the STUN or TURN server with which the error occurred.
-
-## Description
-
-The error object's {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} property is one of the numeric STUN error codes. There is one additional WebRTC-specific error that lies outside the valid STUN error code range: 701. Error 701 indicates that none of the ICE candidates were able to successfully make contact with the STUN or TURN server.
-
-The 701 error is fired only once per server URL from the list of available STUN or TURN servers provided when creating the {{domxref("RTCPeerConnection")}}. These errors occur only when the connection's [ICE gathering state](/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState) is `gathering`.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
@@ -18,14 +18,14 @@ This address identifies the network interface on the local device used to attemp
 This can be useful on multi-homed systems—devices with more than one network connection—to determine which network interface is being used.
 For example, on a mobile phone, there are typically at least two network interfaces available: a cellular connection and a Wi-Fi connection.
 
-If the local IP address isn't exposed as part of a local candidate, the value of `address` is `null`.
+If the local IP address isn't exposed as part of a local ICE candidate, the value of `address` is `null`.
 
 ## Examples
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server that was being used to attempt the connection.
-It then calls a function to display the messages and the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}}.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server used to attempt the connection.
+It then calls a function to display those messages and the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
@@ -8,42 +8,32 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent.address
 
 {{APIRef("WebRTC")}}
 
-The {{domxref("RTCPeerConnectionIceErrorEvent")}} property
-**`address`** is a string which indicates the local IP address
-being used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server
-during negotiations. The error which occurred involved this address.
+The **`address`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface is a string that indicates the local IP address being used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server during negotiations.
+The error which occurred involved this address.
 
 ## Value
 
-A string which specifies the local IP address of the network
-connection to the ICE server with which negotiations were occurring when the error
-occurred. This address identifies the network interface on the local device which is
-being used to attempt to establish the connection to the remote peer.
+A string which specifies the local IP address of the network connection to the ICE server with which negotiations were occurring when the error occurred.
+This address identifies the network interface on the local device which is being used to attempt to establish the connection to the remote peer.
 
-This can be useful on multi-homed systems—devices with more than one network
-connection—to determine which network interface is being used. For example, on a mobile
-phone, there are typically at least two network interfaces available: the cellular
-connection and a Wi-Fi connection.
+This can be useful on multi-homed systems—devices with more than one network connection—to determine which network interface is being used.
+For example, on a mobile phone, there are typically at least two network interfaces available: the cellular connection and a Wi-Fi connection.
 
-If the local IP address isn't exposed as part of a local candidate, the value of
-`address` is `null`.
+If the local IP address isn't exposed as part of a local candidate, the value of `address` is `null`.
 
 ## Examples
 
-This example creates a handler for
-{{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events
-which creates human-readable messages describing the local network interface for the
-connection as well as the ICE server that was being used to try to open the connection,
-then calls a function to display those as well as the event's
-{{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property's
-contents.
+### Basic usage
+
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
+It then calls a function to display the messages as well as the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property's contents.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {
-  let networkInfo = `[Local interface: ${event.address}:${event.port}`;
-  let iceServerInfo = `[ICE server: ${event.url}`;
+  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  let iceServerInfo = `[ICE server: ${event.url}]`;
 
-  showMessage(errorText, iceServerInfo, networkInfo);
+  showMessage(event.errorText, iceServerInfo, networkInfo);
 });
 ```
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
@@ -8,16 +8,15 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent.address
 
 {{APIRef("WebRTC")}}
 
-The **`address`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface is a string that indicates the local IP address being used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server during negotiations.
-The error which occurred involved this address.
+The **`address`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface is a string that indicates the local IP address used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server when the error occurred.
 
 ## Value
 
-A string which specifies the local IP address of the network connection to the ICE server with which negotiations were occurring when the error occurred.
-This address identifies the network interface on the local device which is being used to attempt to establish the connection to the remote peer.
+A string specifying the local IP address of the network connection to the ICE server with which negotiations were occurring when the error occurred.
+This address identifies the network interface on the local device used to attempt to establish the connection to the remote peer.
 
 This can be useful on multi-homed systems—devices with more than one network connection—to determine which network interface is being used.
-For example, on a mobile phone, there are typically at least two network interfaces available: the cellular connection and a Wi-Fi connection.
+For example, on a mobile phone, there are typically at least two network interfaces available: a cellular connection and a Wi-Fi connection.
 
 If the local IP address isn't exposed as part of a local candidate, the value of `address` is `null`.
 
@@ -25,13 +24,13 @@ If the local IP address isn't exposed as part of a local candidate, the value of
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
-It then calls a function to display the messages as well as the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property's contents.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server that was being used to attempt the connection.
+It then calls a function to display the messages and the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}}.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {
-  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
-  let iceServerInfo = `[ICE server: ${event.url}]`;
+  const networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  const iceServerInfo = `[ICE server: ${event.url}]`;
 
   showMessage(event.errorText, iceServerInfo, networkInfo);
 });

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errorcode/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errorcode/index.md
@@ -1,0 +1,42 @@
+---
+title: "RTCPeerConnectionIceErrorEvent: errorCode property"
+short-title: errorCode
+slug: Web/API/RTCPeerConnectionIceErrorEvent/errorCode
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionIceErrorEvent.errorCode
+---
+
+{{APIRef("WebRTC")}}
+
+The **`errorCode`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface represents the [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the {{Glossary("STUN")}} or {{Glossary("TURN")}} server if there was an error during ICE negotiation.
+
+## Value
+
+A positive integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server.
+
+If no host candidate can reach the server, this property is set to the number 701, which is outside the range of valid STUN error codes.
+The 701 error is fired only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
+
+## Examples
+
+### Basic usage
+
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
+It then calls a function to display those messages as well as the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} property.
+
+```js
+pc.addEventListener("icecandidateerror", (event) => {
+  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  let iceServerInfo = `[ICE server: ${event.url}]`;
+
+  showMessage(event.errorCode, iceServerInfo, networkInfo);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errorcode/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errorcode/index.md
@@ -15,7 +15,7 @@ The **`errorCode`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}
 A positive integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server.
 
 If no host candidate can reach the server, this property is set to the number 701, which is outside the range of valid STUN error codes.
-The 701 error is fired only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
+This value is reported only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
 
 ## Examples
 
@@ -26,8 +26,8 @@ It then calls a function to display those messages and the value of the event's 
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {
-  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
-  let iceServerInfo = `[ICE server: ${event.url}]`;
+  const networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  const iceServerInfo = `[ICE server: ${event.url}]`;
 
   showMessage(event.errorCode, iceServerInfo, networkInfo);
 });

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errorcode/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errorcode/index.md
@@ -21,8 +21,8 @@ The 701 error is fired only once per server URL, and only while the {{domxref("R
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
-It then calls a function to display those messages as well as the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} property.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server used to attempt the connection.
+It then calls a function to display those messages and the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} property.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errortext/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errortext/index.md
@@ -10,7 +10,7 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent.errorText
 
 The **`errorText`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface represents the STUN error reason text returned by the {{Glossary("STUN")}} or {{Glossary("TURN")}} server if there was an error during ICE negotiation.
 
-If communication with the STUN or TURN server couldn't be established at all, this string will be a browser-specific string explaining the error.
+If communication with the STUN or TURN server couldn't be established at all, this will be a browser-specific string explaining the error.
 
 ## Value
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errortext/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errortext/index.md
@@ -1,0 +1,41 @@
+---
+title: "RTCPeerConnectionIceErrorEvent: errorText property"
+short-title: errorText
+slug: Web/API/RTCPeerConnectionIceErrorEvent/errorText
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionIceErrorEvent.errorText
+---
+
+{{APIRef("WebRTC")}}
+
+The **`errorText`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface represents the STUN error reason text returned by the {{Glossary("STUN")}} or {{Glossary("TURN")}} server if there was an error during ICE negotiation.
+
+If communication with the STUN or TURN server couldn't be established at all, this string will be a browser-specific string explaining the error.
+
+## Value
+
+A string returned by the STUN or TURN server, or a browser-specific string explaining why communication with the server could not be established.
+
+## Examples
+
+### Basic usage
+
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
+It then calls a function to display those messages as well as the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
+
+```js
+pc.addEventListener("icecandidateerror", (event) => {
+  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  let iceServerInfo = `[ICE server: ${event.url}]`;
+
+  showMessage(event.errorText, iceServerInfo, networkInfo);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errortext/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/errortext/index.md
@@ -20,13 +20,13 @@ A string returned by the STUN or TURN server, or a browser-specific string expla
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
-It then calls a function to display those messages as well as the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server used to attempt the connection.
+It then calls a function to display those messages and the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {
-  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
-  let iceServerInfo = `[ICE server: ${event.url}]`;
+  const networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  const iceServerInfo = `[ICE server: ${event.url}]`;
 
   showMessage(event.errorText, iceServerInfo, networkInfo);
 });

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent
 
 {{APIRef("WebRTC")}}
 
-The **`RTCPeerConnectionIceErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error that occurred while handling {{Glossary("ICE")}} negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
+The **`RTCPeerConnectionIceErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error that occurred while handling {{Glossary("ICE")}} negotiation through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
 
 It inherits from the {{domxref("Event")}} interface, adding details that are relevant to errors in ICE negotiations.
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
@@ -10,7 +10,8 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent
 The **`RTCPeerConnectionIceErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error that occurred while handling {{Glossary("ICE")}} negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
 
 It inherits from the {{domxref("Event")}} interface, adding details that are relevant to errors in ICE negotiations.
-Events of this type are sent to the {{domxref("RTCPeerConnection")}} object.
+
+The {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} event fired at {{domxref("RTCPeerConnection")}} is an instance of this object.
 
 {{InheritanceDiagram}}
 
@@ -39,11 +40,6 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 ## Instance methods
 
 _`RTCPeerConnectionIceErrorEvent` has no methods other than any provided by the parent interface, {{domxref("Event")}}._
-
-## Events
-
-- {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}}
-  - : Error event sent to the {{domxref("RTCPeerConnection")}} object if an error occurs while performing ICE negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent
 
 {{APIRef("WebRTC")}}
 
-The **`RTCPeerConnectionIceErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error that occurred while handling {{Glossary("ICE")}} negotiations.
+The **`RTCPeerConnectionIceErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error that occurred while handling {{Glossary("ICE")}} negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
 
 It inherits from the {{domxref("Event")}} interface, adding details that are relevant to errors in ICE negotiations.
 Events of this type are sent to the {{domxref("RTCPeerConnection")}} object.
@@ -31,8 +31,8 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} {{ReadOnlyInline}}
   - : A string containing the STUN reason text returned by the STUN or TURN server, or a browser-specific string explaining why communication with the server could not be established.
 - {{domxref("RTCPeerConnectionIceErrorEvent.port", "port")}} {{ReadOnlyInline}}
-  - : A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`.
-    `null` if the connection hasn't been established (that is, if `address` is `null`).
+  - : A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in [`address`](#address).
+    This is `null` if the connection hasn't been established (that is, if `address` is `null`).
 - {{domxref("RTCPeerConnectionIceErrorEvent.url", "url")}} {{ReadOnlyInline}}
   - : A string indicating the URL of the STUN or TURN server with which the error occurred.
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
@@ -7,14 +7,18 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent
 
 {{APIRef("WebRTC")}}
 
-The **`RTCPeerConnectionIceErrorEvent`** interface—based upon the {{domxref("Event")}} interface—provides details pertaining to an {{Glossary("ICE")}} error announced by sending an {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} event to the {{domxref("RTCPeerConnection")}} object.
+The **`RTCPeerConnectionIceErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error that occurred while handling {{Glossary("ICE")}} negotiations.
+
+It inherits from the {{domxref("Event")}} interface, adding details that are relevant to errors in ICE negotiations.
+Events of this type are sent to the {{domxref("RTCPeerConnection")}} object.
 
 {{InheritanceDiagram}}
 
 ## Constructor
 
 - {{domxref("RTCPeerConnectionIceErrorEvent.RTCPeerConnectionIceErrorEvent", "RTCPeerConnectionIceErrorEvent()")}}
-  - : Creates and returns a new `RTCPeerConnectionIceErrorEvent` object, with its `type` and other properties initialized as specified in the parameters. You will not normally create an object of this type yourself.
+  - : Creates and returns a new `RTCPeerConnectionIceErrorEvent` object, with its `type` and other properties initialized as specified in the parameters.
+    You will not normally create an object of this type yourself.
 
 ## Instance properties
 
@@ -23,11 +27,12 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 - {{domxref("RTCPeerConnectionIceErrorEvent.address", "address")}} {{ReadOnlyInline}}
   - : A string providing the local IP address used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server being used to negotiate the connection, or `null` if the local IP address has not yet been exposed as part of a local ICE candidate.
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorCode", "errorCode")}} {{ReadOnlyInline}}
-  - : An unsigned integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server. If no host candidate can reach the server, this property is set to the number 701, which is outside the range of valid STUN error codes. The 701 error is fired only once per server URL, and only while the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`.
+  - : A positive integer value stating the numeric [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server, or 701 if no host candidate can reach the server.
 - {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} {{ReadOnlyInline}}
-  - : A string containing the STUN reason text returned by the STUN or TURN server. If communication with the STUN or TURN server couldn't be established at all, this string will be a browser-specific string explaining the error.
+  - : A string containing the STUN reason text returned by the STUN or TURN server, or a browser-specific string explaining why communication with the server could not be established.
 - {{domxref("RTCPeerConnectionIceErrorEvent.port", "port")}} {{ReadOnlyInline}}
-  - : An unsigned integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`. `null` if the connection hasn't been established (that is, if `address` is `null`).
+  - : A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`.
+    `null` if the connection hasn't been established (that is, if `address` is `null`).
 - {{domxref("RTCPeerConnectionIceErrorEvent.url", "url")}} {{ReadOnlyInline}}
   - : A string indicating the URL of the STUN or TURN server with which the error occurred.
 
@@ -35,9 +40,14 @@ _The `RTCPeerConnectionIceErrorEvent` interface includes the properties found on
 
 _`RTCPeerConnectionIceErrorEvent` has no methods other than any provided by the parent interface, {{domxref("Event")}}._
 
+## Events
+
+- {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}}
+  - : Error event sent to the {{domxref("RTCPeerConnection")}} object if an error occurs while performing ICE negotiations through a {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
+
 ## Examples
 
-TBD
+See [Examples](/en-US/docs/Web/API/RTCPeerConnection/icecandidateerror_event#examples) in {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/port/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/port/index.md
@@ -10,7 +10,7 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent.port
 
 The **`port`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface represents the port number over which communication with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server is taking place.
 
-This is `null` if the connection hasn't yet been established ({{domxref("RTCPeerConnectionIceErrorEvent/address","address")}} is `null`).
+This is `null` if the connection hasn't been established ({{domxref("RTCPeerConnectionIceErrorEvent/address","address")}} is `null`).
 
 ## Value
 
@@ -22,7 +22,8 @@ A positive integer.
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server that was being used to try to open the connection, then calls a function to display those and the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server used to attempt the connection.
+It then calls a function to display those messages and the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/port/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/port/index.md
@@ -14,7 +14,7 @@ This is `null` if the connection hasn't yet been established ({{domxref("RTCPeer
 
 ## Value
 
-A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`.
+A positive integer.
 
 `null` if the connection hasn't been established (that is, if `address` is `null`).
 
@@ -22,12 +22,12 @@ A positive integer value giving the port number over which communication with th
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection, then calls a function to display those as well as the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server that was being used to try to open the connection, then calls a function to display those and the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {
-  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
-  let iceServerInfo = `[ICE server: ${event.url}]`;
+  const networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  const iceServerInfo = `[ICE server: ${event.url}]`;
 
   showMessage(event.errorText, iceServerInfo, networkInfo);
 });

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/port/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/port/index.md
@@ -1,0 +1,42 @@
+---
+title: "RTCPeerConnectionIceErrorEvent: port property"
+short-title: port
+slug: Web/API/RTCPeerConnectionIceErrorEvent/port
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionIceErrorEvent.port
+---
+
+{{APIRef("WebRTC")}}
+
+The **`port`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface represents the port number over which communication with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server is taking place.
+
+This is `null` if the connection hasn't yet been established ({{domxref("RTCPeerConnectionIceErrorEvent/address","address")}} is `null`).
+
+## Value
+
+A positive integer value giving the port number over which communication with the STUN or TURN server is taking place, using the IP address given in `address`.
+
+`null` if the connection hasn't been established (that is, if `address` is `null`).
+
+## Examples
+
+### Basic usage
+
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection, then calls a function to display those as well as the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
+
+```js
+pc.addEventListener("icecandidateerror", (event) => {
+  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  let iceServerInfo = `[ICE server: ${event.url}]`;
+
+  showMessage(event.errorText, iceServerInfo, networkInfo);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
@@ -1,0 +1,48 @@
+---
+title: "RTCPeerConnectionIceErrorEvent: RTCPeerConnectionIceErrorEvent() constructor"
+short-title: RTCPeerConnectionIceErrorEvent()
+slug: Web/API/RTCPeerConnectionIceErrorEvent/RTCPeerConnectionIceErrorEvent
+page-type: web-api-constructor
+browser-compat: api.RTCPeerConnectionIceErrorEvent.RTCPeerConnectionIceErrorEvent
+---
+
+{{APIRef("WebRTC")}}
+
+The **`RTCPeerConnectionIceErrorEvent()`** constructor creates a new {{domxref("RTCPeerConnectionIceErrorEvent")}} object with its `type` and other properties initialized as specified in the parameters.
+
+Note that you will not normally create an object of this type yourself.
+
+## Syntax
+
+```js-nolint
+new RTCPeerConnectionIceErrorEvent(type, options)
+```
+
+### Parameters
+
+- `type`
+  - : A string with the name of the event.
+- `options`
+  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+    - `address` {{optional_inline}}
+      - : A string indicating the local address used to communicate with the STUN or TURN server, or `null`.
+    - `errorCode`
+      - : A positive number providing the STUN error code returned by the STUN or TURN server.
+    - `errorText` {{optional_inline}}
+      - : A string providing the STUN reason text returned by the STUN or TURN server.
+    - `port` {{optional_inline}}
+      - : A positive number indicating the local port used to communicate with the STUN or TURN server, or `null`.
+    - `url` {{optional_inline}}
+      - : A string indicating the URL of the STUN or TURN server we're attempting to communicate with.
+
+### Return value
+
+A new `RTCPeerConnectionIceErrorEvent` object.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
@@ -30,7 +30,7 @@ new RTCPeerConnectionIceErrorEvent(type, options)
         This should be set to `null` if the local IP address has not yet been exposed as part of a local {{Glossary("ICE")}} candidate.
     - `errorCode`
       - : A positive number providing the [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server.
-        If no host candidate can reach the server and the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`, this can be indicated by setting this to 701.
+        If no host candidate can reach the server and the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`, this should be set to `701`.
     - `errorText` {{optional_inline}}
       - : A string providing the STUN reason text returned by the STUN or TURN server.
     - `port` {{optional_inline}}

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
@@ -22,16 +22,20 @@ new RTCPeerConnectionIceErrorEvent(type, options)
 
 - `type`
   - : A string with the name of the event.
+    This is usually `"icecandidateerror"`.
 - `options`
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `address` {{optional_inline}}
-      - : A string indicating the local address used to communicate with the STUN or TURN server, or `null`.
+      - : A string indicating the local address used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
+        This should be set to `null` if the local IP address has not yet been exposed as part of a local {{Glossary("ICE")}} candidate.
     - `errorCode`
-      - : A positive number providing the STUN error code returned by the STUN or TURN server.
+      - : A positive number providing the [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server.
+        If no host candidate can reach the server and the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`, this can be indicated by setting the the value 701.
     - `errorText` {{optional_inline}}
       - : A string providing the STUN reason text returned by the STUN or TURN server.
     - `port` {{optional_inline}}
-      - : A positive number indicating the local port used to communicate with the STUN or TURN server, or `null`.
+      - : A positive number indicating the local port used to communicate with the STUN or TURN server.
+        This should be set to `null` if the connection hasn't been established (that is, if [`address`](#address) is `null`).
     - `url` {{optional_inline}}
       - : A string indicating the URL of the STUN or TURN server we're attempting to communicate with.
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/rtcpeerconnectioniceerrorevent/index.md
@@ -24,20 +24,20 @@ new RTCPeerConnectionIceErrorEvent(type, options)
   - : A string with the name of the event.
     This is usually `"icecandidateerror"`.
 - `options`
-  - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+  - : An object that, _in addition to the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `address` {{optional_inline}}
       - : A string indicating the local address used to communicate with the {{Glossary("STUN")}} or {{Glossary("TURN")}} server.
         This should be set to `null` if the local IP address has not yet been exposed as part of a local {{Glossary("ICE")}} candidate.
     - `errorCode`
       - : A positive number providing the [STUN error code](https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml#stun-parameters-6) returned by the STUN or TURN server.
-        If no host candidate can reach the server and the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`, this can be indicated by setting the the value 701.
+        If no host candidate can reach the server and the {{domxref("RTCPeerConnection.iceGatheringState", "iceGatheringState")}} is `gathering`, this can be indicated by setting this to 701.
     - `errorText` {{optional_inline}}
       - : A string providing the STUN reason text returned by the STUN or TURN server.
     - `port` {{optional_inline}}
       - : A positive number indicating the local port used to communicate with the STUN or TURN server.
         This should be set to `null` if the connection hasn't been established (that is, if [`address`](#address) is `null`).
     - `url` {{optional_inline}}
-      - : A string indicating the URL of the STUN or TURN server we're attempting to communicate with.
+      - : A string indicating the URL of the STUN or TURN server being used.
 
 ### Return value
 

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/url/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/url/index.md
@@ -18,8 +18,8 @@ A string.
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server that was being used to try to open the connection.
-It then calls a function to display the messages and the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}}.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server used to attempt the connection.
+It then calls a function to display those messages and the value of the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/url/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/url/index.md
@@ -1,0 +1,39 @@
+---
+title: "RTCPeerConnectionIceErrorEvent: url property"
+short-title: url
+slug: Web/API/RTCPeerConnectionIceErrorEvent/url
+page-type: web-api-instance-property
+browser-compat: api.RTCPeerConnectionIceErrorEvent.url
+---
+
+{{APIRef("WebRTC")}}
+
+The **`url`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface is a string which indicates the URL of the {{Glossary("STUN")}} or {{Glossary("TURN")}} server with which the error occurred.
+
+## Value
+
+A string which indicates the URL of the ICE server with which negotiations were occurring when the error occurred.
+
+## Examples
+
+### Basic usage
+
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
+It then calls a function to display the messages as well as the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property's contents.
+
+```js
+pc.addEventListener("icecandidateerror", (event) => {
+  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  let iceServerInfo = `[ICE server: ${event.url}]`;
+
+  showMessage(event.errorText, iceServerInfo, networkInfo);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/url/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/url/index.md
@@ -8,23 +8,23 @@ browser-compat: api.RTCPeerConnectionIceErrorEvent.url
 
 {{APIRef("WebRTC")}}
 
-The **`url`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface is a string which indicates the URL of the {{Glossary("STUN")}} or {{Glossary("TURN")}} server with which the error occurred.
+The **`url`** property of the {{domxref("RTCPeerConnectionIceErrorEvent")}} interface is a string indicating the URL of the {{Glossary("STUN")}} or {{Glossary("TURN")}} server with which the error occurred.
 
 ## Value
 
-A string which indicates the URL of the ICE server with which negotiations were occurring when the error occurred.
+A string.
 
 ## Examples
 
 ### Basic usage
 
-This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events which creates human-readable messages describing the local network interface for the connection as well as the ICE server that was being used to try to open the connection.
-It then calls a function to display the messages as well as the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}} property's contents.
+This example creates a handler for {{domxref("RTCPeerConnection.icecandidateerror_event", "icecandidateerror")}} events, which creates human-readable messages describing the local network interface for the connection and the ICE server that was being used to try to open the connection.
+It then calls a function to display the messages and the event's {{domxref("RTCPeerConnectionIceErrorEvent.errorText", "errorText")}}.
 
 ```js
 pc.addEventListener("icecandidateerror", (event) => {
-  let networkInfo = `[Local interface: ${event.address}:${event.port}]`;
-  let iceServerInfo = `[ICE server: ${event.url}]`;
+  const networkInfo = `[Local interface: ${event.address}:${event.port}]`;
+  const iceServerInfo = `[ICE server: ${event.url}]`;
 
   showMessage(event.errorText, iceServerInfo, networkInfo);
 });


### PR DESCRIPTION
FF150 adds support for   [`RTCPeerConnectionIceErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnectionIceErrorEvent) and [`icecandidateerror` event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/icecandidateerror_event). 

This updates the docs for those interfaces to match the current API templates and add missing property and constructor docs.
Note that this isn't any real information over what was in the existing docs - it is primarily formatting completion.

Related docs work can be tracked in #43970