### PR TITLE
FF151 CanvasRenderingContext2D.lang - minor tidy

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/lang/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lang/index.md
@@ -35,8 +35,9 @@ When the `inherit` value is used, the language of the canvas context is inherite
 
 Due to technical limitations, the `inherit` value behaves differently for on-screen and off-screen canvases:
 
-- For on-screen canvases, the `lang` value is inherited when the associated `CanvasRenderingContext2D` object is first created; the inherited `lang` value then changes dynamically if the `lang` attribute value is updated.
-- For off-screen canvases, the `lang` value is inherited when the associated `OffscreenCanvasRenderingContext2D` object is first created, and then fixed for the lifetime of the {{domxref("OffscreenCanvas")}}. It **does not** change if the `lang` attribute value is updated. Because of this, the language of an off-screen canvas can only be changed by setting the `lang` value explicitly.
+- For on-screen canvases, the `lang` value of the context is inherited when the associated `CanvasRenderingContext2D` object is first created, and is updated dynamically if the `lang` attribute of the associated canvas is updated (either directly or by inheritance).
+- For off-screen canvases, the `lang` value is inherited when the associated `OffscreenCanvasRenderingContext2D` object is first created "as a snapshot"; subsequent updates to the `lang` attribute from which the offscreen context inherited its value do not change its `lang` attribute.
+  For this reason, the language of an off-screen canvas can only be changed by setting its `lang` value explicitly.
 
 ## Examples
 


### PR DESCRIPTION
FF151 adds support for [`CanvasRenderingContext2D.lang`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lang). 

This allows the rendering language of an offscreen canvas to be changed after the context is created. 
Without this the `lang` is inherited as a snapshot, and can't be changed. Further, since an offscreen canvas might be created without an element in the DOM the value that is inherited is likely the `lang` of the document itself, which might well not be what you want. NOte for an onscreen canvas this is not a problem since the value can be inherited from the canvas element itself.

This adds a minor update - see https://github.com/mdn/content/pull/44071#discussion_r3217185932

Related docs work can be tracked in #43865