### PR TITLE
Replace `{{domxref("Promise")}}` with `{{jsxref("Promise")}}`

### DIFF
--- a/files/en-us/web/api/speechrecognition/available_static/index.md
+++ b/files/en-us/web/api/speechrecognition/available_static/index.md
@@ -35,7 +35,7 @@ available(options)
 
 ### Return value
 
-A {{domxref("Promise")}} that resolves with an enumerated value indicating the availability of the specified languages for speech recognition.
+A {{jsxref("Promise")}} that resolves with an enumerated value indicating the availability of the specified languages for speech recognition.
 
 Possible values include:
 

--- a/files/en-us/web/api/speechrecognition/install_static/index.md
+++ b/files/en-us/web/api/speechrecognition/install_static/index.md
@@ -31,7 +31,7 @@ install(options)
 
 ### Return value
 
-A {{domxref("Promise")}} that resolves with a boolean value indicating whether the language pack was installed successfully. The conditions that result in each return value are as follows:
+A {{jsxref("Promise")}} that resolves with a boolean value indicating whether the language pack was installed successfully. The conditions that result in each return value are as follows:
 
 - `true`
   - : All installation attempts succeeded for the requested languages, or the languages were already installed.


### PR DESCRIPTION
### Description

Replace `{{domxref("Promise")}}` with `{{jsxref("Promise")}}`.

### Motivation

Resolves two flaws: `Promise` is in the JavaScript section, not the Web API section.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.