### PR TITLE
Remove `{{DOMxRef("External"}}`

### DIFF
--- a/files/en-us/web/api/html_dom_api/index.md
+++ b/files/en-us/web/api/html_dom_api/index.md
@@ -165,10 +165,6 @@ These interfaces offer access to the browser window and document that contain th
 - {{DOMxRef("Navigator")}}
 - {{DOMxRef("Window")}}
 
-#### Deprecated web app and browser integration interfaces
-
-- {{DOMxRef("External")}} {{deprecated_inline}}
-
 #### Obsolete web app and browser integration interfaces
 
 - {{DOMxRef("Plugin")}} {{deprecated_inline}}


### PR DESCRIPTION
### Description

Removes `{{DOMxRef("External"}}` and the containing section.

### Motivation

The interface is deprecated (presumably not supported by any browser?), and the page doesn't exist.

### Additional details

See: https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API#web_app_and_browser_integration_interfaces

<img width="1117" height="450" alt="image" src="https://github.com/user-attachments/assets/8b5ec474-38fe-40f2-8c21-18a9de3eab81" />

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

Triggered by https://github.com/mdn/rari/pull/672#issuecomment-4420594998.