### PR TITLE
Fix glossary macro flaws

### DIFF
--- a/files/en-us/glossary/leading/index.md
+++ b/files/en-us/glossary/leading/index.md
@@ -9,7 +9,7 @@ In typography, **leading** is an amount of space included above and below text t
 
 In CSS, typographic leading is the difference between the content height and the line-height, generally set by the {{cssxref("line-height")}} property. Leading set via `line-height` provides spacing between lines, which can be negative. The space is distributed equally above and below the text, which is referred to as **half-leading**.
 
-The area of a font above the cap baseline is referred to as the _over edge_. The area below the {{glossary("/Baseline/Typography", "alphabetic baseline")}} is referred to as the _under edge_. Likewise, the half-leading above and below a line is referred to as the _over leading_ and _under leading_, respectively.
+The area of a font above the cap baseline is referred to as the _over edge_. The area below the {{glossary("Baseline/Typography", "alphabetic baseline")}} is referred to as the _under edge_. Likewise, the half-leading above and below a line is referred to as the _over leading_ and _under leading_, respectively.
 
 The half-leading can be trimmed from the block-start edge and block-end edge of a text element's block container using the {{cssxref("text-box")}} properties.
 

--- a/files/en-us/glossary/rtp/index.md
+++ b/files/en-us/glossary/rtp/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-The **Real-time Transport Protocol** (**RTP**) is a network protocol which described how to transmit various media (audio, video) from one endpoint to another in a real-time fashion. RTP is suitable for video-streaming application, telephony over {{glossary("IP")}} like Skype and conference technologies.
+The **Real-time Transport Protocol** (**RTP**) is a network protocol which described how to transmit various media (audio, video) from one endpoint to another in a real-time fashion. RTP is suitable for video-streaming application, telephony over IP like Skype and conference technologies.
 
 The secure version of RTP, **SRTP**, is used by [WebRTC](/en-US/docs/Web/API/WebRTC_API), and uses encryption and authentication to minimize the risk of denial-of-service attacks and security breaches.
 

--- a/files/en-us/glossary/webassembly/index.md
+++ b/files/en-us/glossary/webassembly/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**WebAssembly** (abbr. _Wasm_) is an open {{Glossary("binary")}} programming format that can be run in modern web {{Glossary("Browser", "browsers")}} in order to gain performance and/or provide new features for web pages.
+**WebAssembly** (abbr. _Wasm_) is an open binary programming format that can be run in modern web {{Glossary("Browser", "browsers")}} in order to gain performance and/or provide new features for web pages.
 
 ## See also
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
@@ -25,7 +25,7 @@ Possible values:
 - `"middle"`
   - : The text baseline is the middle of the em square.
 - `"alphabetic"`
-  - : The text baseline is the normal {{glossary("/Baseline/Typography", "alphabetic baseline")}}. Default value.
+  - : The text baseline is the normal {{glossary("Baseline/Typography", "alphabetic baseline")}}. Default value.
 - `"ideographic"`
   - : The text baseline is the ideographic baseline; this is the bottom of the body of the
     characters, if the main body of characters protrudes beneath the alphabetic baseline.

--- a/files/en-us/web/api/pbkdf2params/index.md
+++ b/files/en-us/web/api/pbkdf2params/index.md
@@ -25,7 +25,7 @@ The **`Pbkdf2Params`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/We
 - `salt`
   - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}}. This should be a random or pseudo-random value of at least 16 bytes. Unlike the input key material passed into [`deriveKey()`](/en-US/docs/Web/API/SubtleCrypto/deriveKey), `salt` does not need to be kept secret.
 - `iterations`
-  - : A `Number` representing the number of times the hash function will be executed in `deriveKey()`. This determines how computationally expensive (that is, slow) the `deriveKey()` operation will be. In this context, slow is good, since it makes it more expensive for an attacker to run a {{Glossary("dictionary attack")}} against the keys. The general guidance here is to use as many iterations as possible, subject to keeping an acceptable level of performance for your application.
+  - : A `Number` representing the number of times the hash function will be executed in `deriveKey()`. This determines how computationally expensive (that is, slow) the `deriveKey()` operation will be. In this context, slow is good, since it makes it more expensive for an attacker to run a dictionary attack against the keys. The general guidance here is to use as many iterations as possible, subject to keeping an acceptable level of performance for your application.
 
 ## Examples
 

--- a/files/en-us/web/api/textmetrics/index.md
+++ b/files/en-us/web/api/textmetrics/index.md
@@ -32,7 +32,7 @@ The **`TextMetrics`** interface represents the dimensions of a piece of text in 
 - {{domxref("TextMetrics.hangingBaseline")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the hanging baseline of the line box, in CSS pixels.
 - {{domxref("TextMetrics.alphabeticBaseline")}} {{ReadOnlyInline}}
-  - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the {{glossary("/Baseline/Typography", "alphabetic baseline")}} of the line box, in CSS pixels.
+  - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the {{glossary("Baseline/Typography", "alphabetic baseline")}} of the line box, in CSS pixels.
 - {{domxref("TextMetrics.ideographicBaseline")}} {{ReadOnlyInline}}
   - : Returns the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the ideographic baseline of the line box, in CSS pixels.
 

--- a/files/en-us/web/css/guides/colors/applying_color/index.md
+++ b/files/en-us/web/css/guides/colors/applying_color/index.md
@@ -80,7 +80,7 @@ You can use the {{cssxref("border")}} shorthand property, which lets you configu
 
 ## Specifying colors as values in stylesheets
 
-Now that you know which [CSS properties let you apply color to elements](#properties_that_can_have_color), you can start adding colors to your websites. Let's look at some examples of using color within a {{Glossary("stylesheet")}}. In this example, we use several previously mentioned properties, with the concept of applying colors in CSS being the same no matter the property.
+Now that you know which [CSS properties let you apply color to elements](#properties_that_can_have_color), you can start adding colors to your websites. Let's look at some examples of using color within a {{Glossary("style sheet")}}. In this example, we use several previously mentioned properties, with the concept of applying colors in CSS being the same no matter the property.
 
 Let's look at the result first, before going on to look at the code we need to create it:
 

--- a/files/en-us/web/css/guides/easing_functions/index.md
+++ b/files/en-us/web/css/guides/easing_functions/index.md
@@ -30,7 +30,7 @@ Alternatively, you may want an animation to move forward in distinct steps, to c
 
 ### Terms and glossary definitions
 
-- {{glossary("Bézier curve")}}
+- {{glossary("Bezier curve", "Bézier curve")}}
 - {{glossary("Interpolation")}}
 
 ## Guides

--- a/files/en-us/web/css/guides/syntax/index.md
+++ b/files/en-us/web/css/guides/syntax/index.md
@@ -35,7 +35,7 @@ This module doesn't define any properties, [data types](/en-US/docs/Web/CSS/Refe
 
 - {{glossary("CSS descriptor")}}
 - {{glossary("Parse")}}
-- {{glossary("Stylesheet")}}
+- {{glossary("Style sheet")}}
 - {{glossary("Whitespace")}}
 
 ## Guides

--- a/files/en-us/web/css/guides/writing_modes/index.md
+++ b/files/en-us/web/css/guides/writing_modes/index.md
@@ -30,7 +30,7 @@ The CSS writing modes module addresses the orientations of all writing modes. Ot
 
 ### Glossary and terms
 
-- {{glossary("/Baseline/Typography", "Baseline")}}
+- {{glossary("Baseline/Typography", "Baseline")}}
 - {{Glossary("Internationalization")}}
 - {{glossary("Localization")}}
 - {{glossary("Leading")}}

--- a/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.font-variant-ligatures
 sidebar: cssref
 ---
 
-The **`font-variant-ligatures`** [CSS](/en-US/docs/Web/CSS) property controls which {{Glossary("ligature", "ligatures")}} and {{Glossary("contextual forms")}} are used in the textual content of the elements it applies to. This leads to more harmonized forms in the resulting text.
+The **`font-variant-ligatures`** [CSS](/en-US/docs/Web/CSS) property controls which {{Glossary("ligature", "ligatures")}} and contextual forms are used in the textual content of the elements it applies to. This leads to more harmonized forms in the resulting text.
 
 {{InteractiveExample("CSS Demo: font-variant-ligatures")}}
 

--- a/files/en-us/web/css/reference/properties/text-underline-position/index.md
+++ b/files/en-us/web/css/reference/properties/text-underline-position/index.md
@@ -64,7 +64,7 @@ text-underline-position: unset;
 ### Values
 
 - `auto`
-  - : The {{glossary("user agent")}} uses its own algorithm to place the line at or under the {{glossary("/Baseline/Typography", "alphabetic baseline")}}.
+  - : The {{glossary("user agent")}} uses its own algorithm to place the line at or under the {{glossary("Baseline/Typography", "alphabetic baseline")}}.
 - `from-font`
   - : If the font file includes information about a preferred position, use that value. If the font file doesn't include this information, behave as if `auto` was set, with the browser choosing an appropriate position.
 - `under`

--- a/files/en-us/web/html/reference/attributes/rel/alternate_stylesheet/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/alternate_stylesheet/index.md
@@ -12,7 +12,7 @@ The **`alternate stylesheet`** keyword pair, when used as a value for the [`rel`
 > [!NOTE]
 > This feature is not well supported in browsers without an extension. To offer alternative presentations that work with a user's existing preferences, see the CSS [media features](/en-US/docs/Web/CSS/Reference/At-rules/@media#media_features) {{cssxref("@media/prefers-color-scheme","prefers-color-scheme")}} and {{cssxref("@media/prefers-contrast","prefers-contrast")}}.
 
-Firefox lets users select alternate {{glossary("stylesheet", "stylesheets")}} using the _View > Page Style_ submenu, which displays the values of the [`title`](/en-US/docs/Web/HTML/Reference/Global_attributes/title) attributes. Other browsers require an extension to enable this functionality. The web page can also provide its own user interface to let users switch styles.
+Firefox lets users select alternate {{glossary("style sheet", "stylesheets")}} using the _View > Page Style_ submenu, which displays the values of the [`title`](/en-US/docs/Web/HTML/Reference/Global_attributes/title) attributes. Other browsers require an extension to enable this functionality. The web page can also provide its own user interface to let users switch styles.
 
 ## Examples
 

--- a/files/en-us/web/http/reference/headers/preference-applied/index.md
+++ b/files/en-us/web/http/reference/headers/preference-applied/index.md
@@ -20,7 +20,7 @@ The server indicates if a preference is applied to a response if it would otherw
       </td>
     </tr>
     <tr>
-      <th scope="row">{{Glossary("Forbidden header name")}}</th>
+      <th scope="row">{{Glossary("Forbidden request header")}}</th>
       <td>No</td>
     </tr>
     <tr>

--- a/files/en-us/web/security/authentication/federated_identity/index.md
+++ b/files/en-us/web/security/authentication/federated_identity/index.md
@@ -67,7 +67,7 @@ In the authentication request:
    - `client_id`: Identifies this RP to the IdP.
    - `response_type`: Always `"code"` if we are using the two-part flow described here, which is the recommended option.
    - `redirect_uri`: The URL in the RP, that the IdP should redirect to once it has attempted to authenticate the user. This is the URL to which the IdP will deliver the authorization code.
-   - `code_challenge`: A cryptographic {{glossary("hash")}} of a secret specific to this authorization request, which will be used by the token endpoint to ensure that the token request is really the counterpart of this authorization request.
+   - `code_challenge`: A cryptographic {{glossary("hash function", "hash")}} of a secret specific to this authorization request, which will be used by the token endpoint to ensure that the token request is really the counterpart of this authorization request.
    - `scope`: A list of strings that specify which sets of user data the RP wishes to access.
 
 3. The IdP authenticates the user. The protocol does not specify a particular method for this: the IdP could use a password, a one-time password, a biometric, or any other appropriate method.
@@ -122,7 +122,7 @@ The `code_challenge` and `code_verifier` values that the RP provides in the auth
 In the authentication request:
 
 - The RP generates a value that is hard to guess and is specific to this authentication request. This value is called the _code verifier_.
-- The RP creates a {{glossary("hash", "cryptographic hash")}} of the code verifier, and uses it as the `code_challenge` parameter in the authentication request.
+- The RP creates a {{glossary("hash function", "cryptographic hash")}} of the code verifier, and uses it as the `code_challenge` parameter in the authentication request.
 - The IdP stores the code challenge, and associates it with the authorization code that it returns to the RP.
 
 In the token request:

--- a/files/en-us/web/security/authentication/federated_identity/index.md
+++ b/files/en-us/web/security/authentication/federated_identity/index.md
@@ -222,7 +222,7 @@ The specification also includes detailed recommendations for security practices 
 Sign-out scenarios are more complex in a federated identity system than in a non-federated system, because:
 
 - The user might sign out of the RP either on the RP's site or on the IdP's site.
-- The user might choose to sign out of the RP only, or to sign out globally: that is, to sign out of all RPs that they are signed into with this IdP. This is a common requirement when we use federated identity to build a {{glossary("single sign-on", "single sign-on (SSO)")}} system, in which an employee might use a single set of corporate credentials to sign into email, a bug tracker, and a discussion forum.
+- The user might choose to sign out of the RP only, or to sign out globally: that is, to sign out of all RPs that they are signed into with this IdP. This is a common requirement when we use federated identity to build a single sign-on (SSO) system, in which an employee might use a single set of corporate credentials to sign into email, a bug tracker, and a discussion forum.
 
 Supporting these scenarios means implementing some communication mechanism between the RP and the IdP. For example:
 

--- a/files/en-us/web/security/authentication/index.md
+++ b/files/en-us/web/security/authentication/index.md
@@ -37,6 +37,6 @@ In this set of guides we'll describe the following authentication systems. Each 
 
 ## Session management
 
-After a website has authenticated a user, the website will typically want to keep this user signed in without the need to reauthenticate, either for a limited time or even indefinitely until the user signs out. Websites typically accomplish this by setting a cookie that contains a secret session identifier, or using a {{glossary("digital signature", "cryptographically signed")}} object such as a {{glossary("JWT", JSON Web Token(JWT)"")}}.
+After a website has authenticated a user, the website will typically want to keep this user signed in without the need to reauthenticate, either for a limited time or even indefinitely until the user signs out. Websites typically accomplish this by setting a cookie that contains a secret session identifier, or using a {{glossary("digital signature", "cryptographically signed")}} object such as a JSON Web Token(JWT).
 
 In our [session management](/en-US/docs/Web/Security/Authentication/Session_management) guide, we outline session management best practices.

--- a/files/en-us/web/svg/reference/attribute/alignment-baseline/index.md
+++ b/files/en-us/web/svg/reference/attribute/alignment-baseline/index.md
@@ -6,7 +6,7 @@ browser-compat: svg.global_attributes.alignment-baseline
 sidebar: svgref
 ---
 
-The **`alignment-baseline`** attribute specifies how an object is aligned with respect to its parent. This property specifies which baseline of this element is to be aligned with the corresponding baseline of the parent. For example, this allows {{glossary("/Baseline/Typography", "alphabetic baselines")}} in Roman text to stay aligned across font size changes. It defaults to the baseline with the same name as the computed value of the `alignment-baseline` property.
+The **`alignment-baseline`** attribute specifies how an object is aligned with respect to its parent. This property specifies which baseline of this element is to be aligned with the corresponding baseline of the parent. For example, this allows {{glossary("Baseline/Typography", "alphabetic baselines")}} in Roman text to stay aligned across font size changes. It defaults to the baseline with the same name as the computed value of the `alignment-baseline` property.
 
 > [!NOTE]
 > As a presentation attribute, `alignment-baseline` also has a CSS property counterpart: {{cssxref("alignment-baseline")}}. When both are specified, the CSS property takes priority.

--- a/files/en-us/web/svg/reference/attribute/glyph-orientation-vertical/index.md
+++ b/files/en-us/web/svg/reference/attribute/glyph-orientation-vertical/index.md
@@ -52,7 +52,7 @@ You can use this attribute with the following SVG elements:
 </table>
 
 - `auto`
-  - : Fullwidth {{Glossary("ideographic")}} and fullwidth Latin text will be set with a glyph orientation of 0 degrees. Ideographic punctuation and other ideographic characters having alternate horizontal and vertical forms will use the vertical form of the glyph. Text which is not fullwidth will be set with a glyph orientation of 90 degrees.
+  - : Fullwidth ideographic and fullwidth Latin text will be set with a glyph orientation of 0 degrees. Ideographic punctuation and other ideographic characters having alternate horizontal and vertical forms will use the vertical form of the glyph. Text which is not fullwidth will be set with a glyph orientation of 90 degrees.
 
     This reorientation rule applies only to the first-level non-ideographic text. All further embedding of writing modes or bidirectional processing will be based on the first-level rotation.
 

--- a/files/en-us/web/svg/reference/attribute/href/index.md
+++ b/files/en-us/web/svg/reference/attribute/href/index.md
@@ -99,7 +99,7 @@ If the `href` attribute or the deprecated {{SVGAttr("xlink:href")}} attribute is
 
 Refer to the descriptions of the individual animation elements for any restrictions on what types of elements can be targets of particular types of animations.
 
-Except for any SVG-specific rules explicitly mentioned in this specification, the normative definition for this attribute is the {{Glossary("SMIL")}} Animation specification. In particular, see [SMIL Animation: Specifying the animation target](https://www.w3.org/TR/smil-animation/#SpecifyingAnimationTarget).
+Except for any SVG-specific rules explicitly mentioned in this specification, the normative definition for this attribute is the SMIL Animation specification. In particular, see [SMIL Animation: Specifying the animation target](https://www.w3.org/TR/smil-animation/#SpecifyingAnimationTarget).
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
### Description

Fixes several Glossary macro flaws:

- Remove leading slashes.
- Fix links.
- Remove some invocations.

### Motivation

Reduce number of flaws.

### Additional details

Only remaining flaws are about `{{glossary("interface")}}`. It probably makes more sense to add a glossary page for interface, instead of removing this glossary link. -> https://github.com/mdn/content/issues/44091

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.