### PR TITLE
Fix jsxref macro flaws

### DIFF
--- a/files/en-us/web/javascript/reference/errors/constructor_cant_be_used_directly/index.md
+++ b/files/en-us/web/javascript/reference/errors/constructor_cant_be_used_directly/index.md
@@ -5,7 +5,7 @@ page-type: javascript-error
 sidebar: jssidebar
 ---
 
-The JavaScript exception "Iterator constructor can't be used directly" or "AsyncIterator constructor can't be used directly" occurs when you try to use the {{jsxref("Iterator/Iterator", "Iterator()")}} or {{jsxref("AsyncIterator/AsyncIterator", "AsyncIterator()")}} constructors directly to create instances. These constructors are _abstract classes_ and should only be inherited from.
+The JavaScript exception "Iterator constructor can't be used directly" or "AsyncIterator constructor can't be used directly" occurs when you try to use the {{jsxref("Iterator/Iterator", "Iterator()")}} or {{jsxref("AsyncIterator")}} constructors directly to create instances. These constructors are _abstract classes_ and should only be inherited from.
 
 ## Message
 

--- a/files/en-us/webassembly/reference/definitions/global/index.md
+++ b/files/en-us/webassembly/reference/definitions/global/index.md
@@ -96,7 +96,7 @@ The WebAssembly `global` definition enables globally-scoped variables to be defi
 
 ### Creating globals from JavaScript
 
-It is also possible to create a Wasm global from within the JavaScript host using the {{jsxref("WebAssembly.Global.Global", "WebAssembly.Global()")}} constructor then importing it into the module.
+It is also possible to create a Wasm global from within the JavaScript host using the [`WebAssembly.Global()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Global/Global) constructor then importing it into the module.
 
 For example:
 


### PR DESCRIPTION
### Description

Fixes two `{{jsxref}}` flaws.

### Motivation

Reduce number of flaws.

### Additional details

The `AsyncIterator()` constructor has no page (the spec doesn't mention this constructor!?), and the `WebAssembly.Global()` constructor is documented in the WebAssembly section, not the JavaScript section.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.
