### PR TITLE
Fix two typos in operators reference

### DIFF
--- a/files/en-us/web/javascript/reference/operators/addition/index.md
+++ b/files/en-us/web/javascript/reference/operators/addition/index.md
@@ -77,7 +77,7 @@ You cannot mix BigInt and number operands in addition. `null`, `undefined`, and 
 2 + 1n; // TypeError: Cannot mix BigInt and other types, use explicit conversions
 ```
 
-Strings have priority over over types, so adding a string to a BigInt produces string concatenation rather than a `TypeError`.
+Strings have priority over other types, so adding a string to a BigInt produces string concatenation rather than a `TypeError`.
 
 ```js
 "1" + 2n; // "12"

--- a/files/en-us/web/javascript/reference/operators/equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/equality/index.md
@@ -58,7 +58,7 @@ Loose equality is _symmetric_: `A == B` always has identical semantics to `B == 
 
 The most notable difference between this operator and the [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (`===`) operator is that the strict equality operator does not attempt type conversion. Instead, the strict equality operator always considers operands of different types to be different. The strict equality operator essentially carries out only step 1, and then returns `false` for all other cases.
 
-There's a "willful violation" of the above algorithm: if one of the operands is [`document.all`](/en-US/docs/Web/API/Document/all), it is treated as if it's `undefined`. This means that `document.all == null` is `true`, but `document.all === undefined && document.all === null` is `false`.
+There's a "willful violation" of the above algorithm: if one of the operands is [`document.all`](/en-US/docs/Web/API/Document/all), it is treated as if it's `undefined`. This means that `document.all == null` is `true`, but `document.all === undefined || document.all === null` is `false`.
 
 ## Examples
 


### PR DESCRIPTION
I haven't opened an issue for this because the changes seemed straightforward. Please let me know if one would be better for discussion.

### Description
Fixing what I think are two small typos for the [`==`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality) and [`+`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Addition) reference pages.

### Motivation
The phrasing change for `+` reflects my intended reading of the sentence.

For `==`, this PR makes the statement stronger, but I also believe it's what was intended. The current version:

> `document.all == null` is `true`, but `document.all === undefined && document.all === null` is `false`

doesn't make much sense to me here: it's  "obvious" that a value cannot be strictly equal to **both** `undefined` and `null`, since strict equality does not perform conversions.

Instead, I took the point of the statement to be that `document.all` is not strictly equal to **either** `undefined` nor `null` (despite being loosely equal to `null`, which, according to the algorithm sketch preceding it, means it would normally be `null` or `undefined`). I updated it to match this understanding. I didn't see anything about this in the PR that introduced the text, so I assume it was a typo.

### Additional details
N/A

### Related issues and pull requests

Relates to #18565 (original change for `==`).
Relates to #43812 (original change for `+`).

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
