### PR TITLE
Add aria-* to HTML attributes index table

### DIFF
--- a/files/en-us/web/html/guides/index.md
+++ b/files/en-us/web/html/guides/index.md
@@ -9,3 +9,7 @@ sidebar: htmlsidebar
 This page lists the guides for using HTML.
 
 {{SubPagesWithSummaries}}
+
+## See also
+
+- <a href="/en-US/docs/Web/Accessibility/ARIA/Guides">ARIA Guides</a>

--- a/files/en-us/web/html/guides/index.md
+++ b/files/en-us/web/html/guides/index.md
@@ -12,4 +12,4 @@ This page lists the guides for using HTML.
 
 ## See also
 
-- <a href="/en-US/docs/Web/Accessibility/ARIA/Guides">ARIA Guides</a>
+- [ARIA Guides](/en-US/docs/Web/Accessibility/ARIA/Guides): use Accessible Rich Internet Applications to write HTML pages that are more accessible to people with disabilities.

--- a/files/en-us/web/html/guides/index.md
+++ b/files/en-us/web/html/guides/index.md
@@ -12,4 +12,4 @@ This page lists the guides for using HTML.
 
 ## See also
 
-- [ARIA Guides](/en-US/docs/Web/Accessibility/ARIA/Guides): use Accessible Rich Internet Applications to write HTML pages that are more accessible to people with disabilities.
+- [ARIA guides](/en-US/docs/Web/Accessibility/ARIA/Guides)

--- a/files/en-us/web/html/reference/attributes/index.md
+++ b/files/en-us/web/html/reference/attributes/index.md
@@ -101,7 +101,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         All elements
       </td>
       <td>
-        Depending on the specific attribute, <a href="/en-US/docs/Web/Accessibility/ARIA/">ARIA</a> attributes modify an element's state or properties as defined in the accessibility tree.
+        Modifies an element's state or properties in the accessibility tree. Applicability depends on the specific <a href="/en-US/docs/Web/Accessibility/ARIA/">ARIA</a> attribute.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/reference/attributes/index.md
+++ b/files/en-us/web/html/reference/attributes/index.md
@@ -101,8 +101,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         Depends on the specific attribute
       </td>
       <td>
-        <p>Allow modifying an element's states and properties as defined in the accessibility tree.</p>
-        See <a href="/en-US/docs/Web/Accessibility/ARIA/Guides">ARIA Guides</a>.
+        Depending on the specific attribute, <a href="/en-US/docs/Web/Accessibility/ARIA/">ARIA</a> attributes modify an element's state or properties as defined in the accessibility tree.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/reference/attributes/index.md
+++ b/files/en-us/web/html/reference/attributes/index.md
@@ -98,7 +98,7 @@ Elements in HTML have **attributes**; these are additional values that configure
         <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes">aria-*</a></code>
       </td>
       <td>
-        Depends on the specific attribute
+        All elements
       </td>
       <td>
         Depending on the specific attribute, <a href="/en-US/docs/Web/Accessibility/ARIA/">ARIA</a> attributes modify an element's state or properties as defined in the accessibility tree.

--- a/files/en-us/web/html/reference/attributes/index.md
+++ b/files/en-us/web/html/reference/attributes/index.md
@@ -95,6 +95,18 @@ Elements in HTML have **attributes**; these are additional values that configure
     </tr>
     <tr>
       <td>
+        <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes">aria-*</a></code>
+      </td>
+      <td>
+        Depends on the specific attribute
+      </td>
+      <td>
+        <p>Allow modifying an element's states and properties as defined in the accessibility tree.</p>
+        See <a href="/en-US/docs/Web/Accessibility/ARIA/Guides">ARIA Guides</a>.
+      </td>
+    </tr>
+    <tr>
+      <td>
         <code><a href="/en-US/docs/Web/HTML/Reference/Elements/link#as">as</a></code>
       </td>
       <td>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Add a new `aria-*` row to the HTML attributes table. The attribute name link points to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes. This family of attributes is a bit of an outlier regarding the `Element` column because members don't all apply to the same set of elements, hence the phrasing "Depends on the specific attribute".

I also struggled to find a good page to link to in the description. [Understanding ARIA Basics](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Accessibility/WAI-ARIA_basics) looked good but it is a learn page and not a reference so it might not be exactly what users are looking for. In the end I went for [ARIA Guides](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides) even though it's not only related to ARIA attributes.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

ARIA attributes are HTML attributes so they need to be mentioned in the HTML attributes table.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Closes #44079 

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
