### PR TITLE
Replace another `webextapiref` link for `contextMenus`

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
@@ -21,7 +21,7 @@ You can also override the context menus displayed in extension pages, such as cu
 
 ## Specifying context menu items
 
-You manage context menu items programmatically, using the {{WebExtAPIRef("contextMenus")}} API. However, you need to request the `contextMenus` permission in your manifest.json to be able to take advantage of the API.
+You manage context menu items programmatically, using the {{WebExtAPIRef("menus")}} API. However, you need to request the `contextMenus` permission in your manifest.json to be able to take advantage of the API.
 
 ```json
 "permissions": ["contextMenus"]


### PR DESCRIPTION
### Description

Replaces a link to the `contextMenus` API, with a link to the `menus` API.

### Motivation

Resolves the only remaining `webextapiref` flaw.

### Additional details

See: https://caugner.github.io/mdn-flawless/#locale=en-US&templ=webextapiref

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

Follow-up of https://github.com/mdn/content/pull/44041.