### PR TITLE
Enhance caret-color documentation with shorthand info

### DIFF
--- a/files/en-us/web/css/reference/properties/caret-color/index.md
+++ b/files/en-us/web/css/reference/properties/caret-color/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`caret-color`** [CSS](/en-US/docs/Web/CSS) property sets the color of the **insertion caret**, sometimes referred to as the **text input cursor**. This is the visible marker appearing at the insertion point where the next character typed will be added or where the next character deleted will be removed.
 
+The `caret-color` can also be set as part of the {{cssxref("caret")}} shorthand property.
+
 {{InteractiveExample("CSS Demo: caret-color")}}
 
 ```css interactive-example-choice


### PR DESCRIPTION
Added information about caret-color being part of the shorthand property.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
