### PR TITLE
Update Firefox 151 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -85,13 +85,27 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Added support for `altitudeAngle` and `azimuthAngle` to pointer actions of subtype `touch`. These properties allow simulating touch interactions with precise angular orientation data, specifying the angle at which a pointer contacts a surface and its rotational direction. ([Firefox bug 2022644](https://bugzil.la/2022644)).
+- Fixed a bug where `UnknownError` DOM exceptions originating from content pages were incorrectly treated as internal WebDriver errors. ([Firefox bug 2032387](https://bugzil.la/2032387)).
 
-<!-- #### Marionette -->
+#### WebDriver BiDi
+
+- Implemented the `browser.setClientWindowState` command. This command allows clients to change the OS-level window state of a browser window, such as maximized, minimized, fullscreen, or normal. It also allows repositioning and resizing the window. ([Firefox bug 1855028](https://bugzil.la/1855028)).
+- Added support for worker realms (for dedicated, shared and service workers) in the `script.getRealms` command. The command now returns realm information for worker scripts in addition to window contexts. ([Firefox bug 2016097](https://bugzil.la/2016097)).
+- Included the top-most stack frame in `log.entryAdded` events for all Console API messages. ([Firefox bug 1941813](https://bugzil.la/1941813)).
+- Improved the `text` field of the `log.entryAdded` event to better align with Firefox DevTools behavior and Google Chrome WebDriver BiDi implementation. ([Firefox bug 2005054](https://bugzil.la/2005054)).
+- Fixed network event cookies to include all properties, not just `name` and `value`. ([Firefox bug 1887118](https://bugzil.la/1887118)).
+- Fixed the `network.getData` command timing out for redirects. ([Firefox bug 2009916](https://bugzil.la/2009916)).
+- Fixed the `browsingContext.reload` command not resetting the location of a navigated iframe. ([Firefox bug 2023917](https://bugzil.la/2023917)).
+- Removed the empty `proxy` capability from the `session.new` command response when no proxy is specified. ([Firefox bug 1916463](https://bugzil.la/1916463)).
+
+#### Marionette
+
+- Enabled browser window repositioning on Linux Wayland in headless mode. ([Firefox bug 2023978](https://bugzil.la/2023978)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Changes for WebDriver conformance for the Firefox 151 release based on the [release note worthy bugs in this list](https://bugzilla.mozilla.org/buglist.cgi?columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&query_format=advanced&product=Remote%20Protocol&resolution=FIXED&f1=cf_status_firefox151&o1=equals&v1=fixed&f2=cf_status_firefox150&o2=notequals&v2=fixed&f3=status_whiteboard&o3=notsubstring&v3=%5Bwptsync%20downstream%5D&component=Agent&component=Marionette&component=WebDriver%20BiDi&list_id=17970146).

@juliandescottes and @lutien can you please review?