### PR TITLE
fix(svg): remove outdated overflow support warning

### DIFF
--- a/files/en-us/web/svg/reference/attribute/overflow/index.md
+++ b/files/en-us/web/svg/reference/attribute/overflow/index.md
@@ -6,7 +6,7 @@ browser-compat: svg.global_attributes.overflow
 sidebar: svgref
 ---
 
-The **`overflow`** attribute sets what to do when an element's content is too big to fit in its block formatting context. **This feature is not widely implemented yet**.
+The **`overflow`** attribute sets what to do when an element's content is too big to fit in its block formatting context.
 
 This attribute has the same parameter values and meaning as the CSS {{cssxref("overflow")}} property, however, the following additional points apply:
 


### PR DESCRIPTION
## Summary

Removes an outdated warning from the SVG `overflow` attribute page that said the feature is not widely implemented yet.

The page's Baseline/browser compatibility information indicates the feature has been broadly available since 2015, so the warning was confusing and no longer accurate.

Fixes #44099.

## Validation

- Confirmed the outdated warning text was removed from `files/en-us/web/svg/reference/attribute/overflow/index.md`
- Reviewed the surrounding introduction to ensure it still reads naturally