### PR TITLE
availability() methods return "unavailable" when blocked

### DIFF
--- a/files/en-us/web/api/languagedetector/availability_static/index.md
+++ b/files/en-us/web/api/languagedetector/availability_static/index.md
@@ -38,7 +38,7 @@ Possible values include:
 - `downloading`
   - : The browser supports the given configuration, but it has to finish an ongoing download before it can proceed.
 - `unavailable`
-  - : The browser does not support the given configuration or the Language Detector API is blocked by a {{httpheader('Permissions-Policy/language-detector','language-detector')}} {{httpheader("Permissions-Policy")}}.
+  - : The browser does not support the given configuration, or the Language Detector API is blocked by a {{httpheader('Permissions-Policy/language-detector','language-detector')}} {{httpheader("Permissions-Policy")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/languagedetector/availability_static/index.md
+++ b/files/en-us/web/api/languagedetector/availability_static/index.md
@@ -38,7 +38,7 @@ Possible values include:
 - `downloading`
   - : The browser supports the given configuration, but it has to finish an ongoing download before it can proceed.
 - `unavailable`
-  - : The browser does not support the given configuration.
+  - : The browser does not support the given configuration or the Language Detector API is blocked by a {{httpheader('Permissions-Policy/language-detector','language-detector')}} {{httpheader("Permissions-Policy")}}.
 
 ### Exceptions
 
@@ -48,8 +48,6 @@ Possible values include:
   - : Thrown if initialization of the AI model failed for any reason.
 - `UnknownError` {{domxref("DOMException")}}
   - : Thrown if the `availability()` call failed for any other reason, or a reason the user agent did not wish to disclose.
-
-If usage of the method is blocked by a {{httpheader('Permissions-Policy/language-detector','language-detector')}} {{httpheader("Permissions-Policy")}}, the promise rejects with a value of `unavailable`.
 
 ## Examples
 

--- a/files/en-us/web/api/summarizer/availability_static/index.md
+++ b/files/en-us/web/api/summarizer/availability_static/index.md
@@ -49,7 +49,7 @@ Possible values include:
 - `downloading`
   - : The browser supports the given configuration, but it needs to finish an ongoing download before it can proceed.
 - `unavailable`
-  - : The browser does not support the given configuration or the Summarizer API is blocked by a {{httpheader('Permissions-Policy/summarizer','summarizer')}} {{httpheader("Permissions-Policy")}}.
+  - : The browser does not support the given configuration, or the Summarizer API is blocked by a {{httpheader('Permissions-Policy/summarizer','summarizer')}} {{httpheader("Permissions-Policy")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/summarizer/availability_static/index.md
+++ b/files/en-us/web/api/summarizer/availability_static/index.md
@@ -49,12 +49,10 @@ Possible values include:
 - `downloading`
   - : The browser supports the given configuration, but it needs to finish an ongoing download before it can proceed.
 - `unavailable`
-  - : The browser does not support the given configuration.
+  - : The browser does not support the given configuration or the Summarizer API is blocked by a {{httpheader('Permissions-Policy/summarizer','summarizer')}} {{httpheader("Permissions-Policy")}}.
 
 ### Exceptions
 
-- `NotAllowedError` {{domxref("DOMException")}}
-  - : Thrown if usage of the Summarizer API is blocked by a {{httpheader('Permissions-Policy/summarizer','summarizer')}} {{httpheader("Permissions-Policy")}}.
 - `NotSupportedError` {{domxref("DOMException")}}
   - : Thrown if the provided `context` is not in language the `Summarizer` supports.
 - `UnknownError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/translator/availability_static/index.md
+++ b/files/en-us/web/api/translator/availability_static/index.md
@@ -40,7 +40,7 @@ Possible values include:
 - `downloading`
   - : The browser supports the given configuration, but it has to finish an ongoing download before it can proceed.
 - `unavailable`
-  - : The browser does not support the given configuration. This value is also returned if the specified `sourceLanguage` and `targetLanguage` are the same or the Translator API is blocked by a {{httpheader('Permissions-Policy/translator','translator')}} {{httpheader("Permissions-Policy")}}.
+  - : The browser does not support the given configuration. This value is also returned if the specified `sourceLanguage` and `targetLanguage` are the same, or if the Translator API is blocked by a {{httpheader('Permissions-Policy/translator','translator')}} {{httpheader("Permissions-Policy")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/translator/availability_static/index.md
+++ b/files/en-us/web/api/translator/availability_static/index.md
@@ -40,7 +40,7 @@ Possible values include:
 - `downloading`
   - : The browser supports the given configuration, but it has to finish an ongoing download before it can proceed.
 - `unavailable`
-  - : The browser does not support the given configuration. This value is also returned if the specified `sourceLanguage` and `targetLanguage` are the same.
+  - : The browser does not support the given configuration. This value is also returned if the specified `sourceLanguage` and `targetLanguage` are the same or the Translator API is blocked by a {{httpheader('Permissions-Policy/translator','translator')}} {{httpheader("Permissions-Policy")}}.
 
 ### Exceptions
 
@@ -50,8 +50,6 @@ Possible values include:
   - : Thrown if initialization of the AI model failed for any reason.
 - `UnknownError` {{domxref("DOMException")}}
   - : Thrown if the `availability()` call failed for any other reason, or a reason the user agent did not wish to disclose.
-
-If usage of the method is blocked by a {{httpheader('Permissions-Policy/translator','translator')}} {{httpheader("Permissions-Policy")}}, the promise rejects with a value of `unavailable`.
 
 ## Examples
 

--- a/files/en-us/web/api/translator_and_language_detector_apis/index.md
+++ b/files/en-us/web/api/translator_and_language_detector_apis/index.md
@@ -43,9 +43,11 @@ See [Using the Translator and Language Detector APIs](/en-US/docs/Web/API/Transl
 ## HTTP headers
 
 - {{httpheader("Permissions-Policy")}}; the {{httpheader("Permissions-Policy/language-detector", "language-detector")}} directive
-  - : Controls access to the language detection functionality. Where a policy specifically disallows its use, the {{domxref("LanguageDetector.availability_static", "LanguageDetector.availability()")}} static method will return `unavailable` and any attempts to call other `LanguageDetector` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+  - : Controls access to the language detection functionality.
+    Where a policy specifically disallows its use, the {{domxref("LanguageDetector.availability_static", "LanguageDetector.availability()")}} static method will return `unavailable`, and any attempts to call other `LanguageDetector` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 - {{httpheader("Permissions-Policy")}}; the {{httpheader("Permissions-Policy/translator", "translator")}} directive
-  - : Controls access to the translation functionality. Where a policy specifically disallows its use, the {{domxref("Translator.availability_static", "Translator.availability()")}} static method will return `unavailable` and any attempts to call other `Translator` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+  - : Controls access to the translation functionality.
+    Where a policy specifically disallows its use, the {{domxref("Translator.availability_static", "Translator.availability()")}} static method will return `unavailable`, and any attempts to call other `Translator` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Security considerations
 

--- a/files/en-us/web/api/translator_and_language_detector_apis/index.md
+++ b/files/en-us/web/api/translator_and_language_detector_apis/index.md
@@ -43,9 +43,9 @@ See [Using the Translator and Language Detector APIs](/en-US/docs/Web/API/Transl
 ## HTTP headers
 
 - {{httpheader("Permissions-Policy")}}; the {{httpheader("Permissions-Policy/language-detector", "language-detector")}} directive
-  - : Controls access to the language detection functionality. Where a policy specifically disallows its use, any attempts to call the `LanguageDetector` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+  - : Controls access to the language detection functionality. Where a policy specifically disallows its use, the {{domxref("LanguageDetector.availability_static", "LanguageDetector.availability()")}} static method will return `unavailable` and any attempts to call other `LanguageDetector` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 - {{httpheader("Permissions-Policy")}}; the {{httpheader("Permissions-Policy/translator", "translator")}} directive
-  - : Controls access to the translation functionality. Where a policy specifically disallows its use, any attempts to call the `Translator` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+  - : Controls access to the translation functionality. Where a policy specifically disallows its use, the {{domxref("Translator.availability_static", "Translator.availability()")}} static method will return `unavailable` and any attempts to call other `Translator` methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Security considerations
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/language-detector/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/language-detector/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `language-detector` directive controls access to the language detection functionality of the [Translator and Language Detector APIs](/en-US/docs/Web/API/Translator_and_Language_Detector_APIs).
 
-Specifically, where a defined policy blocks usage, the {{domxref("LanguageDetector.availability_static", "LanguageDetector.availability()")}} static method will return `unavailable` and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks usage, the {{domxref("LanguageDetector.availability_static", "LanguageDetector.availability()")}} static method will return `unavailable`, and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/language-detector/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/language-detector/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `language-detector` directive controls access to the language detection functionality of the [Translator and Language Detector APIs](/en-US/docs/Web/API/Translator_and_Language_Detector_APIs).
 
-Specifically, where a defined policy blocks usage, any attempts to call the API's language detection methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks usage, the {{domxref("LanguageDetector.availability_static", "LanguageDetector.availability()")}} static method will return `unavailable` and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/summarizer/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/summarizer/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `summarizer` directive controls access to the [Summarizer API](/en-US/docs/Web/API/Summarizer_API).
 
-Specifically, where a defined policy blocks Summarizer API usage, the {{domxref("Summarizer.availability_static", "Summarizer.availability()")}} static method will return `unavailable` and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks Summarizer API usage, the {{domxref("Summarizer.availability_static", "Summarizer.availability()")}} static method will return `unavailable`, and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/summarizer/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/summarizer/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `summarizer` directive controls access to the [Summarizer API](/en-US/docs/Web/API/Summarizer_API).
 
-Specifically, where a defined policy blocks Summarizer API usage, any attempts to call the API's methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks Summarizer API usage, the {{domxref("Summarizer.availability_static", "Summarizer.availability()")}} static method will return `unavailable` and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/translator/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/translator/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `translator` directive controls access to the translation functionality of the [Translator and Language Detector APIs](/en-US/docs/Web/API/Translator_and_Language_Detector_APIs).
 
-Specifically, where a defined policy blocks usage, any attempts to call the API's translation methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks usage, the {{domxref("Translator.availability_static", "Translator.availability()")}} static method will return `unavailable` and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Syntax
 

--- a/files/en-us/web/http/reference/headers/permissions-policy/translator/index.md
+++ b/files/en-us/web/http/reference/headers/permissions-policy/translator/index.md
@@ -13,7 +13,7 @@ sidebar: http
 
 The HTTP {{HTTPHeader("Permissions-Policy")}} header `translator` directive controls access to the translation functionality of the [Translator and Language Detector APIs](/en-US/docs/Web/API/Translator_and_Language_Detector_APIs).
 
-Specifically, where a defined policy blocks usage, the {{domxref("Translator.availability_static", "Translator.availability()")}} static method will return `unavailable` and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
+Specifically, where a defined policy blocks usage, the {{domxref("Translator.availability_static", "Translator.availability()")}} static method will return `unavailable`, and any attempts to call the API's other methods will fail with a `NotAllowedError` {{domxref("DOMException")}}.
 
 ## Syntax
 


### PR DESCRIPTION
This change fixes the documentation of the LanguageDetector, Translator and Summarizer availability() static methods to reflect their specified behavior when API access is denied by Permissions Policy.

Rather than throwing a NotAllowedError or rejecting, these methods resolve with "unavailable".

Specification: https://webmachinelearning.github.io/writing-assistance-apis/#compute-ai-model-availability