### PR TITLE
WebSocket() constructor: add event-driven example

### DIFF
--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -85,6 +85,37 @@ relativeWebSocket = new WebSocket("/local/url");
 relativeWebSocket.close();
 ```
 
+The previous examples show how to _construct_ a `WebSocket`, but the connection is established asynchronously. Calling {{domxref("WebSocket/send", "send()")}} before the {{domxref("WebSocket/open_event", "open")}} event fires throws an `InvalidStateError` exception, because {{domxref("WebSocket/readyState", "readyState")}} is still `CONNECTING`. The example below shows how to wait for the connection before sending, and how to handle the {{domxref("WebSocket/error_event", "error")}} and {{domxref("WebSocket/close_event", "close")}} events:
+
+```js
+// Create WebSocket connection.
+const socket = new WebSocket("wss://websocket.example.org");
+
+// Connection opened
+socket.addEventListener("open", (event) => {
+  socket.send("Hello Server!");
+});
+
+// Listen for messages
+socket.addEventListener("message", (event) => {
+  console.log("Message from server:", event.data);
+});
+
+// Handle errors
+socket.addEventListener("error", (event) => {
+  console.error("WebSocket error:", event);
+});
+
+// Handle disconnection
+socket.addEventListener("close", (event) => {
+  if (event.wasClean) {
+    console.log(`Closed cleanly, code=${event.code}, reason=${event.reason}`);
+  } else {
+    console.log("Connection died");
+  }
+});
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -85,7 +85,7 @@ relativeWebSocket = new WebSocket("/local/url");
 relativeWebSocket.close();
 ```
 
-The previous examples show how to _construct_ a `WebSocket`, but the connection is established asynchronously. Calling {{domxref("WebSocket/send", "send()")}} before the {{domxref("WebSocket/open_event", "open")}} event fires throws an `InvalidStateError` exception, because {{domxref("WebSocket/readyState", "readyState")}} is still `CONNECTING`. The example below shows how to wait for the connection before sending, and how to handle the {{domxref("WebSocket/error_event", "error")}} and {{domxref("WebSocket/close_event", "close")}} events:
+The previous examples show how to _construct_ a `WebSocket`, but the connection is established asynchronously. Calling {{domxref("WebSocket/send", "send()")}} before the {{domxref("WebSocket/open_event", "open")}} event fires throws an `InvalidStateError` exception, because {{domxref("WebSocket/readyState", "readyState")}} is still `CONNECTING`. If the connection cannot be established (for example, the server is unreachable or the handshake fails), an {{domxref("WebSocket/error_event", "error")}} event fires and is followed by a {{domxref("WebSocket/close_event", "close")}} event whose `wasClean` property is `false` — so every connection attempt ultimately ends with either an `open` event or a `close` event. The example below shows how to wait for the connection before sending, and how to handle the `error` and `close` events:
 
 ```js
 // Create WebSocket connection.


### PR DESCRIPTION
### Description

Adds a new example to the `WebSocket()` constructor page showing how to wait for the `open` event before calling `send()`, and how to handle the `error` and `close` events.

### Motivation

The existing examples on this page only show how to construct a `WebSocket` and immediately close it. They don't demonstrate that the connection is asynchronous, that `send()` must wait for the `open` event (otherwise it throws `InvalidStateError`), or how to handle connection failures.

This addresses the request in #31768 to clarify the connection lifecycle through working code.

### Additional details

The new example uses the same `// Create WebSocket connection.` comment style as the canonical example on the parent [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) interface page, so the two examples stay consistent.

### Related issues and pull requests

Fixes #31768
