### PR TITLE
fix(api): clarify Window scroll options

### DIFF
--- a/files/en-us/web/api/element/scrollby/index.md
+++ b/files/en-us/web/api/element/scrollby/index.md
@@ -33,7 +33,10 @@ scrollBy(options)
     - `left`
       - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Determines whether the scrolling is instant or animates smoothly. This option is a string that must take one of the following values:
+        - `smooth`: The scrolling animates smoothly.
+        - `instant`: The scrolling happens instantly in a single jump.
+        - `auto`: The scroll behavior is determined by the computed value of the {{cssxref("scroll-behavior")}} CSS property on the element.
 
 ### Return value
 

--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -23,22 +23,20 @@ scrollTo(options)
 ### Parameters
 
 - `xCoord`
-  - : The pixel along the horizontal axis of the
-    element that you want displayed in the upper left.
+  - : The pixel along the horizontal axis of the element's scrollable content that you want displayed at the left edge.
 - `yCoord`
-  - : The pixel along the vertical axis of the element
-    that you want displayed in the upper left.
+  - : The pixel along the vertical axis of the element's scrollable content that you want displayed at the top edge.
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : Specifies the number of pixels along the Y axis to scroll the window or element.
+      - : The pixel along the vertical axis of the element's scrollable content that you want displayed at the top edge. This is the same as the `yCoord` parameter.
     - `left`
-      - : Specifies the number of pixels along the X axis to scroll the window or element.
+      - : The pixel along the horizontal axis of the element's scrollable content that you want displayed at the left edge. This is the same as the `xCoord` parameter.
     - `behavior`
-      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
-        - `smooth`: scrolling should animate smoothly
-        - `instant`: scrolling should happen instantly in a single jump
-        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
+      - : Determines whether the scrolling is instant or animates smoothly. This option is a string that must take one of the following values:
+        - `smooth`: The scrolling animates smoothly.
+        - `instant`: The scrolling happens instantly in a single jump.
+        - `auto`: The scroll behavior is determined by the computed value of the {{cssxref("scroll-behavior")}} CSS property on the element.
 
 ### Return value
 

--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -23,15 +23,15 @@ scrollTo(options)
 ### Parameters
 
 - `xCoord`
-  - : The x-coordinate of the element's scrollable content that you want the element's left edge to scroll to.
+  - : The x-coordinate of the element's scrollable content that you want the left edge of the element's scrollport to scroll to.
 - `yCoord`
-  - : The y-coordinate of the element's scrollable content that you want the element's top edge to scroll to.
+  - : The y-coordinate of the element's scrollable content that you want the top edge of the element's scrollport to scroll to.
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : The y-coordinate of the element's scrollable content that you want the element's top edge to scroll to. This is the same as the `yCoord` parameter.
+      - : The y-coordinate of the element's scrollable content that you want the top edge of the element's scrollport to scroll to. This is the same as the `yCoord` parameter.
     - `left`
-      - : The x-coordinate of the element's scrollable content that you want the element's left edge to scroll to. This is the same as the `xCoord` parameter.
+      - : The x-coordinate of the element's scrollable content that you want the left edge of the element's scrollport to scroll to. This is the same as the `xCoord` parameter.
     - `behavior`
       - : Determines whether the scrolling is instant or animates smoothly. This option is a string that must take one of the following values:
         - `smooth`: The scrolling animates smoothly.

--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -23,15 +23,15 @@ scrollTo(options)
 ### Parameters
 
 - `xCoord`
-  - : The pixel along the horizontal axis of the element's scrollable content that you want displayed at the left edge.
+  - : The x-coordinate of the element's scrollable content that you want the element's left edge to scroll to.
 - `yCoord`
-  - : The pixel along the vertical axis of the element's scrollable content that you want displayed at the top edge.
+  - : The y-coordinate of the element's scrollable content that you want the element's top edge to scroll to.
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : The pixel along the vertical axis of the element's scrollable content that you want displayed at the top edge. This is the same as the `yCoord` parameter.
+      - : The y-coordinate of the element's scrollable content that you want the element's top edge to scroll to. This is the same as the `yCoord` parameter.
     - `left`
-      - : The pixel along the horizontal axis of the element's scrollable content that you want displayed at the left edge. This is the same as the `xCoord` parameter.
+      - : The x-coordinate of the element's scrollable content that you want the element's left edge to scroll to. This is the same as the `xCoord` parameter.
     - `behavior`
       - : Determines whether the scrolling is instant or animates smoothly. This option is a string that must take one of the following values:
         - `smooth`: The scrolling animates smoothly.

--- a/files/en-us/web/api/window/scrollby/index.md
+++ b/files/en-us/web/api/window/scrollby/index.md
@@ -27,11 +27,14 @@ scrollBy(options)
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : Specifies the number of pixels along the Y axis to scroll the window or element.
+      - : Specifies the number of pixels to scroll by along the Y axis.
     - `left`
-      - : Specifies the number of pixels along the X axis to scroll the window or element.
+      - : Specifies the number of pixels to scroll by along the X axis.
     - `behavior`
-      - : Specifies whether the scrolling should animate smoothly (`smooth`), happen instantly in a single jump (`instant`), or let the browser choose (`auto`, default).
+      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
+        - `smooth`: scrolling should animate smoothly
+        - `instant`: scrolling should happen instantly in a single jump
+        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
 
 ### Return value
 

--- a/files/en-us/web/api/window/scrollby/index.md
+++ b/files/en-us/web/api/window/scrollby/index.md
@@ -27,14 +27,14 @@ scrollBy(options)
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : Specifies the number of pixels to scroll by along the Y axis.
+      - : Specifies the number of pixels along the Y axis to scroll the window or element.
     - `left`
-      - : Specifies the number of pixels to scroll by along the X axis.
+      - : Specifies the number of pixels along the X axis to scroll the window or element.
     - `behavior`
-      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
-        - `smooth`: scrolling should animate smoothly
-        - `instant`: scrolling should happen instantly in a single jump
-        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
+      - : Determines whether the scrolling is instant or animates smoothly. This option is a string that must take one of the following values:
+        - `smooth`: The scrolling animates smoothly.
+        - `instant`: The scrolling happens instantly in a single jump.
+        - `auto`: The scroll behavior is determined by the computed value of the {{cssxref("scroll-behavior")}} CSS property on the document.
 
 ### Return value
 

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -21,15 +21,15 @@ scrollTo(options)
 ### Parameters
 
 - `xCoord`
-  - : The pixel along the horizontal axis of the document that you want displayed at the left edge of the viewport.
+  - : The x-coordinate of the document that you want the viewport's left edge to scroll to.
 - `yCoord`
-  - : The pixel along the vertical axis of the document that you want displayed at the top edge of the viewport.
+  - : The y-coordinate of the document that you want the viewport's top edge to scroll to.
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : The pixel along the vertical axis of the document that you want displayed at the top edge of the viewport. This is the same as the `yCoord` parameter.
+      - : The y-coordinate of the document that you want the viewport's top edge to scroll to. This is the same as the `yCoord` parameter.
     - `left`
-      - : The pixel along the horizontal axis of the document that you want displayed at the left edge of the viewport. This is the same as the `xCoord` parameter.
+      - : The x-coordinate of the document that you want the viewport's left edge to scroll to. This is the same as the `xCoord` parameter.
     - `behavior`
       - : Determines whether the scrolling is instant or animates smoothly. This option is a string that must take one of the following values:
         - `smooth`: The scrolling animates smoothly.

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -21,22 +21,20 @@ scrollTo(options)
 ### Parameters
 
 - `xCoord`
-  - : The pixel along the horizontal axis of the
-    document that you want displayed in the upper left.
+  - : The pixel along the horizontal axis of the document that you want displayed at the left edge of the viewport.
 - `yCoord`
-  - : The pixel along the vertical axis of the document
-    that you want displayed in the upper left.
+  - : The pixel along the vertical axis of the document that you want displayed at the top edge of the viewport.
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : The pixel along the vertical axis of the document that you want displayed in the upper left. This is the same as the `yCoord` parameter.
+      - : The pixel along the vertical axis of the document that you want displayed at the top edge of the viewport. This is the same as the `yCoord` parameter.
     - `left`
-      - : The pixel along the horizontal axis of the document that you want displayed in the upper left. This is the same as the `xCoord` parameter.
+      - : The pixel along the horizontal axis of the document that you want displayed at the left edge of the viewport. This is the same as the `xCoord` parameter.
     - `behavior`
-      - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
-        - `smooth`: scrolling should animate smoothly
-        - `instant`: scrolling should happen instantly in a single jump
-        - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
+      - : Determines whether the scrolling is instant or animates smoothly. This option is a string that must take one of the following values:
+        - `smooth`: The scrolling animates smoothly.
+        - `instant`: The scrolling happens instantly in a single jump.
+        - `auto`: The scroll behavior is determined by the computed value of the {{cssxref("scroll-behavior")}} CSS property on the document.
 
 ### Return value
 

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -29,9 +29,9 @@ scrollTo(options)
 - `options`
   - : An object containing the following properties:
     - `top`
-      - : Specifies the number of pixels along the Y axis to scroll the window or element.
+      - : The pixel along the vertical axis of the document that you want displayed in the upper left. This is the same as the `yCoord` parameter.
     - `left`
-      - : Specifies the number of pixels along the X axis to scroll the window or element.
+      - : The pixel along the horizontal axis of the document that you want displayed in the upper left. This is the same as the `xCoord` parameter.
     - `behavior`
       - : Determines whether scrolling is instant or animates smoothly. This option is a string which must take one of the following values:
         - `smooth`: scrolling should animate smoothly


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

  <!--
  Add details below to help us review your pull request (PR).
  Explain your changes and link to a related issue or pull request.
  Your PR may be delayed or closed if you don't provide enough information.
  -->

  ### Description

  Clarifies that `Window.scrollTo()` options use absolute document coordinates, while `Window.scrollBy()` options use relative scroll amounts. Also aligns the `behavior` option
  description between both pages.

  ### Motivation

  The previous `top` and `left` descriptions looked similar for `scrollTo()` and `scrollBy()`, which could make readers think both methods use delta values. This update makes the
  absolute versus relative behavior explicit.

  ### Additional details

  Tested with:

  - `npx --no-install markdownlint-cli2 files/en-us/web/api/window/scrollto/index.md files/en-us/web/api/window/scrollby/index.md`
  - `npx --no-install prettier -c files/en-us/web/api/window/scrollto/index.md files/en-us/web/api/window/scrollby/index.md`

  ### Related issues and pull requests

  Fixes #44098