### PR TITLE
fix(http): clarify max-age Cache-Control sections

### DIFF
--- a/files/en-us/web/http/guides/caching/index.md
+++ b/files/en-us/web/http/guides/caching/index.md
@@ -113,7 +113,7 @@ Cache-Control: max-age=604800
 
 The cache that stored the example response calculates the time elapsed since the response was generated and uses the result as the response's _age_.
 
-For the example response, the meaning of `max-age` is the following:
+For the example response, the meaning of the [`max-age` response directive](/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#max-age_response_directive) is the following:
 
 - If the age of the response is _less_ than one week, the response is _fresh_.
 - If the age of the response is _more_ than one week, the response is _stale_.

--- a/files/en-us/web/http/reference/headers/cache-control/index.md
+++ b/files/en-us/web/http/reference/headers/cache-control/index.md
@@ -97,7 +97,7 @@ This section lists directives that affect caching — both response directives a
 
 ### Response Directives
 
-#### `max-age`
+#### `max-age` response directive
 
 The `max-age=N` response directive indicates that the response remains [fresh](/en-US/docs/Web/HTTP/Guides/Caching#fresh_and_stale_based_on_age) until _N_ seconds after the response is generated.
 
@@ -282,7 +282,7 @@ The `no-store` request directive allows a client to request that caches refrain 
 Cache-Control: no-store
 ```
 
-#### `max-age`
+#### `max-age` request directive
 
 The `max-age=N` request directive indicates that the client allows a stored response that is generated on the origin server within _N_ seconds — where _N_ may be any non-negative integer (including `0`).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

  <!--
  Add details below to help us review your pull request (PR).
  Explain your changes and link to a related issue or pull request.
  Your PR may be delayed or closed if you don't provide enough information.
  -->

  ### Description

  Clarifies the duplicate `max-age` headings on the `Cache-Control` reference page by distinguishing the response and request directives. Also links the caching guide’s `max-age`
  explanation directly to the `Cache-Control` response directive section.

  ### Motivation

  Searching for `max-age` did not surface the most relevant `Cache-Control` response directive section clearly. Making the heading more specific and adding a direct guide link
  should help readers find the correct reference entry.

  ### Additional details

  Tested with:

  - `npx --no-install markdownlint-cli2 files/en-us/web/http/reference/headers/cache-control/index.md files/en-us/web/http/guides/caching/index.md`
  - `npx --no-install prettier -c files/en-us/web/http/reference/headers/cache-control/index.md files/en-us/web/http/guides/caching/index.md`
  - `git diff --check`

  ### Related issues and pull requests

  Fixes mdn/fred#1577
  
  <!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->