### PR TITLE
[Editorial review] BiDi - Add pages for browsingContext module, part 1: context lifecycle commands

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -37,7 +37,7 @@ Set `params` to an empty object (`{}`) or include any of the following optional 
 The following field in the `result` object of the response describes the created user context:
 
 - `userContext`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) that uniquely identifies the created user context.
+  - : A string that contains the ID that uniquely identifies the created user context.
 
 ### Errors
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/getusercontexts/index.md
@@ -30,7 +30,7 @@ The following field in the `result` object of the response describes the user co
   - : An array of one or more objects, each representing a user context.
     Each object has the following field:
     - `userContext`
-      - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) that uniquely identifies the user context.
+      - : A string that contains the ID that uniquely identifies the user context.
         The default user context has the value `"default"`; it always exists and cannot be removed, so the array is never empty.
 
 ## Examples

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/index.md
@@ -31,6 +31,10 @@ Each user context has a unique string identifier (user context ID). The browser 
 
 Multiple tabs from different user contexts can share the same [client window](#client_windows).
 
+For example, a regular browser tab lives in the `"default"` user context.
+A tab opened in a separate container lives in a different user context.
+Both tabs can appear in the same client window, but their cookies and session data are completely isolated from each other.
+
 User contexts can be created using [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) and removed using [`browser.removeUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/removeUserContext).
 
 ## Commands

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -28,7 +28,7 @@ The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/Bi
 The `params` field contains:
 
 - `userContext`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the user context to remove.
+  - : A string that contains the ID of the user context to remove.
     User context IDs are returned by commands such as [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts).
     The default user context (`"default"`) cannot be removed.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -34,7 +34,7 @@ The `params` field contains:
       - : A string that specifies the path to the folder where downloaded files are saved.
         This field is required when `type` is `"allowed"`.
 - `userContexts` {{optional_inline}}
-  - : An array of strings where each string is the ID ([UUID](/en-US/docs/Glossary/UUID)) of a [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) to apply the download behavior to.
+  - : An array of strings where each string is the ID of a [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) to apply the download behavior to.
     User context IDs are returned by commands such as [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts).
     - If included, the specified download behavior is applied to each listed user context. If `downloadBehavior` is `null`, the per-context override is reset for each listed user context.
     - If not included, the specified download behavior is applied as a global default to all user contexts.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/activate/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/activate/index.md
@@ -1,0 +1,85 @@
+---
+title: "`browsingContext.activate` command"
+short-title: activate
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browsingContext.activate
+sidebar: webdriver
+---
+
+The `browsingContext.activate` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module brings a [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) to the foreground and gives it focus.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browsingContext.activate",
+  "params": {
+    "context": "<contextId>"
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) to bring to the foreground and give focus.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
+    This error is also returned when the context specified by `context` is not a top-level context.
+- `no such frame`
+  - : No context with the given context ID is found.
+- `unsupported operation`
+  - : The browser cannot bring the context to the foreground.
+
+## Examples
+
+### Activating a background tab
+
+The following example shows how to activate a background tab.
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), suppose you create a tab in the background using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) with `background: true`, which returns the context ID of the tab. Send the following message to activate it:
+
+```json
+{
+  "id": 1,
+  "method": "browsingContext.activate",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa"
+  }
+}
+```
+
+The browser brings the tab to the foreground and responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close) command
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/activate/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/activate/index.md
@@ -25,7 +25,7 @@ The `browsingContext.activate` [command](/en-US/docs/Web/WebDriver/Reference/BiD
 The `params` field contains:
 
 - `context`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) to bring to the foreground and give focus.
+  - : A string that contains the ID of the [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) to bring to the foreground and give focus.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
 ### Return value

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
@@ -25,7 +25,7 @@ The `browsingContext.close` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/M
 The `params` field contains:
 
 - `context`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) to close.
+  - : A string that contains the ID of the [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) to close.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `promptUnload` {{optional_inline}}
   - : A boolean that indicates whether the browser runs [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handlers before closing the context.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
@@ -1,0 +1,95 @@
+---
+title: "`browsingContext.close` command"
+short-title: close
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/close
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browsingContext.close
+sidebar: webdriver
+---
+
+The `browsingContext.close` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module closes the specified [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context).
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browsingContext.close",
+  "params": {
+    "context": "<contextId>"
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) to close.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `promptUnload` {{optional_inline}}
+  - : A boolean that indicates whether the browser runs [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handlers before closing the context.
+    The default value is `false`.
+    - `false`: The specified context closes immediately without running `beforeunload` event handlers.
+    - `true`: The browser runs `beforeunload` event handlers before closing the specified context.
+      Any resulting prompt is handled as defined by the `unhandledPromptBehavior` capability specified via the [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#unhandledpromptbehavior) command.
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`).
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
+    This error is also returned when the context specified by `context` is not a top-level context.
+- [`no such frame`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchFrame)
+  - : No context with the given context ID is found.
+
+## Examples
+
+### Closing a tab with a page unload prompt
+
+The following example shows how to close a tab and allow its [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handlers to run before closing.
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), suppose a session is created via [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with `unhandledPromptBehavior` set to `"accept"`.
+First get the context ID using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree), then send the following message:
+
+```json
+{
+  "id": 1,
+  "method": "browsingContext.close",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "promptUnload": true
+  }
+}
+```
+
+The browser closes the context and responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+Since `promptUnload` is `true`, the browser runs any `beforeunload` handlers on the page before closing.
+The confirmation prompt, if shown, is automatically accepted based on the `unhandledPromptBehavior` setting defined in `session.new`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) command
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
+- [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
@@ -43,7 +43,7 @@ The `result` field in the response is an empty object (`{}`).
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
   - : A required parameter is missing or has an invalid type.
     This error is also returned when the context specified by `context` is not a top-level context.
-- [`no such frame`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchFrame)
+- `no such frame`
   - : No context with the given context ID is found.
 
 ## Examples

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -27,8 +27,8 @@ The `params` field contains:
 - `background` {{optional_inline}}
   - : A boolean that indicates whether the context is created in the background or the foreground.
     The default value is `false`.
-    - `false`: The context receives focus after it is created.
-    - `true`: The context is created in the background. See [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) to bring it to the foreground.
+    - `false`: The context is brought to the foreground and receives focus after it is created.
+    - `true`: The context is created in the background. See [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) to bring it to the foreground and give it focus.
 - `referenceContext` {{optional_inline}}
   - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of an existing [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) that is used to position the new context.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
@@ -62,7 +62,8 @@ The `result` object in the response contains the following fields:
 ### Errors
 
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
-  - : A required parameter is missing or has an invalid type. Also returned when the context specified by `referenceContext` is not a top-level context.
+  - : A required parameter is missing or has an invalid type.
+    This error is also returned when the context specified by `referenceContext` is not a top-level context.
 - [`no such frame`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchFrame)
   - : No context with the given `referenceContext` ID is found.
 - [`no such user context`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchUserContext)

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -15,7 +15,7 @@ The `browsingContext.create` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/
 {
   "method": "browsingContext.create",
   "params": {
-    "type": "tab" / "window"
+    "type": "tab"
   }
 }
 ```
@@ -62,11 +62,11 @@ The `result` object in the response contains the following fields:
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
   - : A required parameter is missing or has an invalid type.
     This error is also returned when the context specified by `referenceContext` is not a top-level context.
-- [`no such frame`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchFrame)
+- `no such frame`
   - : No context with the given `referenceContext` ID is found.
-- [`no such user context`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchUserContext)
+- `no such user context`
   - : No user context with the given `userContext` ID is found.
-- [`unsupported operation`](/en-US/docs/Web/WebDriver/Reference/Errors/UnsupportedOperation)
+- `unsupported operation`
   - : The browser is unable to create a new [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context).
 
 ## Description

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -1,0 +1,188 @@
+---
+title: "`browsingContext.create` command"
+short-title: create
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/create
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browsingContext.create
+sidebar: webdriver
+---
+
+The `browsingContext.create` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module creates a [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) as a new tab or a new window and returns its context ID.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browsingContext.create",
+  "params": {
+    "type": "tab" / "window"
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `background` {{optional_inline}}
+  - : A boolean that indicates whether the context is created in the background or the foreground.
+    The default value is `false`.
+    - `false`: The context receives focus after it is created.
+    - `true`: The context is created in the background. See [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) to bring it to the foreground.
+- `referenceContext` {{optional_inline}}
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of an existing [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) that is used to position the new context.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+
+    When `type` is `"tab"`, the new context opens in the same window as the context specified by `referenceContext`.
+    If `type` is `"window"` or `referenceContext` is omitted, the browser determines where the new context appears.
+
+    The new context inherits the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) of the specified reference context, unless `userContext` is explicitly specified.
+
+- `type`
+  - : A string that specifies the type of the context that is created.
+    It accepts one of the following values:
+    - `"tab"`: Creates the context as a tab in an existing window.
+      If `referenceContext` is provided, the new tab opens next to it.
+    - `"window"`: Creates the context in a new browser window.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the context is created.
+    User context IDs are returned by [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts) or [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext).
+
+    If not specified, the new context uses the `"default"` user context or inherits the user context of `referenceContext` if provided.
+
+### Return value
+
+The `result` object in the response contains the following fields:
+
+- `context`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the newly created context.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) associated with the new context.
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type. Also returned when the context specified by `referenceContext` is not a top-level context.
+- [`no such frame`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchFrame)
+  - : No context with the given `referenceContext` ID is found.
+- [`no such user context`](/en-US/docs/Web/WebDriver/Reference/Errors/NoSuchUserContext)
+  - : No user context with the given `userContext` ID is found.
+- [`unsupported operation`](/en-US/docs/Web/WebDriver/Reference/Errors/UnsupportedOperation)
+  - : The browser is unable to create a new [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context).
+
+## Description
+
+The `browsingContext.create` command always creates a [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context).
+The `type` parameter determines how the new context appears in the browser: `"window"` creates a new [client window](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#client_windows), while `"tab"` opens it as a tab inside an existing client window.
+
+By default, the new context receives focus immediately.
+To turn off this behavior, set `background` to `true`.
+You can later bring a background context to the foreground using [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate).
+
+If you want the new tab to open next to a specific existing tab, pass that tab's context ID as `referenceContext`. Without it, the browser places the new tab wherever it decides.
+
+By default, the new context is added to the `"default"` [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) and shares storage with other tabs in that context. To isolate it, that is, give it separate cookies and session data, specify a different user context using `userContext`.
+
+## Examples
+
+### Creating a tab
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), send the following message to create a new tab:
+
+```json
+{
+  "id": 1,
+  "method": "browsingContext.create",
+  "params": {
+    "type": "tab"
+  }
+}
+```
+
+On successful creation, the browser responds with the context ID of the new tab:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa"
+  }
+}
+```
+
+Since `background` is not specified, the tab opens in the foreground by default.
+
+### Creating a tab next to an existing context
+
+The following example shows how to create a tab in the background next to an existing tab within the specified user context.
+
+First, get the context ID of the reference tab using [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) and the user context ID using [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts) or [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext). Then send the following message:
+
+```json
+{
+  "id": 2,
+  "method": "browsingContext.create",
+  "params": {
+    "type": "tab",
+    "referenceContext": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "background": true,
+    "userContext": "3a8e2d1f-4b5c-6d7e-8f9a-0b1c2d3e4f5a"
+  }
+}
+```
+
+The browser opens the new tab in the same window as the reference context and responds as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "context": "b2e3f461-8a5c-4d12-9b87-c3d4e5f6a7b8"
+  }
+}
+```
+
+### Creating a window in the background
+
+Send the following message to create a new window without activating it:
+
+```json
+{
+  "id": 3,
+  "method": "browsingContext.create",
+  "params": {
+    "type": "window",
+    "background": true
+  }
+}
+```
+
+The browser responds with the context ID of the new window as follows:
+
+```json
+{
+  "id": 3,
+  "type": "success",
+  "result": {
+    "context": "d87a0c61-7b0e-4e8b-b4f0-0a7d5af2e0c3"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) command
+- [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
+- [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated) event
+- [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -30,7 +30,7 @@ The `params` field contains:
     - `false`: The context is brought to the foreground and receives focus after it is created.
     - `true`: The context is created in the background. See [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) to bring it to the foreground and give it focus.
 - `referenceContext` {{optional_inline}}
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of an existing [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) that is used to position the new context.
+  - : A string that contains the ID of an existing [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) that is used to position the new context.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
     When `type` is `"tab"`, the new context opens in the same window as the context specified by `referenceContext`.
@@ -45,7 +45,7 @@ The `params` field contains:
       If `referenceContext` is provided, the new tab opens next to it.
     - `"window"`: Creates the context in a new browser window.
 - `userContext` {{optional_inline}}
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the context is created.
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the context is created.
     User context IDs are returned by [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts) or [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext).
 
     If not specified, the new context uses the `"default"` user context or inherits the user context of `referenceContext` if provided.
@@ -55,9 +55,7 @@ The `params` field contains:
 The `result` object in the response contains the following fields:
 
 - `context`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the newly created context.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) associated with the new context.
+  - : A string that contains the ID of the newly created context.
 
 ### Errors
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -7,7 +7,32 @@ browser-compat: webdriver.bidi.browsingContext
 sidebar: webdriver
 ---
 
-The **`browsingContext`** module contains commands and events for managing browsing contexts.
+The **`browsingContext`** module contains commands and events for managing contexts.
+
+## Contexts
+
+A context is a navigable that can load a document, such as a tab, an iframe, or a popup.
+Each context has a unique string identifier called a context ID, expressed as a [UUID](/en-US/docs/Glossary/UUID), that is used to reference it across commands and events.
+
+There are two types of contexts:
+
+- **Top-level context**
+  - : This type of context has no parent, corresponding to a browser tab or a standalone window.
+    Top-level contexts belong to a [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) and live inside a [client window](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#client_windows).
+- **Child context**
+  - : This type of context is nested inside a top-level context, such as an {{HTMLElement("iframe")}}.
+    Child contexts are returned as children of their parent by [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+
+For example, if you open a browser window and navigate to `https://example.com`, that creates one top-level context (with a UUID as its context ID).
+If that page contains an `<iframe>` loading `https://other.com`, that creates a child context nested under the top-level context.
+Opening a new tab creates a second top-level context with its own UUID.
+Calling [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) would return both top-level contexts, with the first one having a child context.
+
+## Commands
+
+- [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate)
+- [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close)
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create)
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -12,7 +12,7 @@ The **`browsingContext`** module contains commands and events for managing conte
 ## Contexts
 
 A context is a navigable that can load a document, such as a tab, an iframe, or a popup.
-Each context has a unique string identifier called a context ID, expressed as a [UUID](/en-US/docs/Glossary/UUID), that is used to reference it across commands and events.
+Each context has a unique string identifier called a context ID that is used to reference it across commands and events.
 
 There are two types of contexts:
 
@@ -23,9 +23,9 @@ There are two types of contexts:
   - : This type of context is nested inside a top-level context, such as an {{HTMLElement("iframe")}}.
     Child contexts are returned as children of their parent by [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
-For example, if you open a browser window and navigate to `https://example.com`, that creates one top-level context (with a UUID as its context ID).
+For example, if you open a browser window and navigate to `https://example.com`, that creates one top-level context with its own context ID.
 If that page contains an `<iframe>` loading `https://other.com`, that creates a child context nested under the top-level context.
-Opening a new tab creates a second top-level context with its own UUID.
+Opening a new tab creates a second top-level context with its own context ID.
 Calling [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) would return both top-level contexts, with the first one having a child context.
 
 ## Commands

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -1,5 +1,5 @@
 ---
-title: browsingContext module
+title: "`browsingContext` module"
 short-title: browsingContext
 slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext
 page-type: listing-page

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
@@ -14,7 +14,7 @@ The `input.fileDialogOpened` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 The `params` field in the event notification is an object with the following fields:
 
 - `context`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context in which the file picker dialog was triggered.
+  - : A string that contains the ID of the context in which the file picker dialog was triggered.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `element` {{optional_inline}}
   - : An object containing the ID that uniquely identifies the [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) DOM element that triggered the file picker dialog.

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -37,7 +37,7 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 The `params` field contains:
 
 - `context`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context in which to perform the actions. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+  - : A string that contains the ID of the context in which to perform the actions. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `actions`
   - : An array of objects, each representing an input source and the actions to perform for that source.
     Each such object represents the outer `actions` object, which in turn, contains an outer `type` (input source type can be `"key"`, `"pointer"`, or `"wheel"`) and an inner `actions` array.

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
@@ -25,7 +25,7 @@ The `input.releaseActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 The `params` field contains:
 
 - `context`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context for which to release inputs. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+  - : A string that contains the ID of the context for which to release inputs. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
 ### Return value
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
@@ -27,7 +27,7 @@ The `input.setFiles` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#
 The `params` field contains:
 
 - `context`
-  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) of the context with the target [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element.
+  - : A string that contains the ID of the context with the target [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `element`
   - : An object containing the ID that uniquely identifies the `<input type="file">` DOM element to use for file selection.

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
@@ -27,7 +27,7 @@ The `params` field contains:
 - `events`
   - : An array of one or more event name strings. Use a module name (for example, `"log"`) to subscribe to all events in that module or a specific event name (for example, `"log.entryAdded"`) to subscribe to only that event.
 - `contexts` {{optional_inline}}
-  - : An array of one or more context IDs ([UUIDs](/en-US/docs/Glossary/UUID)), each corresponding to a tab or frame.
+  - : An array of one or more context ID strings, each corresponding to a tab or frame.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
     If specified, events are received only for those contexts and their descendants.
     If the context ID corresponds to a frame, the subscription is created for the top-level context (tab) that owns the frame.
@@ -35,7 +35,7 @@ The `params` field contains:
     This field cannot be used if `userContexts` is also specified.
 
 - `userContexts` {{optional_inline}}
-  - : An array of one or more user context IDs ([UUIDs](/en-US/docs/Glossary/UUID)), each corresponding to a browser context or container.
+  - : An array of one or more user context ID strings, each corresponding to a browser context or container.
     User context IDs are returned by commands such as [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts).
     If specified, events are received only for those user contexts.
 

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -35,7 +35,18 @@ sidebar:
           - link: /Web/WebDriver/Reference/BiDi/Modules/browser/setDownloadBehavior
             code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext
+        details: closed
         code: true
+        children:
+          - type: section
+            link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext#commands
+            title: Commands
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/close
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/create
+            code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/input


### PR DESCRIPTION
### Description

This PR adds the first set of pages related to the context life cycle:
  - `browsingContext.create`
  - `browsingContext.close`
  - `browsingContext.activate`

In addition:
- Updated the browsingContext module landing page to include a section to explain top-level and child contexts.
- Also updated the browser module landing page to include an example to explain user context vs client window.

### Spec links

- https://w3c.github.io/webdriver-bidi/#command-browsingContext-activate
- https://w3c.github.io/webdriver-bidi/#command-browsingContext-close
- https://w3c.github.io/webdriver-bidi/#command-browsingContext-create

### Related issue

Doc issue: mdn/mdn#339