### PR TITLE
Bug 2015559 Enable executeScript restriction on extension pages on all channels

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -72,6 +72,10 @@ Firefox 152 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
+- The ability of extensions to dynamically execute code in their `moz-extension:` documents with {{WebExtAPIRef("tabs.executeScript")}}, {{WebExtAPIRef("tabs.insertCSS")}}, {{WebExtAPIRef("tabs.removeCSS")}}, {{WebExtAPIRef("scripting.executeScript")}}, {{WebExtAPIRef("scripting.insertCSS")}}, and {{WebExtAPIRef("scripting.removeCSS")}} has been removed. This feature was deprecated in Firefox 149. ([Firefox bug 2015559](https://bugzil.la/2015559))
+
+  As an alternative, an extension can run code in its documents dynamically by registering a {{WebExtAPIRef("runtime.onMessage")}} listener in the document's script, then sending a message to trigger execution of the required code.
+
 <!-- ### Removals -->
 
 <!-- ### Other -->


### PR DESCRIPTION
### Description

Add a release note for [Bug 2015559](https://bugzilla.mozilla.org/show_bug.cgi?id=2015559) Enable executeScript restriction on extension pages on all channels
