### PR TITLE
Add `demuxer` to code entities dictionary

### DIFF
--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -168,10 +168,10 @@ currentscreenchange
 cwrap
 daala
 dangi
+demuxer
 deviceproximity
 devtools.aboutdebugging
 devtools.errorconsole
-demuxer
 diak
 dialogtext
 diffe

--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -171,6 +171,7 @@ dangi
 deviceproximity
 devtools.aboutdebugging
 devtools.errorconsole
+demuxer
 diak
 dialogtext
 diffe


### PR DESCRIPTION
### Description
Adds `demuxer` to the `code-entities.txt` dictionary.

### Motivation
`demuxer` is a valid media-processing technical term (demultiplexer) commonly used in WebCodecs and related documentation, but it was being incorrectly flagged as an unknown word by spellcheck tooling.

### Additional details
This prevents false-positive spellcheck warnings for valid codec and media pipeline terminology in MDN documentation.

### Related issues and pull requests
N/A