### PR TITLE
fix typo in `RTCIceCandidatePairStats/requestsSent`

### DIFF
--- a/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
@@ -16,7 +16,7 @@ An integer value which specifies the number of STUN connectivity requests that h
 
 > [!NOTE]
 > The reported number of requests _does not_ include retransmissions.
-> If a request had to be repeated due to network issues, it will be counted multiple times here.
+> If a request had to be repeated due to network issues, it will not be counted multiple times here.
 > This differs from {{domxref("RTCIceCandidatePairStats.requestsReceived", "requestsReceived")}}, which _does_ include retransmissions.
 
 ## Specifications


### PR DESCRIPTION
typo seems to be in `RTCIceCandidatePairStats/requestsSent` L19:

```diff
- > If a request had to be repeated due to network issues, it will be counted multiple times here.
+ > If a request had to be repeated due to network issues, it will not be counted multiple times here.
```

yet this property will not count the retx, making it contradicatorial here.

in comparison with `RTCIceCandidatePairStats/requestsReceived`, it seems to be typo when it was copied from `requestsReceived` and, this line was not updated like the line before and after it?
