### PR TITLE
Add format option to AudioData.copyTo()

### DIFF
--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -25,11 +25,14 @@ copyTo(destination, options)
     - `planeIndex`
       - : The index of the plane to copy from.
     - `frameOffset` {{optional_inline}}
-      - : An integer giving the number of frames to skip before reading output. Defaults to `0`.
+      - : An integer giving the offset of the first frame to copy within the plane. Defaults to `0`.
     - `frameCount` {{optional_inline}}
       - : An integer giving the number of frames to copy. If omitted, all frames from `frameOffset` to the end of the plane are copied.
     - `format` {{optional_inline}}
-      - : An {{domxref("AudioData.format", "AudioSampleFormat")}} to convert the samples to when writing them to `destination`. If omitted, the samples are copied in the `AudioData`'s own format. If `format` differs from the `AudioData`'s format, format conversion occurs during the copy.
+      - : A string indicating the audio format that the source samples should be converted to when copied to the destination.
+      This can be any of the values: `"u8"`, `"s16"`, `"s32"`, `"f32"`, `"u8-planar"`, `"s16-planar"`, `"s32-planar"`, and `"f32-planar"` (see {{domxref("AudioData.format")}} for more information).
+      Note that `"f32-planar"` must be supported.
+      If omitted, the samples are copied in the `AudioData`'s own format. 
 
 ### Return value
 
@@ -44,6 +47,8 @@ Undefined.
     - The length of the sample is longer than the destination length.
     - The format of the `AudioData` object describes a planar format, but `options.planeIndex` is outside of the number of planes available.
     - The format of the `AudioData` object describes an interleaved format, but `options.planeIndex` is greater than `0`.
+- `NotSupportedError` {{domxref("DOMException")}}
+  - : Thrown if the specified [`format`](#format) to convert the data to is not supported.
 
 ## Examples
 

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -25,9 +25,11 @@ copyTo(destination, options)
     - `planeIndex`
       - : The index of the plane to copy from.
     - `frameOffset` {{optional_inline}}
-      - : An integer giving an offset into the plane data indicating which plane to begin copying from. Defaults to `0`.
+      - : An integer giving the number of frames to skip before reading output. Defaults to `0`.
     - `frameCount` {{optional_inline}}
-      - : An integer giving the number of frames to copy. If omitted then all frames in the plane will be copied, beginning with the frame specified in `frameOffset`.
+      - : An integer giving the number of frames to copy. If omitted, all frames from `frameOffset` to the end of the plane are copied.
+    - `format` {{optional_inline}}
+      - : An {{domxref("AudioData.format", "AudioSampleFormat")}} to convert the samples to when writing them to `destination`. If omitted, the samples are copied in the `AudioData`'s own format. If `format` differs from the `AudioData`'s format, format conversion occurs during the copy.
 
 ### Return value
 

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -30,9 +30,9 @@ copyTo(destination, options)
       - : An integer giving the number of frames to copy. If omitted, all frames from `frameOffset` to the end of the plane are copied.
     - `format` {{optional_inline}}
       - : A string indicating the audio format that the source samples should be converted to when copied to the destination.
-      This can be any of the values: `"u8"`, `"s16"`, `"s32"`, `"f32"`, `"u8-planar"`, `"s16-planar"`, `"s32-planar"`, and `"f32-planar"` (see {{domxref("AudioData.format")}} for more information).
-      Note that `"f32-planar"` must be supported.
-      If omitted, the samples are copied in the `AudioData`'s own format. 
+        This can be any of the values: `"u8"`, `"s16"`, `"s32"`, `"f32"`, `"u8-planar"`, `"s16-planar"`, `"s32-planar"`, and `"f32-planar"` (see {{domxref("AudioData.format")}} for more information).
+        Note that `"f32-planar"` must be supported.
+        If omitted, the samples are copied in the `AudioData`'s own format.
 
 ### Return value
 


### PR DESCRIPTION
Fixes #42530.

Adds the missing `format` option to the `AudioData.copyTo()` `options` parameter, per the [WebCodecs spec](https://w3c.github.io/webcodecs/#dictdef-audiodatacopytooptions) which defines `AudioSampleFormat format;` as a member of `AudioDataCopyToOptions`.

Also corrects the `frameOffset` description: it previously said "which plane to begin copying from" (wrong — that's `planeIndex`), and now correctly describes the offset within a plane.