### PR TITLE
Correct `as` values for `link`

### DIFF
--- a/files/en-us/web/html/reference/attributes/rel/modulepreload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/modulepreload/index.md
@@ -22,7 +22,7 @@ If `crossorigin` is set to [`anonymous`](/en-US/docs/Web/HTML/Reference/Attribut
 If `crossorigin` is set to [`use-credentials`](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin#use-credentials) then the credentials mode is [`include`](/en-US/docs/Web/API/Request/credentials#include), and user credentials for both single- and cross-origin requests.
 
 The [`as`](/en-US/docs/Web/HTML/Reference/Elements/link#as) attribute is optional for links with `rel="modulepreload"`, and defaults to `"script"`.
-It can be set to `"script"`, `"style"`, `"json"`, or any script-like destination, such as `"audioworklet"`, `"paintworklet"`, `"serviceworker"`, `"sharedworker"`, or `"worker"`.
+Other possible values are governed by [Links spec](https://html.spec.whatwg.org/multipage/links.html#module-preload-destination). For list of script-like destinations refer [Fetch spec](https://fetch.spec.whatwg.org/#request-destination-script-like).
 An [`Event`](/en-US/docs/Web/API/Event/Event) named "error" is fired on the element if any other destination is used.
 
 A browser _may_ additionally also choose to automatically fetch any dependencies of the module resource.

--- a/files/en-us/web/html/reference/attributes/rel/modulepreload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/modulepreload/index.md
@@ -22,7 +22,7 @@ If `crossorigin` is set to [`anonymous`](/en-US/docs/Web/HTML/Reference/Attribut
 If `crossorigin` is set to [`use-credentials`](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin#use-credentials) then the credentials mode is [`include`](/en-US/docs/Web/API/Request/credentials#include), and user credentials for both single- and cross-origin requests.
 
 The [`as`](/en-US/docs/Web/HTML/Reference/Elements/link#as) attribute is optional for links with `rel="modulepreload"`, and defaults to `"script"`.
-Other possible values are governed by [Links spec](https://html.spec.whatwg.org/multipage/links.html#module-preload-destination). For list of script-like destinations refer [Fetch spec](https://fetch.spec.whatwg.org/#request-destination-script-like).
+It can be set to `"script"`, `"style"`, `"json"`, `"text"`, or any script-like destination, such as `"audioworklet"`, `"paintworklet"`, `"serviceworker"`, `"sharedworker"`, or `"worker"`. The full set of allowed values is defined in the HTML spec's [module preload destination](https://html.spec.whatwg.org/multipage/links.html#module-preload-destination) mapping. For the list of script-like destinations, refer to the [Fetch spec](https://fetch.spec.whatwg.org/#request-destination-script-like).
 An [`Event`](/en-US/docs/Web/API/Event/Event) named "error" is fired on the element if any other destination is used.
 
 A browser _may_ additionally also choose to automatically fetch any dependencies of the module resource.

--- a/files/en-us/web/html/reference/attributes/rel/preload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/preload/index.md
@@ -71,7 +71,7 @@ Many content types can be preloaded. The possible `as` attribute values are:
 > `font` and `fetch` preloading requires the `crossorigin` attribute to be set; see [CORS-enabled fetches](#cors-enabled_fetches) below.
 
 > [!NOTE]
-> There's more detail about these values and the web features they expect to be consumed by in the HTML spec — see [Link type "preload"](https://html.spec.whatwg.org/#match-preload-type). Also note that the full list of values the `as` attribute can take is governed by the Links spec — see [preload destinations](https://html.spec.whatwg.org/multipage/links.html#preload-destination).
+> There's more detail about these values and the web features they expect to be consumed by in the HTML spec — see [Link type "preload"](https://html.spec.whatwg.org/multipage/links.html#link-type-preload). Also note that the full list of values the `as` attribute can take is governed by the HTML spec — see [Link type "preload" destinations](https://html.spec.whatwg.org/multipage/links.html#preload-destination).
 
 ## Including a MIME type
 

--- a/files/en-us/web/html/reference/attributes/rel/preload/index.md
+++ b/files/en-us/web/html/reference/attributes/rel/preload/index.md
@@ -71,7 +71,7 @@ Many content types can be preloaded. The possible `as` attribute values are:
 > `font` and `fetch` preloading requires the `crossorigin` attribute to be set; see [CORS-enabled fetches](#cors-enabled_fetches) below.
 
 > [!NOTE]
-> There's more detail about these values and the web features they expect to be consumed by in the HTML spec — see [Link type "preload"](https://html.spec.whatwg.org/#match-preload-type). Also note that the full list of values the `as` attribute can take is governed by the Fetch spec — see [request destinations](https://fetch.spec.whatwg.org/#concept-request-destination).
+> There's more detail about these values and the web features they expect to be consumed by in the HTML spec — see [Link type "preload"](https://html.spec.whatwg.org/#match-preload-type). Also note that the full list of values the `as` attribute can take is governed by the Links spec — see [preload destinations](https://html.spec.whatwg.org/multipage/links.html#preload-destination).
 
 ## Including a MIME type
 

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -144,7 +144,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
           <td>json</td>
           <td>modulepreload</td>
           <td>
-            Link to supplementary JSON file.
+            Supplementary JSON file
           </td>
         </tr>
         <tr>

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -162,7 +162,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         <tr>
           <td>serviceworker</td>
           <td>modulepreload</td>
-          <td><a href="/en-US/docs/Web/API/ServiceWorker">ServiceWorker</a></td>
+          <td><a href="/en-US/docs/Web/API/ServiceWorker">ServiceWorker</a> modules</td>
         </tr>
         <tr>
           <td>sharedworker</td>

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -171,7 +171,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         </tr>
         <tr>
           <td>style</td>
-          <td>preload</td>
+          <td>preload or modulepreload</td>
           <td>
             <code>&#x3C;link rel=stylesheet></code> elements, CSS
             <code>@import</code> and <code>modulepreload</code> destinations.

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -103,7 +103,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         <tr>
           <td>audioworklet</td>
           <td>modulepreload</td>
-          <td><a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklet</a></td>
+          <td><a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklet</a> modules</td>
         </tr>
         <tr>
           <td>fetch</td>

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -150,7 +150,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         <tr>
           <td>paintworklet</td>
           <td>modulepreload</td>
-          <td><a href="/en-US/docs/Web/API/PaintWorkletGlobalScope">PaintWorklet</a></td>
+          <td><a href="/en-US/docs/Web/API/PaintWorkletGlobalScope">PaintWorklet</a> modules</td>
         </tr>
         <tr>
           <td>script</td>

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -94,25 +94,20 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
     <table class="standard-table">
       <thead>
         <tr>
-          <th scope="col">Value</th>
+          <th scope="col"><code>As</code> value</th>
+          <th scope="col"><code>Rel</code> value</th>
           <th scope="col">Applies To</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td>audio</td>
-          <td><code>&#x3C;audio></code> elements</td>
-        </tr>
-        <tr>
-          <td>document</td>
-          <td><code>&#x3C;iframe></code> and <code>&#x3C;frame></code> elements</td>
-        </tr>
-        <tr>
-          <td>embed</td>
-          <td><code>&#x3C;embed></code> elements</td>
+          <td>audioworklet</td>
+          <td>modulepreload</td>
+          <td><a href="/en-US/docs/Web/API/AudioWorklet">AudioWorklet</a></td>
         </tr>
         <tr>
           <td>fetch</td>
+          <td>preload</td>
           <td>
             <p>fetch, XHR</p>
             <div class="notecard note">
@@ -125,6 +120,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         </tr>
         <tr>
           <td>font</td>
+          <td>preload</td>
           <td>
             <p>CSS @font-face</p>
             <div class="notecard note">
@@ -137,6 +133,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         </tr>
         <tr>
           <td>image</td>
+          <td>preload</td>
           <td>
             <code>&#x3C;img></code> and <code>&#x3C;picture></code> elements with
             srcset or imageset attributes, SVG <code>&#x3C;image></code> elements,
@@ -145,38 +142,55 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         </tr>
         <tr>
           <td>json</td>
+          <td>modulepreload</td>
           <td>
-            <code>modulepreload</code> destinations.
+            Link to supplementary JSON file.
           </td>
         </tr>
         <tr>
-          <td>object</td>
-          <td><code>&#x3C;object></code> elements</td>
+          <td>paintworklet</td>
+          <td>modulepreload</td>
+          <td><a href="/en-US/docs/Web/API/PaintWorkletGlobalScope">PaintWorklet</a></td>
         </tr>
         <tr>
           <td>script</td>
+          <td>preload or modulepreload</td>
           <td>
             <code>&#x3C;script></code> elements, Worker <code>importScripts</code>, and <code>modulepreload</code> destinations.
           </td>
         </tr>
         <tr>
+          <td>serviceworker</td>
+          <td>modulepreload</td>
+          <td><a href="/en-US/docs/Web/API/ServiceWorker">ServiceWorker</a></td>
+        </tr>
+        <tr>
+          <td>sharedworker</td>
+          <td>modulepreload</td>
+          <td><a href="/en-US/docs/Web/API/SharedWorker">SharedWorker</a></td>
+        </tr>
+        <tr>
           <td>style</td>
+          <td>preload</td>
           <td>
             <code>&#x3C;link rel=stylesheet></code> elements, CSS
             <code>@import</code> and <code>modulepreload</code> destinations.
           </td>
         </tr>
         <tr>
-          <td>track</td>
-          <td><code>&#x3C;track></code> elements</td>
+          <td>text</td>
+          <td>modulepreload</td>
+          <td>Supplementary plain text file</td>
         </tr>
         <tr>
-          <td>video</td>
-          <td><code>&#x3C;video></code> elements</td>
+          <td>track</td>
+          <td>preload</td>
+          <td><code>&#x3C;track></code> <a href="/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format">elements</a> (MIME type <code>text/vtt</code>)</td>
         </tr>
         <tr>
           <td>worker</td>
-          <td>Worker, SharedWorker</td>
+          <td>modulepreload</td>
+          <td><a href="/en-US/docs/Web/API/Worker">Worker</a></td>
         </tr>
       </tbody>
     </table>

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -190,7 +190,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         <tr>
           <td>worker</td>
           <td>modulepreload</td>
-          <td><a href="/en-US/docs/Web/API/Worker">Worker</a></td>
+          <td><a href="/en-US/docs/Web/API/Worker">Worker</a> modules</td>
         </tr>
       </tbody>
     </table>

--- a/files/en-us/web/html/reference/elements/link/index.md
+++ b/files/en-us/web/html/reference/elements/link/index.md
@@ -185,7 +185,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
         <tr>
           <td>track</td>
           <td>preload</td>
-          <td><code>&#x3C;track></code> <a href="/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format">elements</a> (MIME type <code>text/vtt</code>)</td>
+          <td><code>&#x3C;track></code> elements (<a href="/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format">WebVTT</a>, MIME type <code>text/vtt</code>)</td>
         </tr>
         <tr>
           <td>worker</td>


### PR DESCRIPTION
### Description

Adjusted values for `as` attribute in `link` element description to match current spec, and also corrected spec references for `preload` and `modulepreload` values for `rel` attribute.

### Motivation

Documentation does not match WHATWG.

### Additional details

https://html.spec.whatwg.org/multipage/semantics.html#attr-link-as
https://html.spec.whatwg.org/multipage/links.html#preload-destination
https://html.spec.whatwg.org/multipage/links.html#module-preload-destination
https://fetch.spec.whatwg.org/#request-destination-script-like
