### PR TITLE
fix(css): clarify unitless zero for angle values

### DIFF
--- a/files/en-us/web/css/reference/values/angle/index.md
+++ b/files/en-us/web/css/reference/values/angle/index.md
@@ -47,7 +47,8 @@ transform: rotate(1.75turn);
 
 ## Syntax
 
-The `<angle>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by one of the units listed below. As with all dimensions, there is no space between the unit literal and the number. Some legacy uses of `<angle>` allow a unitless zero angle, but this is not generally true. To represent a zero angle, include a unit such as `0deg`, `0grad`, `0rad`, or `0turn`.
+The `<angle>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by one of the units listed below. As with all dimensions, there is no space between the unit literal and the number.
+While some legacy uses accept a unitless `0`, you should always include a unit for zero values, such as: `0deg`, `0grad`, `0rad`, or `0turn`.
 
 Optionally, it may be preceded by a single `+` or `-` sign. Positive numbers represent clockwise angles, while negative numbers represent counterclockwise angles. For static properties of a given unit, any angle can be represented by various equivalent values. For example, `90deg` equals `-270deg`, and `1turn` equals `4turn`. For dynamic properties, like when applying an {{cssxref("animation")}} or {{cssxref("transition")}}, the effect will nevertheless be different.
 

--- a/files/en-us/web/css/reference/values/angle/index.md
+++ b/files/en-us/web/css/reference/values/angle/index.md
@@ -47,7 +47,7 @@ transform: rotate(1.75turn);
 
 ## Syntax
 
-The `<angle>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by one of the units listed below. As with all dimensions, there is no space between the unit literal and the number. The angle unit is optional after the number `0`.
+The `<angle>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by one of the units listed below. As with all dimensions, there is no space between the unit literal and the number. Some legacy uses of `<angle>` allow a unitless zero angle, but this is not generally true. To represent a zero angle, include a unit such as `0deg`, `0grad`, `0rad`, or `0turn`.
 
 Optionally, it may be preceded by a single `+` or `-` sign. Positive numbers represent clockwise angles, while negative numbers represent counterclockwise angles. For static properties of a given unit, any angle can be represented by various equivalent values. For example, `90deg` equals `-270deg`, and `1turn` equals `4turn`. For dynamic properties, like when applying an {{cssxref("animation")}} or {{cssxref("transition")}}, the effect will nevertheless be different.
 
@@ -103,7 +103,7 @@ Optionally, it may be preceded by a single `+` or `-` sign. Positive numbers rep
   <tbody>
     <tr>
       <td><img class="default internal" src="angle0.png" alt="A diagram showing a 0-degree rotation. There is no movement." /></td>
-      <td><code>0 = 0deg = 0grad = 0turn = 0rad</code></td>
+      <td><code>0deg = 0grad = 0turn = 0rad</code></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary

Fixes mdn/content#44143.

Updates the CSS `<angle>` value documentation to clarify that a unitless `0` is not generally valid for angle values.

The previous wording said:

> The angle unit is optional after the number `0`.

That was too broad. Some legacy angle contexts may allow a unitless zero, but `<angle>` values should generally include an angle unit such as `0deg`, `0grad`, `0rad`, or `0turn`.

This PR also updates the null angle example so it no longer lists bare `0` as equivalent to angle values.

## Changes

- Clarified the `<angle>` syntax note for zero angles.
- Removed bare `0` from the null angle equivalence example.

## Validation

- `npm run filecheck -- files/en-us/web/css/reference/values/angle/index.md`
- `npx markdownlint-cli2 files/en-us/web/css/reference/values/angle/index.md`
- `npx prettier -c files/en-us/web/css/reference/values/angle/index.md`
- `npx cspell --no-progress --gitignore --config .vscode/cspell.json files/en-us/web/css/reference/values/angle/index.md`
- `git diff --check`