### PR TITLE
fix(svg): clarify feOffset filter units example

### DIFF
--- a/files/en-us/web/svg/reference/element/feoffset/index.md
+++ b/files/en-us/web/svg/reference/element/feoffset/index.md
@@ -30,7 +30,7 @@ This element implements the {{domxref("SVGFEOffsetElement")}} interface.
 ```html
 <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <filter id="offset" width="180" height="180">
+    <filter id="offset" width="180" height="180" filterUnits="userSpaceOnUse">
       <feOffset in="SourceGraphic" dx="60" dy="60" />
     </filter>
   </defs>


### PR DESCRIPTION
### Summary

Adds `filterUnits="userSpaceOnUse"` to the `<feOffset>` example filter so the `width` and `height` values are interpreted as user-space units.

### Details

The current example uses:

```svg
<filter id="offset" width="180" height="180">
```

Without an explicit `filterUnits`, the default is `objectBoundingBox`, so `width` and `height` are interpreted relative to the bounding box rather than as user-space dimensions.

This update makes the example match the apparent intent and avoids teaching readers that bare numeric filter dimensions behave like pixel/user-space values by default.

Fixes #44122.