### PR TITLE
FF151 Relnote WebSerial API

### DIFF
--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -79,6 +79,7 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
   ([Firefox bug 2022827](https://bugzil.la/2022827)).
 - The [Web Serial API](/en-US/docs/Web/API/Web_Serial_API) is supported on desktop platforms, allowing the control of microcontrollers that support serial communications.
   This lets you, for example, program microcontrollers and development boards, such as ESP devices, BBCmicro:bit, and Raspberry Pi Picos, 3D printers and CNC machines, and other supported devices.
+  Use of the API will require that website users install a synthetically generated site permission addon — this is the same approach used to safely manage access to WebMIDI.
   ([Firefox bug 2029625](https://bugzil.la/2029625)).
 
 <!-- #### DOM -->

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -77,6 +77,9 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{domxref("CSSContainerRule.conditions")}} property is now supported, mirroring [`@container`](/en-US/docs/Web/CSS/Reference/At-rules/@container) at-rule support for multiple comma-separated container conditions.
   The `condition` property reflects a corresponding `@container` as an array of objects, where each object represents a single container condition.
   ([Firefox bug 2022827](https://bugzil.la/2022827)).
+- The [Web Serial API](/en-US/docs/Web/API/Web_Serial_API) is supported on desktop platforms, allowing the control of microcontrollers that support serial communications.
+  This lets you, for example, program microcontrollers and development boards, such as ESP devices, BBCmicro:bit, and Raspberry Pi Picos, 3D printers and CNC machines, and other supported devices.
+  ([Firefox bug 2029625](https://bugzil.la/2029625)).
 
 <!-- #### DOM -->
 

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -79,7 +79,7 @@ Firefox 151 is the current [Beta version of Firefox](https://www.firefox.com/en-
   ([Firefox bug 2022827](https://bugzil.la/2022827)).
 - The [Web Serial API](/en-US/docs/Web/API/Web_Serial_API) is supported on desktop platforms, allowing the control of microcontrollers that support serial communications.
   This lets you, for example, program microcontrollers and development boards, such as ESP devices, BBCmicro:bit, and Raspberry Pi Picos, 3D printers and CNC machines, and other supported devices.
-  Use of the API will require that website users install a synthetically generated site permission addon — this is the same approach used to safely manage access to WebMIDI.
+  Use of the API will require that website users install a [synthetically generated site permission add-on](https://support.mozilla.org/en-US/kb/site-permission-add-ons) — this is the same approach used to safely manage access to WebMIDI.
   ([Firefox bug 2029625](https://bugzil.la/2029625)).
 
 <!-- #### DOM -->


### PR DESCRIPTION
FF151 supports the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API) on desktop in https://bugzilla.mozilla.org/show_bug.cgi?id=2029625

This adds a release note.

Related docs work can be tracked in #43967
