### PR TITLE
Web Serial API - consistency updates

### DIFF
--- a/files/en-us/web/api/navigator/serial/index.md
+++ b/files/en-us/web/api/navigator/serial/index.md
@@ -8,15 +8,17 @@ browser-compat: api.Navigator.serial
 
 {{APIRef("Web Serial API")}}{{SecureContext_Header}}
 
-The **`serial`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the [Web Serial API](/en-US/docs/Web/API/Web_Serial_API).
+The **`serial`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Serial")}} object, which represents the entry point into the [Web Serial API](/en-US/docs/Web/API/Web_Serial_API).
 
-When getting, the same instance of the {{domxref("Serial")}} object will always be returned.
+The same instance of the {{domxref("Serial")}} object will always be returned.
 
 ## Value
 
 A {{domxref("Serial")}} object.
 
 ## Examples
+
+### List available ports
 
 The following example uses the `getPorts()` method to initialize a list of available ports.
 
@@ -37,4 +39,4 @@ navigator.serial.getPorts().then((ports) => {
 ## See also
 
 - [Read from and write to a serial port](https://developer.chrome.com/docs/capabilities/serial)
-- [Getting started with the web serial API](https://codelabs.developers.google.com/codelabs/web-serial#0)
+- [Getting started with the Web Serial API](https://codelabs.developers.google.com/codelabs/web-serial#0)

--- a/files/en-us/web/api/serial/getports/index.md
+++ b/files/en-us/web/api/serial/getports/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Serial.getPorts
 
 {{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
-The **`getPorts()`** method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host which the origin has permission to access.
+The **`getPorts()`** method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host that the origin has permission to access.
 
 ## Syntax
 
@@ -32,6 +32,8 @@ A {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}}
     - A user permission prompt was denied.
 
 ## Examples
+
+### List available ports
 
 The following example uses `getPorts()` to initialize a list of available ports.
 

--- a/files/en-us/web/api/serial/index.md
+++ b/files/en-us/web/api/serial/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.Serial
 ---
 
-{{securecontext_header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The `Serial` interface of the [Web Serial API](/en-US/docs/Web/API/Web_Serial_API) provides attributes and methods for finding and connecting to serial ports from a web page.
 
@@ -14,11 +14,11 @@ The `Serial` interface of the [Web Serial API](/en-US/docs/Web/API/Web_Serial_AP
 ## Instance methods
 
 - {{domxref("Serial.requestPort()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user. This method must be called via [transient activation](/en-US/docs/Glossary/Transient_activation).
+  - : Returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user.
+    This method must be called via [transient activation](/en-US/docs/Glossary/Transient_activation).
 
 - {{domxref("Serial.getPorts()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to
-    the host which the origin has permission to access.
+  - : Returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host which the origin has permission to access.
 
 ## Events
 
@@ -31,11 +31,15 @@ The following events are available to `Serial` via event bubbling from {{domxref
 
 ## Examples
 
+### Basic usage
+
 The following example shows how a site can check for available ports and allow the user to grant it permission to access additional ports.
 
 On load event listeners are added for the {{domxref("SerialPort.connect_event", "connect")}} and {{domxref("SerialPort.disconnect_event", "disconnect")}} events so that the site can react when a device is connected or disconnected from the system. The {{domxref("Serial.getPorts()","getPorts()")}} method is then called to see which ports are connected that the site already has access to.
 
-If the site doesn't have access to any connected ports it has to wait until it has user activation to proceed. In this example we use a {{domxref("Element.click_event", "click")}} event handler on a button for this task. A filter is passed to {{domxref("Serial.requestPort()","requestPort()")}} with a USB vendor ID in order to limit the set of devices shown to the user to only USB devices built by a particular manufacturer.
+If the site doesn't have access to any connected ports it has to wait until it has user activation to proceed.
+In this example we use a {{domxref("Element.click_event", "click")}} event handler on a button for this task.
+A filter is passed to {{domxref("Serial.requestPort()","requestPort()")}} with a USB vendor ID in order to limit the set of devices shown to the user to only USB devices built by a particular manufacturer.
 
 ```js
 navigator.serial.addEventListener("connect", (e) => {

--- a/files/en-us/web/api/serial/index.md
+++ b/files/en-us/web/api/serial/index.md
@@ -18,7 +18,7 @@ The `Serial` interface of the [Web Serial API](/en-US/docs/Web/API/Web_Serial_AP
     This method must be called via [transient activation](/en-US/docs/Glossary/Transient_activation).
 
 - {{domxref("Serial.getPorts()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host which the origin has permission to access.
+  - : Returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host that the origin has permission to access.
 
 ## Events
 

--- a/files/en-us/web/api/serial/requestport/index.md
+++ b/files/en-us/web/api/serial/requestport/index.md
@@ -8,13 +8,7 @@ browser-compat: api.Serial.requestPort
 
 {{APIRef("Web Serial API")}}{{SecureContext_Header}}
 
-The **`Serial.requestPort()`** method of the {{domxref("Serial")}} interface presents the user with a dialog asking them to select a serial device to connect to. It returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user.
-
-## Description
-
-When the user first visits a site it will not have permission to access any serial devices. A site must first call `requestPort()` to prompt the user to select which device the site should be allowed to control.
-
-This method must be called via [transient activation](/en-US/docs/Glossary/Transient_activation). The user has to interact with the page or a UI element in order for this feature to work.
+The **`requestPort()`** method of the {{domxref("Serial")}} interface presents the user with a dialog asking them to select a serial device to connect to. It returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user.
 
 ## Syntax
 
@@ -28,15 +22,22 @@ requestPort(options)
 - `options` {{optional_inline}}
   - : An object with the following properties:
     - `filters` {{optional_inline}}
-      - : A list of objects containing vendor, product, or Bluetooth service class IDs used to filter the specific device types made available for the user to request a connection to. If no filters are specified, the user is presented with a list of every available device to choose from. Filters can contain the following values:
+      - : A list of objects containing vendor, product, or Bluetooth service class IDs used to filter the specific device types made available for the user to request a connection to.
+        If no filters are specified, the user is presented with a list of every available device to choose from.
+        Filters can contain the following values:
         - `bluetoothServiceClassId` {{optional_inline}}
-          - : An unsigned long integer or string representing a Bluetooth service class ID. This can be a 16- or 32-bit UUID alias, any valid UUID, or a valid name from a [GATT assigned services key](https://github.com/WebBluetoothCG/registries/blob/master/gatt_assigned_services.txt).
+          - : A positive integer or string representing a Bluetooth service class ID.
+            This can be a 16- or 32-bit UUID alias, any valid UUID, or a valid name from a [GATT assigned services key](https://github.com/WebBluetoothCG/registries/blob/master/gatt_assigned_services.txt).
         - `usbVendorId` {{optional_inline}}
-          - : An unsigned short integer that identifies a USB device vendor. The [USB Implementors Forum](https://www.usb.org/) assigns IDs to specific vendors.
+          - : A positive integer that identifies a USB device vendor.
+            The [USB Implementors Forum](https://www.usb.org/) assigns IDs to specific vendors.
         - `usbProductId` {{optional_inline}}
-          - : An unsigned short integer that identifies a USB device. Each vendor assigns IDs to its products.
+          - : A positive integer that identifies a USB device.
+            Each vendor assigns IDs to its products.
     - `allowedBluetoothServiceClassIds` {{optional_inline}}
-      - : A list of unsigned long integers and/or strings representing Bluetooth service class IDs. Bluetooth ports with custom service class IDs are excluded from the list of ports presented to the user unless the service class ID is included in this list. This is true whether you filter the list or not.
+      - : A list of unsigned long integers and/or strings representing Bluetooth service class IDs.
+        Bluetooth ports with custom service class IDs are excluded from the list of ports presented to the user unless the service class ID is included in this list.
+        This is true whether you filter the list or not.
 
 ### Return value
 
@@ -51,11 +52,23 @@ A {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort"
 - `NotFoundError` {{domxref("DOMException")}}
   - : The returned `Promise` rejects with this exception if the user does not select a port when prompted.
 
+## Description
+
+When the user first visits a site it will not have permission to access any serial devices.
+A site must first call `requestPort()` to prompt the user to select which device the site should be allowed to control.
+
+This method must be called via [transient activation](/en-US/docs/Glossary/Transient_activation).
+The user has to interact with the page or a UI element in order for this feature to work.
+
+Access to the site might also be blocked by the {{httpheader('Permissions-Policy/serial','serial')}} [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy).
+If blocked, the user won't be prompted for access to devices.
+
 ## Examples
 
 ### Allow the user to select any device
 
-This example prompts the user to select a device via `requestPort()` when a `<button>` is pressed. It does not include a filter, which means that the selection list will include all available devices:
+This example prompts the user to select a device via `requestPort()` when a `<button>` is pressed.
+It does not include a filter, which means that the selection list will include all available devices:
 
 ```html
 <button id="connect">Connect</button>
@@ -63,7 +76,7 @@ This example prompts the user to select a device via `requestPort()` when a `<bu
 
 ```js
 const connectBtn = document.getElementById("connect");
-connectBtn.addEventListener("click", () => {
+connectBtn.addEventListener("click", async () => {
   try {
     const port = await navigator.serial.requestPort();
     // Connect to port or add it to the list of available ports
@@ -78,10 +91,12 @@ connectBtn.addEventListener("click", () => {
 In this case, a filter is passed to `requestPort()` with a USB vendor ID to limit the set of devices shown to the user to only USB devices built by a particular manufacturer.
 
 ```js
-connectBtn.addEventListener("click", () => {
+connectBtn.addEventListener("click", async () => {
   const usbVendorId = 0xabcd;
   try {
-    const port = await navigator.serial.requestPort({ filters: [{ usbVendorId }] });
+    const port = await navigator.serial.requestPort({
+      filters: [{ usbVendorId }],
+    });
     // Connect to port or add it to the list of available ports
   } catch (e) {
     // The user didn't select a device

--- a/files/en-us/web/api/serial/requestport/index.md
+++ b/files/en-us/web/api/serial/requestport/index.md
@@ -35,7 +35,7 @@ requestPort(options)
           - : A positive integer that identifies a USB device.
             Each vendor assigns IDs to its products.
     - `allowedBluetoothServiceClassIds` {{optional_inline}}
-      - : A list of unsigned long integers and/or strings representing Bluetooth service class IDs.
+      - : A list of positive integers and/or strings representing Bluetooth service class IDs.
         Bluetooth ports with custom service class IDs are excluded from the list of ports presented to the user unless the service class ID is included in this list.
         This is true whether you filter the list or not.
 

--- a/files/en-us/web/api/serialport/close/index.md
+++ b/files/en-us/web/api/serialport/close/index.md
@@ -34,9 +34,11 @@ Closing a serial port is more complicated when using [transform streams](/en-US/
 
 ## Examples
 
-### Closing a port after reading until the stream is done
+### Closing a port after reading once the stream is done
 
-The following example shows how to close a port while continuously reading data from it. A `keepReading` flag is used to control when to stop reading. A button click sets `keepReading` to `false` and cancels the reader, which causes `reader.read()` to resolve immediately so the loop can release the lock and `close()` can be called.
+The following example shows how to close a port after continuously reading data from it, once the stream is done.
+A `keepReading` flag controls when to stop reading.
+A button click sets `keepReading` to `false` and cancels the reader, which causes `reader.read()` to resolve immediately so the loop can release the lock and `close()` can be called.
 
 ```js
 // Without transform streams.

--- a/files/en-us/web/api/serialport/close/index.md
+++ b/files/en-us/web/api/serialport/close/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SerialPort.close
 
 {{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
-The **`SerialPort.close()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port closes.
+The **`close()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port closes.
 
 ## Syntax
 
@@ -29,6 +29,14 @@ A {{jsxref("Promise")}}.
 `close()` closes the serial port if previously-locked {{domxref("SerialPort.readable")}} and {{domxref("SerialPort.writable")}} members are unlocked, meaning the `releaseLock()` methods have been called for their respective reader and writer.
 
 However, when continuously reading data from a serial device using a loop, the associated [readable stream](/en-US/docs/Web/API/ReadableStream) will always be locked until the [reader](/en-US/docs/Web/API/ReadableStreamDefaultReader) encounters an error. In this case, calling [`reader.cancel()`](/en-US/docs/Web/API/ReadableStreamDefaultReader/cancel) will force [`reader.read()`](/en-US/docs/Web/API/ReadableStreamDefaultReader/read) to resolve immediately with `{ value: undefined, done: true }` allowing the loop to call [`reader.releaseLock()`](/en-US/docs/Web/API/ReadableStreamDefaultReader/releaseLock).
+
+Closing a serial port is more complicated when using [transform streams](/en-US/docs/Web/API/TransformStream). See [Close a serial port](https://developer.chrome.com/docs/capabilities/serial#close-port) for guidance.
+
+## Examples
+
+### Closing a port after reading until the stream is done
+
+The following example shows how to close a port while continuously reading data from it. A `keepReading` flag is used to control when to stop reading. A button click sets `keepReading` to `false` and cancels the reader, which causes `reader.read()` to resolve immediately so the loop can release the lock and `close()` can be called.
 
 ```js
 // Without transform streams.
@@ -71,8 +79,6 @@ document.querySelector("button").addEventListener("click", async () => {
   await closedPromise;
 });
 ```
-
-Closing a serial port is more complicated when using [transform streams](/en-US/docs/Web/API/TransformStream). See [Close a serial port](https://developer.chrome.com/docs/capabilities/serial#close-port) for guidance.
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/connect_event/index.md
+++ b/files/en-us/web/api/serialport/connect_event/index.md
@@ -10,19 +10,6 @@ browser-compat: api.SerialPort.connect_event
 
 The **`connect`** event of the {{domxref("SerialPort")}} interface is fired when the port connects to the device.
 
-## Description
-
-More specifically, the `connect` event fires when the port becomes **logically connected** to the device after a user grants permission for a site to access the port following a {{domxref("Serial.requestPort()")}} call:
-
-- In the case of a wired serial port, this occurs when the port is physically connected to the device, for example via USB.
-- In the case of a wireless serial port (for example, Bluetooth RFCOMM), this occurs when the port makes one or more active connections to the device (for example via Bluetooth L2CAP channels).
-
-### Bubbling
-
-This event bubbles to the instance of {{domxref("Serial")}} that returned this interface. The `event.target` property refers to the {{domxref('SerialPort')}} object that bubbles up.
-
-For more information, see [Event bubbling](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling).
-
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -36,6 +23,19 @@ onconnect = (event) => { }
 ## Event type
 
 A generic {{domxref("Event")}}.
+
+## Description
+
+More specifically, the `connect` event fires when the port becomes **logically connected** to the device after a user grants permission for a site to access the port following a {{domxref("Serial.requestPort()")}} call:
+
+- In the case of a wired serial port, this occurs when the port is physically connected to the device, for example via USB.
+- In the case of a wireless serial port (for example, Bluetooth RFCOMM), this occurs when the port makes one or more active connections to the device (for example via Bluetooth L2CAP channels).
+
+### Bubbling
+
+This event bubbles to the instance of {{domxref("Serial")}} that returned this interface. The `event.target` property refers to the {{domxref('SerialPort')}} object that bubbles up.
+
+For more information, see [Event bubbling](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling).
 
 ## Examples
 

--- a/files/en-us/web/api/serialport/connect_event/index.md
+++ b/files/en-us/web/api/serialport/connect_event/index.md
@@ -26,14 +26,16 @@ A generic {{domxref("Event")}}.
 
 ## Description
 
-More specifically, the `connect` event fires when the port becomes **logically connected** to the device after a user grants permission for a site to access the port following a {{domxref("Serial.requestPort()")}} call:
+More specifically, the `connect` event fires when the port becomes **logically connected** to the device.
+This happens after a user grants permission for a site to access the port that the device is attached to, following a {{domxref("Serial.requestPort()")}} call:
 
 - In the case of a wired serial port, this occurs when the port is physically connected to the device, for example via USB.
 - In the case of a wireless serial port (for example, Bluetooth RFCOMM), this occurs when the port makes one or more active connections to the device (for example via Bluetooth L2CAP channels).
 
 ### Bubbling
 
-This event bubbles to the instance of {{domxref("Serial")}} that returned this interface. The `event.target` property refers to the {{domxref('SerialPort')}} object that bubbles up.
+This event bubbles up to the {{domxref("Serial")}} instance that returned this interface.
+The `event.target` property refers to the {{domxref("SerialPort")}} object that bubbles up.
 
 For more information, see [Event bubbling](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling).
 

--- a/files/en-us/web/api/serialport/connected/index.md
+++ b/files/en-us/web/api/serialport/connected/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SerialPort.connected
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`connected`** read-only property of the {{domxref("SerialPort")}} interface returns a boolean value that indicates whether the port is [logically connected](/en-US/docs/Web/API/SerialPort/connect_event#description) to the device.
 

--- a/files/en-us/web/api/serialport/disconnect_event/index.md
+++ b/files/en-us/web/api/serialport/disconnect_event/index.md
@@ -6,19 +6,9 @@ page-type: web-api-event
 browser-compat: api.SerialPort.disconnect_event
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`disconnect`** event of the {{domxref("SerialPort")}} interface is fired when the port disconnects from the device.
-
-## Description
-
-More specifically, the `disconnect` event fires when a port that was previously [logically connected](/en-US/docs/Web/API/SerialPort/connect_event#description) after a user granted permission for a site to access it (following a {{domxref("Serial.requestPort()")}} call) is no longer connected.
-
-### Bubbling
-
-This event bubbles to the instance of {{domxref("Serial")}} that returned this interface. The `event.target` property refers to the {{domxref('SerialPort')}} object that bubbles up.
-
-For more information, see [Event bubbling](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling).
 
 ## Syntax
 
@@ -33,6 +23,17 @@ ondisconnect = (event) => { }
 ## Event type
 
 A generic {{domxref("Event")}}.
+
+## Description
+
+The `disconnect` event fires when a port that was previously [logically connected](/en-US/docs/Web/API/SerialPort/connect_event#description) to the device is no longer connected.
+
+### Bubbling
+
+This event bubbles to the instance of {{domxref("Serial")}} that returned this interface.
+The `event.target` property refers to the {{domxref('SerialPort')}} object that bubbles up.
+
+For more information, see [Event bubbling](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling).
 
 ## Examples
 

--- a/files/en-us/web/api/serialport/disconnect_event/index.md
+++ b/files/en-us/web/api/serialport/disconnect_event/index.md
@@ -30,8 +30,8 @@ The `disconnect` event fires when a port that was previously [logically connecte
 
 ### Bubbling
 
-This event bubbles to the instance of {{domxref("Serial")}} that returned this interface.
-The `event.target` property refers to the {{domxref('SerialPort')}} object that bubbles up.
+This event bubbles up to the {{domxref("Serial")}} instance that returned this interface.
+The `event.target` property refers to the {{domxref("SerialPort")}} object that bubbles up.
 
 For more information, see [Event bubbling](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling).
 

--- a/files/en-us/web/api/serialport/forget/index.md
+++ b/files/en-us/web/api/serialport/forget/index.md
@@ -26,9 +26,11 @@ A {{jsxref("Promise")}} that resolves with `undefined` once the connection is re
 
 ## Description
 
-A website can clean up permissions to access a serial port it is no longer interested in retaining by calling `forget()`. Calling this "forgets" the device, resetting any previously-set permissions so the calling site can no longer communicate with the port.
+A website can clean up permissions to access a serial port it is no longer interested in retaining by calling `forget()`.
+Calling this "forgets" the device, resetting any previously-set permissions so the calling site can no longer communicate with the port.
 
 For example, for an educational web application used on a shared computer with many devices, a large number of accumulated user-generated permissions creates a poor user experience.
+The application should call `forget()` after each user device is disconnected, to clean up after each session.
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/forget/index.md
+++ b/files/en-us/web/api/serialport/forget/index.md
@@ -6,15 +6,9 @@ page-type: web-api-instance-method
 browser-compat: api.SerialPort.forget
 ---
 
-{{securecontext_header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
-The **`SerialPort.forget()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when access to the serial port is revoked.
-
-## Description
-
-A website can clean up permissions to access a serial port it is no longer interested in retaining by calling `SerialPort.forget()`. Calling this "forgets" the device, resetting any previously-set permissions so the calling site can no longer communicate with the port.
-
-For example, for an educational web application used on a shared computer with many devices, a large number of accumulated user-generated permissions creates a poor user experience.
+The **`forget()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when access to the serial port is revoked.
 
 ## Syntax
 
@@ -29,6 +23,12 @@ None.
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with `undefined` once the connection is revoked.
+
+## Description
+
+A website can clean up permissions to access a serial port it is no longer interested in retaining by calling `forget()`. Calling this "forgets" the device, resetting any previously-set permissions so the calling site can no longer communicate with the port.
+
+For example, for an educational web application used on a shared computer with many devices, a large number of accumulated user-generated permissions creates a poor user experience.
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/getinfo/index.md
+++ b/files/en-us/web/api/serialport/getinfo/index.md
@@ -33,7 +33,11 @@ An object containing the following properties:
 
 ## Examples
 
-This snippet calls the {{domxref("Serial.requestPort()")}} method when a `<button>` is pressed. We pass a filter to `requestPort()` to filter for Arduino Uno USB devices. Once a port is requested, we call `getInfo()` to return the device's `usbProductId` and `usbVendorId`.
+### Get information from a selected device
+
+This snippet calls the {{domxref("Serial.requestPort()")}} method when a `<button>` is pressed.
+We pass a filter to `requestPort()` to filter for Arduino Uno USB devices.
+Once a port is requested, we call `getInfo()` to return the device's `usbProductId` and `usbVendorId`.
 
 ```html
 <button id="connect">Connect</button>

--- a/files/en-us/web/api/serialport/getinfo/index.md
+++ b/files/en-us/web/api/serialport/getinfo/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.SerialPort.getInfo
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`getInfo()`** method of the {{domxref("SerialPort")}} interface returns an object containing identifying information for the device available via the port.
 
@@ -25,13 +25,13 @@ None.
 An object containing the following properties:
 
 - `usbVendorId`
-  - : If the port is part of a USB device, this property is an unsigned short integer that identifies the device's vendor. If not, it is `undefined`.
+  - : If the port is part of a USB device, this property is a positive integer that identifies the device's vendor. If not, it is `undefined`.
 - `usbProductId`
-  - : If the port is part of a USB device, this property is an unsigned short integer that identifies the USB device. If not, it is `undefined`.
+  - : If the port is part of a USB device, this property is a positive integer that identifies the USB device. If not, it is `undefined`.
 - `bluetoothServiceClassId` {{experimental_inline}}
-  - : If the port is a Bluetooth RFCOMM service, this property is an unsigned long integer or string representing the device's Bluetooth service class ID. If not, it is `undefined`.
+  - : If the port is a Bluetooth RFCOMM service, this property is a positive integer or string representing the device's Bluetooth service class ID. If not, it is `undefined`.
 
-## Example
+## Examples
 
 This snippet calls the {{domxref("Serial.requestPort()")}} method when a `<button>` is pressed. We pass a filter to `requestPort()` to filter for Arduino Uno USB devices. Once a port is requested, we call `getInfo()` to return the device's `usbProductId` and `usbVendorId`.
 
@@ -45,10 +45,10 @@ const connectBtn = document.getElementById("connect");
 // Filter for devices with the Arduino Uno USB Vendor/Product IDs
 const filters = [
   { usbVendorId: 0x2341, usbProductId: 0x0043 },
-  { usbVendorId: 0x2341, usbProductId: 0x0001 }
+  { usbVendorId: 0x2341, usbProductId: 0x0001 },
 ];
 
-connectBtn.addEventListener("click", () => {
+connectBtn.addEventListener("click", async () => {
   try {
     // Prompt the user to select an Arduino Uno device
     const port = await navigator.serial.requestPort({ filters });

--- a/files/en-us/web/api/serialport/getsignals/index.md
+++ b/files/en-us/web/api/serialport/getsignals/index.md
@@ -6,9 +6,9 @@ page-type: web-api-instance-method
 browser-compat: api.SerialPort.getSignals
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
-The **`SerialPort.getSignals()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves with an object containing the current state of the port's control signals.
+The **`getSignals()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves with an object containing the current state of the port's control signals.
 
 ## Syntax
 
@@ -35,10 +35,23 @@ Returns a {{jsxref("Promise")}} that resolves with an object containing the foll
 
 ### Exceptions
 
+The returned `Promise` rejects with one of the following exceptions:
+
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
+  - : If `getSignals()` is called when the port is not open. Call {{domxref("SerialPort.open()")}} to open the port first.
 - `NetworkError` {{domxref("DOMException")}}
-  - : Returned if the signals on the device could not be read.
+  - : If the signals on the device could not be read.
+
+## Examples
+
+### Check whether the device is ready to send and receive data
+
+The following example reads the control signals from an open port and checks the `dataSetReady` property to determine whether the connected device is ready to communicate.
+
+```js
+const signals = await port.getSignals();
+console.log(`Device ready: ${signals.dataSetReady}`);
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/index.md
+++ b/files/en-us/web/api/serialport/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.SerialPort
 ---
 
-{{securecontext_header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The `SerialPort` interface of the [Web Serial API](/en-US/docs/Web/API/Web_Serial_API) provides access to a serial port on the host device.
 

--- a/files/en-us/web/api/serialport/open/index.md
+++ b/files/en-us/web/api/serialport/open/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.SerialPort.open
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`open()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port is opened. By default the port is opened with 8 data bits, 1 stop bit and no parity checking. The `baudRate` parameter is required.
 
@@ -39,10 +39,12 @@ A {{jsxref("Promise")}}.
 
 ### Exceptions
 
+The returned `Promise` rejects with one of the following exceptions:
+
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if the port is already open.
+  - : If `open()` is called when the port is already open.
 - `NetworkError` {{domxref("DOMException")}}
-  - : Returned if the attempt to open the port failed.
+  - : If the attempt to open the port failed.
 
 ## Examples
 

--- a/files/en-us/web/api/serialport/readable/index.md
+++ b/files/en-us/web/api/serialport/readable/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.SerialPort.readable
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`readable`** read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("ReadableStream")}} for receiving data from the device connected to the port. Chunks read from this stream are instances of {{jsxref("Uint8Array")}}. This property is non-null as long as the port is open and has not encountered a fatal error.
 

--- a/files/en-us/web/api/serialport/setsignals/index.md
+++ b/files/en-us/web/api/serialport/setsignals/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.SerialPort.setSignals
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`setSignals()`** method of the {{domxref("SerialPort")}} interface sets control signals on the port and returns a {{jsxref("Promise")}} that resolves when they are set.
 
@@ -34,10 +34,23 @@ A {{jsxref("Promise")}}.
 
 ### Exceptions
 
+The returned `Promise` rejects with one of the following exceptions:
+
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if the port is not open. Call {{domxref("SerialPort.open()")}} to avoid this error.
+  - : If `setSignals()` is called when the port is not open. Call {{domxref("SerialPort.open()")}} to open the port first.
 - `NetworkError` {{domxref("DOMException")}}
-  - : Returned if the signals on the device could not be set.
+  - : If the signals on the device could not be set.
+
+## Examples
+
+### Assert the data terminal ready signal
+
+The following example asserts the DTR signal when a connection is established.
+
+```js
+await port.open({ baudRate: 9600 });
+await port.setSignals({ dataTerminalReady: true });
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/serialport/writable/index.md
+++ b/files/en-us/web/api/serialport/writable/index.md
@@ -6,17 +6,21 @@ page-type: web-api-instance-property
 browser-compat: api.SerialPort.writable
 ---
 
-{{SecureContext_Header}}{{APIRef("Web Serial API")}}{{AvailableInWorkers("window_and_dedicated")}}
+{{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("window_and_dedicated")}}
 
-The **`writable`** read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("WritableStream")}} for sending data to the device connected to the port. Chunks written to this stream must be instances of {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}. This property is non-null as long as the port is open and has not encountered a fatal error.
+The **`writable`** read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("WritableStream")}} for sending data to the device connected to the port.
+Chunks written to this stream must be instances of {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}. This property is non-null as long as the port is open and has not encountered a fatal error.
 
 ## Value
 
-A {{domxref("WritableStream")}}
+A {{domxref("WritableStream")}}.
 
 ## Examples
 
-The following example shows how to write a string to a port. A {{domxref("TextEncoder")}} converts the string to a `Uint8Array` before transmission.
+### Writing a string to a port
+
+The following example shows how to write a string to a port.
+A {{domxref("TextEncoder")}} converts the string to a `Uint8Array` before transmission.
 
 ```js
 const encoder = new TextEncoder();

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -11,8 +11,10 @@ The **Web Serial API** provides a way for websites to read from and write to ser
 
 ## Concepts and Usage
 
-The Web Serial API is one of a set of APIs that allow websites to communicate with peripherals connected to a user's computer.
-It provides the ability to connect to devices that communicate via a serial port, rather than USB devices accessible via the [WebUSB API](/en-US/docs/Web/API/WebUSB_API), or input devices accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
+The Web Serial API provides the ability to connect to devices that communicate via a serial protocol.
+This includes USB and Bluetooth devices that connect over USB or Bluetooth but expose a virtual serial port to the operating system (via USB CDC-ACM or Bluetooth SPP).
+
+Note that these are distinct from devices accessed via the  [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 
 Examples of serial devices include 3D printers, ESP32 devices, and microcontrollers such as the [BBC micro:bit board](https://microbit.org/).
 

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -16,6 +16,8 @@ This includes USB and Bluetooth devices that connect over USB or Bluetooth but e
 
 Note that these are distinct from devices accessed via the  [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 
+Note that these are distinct from devices accessed via the  [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
+
 Examples of serial devices include 3D printers, ESP32 devices, and microcontrollers such as the [BBC micro:bit board](https://microbit.org/).
 
 ## Interfaces

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -11,7 +11,8 @@ The **Web Serial API** provides a way for websites to read from and write to ser
 
 ## Concepts and Usage
 
-The Web Serial API is one of a set of APIs that allow websites to communicate with peripherals connected to a user's computer. It provides the ability to connect to devices that are required by the operating system to communicate via the serial API, rather than USB which can be accessed via the [WebUSB API](/en-US/docs/Web/API/WebUSB_API), or input devices that can be accessed via [WebHID API](/en-US/docs/Web/API/WebHID_API).
+The Web Serial API is one of a set of APIs that allow websites to communicate with peripherals connected to a user's computer.
+It provides the ability to connect to devices that communicate via a serial port, rather than USB devices accessible via the [WebUSB API](/en-US/docs/Web/API/WebUSB_API), or input devices accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 
 Examples of serial devices include 3D printers, and microcontrollers such as the [BBC micro:bit board](https://microbit.org/).
 
@@ -25,9 +26,9 @@ Examples of serial devices include 3D printers, and microcontrollers such as the
 ## Extensions to other interfaces
 
 - {{domxref("Navigator.serial")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns a {{domxref("Serial")}} object, which represents the entry point into the Web Serial API to enable the control of serial ports.
+  - : Returns a {{domxref("Serial")}} object, which represents the main thread entry point into the Web Serial API.
 - {{domxref("WorkerNavigator.serial")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns a {{domxref("Serial")}} object, which represents the entry point into the Web Serial API to enable the control of serial ports.
+  - : Returns a {{domxref("Serial")}} object, which represents the worker entry point into the Web Serial API.
 
 ## HTTP headers
 
@@ -44,7 +45,9 @@ The following example shows how to check for available ports and allows the user
 
 The `connect` and `disconnect` events let sites react when a device is connected or disconnected from the system. The {{domxref("Serial.getPorts()","getPorts()")}} method is then called to see connected ports that the site already has access to.
 
-If the site doesn't have access to any connected ports it has to wait until it has user activation to proceed. In this example we use a {{domxref("Element.click_event", "click")}} event handler on a button for this task. A filter is passed to {{domxref("Serial.requestPort()","requestPort()")}} with a USB vendor ID in order to limit the set of devices shown to the user to only USB devices built by a particular manufacturer.
+If the site doesn't have access to any connected ports it has to wait until it has user activation to proceed.
+In this example we use a {{domxref("Element.click_event", "click")}} event handler on a button for this task.
+A filter is passed to {{domxref("Serial.requestPort()","requestPort()")}} with a USB vendor ID in order to limit the set of devices shown to the user to only USB devices built by a particular manufacturer.
 
 ```js
 navigator.serial.addEventListener("connect", (e) => {
@@ -74,8 +77,8 @@ button.addEventListener("click", () => {
 
 ### Reading data from a port
 
-The following example shows how to read data from a port. The outer loop handles non-fatal errors,
-creating a new reader until a fatal error is encountered and {{domxref("SerialPort.readable")}} becomes `null`.
+The following example shows how to read data from a port.
+The outer loop handles non-fatal errors, creating a new reader until a fatal error is encountered and {{domxref("SerialPort.readable")}} becomes `null`.
 
 ```js
 while (port.readable) {

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -14,7 +14,7 @@ The **Web Serial API** provides a way for websites to read from and write to ser
 The Web Serial API is one of a set of APIs that allow websites to communicate with peripherals connected to a user's computer.
 It provides the ability to connect to devices that communicate via a serial port, rather than USB devices accessible via the [WebUSB API](/en-US/docs/Web/API/WebUSB_API), or input devices accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 
-Examples of serial devices include 3D printers, and microcontrollers such as the [BBC micro:bit board](https://microbit.org/).
+Examples of serial devices include 3D printers, ESP32 devices, and microcontrollers such as the [BBC micro:bit board](https://microbit.org/).
 
 ## Interfaces
 
@@ -46,7 +46,7 @@ The following example shows how to check for available ports and allows the user
 The `connect` and `disconnect` events let sites react when a device is connected or disconnected from the system. The {{domxref("Serial.getPorts()","getPorts()")}} method is then called to see connected ports that the site already has access to.
 
 If the site doesn't have access to any connected ports it has to wait until it has user activation to proceed.
-In this example we use a {{domxref("Element.click_event", "click")}} event handler on a button for this task.
+In this example, we use a {{domxref("Element.click_event", "click")}} event handler on a button for this task.
 A filter is passed to {{domxref("Serial.requestPort()","requestPort()")}} with a USB vendor ID in order to limit the set of devices shown to the user to only USB devices built by a particular manufacturer.
 
 ```js

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -14,7 +14,7 @@ The **Web Serial API** provides a way for websites to read from and write to ser
 The Web Serial API provides the ability to connect to devices that communicate via a serial protocol.
 This includes USB and Bluetooth devices that connect over USB or Bluetooth but expose a virtual serial port to the operating system (via USB CDC-ACM or Bluetooth SPP).
 
-Note that these are distinct from devices accessed via the  [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
+Note that these are distinct from devices accessed via the [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 
 Note that these are distinct from devices accessed via the [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -16,7 +16,7 @@ This includes USB and Bluetooth devices that connect over USB or Bluetooth but e
 
 Note that these are distinct from devices accessed via the  [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 
-Note that these are distinct from devices accessed via the  [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
+Note that these are distinct from devices accessed via the [WebUSB API](/en-US/docs/Web/API/WebUSB_API), — which provides raw access to USB devices that have not been claimed by an OS driver — or input devices that use the USB HID class, which are accessible via the [WebHID API](/en-US/docs/Web/API/WebHID_API).
 
 Examples of serial devices include 3D printers, ESP32 devices, and microcontrollers such as the [BBC micro:bit board](https://microbit.org/).
 

--- a/files/en-us/web/api/workernavigator/serial/index.md
+++ b/files/en-us/web/api/workernavigator/serial/index.md
@@ -18,7 +18,7 @@ A {{domxref("Serial")}} object.
 
 ## Examples
 
-### List available ports
+### List the available ports
 
 The following example uses the `getPorts()` method to initialize a list of available ports.
 

--- a/files/en-us/web/api/workernavigator/serial/index.md
+++ b/files/en-us/web/api/workernavigator/serial/index.md
@@ -8,15 +8,17 @@ browser-compat: api.WorkerNavigator.serial
 
 {{APIRef("Web Serial API")}}{{SecureContext_Header}}{{AvailableInWorkers("dedicated")}}
 
-The **`serial`** read-only property of the {{domxref("WorkerNavigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the [Web Serial API](/en-US/docs/Web/API/Web_Serial_API).
+The **`serial`** read-only property of the {{domxref("WorkerNavigator")}} interface returns a {{domxref("Serial")}} object which represents the worker entry point into the [Web Serial API](/en-US/docs/Web/API/Web_Serial_API).
 
-When getting, the same instance of the {{domxref("Serial")}} object will always be returned.
+The same instance of the {{domxref("Serial")}} object will always be returned.
 
 ## Value
 
 A {{domxref("Serial")}} object.
 
 ## Examples
+
+### List available ports
 
 The following example uses the `getPorts()` method to initialize a list of available ports.
 
@@ -37,4 +39,4 @@ navigator.serial.getPorts().then((ports) => {
 ## See also
 
 - [Read from and write to a serial port](https://developer.chrome.com/docs/capabilities/serial)
-- [Getting started with the web serial API](https://codelabs.developers.google.com/codelabs/web-serial#0)
+- [Getting started with the Web Serial API](https://codelabs.developers.google.com/codelabs/web-serial#0)


### PR DESCRIPTION
FF151 supports the [Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API) on desktop.

This updates the API for consistency. Things like Description sections below the syntax, and so on. There were some error fixes, such as missing `async` in event handler lambdas (thanks Claude). General spelling and grammar tidy.

Related docs work can be tracked in #43967
