### PR TITLE
Clarify that native events dispatch asynchronously, not handlers

### DIFF
--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -19,7 +19,7 @@ should have already been created and initialized using an {{domxref("Event/Event
 > [!NOTE]
 > When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
 
-Unlike "native" events, which are fired by the browser and invoke event handlers
+Unlike "native" events, which are fired by the browser and invoke dispatchEvent
 asynchronously via the [event loop](/en-US/docs/Web/JavaScript/Reference/Execution_model),
 `dispatchEvent()` invokes event handlers _synchronously_. All applicable event
 handlers are called and return before `dispatchEvent()` returns.


### PR DESCRIPTION
`LinearConstraint.__init__` used `simplefilter("error")` without a category. In multithreaded code promoted unrelated warnings (e.g. `UserWarning`) to errors , as reported in gh-25123.

Narrow the filter to `VisibleDeprecationWarning` only, matching the intent of the comment already present in the code. Added a
regression test to verify unrelated warnings are not affected.

Closes gh-25123