### PR TITLE
updated theflag information for GeometryUtils methods

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -582,12 +582,12 @@ The `GeometryUtils` methods `convertPointFromNode()`, `convertRectFromNode()`, a
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 31            | Yes                 |
+| Nightly           | 31            | No                  |
 | Developer Edition | 31            | No                  |
 | Beta              | 31            | No                  |
 | Release           | 31            | No                  |
 
-- `layout.css.convertFromNode.enable`
+- `layout.css.convertFromNode.enabled`
   - : Set to `true` to enable.
 
 ### GeometryUtils method: getBoxQuads()
@@ -596,7 +596,7 @@ The `GeometryUtils` method `getBoxQuads()` returns the CSS boxes for a {{domxref
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 31            | Yes                 |
+| Nightly           | 31            | No                  |
 | Developer Edition | 31            | No                  |
 | Beta              | 31            | No                  |
 | Release           | 31            | No                  |

--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -144,3 +144,11 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **`<timeline-range-name>` values**: `layout.css.scroll-driven-animations.enabled`
 
   The {{cssxref("animation-range-start")}}, {{cssxref("animation-range-end")}} CSS properties and {{cssxref("animation-range")}} shorthand property now support [`<timeline-range-name>`](/en-US/docs/Web/CSS/Reference/Values/timeline-range-name) values. These [`<timeline-range-name>`](/en-US/docs/Web/CSS/Guides/Scroll-driven_animations/Timeline_range_names#timeline_range_names) values allow you to precisely state which segment that a scroll driven animation will take place within. ([Firefox bug 1804775](https://bugzil.la/1804775)).
+
+- **GeometryUtils methods: `convertPointFromNode()`, `convertRectFromNode()`, and `convertQuadFromNode()`**: `layout.css.convertFromNode.enabled`
+
+  The GeometryUtils methods: `convertPointFromNode()`, `convertRectFromNode()`, and `convertQuadFromNode()` are no longer enabled by default in Firefox Nightly. ([Firefox bug 2026051](https://bugzil.la/2026051)).
+
+- **GeometryUtils methods: `getBoxQuads()`**: `layout.css.getBoxQuads.enabled`
+
+  The GeometryUtils methods: `getBoxQuads()` is no longer enabled by default in Firefox Nightly. ([Firefox bug 2026051](https://bugzil.la/2026051)).


### PR DESCRIPTION
### Description

- Removed the enabled by default for GeometryUtils method: `getBoxQuads()`
- Removed the enabled by default for GeometryUtils method: `convertPointFromNode()`, `convertRectFromNode()`, and `convertQuadFromNode()`
- Corrected the flag name for GeometryUtils method: `convertPointFromNode()`, `convertRectFromNode()`, and `convertQuadFromNode()`
- Added notes to experimental release section of 151 to highlight the removal of enabled by default

### Motivation

- Working on [MDN Issue #43872](https://github.com/mdn/content/issues/43872)

### Related issues and pull requests

- N/A