### PR TITLE
Notifications API actions/maxActions and friends

### DIFF
--- a/files/en-us/web/api/notification/actions/index.md
+++ b/files/en-us/web/api/notification/actions/index.md
@@ -23,13 +23,13 @@ Each element in the array is an object with the following members:
   - : A string containing the URL of an icon to display with the action.
 - `navigate` {{optional_inline}} {{experimental_inline}}
   - : A string containing a URL to navigate to when the user activates this action.
-    When set, the user agent navigates to this URL instead of firing the {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event
+    When set, the user agent navigates to this URL instead of firing the {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event.
     See {{domxref("Notification.navigate")}} for more information.
 
 ## Description
 
 Notification actions are buttons or controls that appear within [persistent notifications](/en-US/docs/Web/API/Notifications_API#persistent_and_non-persistent_notifications).
-They are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{DOMxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
+They are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{domxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
 Note that actions are not available for non-persistent notifications: a `TypeError` is thrown if you pass an options object with a non-`null` actions property to the {{domxref("Notification/Notification", "Notification()")}} constructor.
 
 Clicking the button associated with an action navigates to the URL set in the [`navigate`](#navigate) option if one is specified.
@@ -37,7 +37,7 @@ Otherwise it fires a [`notificationclick`](/en-US/docs/Web/API/ServiceWorkerGlob
 
 > [!NOTE]
 > Browsers typically limit the maximum number of actions they will display for a particular notification.
-> Check the static {{DOMxref("Notification.maxActions_static", "Notification.maxActions")}} property to determine the limit.
+> Check the static {{domxref("Notification.maxActions_static", "Notification.maxActions")}} property to determine the limit.
 
 ## Examples
 
@@ -69,4 +69,4 @@ self.addEventListener("notificationclick", (event) => {
 ## See also
 
 - [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API)
-- {{DOMxref("Notification.maxActions_static", "Notification.maxActions")}}
+- {{domxref("Notification.maxActions_static", "Notification.maxActions")}}

--- a/files/en-us/web/api/notification/actions/index.md
+++ b/files/en-us/web/api/notification/actions/index.md
@@ -8,16 +8,12 @@ browser-compat: api.Notification.actions
 
 {{APIRef("Web Notifications")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
-The **`actions`** read-only property of the {{domxref("Notification")}} interface provides the actions available for users to choose from for interacting with the notification.
-
-The actions are set using the `actions` option of the second argument for the {{DOMxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method and {{DOMxref("Notification/Notification", "Notification()")}} constructor.
-
-> [!NOTE]
-> Browsers typically limit the maximum number of actions they will display for a particular notification. Check the static {{DOMxref("Notification.maxActions_static", "Notification.maxActions")}} property to determine the limit.
+The **`actions`** read-only property of the {{domxref("Notification")}} interface provides the actions available for users to select when interacting with the notification.
 
 ## Value
 
-A read-only array of actions. Each element in the array is an object with the following members:
+A read-only array of actions.
+Each element in the array is an object with the following members:
 
 - `action`
   - : A string identifying a user action to be displayed on the notification.
@@ -25,6 +21,42 @@ A read-only array of actions. Each element in the array is an object with the fo
   - : A string containing action text to be shown to the user.
 - `icon`
   - : A string containing the URL of an icon to display with the action.
+- `navigate` {{optional_inline}} {{experimental_inline}}
+  - : A string containing a URL to navigate to when the user activates this action.
+    When set, the user agent navigates to this URL instead of firing the {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event
+    See {{domxref("Notification.navigate")}} for more information.
+
+## Description
+
+Notification actions are buttons or controls that appear within [persistent notifications](/en-US/docs/Web/API/Notifications_API#persistent_and_non-persistent_notifications).
+They are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{DOMxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
+Note that actions are not available for non-persistent notifications: a `TypeError` is thrown if you pass an options object with a non-`null` actions property to the {{domxref("Notification/Notification", "Notification()")}} constructor.
+
+Clicking the button associated with an action navigates to the URL set in the [`navigate`](#navigate) option if one is specified.
+Otherwise it fires a [`notificationclick`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/notificationclick_event) event on the service worker that includes the action that was selected (and the associated `Notification` instance), so the worker can handle it without the user ever switching to your page.
+
+> [!NOTE]
+> Browsers typically limit the maximum number of actions they will display for a particular notification.
+> Check the static {{DOMxref("Notification.maxActions_static", "Notification.maxActions")}} property to determine the limit.
+
+## Examples
+
+### Basic usage
+
+The following code shows how a service worker might listen for the `notificationclick` event and use it to get both the clicked action and all the actions.
+
+```js
+// sw.js
+self.addEventListener("notificationclick", (event) => {
+  const clickedAction = event.action; // e.g. "reply" or "" if body was clicked
+
+  // Read all defined actions
+  const notification = event.notification; // the Notification object
+  console.log(notification.actions); // full array of action objects
+
+  notification.close();
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/notification/actions/index.md
+++ b/files/en-us/web/api/notification/actions/index.md
@@ -30,10 +30,11 @@ Each element in the array is an object with the following members:
 
 Notification actions are buttons or controls that appear within [persistent notifications](/en-US/docs/Web/API/Notifications_API#persistent_and_non-persistent_notifications).
 They are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{domxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
-Note that actions are not available for non-persistent notifications: a `TypeError` is thrown if you pass an options object with a non-`null` actions property to the {{domxref("Notification/Notification", "Notification()")}} constructor.
+Note that actions are not available for non-persistent notifications.
+If you pass an `options` object with an `actions` property that is anything other than `null` to the {{domxref("Notification/Notification", "Notification()")}} constructor, a `TypeError` is thrown.
 
 Clicking the button associated with an action navigates to the URL set in the [`navigate`](#navigate) option if one is specified.
-Otherwise it fires a [`notificationclick`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/notificationclick_event) event on the service worker that includes the action that was selected (and the associated `Notification` instance), so the worker can handle it without the user ever switching to your page.
+Otherwise, it fires a [`notificationclick`](/en-US/docs/Web/API/ServiceWorkerGlobalScope/notificationclick_event) event on the service worker that includes the action that was selected (and the associated `Notification` instance), so the worker can handle it without the user ever switching to your page.
 
 > [!NOTE]
 > Browsers typically limit the maximum number of actions they will display for a particular notification.
@@ -43,7 +44,7 @@ Otherwise it fires a [`notificationclick`](/en-US/docs/Web/API/ServiceWorkerGlob
 
 ### Basic usage
 
-The following code shows how a service worker might listen for the `notificationclick` event and use it to get both the clicked action and all the actions.
+The following code shows how a service worker might listen for the `notificationclick` event and use it to retrieve both the clicked action and an array of all actions.
 
 ```js
 // sw.js

--- a/files/en-us/web/api/notification/maxactions_static/index.md
+++ b/files/en-us/web/api/notification/maxactions_static/index.md
@@ -8,17 +8,23 @@ browser-compat: api.Notification.maxActions_static
 
 {{APIRef("Web Notifications")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
-The **`maxActions`** read-only static property of the
-{{domxref("Notification")}} interface returns the maximum number of actions supported by
-the device and the User Agent. Effectively, this is the maximum number of elements in
-{{domxref("Notification.actions")}} array which will be respected by the User Agent.
+The **`maxActions`** read-only static property of the {{domxref("Notification")}} interface returns the maximum number of actions supported by the device and the user agent.
 
 ## Value
 
-An integer number which indicates the largest number of notification
-actions that can be presented to the user by the User Agent and the device.
+An integer number.
+
+## Description
+
+Notification actions are buttons or controls that appear within [persistent notifications](/en-US/docs/Web/API/Notifications_API#persistent_and_non-persistent_notifications), created using {{domxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} on a service worker.
+Actions are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{DOMxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
+
+Browsers typically limit the maximum number of actions they will display for a particular notification.
+This property returns that limit, which is the maximum number of elements in {{domxref("Notification.actions")}} array that will be respected by the user agent.
 
 ## Examples
+
+### Log the maximum possible number of actions
 
 The following snippet logs the maximum number of supported actions.
 

--- a/files/en-us/web/api/notification/maxactions_static/index.md
+++ b/files/en-us/web/api/notification/maxactions_static/index.md
@@ -6,7 +6,7 @@ page-type: web-api-static-property
 browser-compat: api.Notification.maxActions_static
 ---
 
-{{APIRef("Web Notifications")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+{{APIRef("Web Notifications")}}{{SecureContext_Header}}{{SeeCompatTable}} {{AvailableInWorkers}}
 
 The **`maxActions`** read-only static property of the {{domxref("Notification")}} interface returns the maximum number of actions supported by the device and the user agent.
 
@@ -16,11 +16,11 @@ An integer number.
 
 ## Description
 
-Notification actions are buttons or controls that appear within [persistent notifications](/en-US/docs/Web/API/Notifications_API#persistent_and_non-persistent_notifications), created using {{domxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} on a service worker.
-Actions are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{DOMxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
+Notification actions are buttons or controls that appear within [persistent notifications](/en-US/docs/Web/API/Notifications_API#persistent_and_non-persistent_notifications).
+Actions are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{domxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
 
 Browsers typically limit the maximum number of actions they will display for a particular notification.
-This property returns that limit, which is the maximum number of elements in {{domxref("Notification.actions")}} array that will be respected by the user agent.
+This property returns that limit, which is the maximum number of elements in the {{domxref("Notification.actions")}} array that will be respected by the user agent.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/maxactions_static/index.md
+++ b/files/en-us/web/api/notification/maxactions_static/index.md
@@ -8,11 +8,11 @@ browser-compat: api.Notification.maxActions_static
 
 {{APIRef("Web Notifications")}}{{SecureContext_Header}}{{SeeCompatTable}} {{AvailableInWorkers}}
 
-The **`maxActions`** read-only static property of the {{domxref("Notification")}} interface returns the maximum number of actions supported by the device and the user agent.
+The **`maxActions`** read-only static property of the {{domxref("Notification")}} interface returns the maximum number of actions that can be displayed in a notification.
 
 ## Value
 
-An integer number.
+An integer.
 
 ## Description
 
@@ -20,7 +20,7 @@ Notification actions are buttons or controls that appear within [persistent noti
 Actions are set using the [`actions`](/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification#actions) option of the second argument of the {{domxref("ServiceWorkerRegistration.showNotification", "showNotification()")}} method.
 
 Browsers typically limit the maximum number of actions they will display for a particular notification.
-This property returns that limit, which is the maximum number of elements in the {{domxref("Notification.actions")}} array that will be respected by the user agent.
+The `maxActions` property returns that limit, which is the maximum number of elements in the {{domxref("Notification.actions")}} array that will be respected by the user agent.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -95,9 +95,6 @@ An instance of the {{domxref("Notification")}} object.
 
 The constructor creates a new {{domxref("Notification")}} object instance, which represents a user notification.
 
-Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`.
-Use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
-
 You must get permission to display notifications using {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}}.
 The permission may not be grantable, for example if the page is in private browsing mode.
 

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -122,9 +122,9 @@ if (Notification.permission === "granted") {
 
 ### Using Notification() as a fallback
 
-This example shows a more robust approach, that allows showing notifications on both desktop and mobile devices.
+This example shows a more robust approach that allows showing notifications on both desktop and mobile devices.
 
-First we check if {{domxref("Notification")}} is supported, and if permission has been granted, returning if either are not true.
+First we check if {{domxref("Notification")}} is supported, and if permission has been granted, returning if either is not true.
 We then check if there is an active service worker.
 If there is an active service worker we use it to call {{domxref("ServiceWorkerRegistration.showNotification()")}}, but if not, we fall back to calling the constructor.
 
@@ -147,7 +147,7 @@ async function showNotification(title, options = {}) {
 ```
 
 Note that this will still throw an error if called on a mobile device if the page does not have a service worker ready.
-Depending on your application you might wrap the method code in a `try..catch` block.
+Depending on your application you might wrap the method code in a `try...catch` block.
 
 ## Specifications
 

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -10,15 +10,9 @@ browser-compat: api.Notification.Notification
 
 The **`Notification()`** constructor creates a new {{domxref("Notification")}} object instance, which represents a user notification.
 
-Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`.
-Use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
-
-You must first get permission before being able to display notifications, using {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}}.
-The permission may not be grantable, for example if the page is in private browsing mode.
-
-This constructor throws a {{jsxref("TypeError")}} when called in nearly all mobile browsers and this is unlikely to change, because web pages on mobile devices almost never "run in the background", which is the main use case for notifications.
-Instead, you need to register a service worker and use {{domxref("ServiceWorkerRegistration.showNotification()")}}.
-See [Chrome issue](https://crbug.com/481856) for more information.
+> [!WARNING]
+> This constructor throws a {{jsxref("TypeError")}} when called in nearly all mobile browsers.
+> Instead, you need to register a service worker and use {{domxref("ServiceWorkerRegistration.showNotification()")}}.
 
 ## Syntax
 
@@ -97,16 +91,63 @@ An instance of the {{domxref("Notification")}} object.
 - `DataCloneError` {{domxref("DOMException")}}
   - : Thrown if serializing the `data` option failed for some reason.
 
+## Description
+
+The constructor creates a new {{domxref("Notification")}} object instance, which represents a user notification.
+
+Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`.
+Use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
+
+You must first get permission before being able to display notifications, using {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}}.
+The permission may not be grantable, for example if the page is in private browsing mode.
+
+This constructor throws a {{jsxref("TypeError")}} when called in nearly all mobile browsers and this is unlikely to change, because web pages on mobile devices almost never "run in the background", which is the main use case for notifications.
+Instead, you need to register a service worker and use {{domxref("ServiceWorkerRegistration.showNotification()")}}.
+See [Chrome issue](https://crbug.com/481856) for more information.
+
 ## Examples
 
-Here is a most basic example to only show a notification if permission is already granted.
-For more complete examples, see the {{domxref("Notification")}} page.
+For more examples, see the {{domxref("Notification")}} page and [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).
+
+### Basic example
+
+This is a basic example that shows a notification if permission is already granted.
+This will not work on mobile devices.
 
 ```js
 if (Notification.permission === "granted") {
   const notification = new Notification("Hi there!");
 }
 ```
+
+### Using Notification() as a fallback
+
+This example shows a more robust approach, that allows showing notifications on both desktop and mobile devices.
+
+First we check if {{domxref("Notification")}} is supported, and if permission has been granted, returning if either are not true.
+We then check if there is an active service worker.
+If there is an active service worker we use it to call {{domxref("ServiceWorkerRegistration.showNotification()")}}, but if not, we fall back to calling the constructor.
+
+```js
+async function showNotification(title, options = {}) {
+  if (!("Notification" in window)) return;
+  if (Notification.permission !== "granted") return;
+
+  // Only use SW if one is already active — don't hang waiting
+  const swReg = navigator.serviceWorker?.controller
+    ? await navigator.serviceWorker.getRegistration()
+    : null;
+
+  if (swReg) {
+    await swReg.showNotification(title, options);
+  } else {
+    new Notification(title, options);
+  }
+}
+```
+
+Note that this will still throw an error if called on a mobile device if the page does not have a service worker ready.
+Depending on your application you might wrap the method code in a `try..catch` block.
 
 ## Specifications
 

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -98,7 +98,7 @@ The constructor creates a new {{domxref("Notification")}} object instance, which
 Trying to create a notification inside the {{domxref("ServiceWorkerGlobalScope")}} using the `Notification()` constructor will throw a `TypeError`.
 Use {{domxref("ServiceWorkerRegistration.showNotification()")}} instead.
 
-You must first get permission before being able to display notifications, using {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}}.
+You must get permission to display notifications using {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}}.
 The permission may not be grantable, for example if the page is in private browsing mode.
 
 This constructor throws a {{jsxref("TypeError")}} when called in nearly all mobile browsers and this is unlikely to change, because web pages on mobile devices almost never "run in the background", which is the main use case for notifications.
@@ -126,7 +126,7 @@ This example shows a more robust approach that allows showing notifications on b
 
 First we check if {{domxref("Notification")}} is supported, and if permission has been granted, returning if either is not true.
 We then check if there is an active service worker.
-If there is an active service worker we use it to call {{domxref("ServiceWorkerRegistration.showNotification()")}}, but if not, we fall back to calling the constructor.
+If so, we use it to call {{domxref("ServiceWorkerRegistration.showNotification()")}}; if not, we fall back to calling the constructor.
 
 ```js
 async function showNotification(title, options = {}) {

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -33,7 +33,7 @@ new Notification(title, options)
         `actions` is only supported for [persistent notifications](/en-US/docs/Web/API/Notifications_API#persistent_and_non-persistent_notifications) fired from a service worker using {{domxref("ServiceWorkerRegistration.showNotification()")}}.
     - `badge` {{optional_inline}}
       - : A string containing the URL of the image used to represent the notification when there isn't enough space to display the notification itself; for example, the Android Notification Bar.
-        On Android devices, the badge should accommodate devices up to 4x resolution, about 96x96px, and the image will be automatically masked.
+        On Android devices, the badge should support devices with up to 4x resolution, about 96x96px, and the image will be automatically masked.
     - `body` {{optional_inline}}
       - : A string representing the body text of the notification, which is displayed below the title.
         The default is the empty string.
@@ -59,7 +59,7 @@ new Notification(title, options)
     - `renotify` {{optional_inline}}
       - : A boolean value specifying whether the user should be notified after a new notification replaces an old one.
         The default is `false`, which means they won't be notified.
-        If `true`, then `tag` also must be set.
+        If `true`, `tag` must also be set.
     - `requireInteraction` {{optional_inline}}
       - : Indicates that a notification should remain active until the user clicks or dismisses it, rather than closing automatically.
         The default value is `false`.
@@ -98,9 +98,9 @@ The constructor creates a new {{domxref("Notification")}} object instance, which
 You must get permission to display notifications using {{domxref("Notification.requestPermission_static", "Notification.requestPermission()")}}.
 The permission may not be grantable, for example if the page is in private browsing mode.
 
-This constructor throws a {{jsxref("TypeError")}} when called in nearly all mobile browsers and this is unlikely to change, because web pages on mobile devices almost never "run in the background", which is the main use case for notifications.
+This constructor throws a {{jsxref("TypeError")}} when called in nearly all mobile browsers, and this is unlikely to change, because web pages on mobile devices almost never "run in the background", which is the main use case for notifications.
 Instead, you need to register a service worker and use {{domxref("ServiceWorkerRegistration.showNotification()")}}.
-See [Chrome issue](https://crbug.com/481856) for more information.
+See [Chrome issue #481856](https://crbug.com/481856) for more information.
 
 ## Examples
 
@@ -121,7 +121,7 @@ if (Notification.permission === "granted") {
 
 This example shows a more robust approach that allows showing notifications on both desktop and mobile devices.
 
-First we check if {{domxref("Notification")}} is supported, and if permission has been granted, returning if either is not true.
+First we check if {{domxref("Notification")}} is supported, and if permission has been granted, returning early if either condition is not met.
 We then check if there is an active service worker.
 If so, we use it to call {{domxref("ServiceWorkerRegistration.showNotification()")}}; if not, we fall back to calling the constructor.
 
@@ -143,8 +143,8 @@ async function showNotification(title, options = {}) {
 }
 ```
 
-Note that this will still throw an error if called on a mobile device if the page does not have a service worker ready.
-Depending on your application you might wrap the method code in a `try...catch` block.
+Note that this will still throw an error on a mobile device if the page does not have a service worker ready.
+Depending on your application, you might wrap this code in a `try...catch` block.
 
 ## Specifications
 

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -12,12 +12,34 @@ spec-urls: https://notifications.spec.whatwg.org/
 {{DefaultAPISidebar("Web Notifications")}}{{securecontext_header}} {{AvailableInWorkers}}
 
 The Notifications API allows web pages to control the display of system notifications to the end user.
-These are outside the top-level browsing context viewport, so therefore can be displayed even when the user has switched tabs or moved to a different app.
-The API is designed to be compatible with existing notification systems, across different platforms.
 
 ## Concepts and usage
 
-Showing a system notification generally involves first requesting permission to use the feature, and then creating a notification.
+A notification is a system-level UI element rendered by the operating system's native notification system, making it identical to notifications from any other app on the platform.
+It is used to inform users of events.
+Because it is a system-level element, it is outside the top-level browsing context viewport, and can be displayed even when the user has switched tabs or moved to a different app.
+
+There are two types of notifications: persistent and non-persistent.
+Persistent notifications can run on mobile devices, are created through service workers, and can exist after their originating page has been closed.
+By contrast, non-persistent notifications can only be used in desktop operating systems and have a lifetime bounded by the {{domxref("Notification")}} instance — and hence their originating page.
+Both types require user-permission before a notification can be created.
+
+### Persistent and non-persistent notifications
+
+The Notifications API supports two types of notifications:
+
+- **Non-persistent notifications** are created in a browsing context, such as a web page or tab.
+  Their lifetime is tied to the lifetime of the page — if the page is closed, the notification can no longer be interacted with.
+
+  They are created using the {{domxref("Notification.Notification","Notification()")}} constructor and fire events such as {{domxref("Notification/click_event", "click")}} directly on the `Notification` instance
+
+- **Persistent notifications** are created from a service worker, and can remain interactive beyond the lifetime of an individual page.
+
+  They are created using {{domxref("ServiceWorkerRegistration.showNotification()")}} from a service worker and fire {{domxref("ServiceWorkerGlobalScope/notificationclick_event", "notificationclick")}} and {{domxref("ServiceWorkerGlobalScope/notificationclose_event", "notificationclose")}} events on the {{domxref("ServiceWorkerGlobalScope")}}.
+
+> [!NOTE]
+> If your code needs to run on mobile devices then you **must** use persistent notifications!
+> The {{domxref("Notification.Notification","Notification()")}} constructor will throw a {{jsxref("TypeError")}} on most mobile browsers.
 
 ### Notifications require user permission
 
@@ -57,19 +79,6 @@ if (Notification.permission === "granted") {
 ```
 
 For more usage examples see [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API).
-
-### Persistent and non-persistent notifications
-
-The Notifications API supports two types of notifications:
-
-- **Non-persistent notifications** are created in a browsing context, such as a web page or tab.
-  Their lifetime is tied to the lifetime of the page — if the page is closed, the notification can no longer be interacted with.
-
-  They are created using the {{domxref("Notification.Notification","Notification()")}} constructor and fire events such as {{domxref("Notification/click_event", "click")}} directly on the `Notification` instance
-
-- **Persistent notifications** are created from a service worker, and can remain interactive beyond the lifetime of an individual page.
-
-  They are created using {{domxref("ServiceWorkerRegistration.showNotification()")}} from a service worker and fire {{domxref("ServiceWorkerGlobalScope/notificationclick_event", "notificationclick")}} and {{domxref("ServiceWorkerGlobalScope/notificationclose_event", "notificationclose")}} events on the {{domxref("ServiceWorkerGlobalScope")}}.
 
 ## Interfaces
 

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -15,14 +15,13 @@ The Notifications API allows web pages to control the display of system notifica
 
 ## Concepts and usage
 
-A notification is a system-level UI element rendered by the operating system's native notification system, making it identical to notifications from any other app on the platform.
-It is used to inform users of events.
-Because it is a system-level element, it is outside the top-level browsing context viewport, and can be displayed even when the user has switched tabs or moved to a different app.
+A web notification is a message box used to inform users when events occur on web apps. Web notifications are rendered by the operating system's native notification system, making them display identically to notifications from any other app on the platform.
+Web notifications are displayed by the underlying OS; they are therefore outside the top-level browsing context viewport, and can be shown even when the user has switched tabs or moved to a different app.
 
 There are two types of notifications: persistent and non-persistent.
 Persistent notifications can run on mobile devices, are created through service workers, and can exist after their originating page has been closed.
 By contrast, non-persistent notifications can only be used in desktop operating systems and have a lifetime bounded by the {{domxref("Notification")}} instance — and hence their originating page.
-Both types require user-permission before a notification can be created.
+Both types require the user's permission before a notification can be created.
 
 ### Persistent and non-persistent notifications
 
@@ -35,7 +34,7 @@ The Notifications API supports two types of notifications:
 
 - **Persistent notifications** are created from a service worker, and can remain interactive beyond the lifetime of an individual page.
 
-  They are created using {{domxref("ServiceWorkerRegistration.showNotification()")}} from a service worker and fire {{domxref("ServiceWorkerGlobalScope/notificationclick_event", "notificationclick")}} and {{domxref("ServiceWorkerGlobalScope/notificationclose_event", "notificationclose")}} events on the {{domxref("ServiceWorkerGlobalScope")}}.
+  They are created by calling {{domxref("ServiceWorkerRegistration.showNotification()")}} from inside a service worker and fire {{domxref("ServiceWorkerGlobalScope/notificationclick_event", "notificationclick")}} and {{domxref("ServiceWorkerGlobalScope/notificationclose_event", "notificationclose")}} events on the {{domxref("ServiceWorkerGlobalScope")}}.
 
 > [!NOTE]
 > If your code needs to run on mobile devices then you **must** use persistent notifications!

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -18,11 +18,6 @@ The Notifications API allows web pages to control the display of system notifica
 A web notification is a message box used to inform users when events occur on web apps. Web notifications are rendered by the operating system's native notification system, making them display identically to notifications from any other app on the platform.
 Web notifications are displayed by the underlying OS; they are therefore outside the top-level browsing context viewport, and can be shown even when the user has switched tabs or moved to a different app.
 
-There are two types of notifications: persistent and non-persistent.
-Persistent notifications can run on mobile devices, are created through service workers, and can exist after their originating page has been closed.
-By contrast, non-persistent notifications can only be used in desktop operating systems and have a lifetime bounded by the {{domxref("Notification")}} instance — and hence their originating page.
-Both types require the user's permission before a notification can be created.
-
 ### Persistent and non-persistent notifications
 
 The Notifications API supports two types of notifications:

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -31,7 +31,7 @@ The Notifications API supports two types of notifications:
 - **Non-persistent notifications** are created in a browsing context, such as a web page or tab.
   Their lifetime is tied to the lifetime of the page — if the page is closed, the notification can no longer be interacted with.
 
-  They are created using the {{domxref("Notification.Notification","Notification()")}} constructor and fire events such as {{domxref("Notification/click_event", "click")}} directly on the `Notification` instance
+  They are created using the {{domxref("Notification.Notification","Notification()")}} constructor and fire events such as {{domxref("Notification/click_event", "click")}} directly on the `Notification` instance.
 
 - **Persistent notifications** are created from a service worker, and can remain interactive beyond the lifetime of an individual page.
 
@@ -67,7 +67,7 @@ Once a choice has been made, the setting will generally persist for the current 
 Notifications are created using the {{domxref("Notification.Notification","Notification()")}} constructor.
 This must be passed a title argument, and can optionally be passed a parameter to specify options such as text direction, body text, icon to display, notification sound to play, and more.
 
-For example, the following code shows how you might create a notification that sets the [`navigate`](/en-US/docs/Web/API/Notification/Notification#navigate) option, specifying a URL that will be opened if the notification is accepted (you can also defined click handlers to process notification actions).
+For example, the following code shows how you might create a notification that sets the [`navigate`](/en-US/docs/Web/API/Notification/Notification#navigate) option, specifying a URL that will be opened if the notification is accepted (you can also define click handlers to process notification actions).
 
 ```js
 if (Notification.permission === "granted") {

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -16,7 +16,7 @@ The Notifications API allows web pages to control the display of system notifica
 ## Concepts and usage
 
 A web notification is a message box used to inform users when events occur on web apps. Web notifications are rendered by the operating system's native notification system, making them display identically to notifications from any other app on the platform.
-Web notifications are displayed by the underlying OS; they are therefore outside the top-level browsing context viewport, and can be shown even when the user has switched tabs or moved to a different app.
+Because the underlying OS renders web notifications, they are outside the top-level browsing context viewport, and can be shown even when the user has switched tabs or moved to a different app.
 
 ### Persistent and non-persistent notifications
 

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -30,7 +30,10 @@ showNotification(title, options)
       - : An array of actions to display in the notification, for which the default is an empty array.
         Each element in the array can be an object with the following members:
         - `action`
-          - : A string identifying a user action to be displayed on the notification.
+          - : A string that uniquely identifies this particular action within the array of actions.
+
+            When an action button without a `navigate` URL is clicked, you can determine which button was selected by checking `event.action` inside your {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event listener
+
         - `title`
           - : A string containing action text to be shown to the user.
         - `icon` {{optional_inline}}
@@ -39,8 +42,6 @@ showNotification(title, options)
           - : A string containing a URL to navigate to when the user activates this action.
             When set, the user agent navigates to this URL instead of firing the {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event
             See {{domxref("Notification.navigate")}} for more information.
-
-        Appropriate responses are built using `event.action` within the {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event.
 
     - `badge` {{optional_inline}} {{experimental_inline}}
       - : A string containing the URL of the image used to represent the notification when there isn't enough space to display the notification itself; for example, the Android Notification Bar.
@@ -105,31 +106,84 @@ A {{jsxref('Promise')}} that resolves to `undefined`.
 
 ## Examples
 
+### Basic usage
+
+This example shows a function running in a service worker that displays a notification after first requesting, and being granted, permission.
+Code to actually call the function is not shown.
+
 ```js
 navigator.serviceWorker.register("sw.js");
 
-function showNotification() {
-  Notification.requestPermission().then((result) => {
-    if (result === "granted") {
-      navigator.serviceWorker.ready.then((registration) => {
-        registration.showNotification("Vibration Sample", {
-          body: "Buzz! Buzz!",
-          icon: "../images/touch/chrome-touch-icon-192x192.png",
-          vibrate: [200, 100, 200, 100, 200, 100, 200],
-          tag: "vibration-sample",
-        });
-      });
-    }
-  });
+async function showNotification() {
+  const result = await Notification.requestPermission();
+
+  if (result === "granted") {
+    const registration = await navigator.serviceWorker.ready;
+
+    registration.showNotification("Vibration Sample", {
+      body: "Buzz! Buzz!",
+      icon: "../images/touch/chrome-touch-icon-192x192.png",
+      vibrate: [200, 100, 200, 100, 200, 100, 200],
+      tag: "vibration-sample",
+    });
+  }
 }
 ```
 
-To invoke the above function at an appropriate time, you could listen to the
-{{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event.
+The following code shows how you might listen to the {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event in order to handle user interaction with this particular notification.
 
-You can also retrieve details of the {{domxref("Notification")}}s that have been fired
-from the current service worker using
-{{domxref("ServiceWorkerRegistration.getNotifications()")}}.
+```js
+self.addEventListener("notificationclick", (event) => {
+  const notification = event.notification;
+
+  // Close notification if we don't need it any more.
+  notification.close();
+
+  // Process our particular notification
+  if (notification.tag === "vibration-sample") {
+    // Use event.waitUntil to keep the service worker alive until the promise resolves
+    event
+      .waitUntil
+      // Code to handle the particular event.
+      ();
+  }
+});
+```
+
+You can also retrieve details of the {{domxref("Notification")}}s that have been fired from the current service worker using {{domxref("ServiceWorkerRegistration.getNotifications()")}}.
+
+### Notifications with actions and action handlers
+
+This example shows how you might display a persistent notification, such as might be triggered by a push message when an email is received.
+
+The code to display the notification includes two `actions` that will be displayed on the notification: one to reply to the message, and the other to dismiss the notification.
+Each action includes a `title`, which is usually rendered as button text on the notification, and an `action`, which is used to identify the action that was selected if a user interacts with the notification.
+
+```js
+registration.showNotification("New Message", {
+  body: "You've got mail.",
+  icon: "/images/icon.png",
+  actions: [
+    { action: "reply", title: "Reply" },
+    { action: "dismiss", title: "Dismiss" },
+  ],
+});
+```
+
+The following code shows how you can listen for `notificationclick` events from the notification, and then use the value of the `event.action` property to determine which action was selected.
+Note that if the user clicks the notification body instead of an action button, `event.action` will be an empty string.
+
+```js
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+
+  if (event.action === "reply") {
+    // handle reply
+  } else if (event.action === "dismiss") {
+    // handle dismiss
+  }
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -32,7 +32,7 @@ showNotification(title, options)
         - `action`
           - : A string that uniquely identifies this particular action within the array of actions.
 
-            When an action button without a `navigate` URL is clicked, you can determine which button was selected by checking `event.action` inside your {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event listener
+            When an action button without a `navigate` URL is clicked, you can determine which button was selected by checking `event.action` inside your {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event listener.
 
         - `title`
           - : A string containing action text to be shown to the user.
@@ -154,9 +154,9 @@ You can also retrieve details of the {{domxref("Notification")}}s that have been
 
 ### Notifications with actions and action handlers
 
-This example shows how you might display a persistent notification, such as might be triggered by a push message when an email is received.
+This example shows how you might display a persistent notification, which might be triggered by a push message when an email is received, for example.
 
-The code to display the notification includes two `actions` that will be displayed on the notification: one to reply to the message, and the other to dismiss the notification.
+The code to generate the notification includes two `actions` that will be displayed on the notification: one to reply to the message, and the other to dismiss the notification.
 Each action includes a `title`, which is usually rendered as button text on the notification, and an `action`, which is used to identify the action that was selected if a user interacts with the notification.
 
 ```js


### PR DESCRIPTION
FF152 supports `Notification.actions` and `Notification/.maxActions` in https://bugzilla.mozilla.org/show_bug.cgi?id=1959931

This does some work on those methods to make them more useful and specification compliant.

I also did some work on the top level API page to better highlight the two types of notifications and where you choose them.
There are problems with non-persistent notifications not working on mobile plaforms, so most users who aren't locking down their code to run on desktop will need to use the persistent notifications.
However the docs were written before the persistent notifications were invented.
While they mention them in the top level, the user guide is very thin.
The whole thing needs a revisit. This is what I have time for as part of FF release work.

Related docs work can be tracked in #44159
