### PR TITLE
FF152Relnote RTCEncodedFrameMetadata.receiveTime

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -50,11 +50,14 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
 
 <!-- #### DOM -->
 
-<!-- #### Media, WebRTC, and Web Audio -->
+#### Media, WebRTC, and Web Audio
+
+- The `recieveTime` property is now included in the metadata returned from [`RTCEncodedVideoFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/getMetadata#receivetime) and [`RTCEncodedAudioFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/getMetadata#receivetime), and can be passed to the [`RTCEncodedVideoFrame()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/RTCEncodedVideoFrame) and [`RTCEncodedAudioFrame()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/RTCEncodedAudioFrame) constructors as a property in the `options` parameter.
+  ([Firefox bug 2033420](https://bugzil.la/2033420)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
FF152 adds support for `RTCEncodedFrameMetadata.receiveTime` (which is returned from `getMetadata()` and passed to constructors for encoded video and audio frames)  in https://bugzilla.mozilla.org/show_bug.cgi?id=2033420

This adds a release note. It isn't interesting - I've just noted support.

Related docs can be tracked in #44161
