### PR TITLE
Fix typo in "The page-type front matter key" page

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -200,7 +200,7 @@ This section lists `page-type` values for pages under [Web/XSLT](/en-US/docs/Web
 
 This section lists `page-type` values for pages under [Web/EXSLT](/en-US/docs/Web/XML/EXSLT). Every page in that part of the tree must have a `page-type`, and its value must be one of those listed below or one of the [generic page type](#generic_page_types) values.
 
-- `xslt-function`: a function of EXSLT, like [`exsl:node-set()`](/en-US/docs/Web/XML/EXSLT/Reference/exsl/node-set).
+- `exslt-function`: a function of EXSLT, like [`exsl:node-set()`](/en-US/docs/Web/XML/EXSLT/Reference/exsl/node-set).
 
 ### Firefox page types
 


### PR DESCRIPTION
### Description

Updates the [The page-type front matter key](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key) page to use the correct page type for EXSLT functions.

### Motivation

The EXSLT page type is `exslt-function`, not `xslt-function`.

### Additional details

The only occurrence of `xslt-function` was in these docs: https://github.com/search?q=repo%3Amdn%2Fcontent%20%2F%5Cbxslt-function%5Cb%2F&type=code

### Related issues and pull requests

Noticed via https://github.com/mdn/rari/pull/713.