### PR TITLE
add `Snap a length as a line width`

### DIFF
--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -29,7 +29,6 @@ For some properties, such as `border-width`, `outline-width`, `column-rule-width
 
 For example, on a screen with a {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} of 3, `border-width: 1.5px` computes to approximately `1.33px` (rounded down from 4.5 to 4 device pixels), and `outline-width: 0.2px` computes to approximately `0.33px` (rounded up from 0.6 to 1 device pixel).
 
-
 ### Relative vs. absolute lengths
 
 The `<length>` units can be relative or absolute. Relative lengths represent a measurement in terms of some other distance. Depending on the unit, this distance can be the size of a specific character, the [line height](/en-US/docs/Web/CSS/Reference/Properties/line-height), or the size of the {{Glossary("viewport")}}. Style sheets that use relative length units can more easily scale from one output environment to another.

--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -25,6 +25,35 @@ The `<length>` units can be relative or absolute. Relative lengths represent a m
 > [!NOTE]
 > Child elements do not inherit the relative values as specified for their parent; they inherit the computed values.
 
+### Length snapped as a line width
+
+Computed `<length>` values in `border-width` and a few other properties are rounded as a "line width" to ensure reasonable visual display.
+
+This rounding method first converts the `length` to a number of {{glossary("Device pixel")}}.
+If the absolute value of `length` is smaller than 1 and non-zero, `length` is rounded away from zero to 1 or -1, depending on the sign.
+Otherwise, if the absolute value of `length` is greater than 1, `length` is rounded towards zero to the nearest integer number. 
+The resulting value of `length` is then converted back to {{glossary("CSS pixel")}}.
+
+For example, if {{domxref("Window.devicePixelRatio")}} is 3:
+
+```css
+border-width: 1.5px;
+/*
+1.5px corresponds to 1.5*3 = 4.5 device pixels,
+which is rounded to 4 device pixels,
+that corresponds to 4px/3,
+so the computed value is approximately 1.33333px.
+*/
+
+outline-width: 0.2px;
+/*
+0.2px corresponds to 0.2*3 = 0.6 device pixels,
+which is rounded to 1 device pixel,
+that corresponds to 1px/3,
+so the computed value is approximately 0.33333px.
+*/
+```
+
 ## Relative length units
 
 CSS relative length units are based on font, container, or viewport sizes.
@@ -192,12 +221,6 @@ For high-dpi devices, inches (`in`), centimeters (`cm`), and millimeters (`mm`) 
   - : One pica. `1pc` = `12pt` = `1in / 6`.
 - `pt`
   - : One point. `1pt` = `1in / 72`.
-
-## Rounding
-
-### Snap a length as a line width
-
-While the exact supported precision of numeric values, and how they are rounded to match that precision, is generally implementation-defined, computed `<length>` values in `border-width` and a few other properties are rounded in a specific way to ensure reasonable visual display. This rounding method effectively rounds `<length>` to an integer number of device pixels, while ensuring non-zero values remain visible. The <a href="https://drafts.csswg.org/css-values/#snap-as-a-line-width" title="To snap a &lt;length&gt; len as a line width:&#10;1. If len is an integer number of device pixels, leave it as is.&#10;2. If the absolute value of len is greater than zero, but less than 1 device pixel, round it away from zero to &pm;1 device pixel.&#10;3. If the absolute value of len is greater than 1 device pixel, round it towards zero to the nearest integer number of device pixels.">CSS-Values specification</a> provides the details.
 
 ## Interpolation
 

--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -18,41 +18,22 @@ The `<length>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by
 > [!NOTE]
 > Some properties allow negative `<length>` values, while others do not.
 
+### Specified vs. computed values
+
 The [specified value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#specified_value) of a length (_specified length_) is represented by its quantity and unit. The [computed value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#computed_value) of a length (_computed length_) is the specified length resolved to an absolute length, and its unit is not distinguished.
+The [specified value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#specified_value) of a length (_specified length_) is represented by its quantity and unit. The [computed value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#computed_value) of a length (_computed length_) is the specified length resolved to an absolute length, and its unit is not distinguished.
+
+For some properties, such as `border-width`, `outline-width`, `column-rule-width`, and `outline-offset`, the computed `<length>` values are rounded to an integer number of {{glossary("device pixel", "device pixels")}} to ensure reasonable visual display:
+- A non-zero value less than 1 device pixel is rounded up.
+- A value greater than 1 device pixel is rounded down to the nearest whole device pixel.
+ 
+ For example, on a screen with a {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} of 3, `border-width: 1.5px` computes to approximately `1.33px` (rounded down from 4.5 to 4 device pixels), and `outline-width: 0.2px` computes to approximately `0.33px` (rounded up from 0.6 to 1 device pixel).
+### Relative vs. absolute lengths
 
 The `<length>` units can be relative or absolute. Relative lengths represent a measurement in terms of some other distance. Depending on the unit, this distance can be the size of a specific character, the [line height](/en-US/docs/Web/CSS/Reference/Properties/line-height), or the size of the {{Glossary("viewport")}}. Style sheets that use relative length units can more easily scale from one output environment to another.
 
 > [!NOTE]
 > Child elements do not inherit the relative values as specified for their parent; they inherit the computed values.
-
-### Length snapped as a line width
-
-Computed `<length>` values in `border-width` and a few other properties are rounded as a "line width" to ensure reasonable visual display.
-
-This rounding method first converts the `length` to a number of {{glossary("Device pixel")}}.
-If the absolute value of `length` is smaller than 1 and non-zero, `length` is rounded away from zero to 1 or -1, depending on the sign.
-Otherwise, if the absolute value of `length` is greater than 1, `length` is rounded towards zero to the nearest integer number.
-The resulting value of `length` is then converted back to {{glossary("CSS pixel")}}.
-
-For example, if {{domxref("Window.devicePixelRatio")}} is 3:
-
-```css
-border-width: 1.5px;
-/*
-1.5px corresponds to 1.5*3 = 4.5 device pixels,
-which is rounded to 4 device pixels,
-that corresponds to 4px/3,
-so the computed value is approximately 1.33333px.
-*/
-
-outline-width: 0.2px;
-/*
-0.2px corresponds to 0.2*3 = 0.6 device pixels,
-which is rounded to 1 device pixel,
-that corresponds to 1px/3,
-so the computed value is approximately 0.33333px.
-*/
-```
 
 ## Relative length units
 

--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -31,7 +31,7 @@ Computed `<length>` values in `border-width` and a few other properties are roun
 
 This rounding method first converts the `length` to a number of {{glossary("Device pixel")}}.
 If the absolute value of `length` is smaller than 1 and non-zero, `length` is rounded away from zero to 1 or -1, depending on the sign.
-Otherwise, if the absolute value of `length` is greater than 1, `length` is rounded towards zero to the nearest integer number. 
+Otherwise, if the absolute value of `length` is greater than 1, `length` is rounded towards zero to the nearest integer number.
 The resulting value of `length` is then converted back to {{glossary("CSS pixel")}}.
 
 For example, if {{domxref("Window.devicePixelRatio")}} is 3:

--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -193,6 +193,12 @@ For high-dpi devices, inches (`in`), centimeters (`cm`), and millimeters (`mm`) 
 - `pt`
   - : One point. `1pt` = `1in / 72`.
 
+## Rounding
+
+### Snap a length as a line width
+
+While the exact supported precision of numeric values, and how they are rounded to match that precision, is generally implementation-defined, computed `<length>` values in `border-width` and a few other properties are rounded in a specific way to ensure reasonable visual display. This rounding method effectively rounds `<length>` to an integer number of device pixels, while ensuring non-zero values remain visible. The <a href="https://drafts.csswg.org/css-values/#snap-as-a-line-width" title="To snap a &lt;length&gt; len as a line width:&#10;1. If len is an integer number of device pixels, leave it as is.&#10;2. If the absolute value of len is greater than zero, but less than 1 device pixel, round it away from zero to &pm;1 device pixel.&#10;3. If the absolute value of len is greater than 1 device pixel, round it towards zero to the nearest integer number of device pixels.">CSS-Values specification</a> provides the details.
+
 ## Interpolation
 
 When animated, values of the `<length>` data type are interpolated as real, floating-point numbers. The {{glossary("interpolation")}} happens on the calculated value. The speed of the interpolation is determined by the [easing function](/en-US/docs/Web/CSS/Reference/Values/easing-function) associated with the animation.

--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -24,6 +24,7 @@ The [specified value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processi
 
 For some properties, such as `border-width`, `outline-width`, `column-rule-width`, and `outline-offset`, the computed `<length>` values are rounded to an integer number of {{glossary("device pixel", "device pixels")}} to ensure reasonable visual display:
 - A non-zero value less than 1 device pixel is rounded up.
+
 - A value greater than 1 device pixel is rounded down to the nearest whole device pixel.
 
 For example, on a screen with a {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} of 3, `border-width: 1.5px` computes to approximately `1.33px` (rounded down from 4.5 to 4 device pixels), and `outline-width: 0.2px` computes to approximately `0.33px` (rounded up from 0.6 to 1 device pixel).

--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -23,11 +23,12 @@ The `<length>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by
 The [specified value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#specified_value) of a length (_specified length_) is represented by its quantity and unit. The [computed value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#computed_value) of a length (_computed length_) is the specified length resolved to an absolute length, and its unit is not distinguished.
 
 For some properties, such as `border-width`, `outline-width`, `column-rule-width`, and `outline-offset`, the computed `<length>` values are rounded to an integer number of {{glossary("device pixel", "device pixels")}} to ensure reasonable visual display:
-- A non-zero value less than 1 device pixel is rounded up.
 
+- A non-zero value less than 1 device pixel is rounded up.
 - A value greater than 1 device pixel is rounded down to the nearest whole device pixel.
 
 For example, on a screen with a {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} of 3, `border-width: 1.5px` computes to approximately `1.33px` (rounded down from 4.5 to 4 device pixels), and `outline-width: 0.2px` computes to approximately `0.33px` (rounded up from 0.6 to 1 device pixel).
+
 
 ### Relative vs. absolute lengths
 

--- a/files/en-us/web/css/reference/values/length/index.md
+++ b/files/en-us/web/css/reference/values/length/index.md
@@ -21,13 +21,13 @@ The `<length>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by
 ### Specified vs. computed values
 
 The [specified value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#specified_value) of a length (_specified length_) is represented by its quantity and unit. The [computed value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#computed_value) of a length (_computed length_) is the specified length resolved to an absolute length, and its unit is not distinguished.
-The [specified value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#specified_value) of a length (_specified length_) is represented by its quantity and unit. The [computed value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#computed_value) of a length (_computed length_) is the specified length resolved to an absolute length, and its unit is not distinguished.
 
 For some properties, such as `border-width`, `outline-width`, `column-rule-width`, and `outline-offset`, the computed `<length>` values are rounded to an integer number of {{glossary("device pixel", "device pixels")}} to ensure reasonable visual display:
 - A non-zero value less than 1 device pixel is rounded up.
 - A value greater than 1 device pixel is rounded down to the nearest whole device pixel.
- 
- For example, on a screen with a {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} of 3, `border-width: 1.5px` computes to approximately `1.33px` (rounded down from 4.5 to 4 device pixels), and `outline-width: 0.2px` computes to approximately `0.33px` (rounded up from 0.6 to 1 device pixel).
+
+For example, on a screen with a {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} of 3, `border-width: 1.5px` computes to approximately `1.33px` (rounded down from 4.5 to 4 device pixels), and `outline-width: 0.2px` computes to approximately `0.33px` (rounded up from 0.6 to 1 device pixel).
+
 ### Relative vs. absolute lengths
 
 The `<length>` units can be relative or absolute. Relative lengths represent a measurement in terms of some other distance. Depending on the unit, this distance can be the size of a specific character, the [line height](/en-US/docs/Web/CSS/Reference/Properties/line-height), or the size of the {{Glossary("viewport")}}. Style sheets that use relative length units can more easily scale from one output environment to another.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Add high level description of  the `Snap a length as a line width` rounding method, to the [`<length>` CSS type"](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/length) page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The computed value for `border-*-width`, `column-rule-width`, `outline-width`, `outline-offset`, `-webkit-border-*-width`, is specified as **"the absolute length, snapped as a line width"** .
There is no docs explaing what that means, that I can easely link in the computed value description.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

`border-*-width`, `column-rule-width`, `outline-width` snapped as a line width:
https://github.com/w3c/csswg-drafts/issues/5210

Computed value untangled from `*-style` properties value:
https://github.com/w3c/csswg-drafts/issues/11494#issuecomment-2675800489

`outline-offset` snapped as a line width:
https://github.com/w3c/csswg-drafts/issues/12906

Definition of "length snapped as a line width":
https://drafts.csswg.org/css-values-4/#snap-as-a-line-width

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

Fixes https://github.com/mdn/content/issues/44193

Relates https://github.com/mdn/data/pull/1069

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
