### PR TITLE
untangle `border/column-rule/outline-width` from `*-style` properties value

### DIFF
--- a/files/en-us/web/css/reference/properties/border-style/index.md
+++ b/files/en-us/web/css/reference/properties/border-style/index.md
@@ -113,9 +113,9 @@ Each value is a keyword chosen from the list below.
 - `<line-style>`
   - : Describes the style of the border. It can have the following values:
     - `none`
-      - : Like the `hidden` keyword, displays no border. Unless a {{cssxref("background-image")}} is set. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority: if any other conflicting border is set, it will be displayed.
+      - : Like the `hidden` keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the same side's {{cssxref("border-width")}} will be `0`, even if the specified value is something else. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority: if any other conflicting border is set, it will be displayed.
     - `hidden`
-      - : Like the `none` keyword, displays no border. Unless a {{cssxref("background-image")}} is set. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority: if any other conflicting border is set, it won't be displayed.
+      - : Like the `none` keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the same side's {{cssxref("border-width")}} will be `0`, even if the specified value is something else. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority: if any other conflicting border is set, it won't be displayed.
     - `dotted`
       - : Displays a series of rounded dots. The spacing of the dots is not defined by the specification and is implementation-specific. The radius of the dots is half the computed value of the same side's {{cssxref("border-width")}}.
     - `dashed`

--- a/files/en-us/web/css/reference/properties/border-style/index.md
+++ b/files/en-us/web/css/reference/properties/border-style/index.md
@@ -113,9 +113,9 @@ Each value is a keyword chosen from the list below.
 - `<line-style>`
   - : Describes the style of the border. It can have the following values:
     - `none`
-      - : Like the `hidden` keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the computed value of the same side's {{cssxref("border-width")}} will be `0`, even if the specified value is something else. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority: if any other conflicting border is set, it will be displayed.
+      - : Like the `hidden` keyword, displays no border. Unless a {{cssxref("background-image")}} is set. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority: if any other conflicting border is set, it will be displayed.
     - `hidden`
-      - : Like the `none` keyword, displays no border. Unless a {{cssxref("background-image")}} is set, the computed value of the same side's {{cssxref("border-width")}} will be `0`, even if the specified value is something else. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority: if any other conflicting border is set, it won't be displayed.
+      - : Like the `none` keyword, displays no border. Unless a {{cssxref("background-image")}} is set. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority: if any other conflicting border is set, it won't be displayed.
     - `dotted`
       - : Displays a series of rounded dots. The spacing of the dots is not defined by the specification and is implementation-specific. The radius of the dots is half the computed value of the same side's {{cssxref("border-width")}}.
     - `dashed`

--- a/files/en-us/web/css/reference/properties/outline-style/index.md
+++ b/files/en-us/web/css/reference/properties/outline-style/index.md
@@ -80,7 +80,7 @@ The `outline-style` property is specified as any one of the values listed below.
 - `auto`
   - : Permits the user agent to render a custom outline style.
 - `none`
-  - : No outline is used. The {{cssxref("outline-width")}} is `0`.
+  - : No outline is used.
 - `dotted`
   - : The outline is a series of dots.
 - `dashed`

--- a/files/en-us/web/css/reference/properties/outline/index.md
+++ b/files/en-us/web/css/reference/properties/outline/index.md
@@ -103,7 +103,7 @@ An outline is not required to be rectangular: While dealing with multiline text,
 
 ## Accessibility
 
-Assigning `outline` a value of `none` will remove the browser's default focus style. If an element can be interacted with it must have a visible focus indicator. Provide obvious focus styling if the default focus style is removed.
+Assigning `outline` a value of `0` or `none` will remove the browser's default focus style. If an element can be interacted with it must have a visible focus indicator. Provide obvious focus styling if the default focus style is removed.
 
 - [How to Design Useful and Usable Focus Indicators](https://www.deque.com/blog/give-site-focus-tips-designing-usable-focus-indicators/)
 - WCAG 2.1: [Understanding Success Criterion 2.4.7: Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)

--- a/files/en-us/web/css/reference/properties/outline/index.md
+++ b/files/en-us/web/css/reference/properties/outline/index.md
@@ -103,7 +103,7 @@ An outline is not required to be rectangular: While dealing with multiline text,
 
 ## Accessibility
 
-Assigning `outline` a value of `0` or `none` will remove the browser's default focus style. If an element can be interacted with it must have a visible focus indicator. Provide obvious focus styling if the default focus style is removed.
+Assigning `outline` a value of `none` will remove the browser's default focus style. If an element can be interacted with it must have a visible focus indicator. Provide obvious focus styling if the default focus style is removed.
 
 - [How to Design Useful and Usable Focus Indicators](https://www.deque.com/blog/give-site-focus-tips-designing-usable-focus-indicators/)
 - WCAG 2.1: [Understanding Success Criterion 2.4.7: Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)

--- a/files/en-us/web/css/reference/values/line-style/index.md
+++ b/files/en-us/web/css/reference/values/line-style/index.md
@@ -30,9 +30,9 @@ The **`<line-style>`** {{glossary("enumerated")}} value type represents keyword 
 The `<line-style>` enumerated type is specified using one of the values listed below:
 
 - `none`
-  - : Displays no line. The computed value of the line width is `0` even if a width value is specified. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority. If any other conflicting border is set, it will be displayed. The `none` value is similar to `hidden`.
+  - : Displays no line. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority. If any other conflicting border is set, it will be displayed. The `none` value is similar to `hidden`.
 - `hidden`
-  - : Displays no line. The computed width of the line is `0` even if a width value is specified. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority. If any other conflicting border is set, it won't be displayed. The `hidden` value is similar to `none`, but `hidden` is not a valid value for outline styles.
+  - : Displays no line. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority. If any other conflicting border is set, it won't be displayed. The `hidden` value is similar to `none`, but `hidden` is not a valid value for outline styles.
 - `dotted`
   - : Displays a series of round dots. The radius of the dots is half the computed value of the line's width. The spacing of the dots is not defined by the specification and is implementation-specific.
 - `dashed`

--- a/files/en-us/web/css/reference/values/line-style/index.md
+++ b/files/en-us/web/css/reference/values/line-style/index.md
@@ -30,9 +30,9 @@ The **`<line-style>`** {{glossary("enumerated")}} value type represents keyword 
 The `<line-style>` enumerated type is specified using one of the values listed below:
 
 - `none`
-  - : Displays no line. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority. If any other conflicting border is set, it will be displayed. The `none` value is similar to `hidden`.
+  - : Displays no line. The [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the line width is `0` even if a width value is specified. In the case of table cell and border collapsing, the `none` value has the _lowest_ priority. If any other conflicting border is set, it will be displayed. The `none` value is similar to `hidden`.
 - `hidden`
-  - : Displays no line. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority. If any other conflicting border is set, it won't be displayed. The `hidden` value is similar to `none`, but `hidden` is not a valid value for outline styles.
+  - : Displays no line. The [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the line width is `0` even if a width value is specified. In the case of table cell and border collapsing, the `hidden` value has the _highest_ priority. If any other conflicting border is set, it won't be displayed. The `hidden` value is similar to `none`, but `hidden` is not a valid value for outline styles.
 - `dotted`
   - : Displays a series of round dots. The radius of the dots is half the computed value of the line's width. The spacing of the dots is not defined by the specification and is implementation-specific.
 - `dashed`


### PR DESCRIPTION

### Description

untangle the computed value for `border-*-width`, `column-rule-width` and `outline-width` from their related `*-style` properties.

### Additional details

https://github.com/w3c/csswg-drafts/issues/11494#issuecomment-2675800489

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->

Relates https://github.com/mdn/content/issues/44193
Relates https://github.com/mdn/data/pull/1069
