### PR TITLE
Add missing SVG offset attribute reference page

### DIFF
--- a/files/en-us/web/svg/reference/attribute/offset/index.md
+++ b/files/en-us/web/svg/reference/attribute/offset/index.md
@@ -31,3 +31,4 @@ You can use this attribute with the following SVG elements:
 
   <rect width="200" height="100" fill="red" filter="url(#gamma)" />
 </svg>
+```

--- a/files/en-us/web/svg/reference/attribute/offset/index.md
+++ b/files/en-us/web/svg/reference/attribute/offset/index.md
@@ -1,0 +1,33 @@
+---
+title: offset
+slug: Web/SVG/Reference/Attribute/offset
+page-type: svg-attribute
+browser-compat: svg.elements.feFuncA.offset
+---
+
+{{SVGRef}}
+
+The **`offset`** attribute defines an offset value used for color component transfer functions in SVG filter effects.
+
+You can use this attribute with the following SVG elements:
+
+- {{SVGElement("feFuncA")}}
+- {{SVGElement("feFuncB")}}
+- {{SVGElement("feFuncG")}}
+- {{SVGElement("feFuncR")}}
+- {{SVGElement("stop")}}
+
+## Example
+
+```html
+<svg viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="gamma">
+      <feComponentTransfer>
+        <feFuncR type="linear" slope="1" offset="0.2" />
+      </feComponentTransfer>
+    </filter>
+  </defs>
+
+  <rect width="200" height="100" fill="red" filter="url(#gamma)" />
+</svg>


### PR DESCRIPTION
## Summary

This PR adds the missing SVG `offset` attribute reference page.

The `{{SVGAttr("offset")}}` macro was linking to a non-existent page across several SVG and Web API reference pages, resulting in broken links.

## Changes made

* Added `/en-US/docs/Web/SVG/Reference/Attribute/offset`
* Included usage description and example
* Added related SVG elements and references

## Issue addressed

Fixes broken SVG attribute reference links for `offset`.
