### PR TITLE
Clarify <ident> data type is not quoted

### DIFF
--- a/files/en-us/web/css/reference/values/ident/index.md
+++ b/files/en-us/web/css/reference/values/ident/index.md
@@ -7,7 +7,7 @@ spec-urls: https://drafts.csswg.org/css-values/#typedef-ident
 sidebar: cssref
 ---
 
-The **`<ident>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/Reference/Values/Data_types) denotes an arbitrary string used as an {{glossary("identifier")}}.
+The **`<ident>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/Reference/Values/Data_types) denotes an arbitrary unquoted string of characters used as an {{glossary("identifier")}}.
 
 ## Syntax
 


### PR DESCRIPTION
a string is quoted, so we need to ensure readers realize it is not a string.