### PR TITLE
docs(HTMLImageElement.sizes): fix duplicate "the"

### DIFF
--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -178,7 +178,7 @@ The example is best {{LiveSampleLink('Selecting an image to fit window width', '
    The label at the bottom of the image shows the current container width.
 2. Resize the window — you should see the image change at the `sizes` attribute's media query break points.
 
-   Note that the the selected image may be larger than the container width alone suggests.
+   Note that the selected image may be larger than the container width alone suggests.
    Many displays, if not most, have a [device pixel ratio (DPR)](/en-US/docs/Web/API/Window/devicePixelRatio) greater than one.
    In order to render a sharp image at the physical pixel density of the display, a browser will multiply the matched `sizes` hint by the DPR before selecting from `srcset`.
    For example, on a 2× display with a viewport of ~500px, the matched hint is `600px`, but the browser looks for a ~1200px image and selects `1200.png` as the closest available size and then scales it to fit in the available space.


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a duplicate `the` in the [`HTMLImageElement: sizes` reference page](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes) — `the the selected image` → `the selected image`.

## Why

Reads cleanly on the rendered page.

## How verified

Single-character/word change, no rendered structure altered. Read the surrounding paragraph and the new sentence still parses unambiguously.

## Maintainer note

Feel free to close if not worth the review cycle.
