### PR TITLE
module title uniformity

### DIFF
--- a/files/en-us/web/css/guides/overflow/index.md
+++ b/files/en-us/web/css/guides/overflow/index.md
@@ -234,7 +234,7 @@ A link is included in the content box above to demonstrate the effects of keyboa
 
 The CSS overflow level 4 module also introduces the `block-ellipsis`, `continue`, `max-lines`, `overflow-clip-margin-block`, `overflow-clip-margin-block-end`, `overflow-clip-margin-block-start`, `overflow-clip-margin-bottom`, `overflow-clip-margin-inline`, `overflow-clip-margin-inline-end`, `overflow-clip-margin-inline-start`, `overflow-clip-margin-left`, `overflow-clip-margin-right`, and `overflow-clip-margin-top` properties. Currently, no browsers support these features.
 
-### Selectors and pseudo-elements
+### Selectors
 
 - {{cssxref("::scroll-button()")}}
 - {{cssxref("::scroll-marker")}}

--- a/files/en-us/web/css/guides/paged_media/index.md
+++ b/files/en-us/web/css/guides/paged_media/index.md
@@ -29,7 +29,7 @@ The process of paginating content into generated pages and controlling breaks in
 
 The CSS paged media module also introduces the `bleeds` and `marks` descriptors of the `@page` at-rule. Currently, no browsers support these features.
 
-### Pseudo-classes
+### Selectors
 
 - {{cssxref(":blank")}}
 - {{cssxref(":first")}}


### PR DESCRIPTION
all the other module landing pages read simply "selectors". This make these two pages follow that standard,