### PR TITLE
Fix casing of `{{jsxref}}` arguments

### DIFF
--- a/files/en-us/learn_web_development/core/scripting/arrays/index.md
+++ b/files/en-us/learn_web_development/core/scripting/arrays/index.md
@@ -193,7 +193,7 @@ console.log(cities); // [ "Manchester", "Carlisle" ]
 
 ## Accessing every item
 
-Very often you will want to access every item in the array. You can do this using the {{jsxref("statements/for...of","for...of")}} statement:
+Very often you will want to access every item in the array. You can do this using the {{jsxref("Statements/for...of","for...of")}} statement:
 
 ```js
 const birds = ["Parrot", "Falcon", "Owl"];

--- a/files/en-us/learn_web_development/core/scripting/loops/index.md
+++ b/files/en-us/learn_web_development/core/scripting/loops/index.md
@@ -148,7 +148,7 @@ But there are other collections in JavaScript as well, including {{jsxref("Set")
 
 ### The for...of loop
 
-The basic tool for looping through a collection is the {{jsxref("statements/for...of","for...of")}} loop:
+The basic tool for looping through a collection is the {{jsxref("Statements/for...of","for...of")}} loop:
 
 ```js
 const cats = ["Leopard", "Serval", "Jaguar", "Tiger", "Caracal", "Lion"];
@@ -225,7 +225,7 @@ console.log(filtered);
 ## The standard for loop
 
 In the "drawing circles" example above, you don't have a collection of items to loop through: you really just want to run the same code 100 times.
-In a case like that, you can use the {{jsxref("statements/for","for")}} loop.
+In a case like that, you can use the {{jsxref("Statements/for","for")}} loop.
 This has the following syntax:
 
 ```js-nolint

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -13,7 +13,7 @@ An object of type `bookmarks.BookmarkTreeNode` represents a node in the bookmark
 An {{jsxref("Object")}} with the following properties:
 
 - `children` {{optional_inline}}
-  - : An {{jsxref("array")}} of `bookmarks.BookmarkTreeNode` objects which represent the node's children. The list is ordered in the list in which the children appear in the user interface. This field is omitted if the node isn't a folder.
+  - : An {{jsxref("Array")}} of `bookmarks.BookmarkTreeNode` objects which represent the node's children. The list is ordered in the list in which the children appear in the user interface. This field is omitted if the node isn't a folder.
 - `dateAdded` {{optional_inline}}
   - : A number representing the creation date of the node in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 - `dateGroupModified` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -19,21 +19,21 @@ An {{jsxref("object")}} with the following properties:
 - `dateGroupModified` {{optional_inline}}
   - : A number representing the date and time the contents of this folder last changed, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 - `id`
-  - : A {{jsxref("string")}} which uniquely identifies the node. Each ID is unique within the user's profile and remains unchanged across browser restarts.
+  - : A {{jsxref("String")}} which uniquely identifies the node. Each ID is unique within the user's profile and remains unchanged across browser restarts.
 - `index` {{optional_inline}}
   - : A number which represents the zero-based position of this node within its parent folder, where zero represents the first entry.
     > [!NOTE]
     > If you create or move multiple bookmarks, because the {{WebExtAPIRef("bookmarks.create()")}} and {{WebExtAPIRef("bookmarks.move()")}} methods are asynchronous, the requests may get processed in any order. Consequently, the value of each bookmark's index may change or be unknown until all the requests are completed. If the index associated with a bookmark matters to your extension, then – when creating or moving multiple bookmarks – the extension should wait for each `bookmarks.create` or `bookmarks.move` call to complete before creating or moving the next bookmark. Waiting ensures that the index associated with each bookmark is not affected by a create or move call executing concurrently while the original call is in progress.
 - `parentId` {{optional_inline}}
-  - : A {{jsxref("string")}} which specifies the ID of the parent folder. This property is not present in the root node.
+  - : A {{jsxref("String")}} which specifies the ID of the parent folder. This property is not present in the root node.
 - `title`
-  - : A {{jsxref("string")}} which contains the text displayed for the node in menus and lists of bookmarks.
+  - : A {{jsxref("String")}} which contains the text displayed for the node in menus and lists of bookmarks.
 - `type` {{optional_inline}}
   - : A {{WebExtAPIRef("bookmarks.BookmarkTreeNodeType")}} object indicating whether this is a bookmark, a folder, or a separator. Defaults to `"bookmark"` unless `url` is omitted, in which case it defaults to `"folder"`.
 - `unmodifiable` {{optional_inline}}
-  - : A {{jsxref("string")}} as described by the type {{WebExtAPIRef('bookmarks.BookmarkTreeNodeUnmodifiable')}}. Represents the reason that the node can't be changed. If the node can be changed, this is omitted.
+  - : A {{jsxref("String")}} as described by the type {{WebExtAPIRef('bookmarks.BookmarkTreeNodeUnmodifiable')}}. Represents the reason that the node can't be changed. If the node can be changed, this is omitted.
 - `url` {{optional_inline}}
-  - : A {{jsxref("string")}} which represents the URL for the bookmark. If the node represents a folder, this property is omitted.
+  - : A {{jsxref("String")}} which represents the URL for the bookmark. If the node represents a folder, this property is omitted.
 
 {{WebExtExamples}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -10,7 +10,7 @@ An object of type `bookmarks.BookmarkTreeNode` represents a node in the bookmark
 
 ## Type
 
-An {{jsxref("object")}} with the following properties:
+An {{jsxref("Object")}} with the following properties:
 
 - `children` {{optional_inline}}
   - : An {{jsxref("array")}} of `bookmarks.BookmarkTreeNode` objects which represent the node's children. The list is ordered in the list in which the children appear in the user interface. This field is omitted if the node isn't a folder.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodetype/index.md
@@ -10,7 +10,7 @@ The **`bookmarks.BookmarkTreeNodeType`** type is used to describe whether a node
 
 ## Type
 
-`bookmarks.BookmarkTreeNodeType` is a {{jsxref("string")}} which can have one of the following three values:
+`bookmarks.BookmarkTreeNodeType` is a {{jsxref("String")}} which can have one of the following three values:
 
 - `"bookmark"`: the node is a bookmark.
 - `"folder"`: the node is a folder.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenodeunmodifiable/index.md
@@ -10,7 +10,7 @@ The **`bookmarks.BookmarkTreeNodeUnmodifiable`** type is used to indicate the re
 
 ## Type
 
-`bookmarks.BookmarkTreeNodeUnmodifiable` is a {{jsxref("string")}} which can currently have only one value: `"managed"`. This indicates that the bookmark node was configured by an administrator or by the custodian of a supervised user (such as a parent, in the case of parental controls).
+`bookmarks.BookmarkTreeNodeUnmodifiable` is a {{jsxref("String")}} which can currently have only one value: `"managed"`. This indicates that the bookmark node was configured by an administrator or by the custodian of a supervised user (such as a parent, in the case of parental controls).
 
 {{WebExtExamples}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -15,13 +15,13 @@ An {{jsxref("object")}} containing some combination of the following fields:
 - `index` {{optional_inline}}
   - : An integer {{jsxref("Number")}} which specifies the position at which to place the new bookmark under its parent. A value of 0 will put it at the top of the list.
 - `parentId` {{optional_inline}}
-  - : A {{jsxref("string")}} which indicates the ID of the parent folder into which to place the new bookmark or bookmark folder. On Chrome and Firefox, the default is the "Other Bookmarks" folder on the Bookmarks menu.
+  - : A {{jsxref("String")}} which indicates the ID of the parent folder into which to place the new bookmark or bookmark folder. On Chrome and Firefox, the default is the "Other Bookmarks" folder on the Bookmarks menu.
 - `title` {{optional_inline}}
-  - : A {{jsxref("string")}} which specifies the title for the bookmark or the name of the folder to be created. If this isn't specified, the title is `""`.
+  - : A {{jsxref("String")}} which specifies the title for the bookmark or the name of the folder to be created. If this isn't specified, the title is `""`.
 - `type` {{optional_inline}}
   - : A {{WebExtAPIRef("bookmarks.BookmarkTreeNodeType")}} object indicating whether this is a bookmark, a folder, or a separator. Defaults to `"bookmark"` unless `url` is omitted, in which case it defaults to `"folder"`.
 - `url` {{optional_inline}}
-  - : `string`. A {{jsxref("string")}} which specifies the URL of the page to bookmark. If this is omitted or is `null`, a folder is created instead of a bookmark.
+  - : `string`. A {{jsxref("String")}} which specifies the URL of the page to bookmark. If this is omitted or is `null`, a folder is created instead of a bookmark.
 
 {{WebExtExamples}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -10,7 +10,7 @@ The `CreateDetails` type is used to describe the properties of a new, bookmark, 
 
 ## Type
 
-An {{jsxref("object")}} containing some combination of the following fields:
+An {{jsxref("Object")}} containing some combination of the following fields:
 
 - `index` {{optional_inline}}
   - : An integer {{jsxref("Number")}} which specifies the position at which to place the new bookmark under its parent. A value of 0 will put it at the top of the list.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -21,7 +21,7 @@ let getBookmarks = browser.bookmarks.get(
 ### Parameters
 
 - `idOrIdList`
-  - : A {{jsxref("String")}} or {{jsxref("array")}} of strings specifying the IDs of one or more {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} objects to retrieve.
+  - : A {{jsxref("String")}} or {{jsxref("Array")}} of strings specifying the IDs of one or more {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} objects to retrieve.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/get/index.md
@@ -21,7 +21,7 @@ let getBookmarks = browser.bookmarks.get(
 ### Parameters
 
 - `idOrIdList`
-  - : A {{jsxref("string")}} or {{jsxref("array")}} of strings specifying the IDs of one or more {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} objects to retrieve.
+  - : A {{jsxref("String")}} or {{jsxref("array")}} of strings specifying the IDs of one or more {{WebExtAPIRef("bookmarks.BookmarkTreeNode", "BookmarkTreeNode")}} objects to retrieve.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getchildren/index.md
@@ -21,7 +21,7 @@ let gettingChildren = browser.bookmarks.getChildren(
 ### Parameters
 
 - `id`
-  - : A {{jsxref("string")}} that specifies the ID of the folder whose children are to be retrieved.
+  - : A {{jsxref("String")}} that specifies the ID of the folder whose children are to be retrieved.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/getsubtree/index.md
@@ -23,7 +23,7 @@ let gettingSubTree = browser.bookmarks.getSubTree(
 ### Parameters
 
 - `id`
-  - : A {{jsxref("string")}} specifying the ID of the root of the subtree to retrieve.
+  - : A {{jsxref("String")}} specifying the ID of the root of the subtree to retrieve.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -25,11 +25,11 @@ let movingBookmark = browser.bookmarks.move(
 ### Parameters
 
 - `id`
-  - : A {{jsxref("string")}} containing the ID of the bookmark or folder to move.
+  - : A {{jsxref("String")}} containing the ID of the bookmark or folder to move.
 - `destination`
   - : An {{jsxref("object")}} which specifies the destination for the bookmark. This object must contain one or both of the following fields:
     - `parentId` {{optional_inline}}
-      - : A {{jsxref("string")}} which specifies the ID of the destination folder. If this value is left out, the bookmark is moved to a new location within its current folder.
+      - : A {{jsxref("String")}} which specifies the ID of the destination folder. If this value is left out, the bookmark is moved to a new location within its current folder.
     - `index` {{optional_inline}}
       - : A 0-based index specifying the position within the folder to which to move the bookmark. A value of 0 moves the bookmark to the top of the folder. If this value is omitted, the bookmark is placed at the end of the new parent folder.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -27,7 +27,7 @@ let movingBookmark = browser.bookmarks.move(
 - `id`
   - : A {{jsxref("String")}} containing the ID of the bookmark or folder to move.
 - `destination`
-  - : An {{jsxref("object")}} which specifies the destination for the bookmark. This object must contain one or both of the following fields:
+  - : An {{jsxref("Object")}} which specifies the destination for the bookmark. This object must contain one or both of the following fields:
     - `parentId` {{optional_inline}}
       - : A {{jsxref("String")}} which specifies the ID of the destination folder. If this value is left out, the bookmark is moved to a new location within its current folder.
     - `index` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/remove/index.md
@@ -24,7 +24,7 @@ let removingBookmark = browser.bookmarks.remove(
 ### Parameters
 
 - `id`
-  - : A {{jsxref("string")}} specifying the ID of the bookmark or empty folder to remove.
+  - : A {{jsxref("String")}} specifying the ID of the bookmark or empty folder to remove.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/removetree/index.md
@@ -24,7 +24,7 @@ let removingTree = browser.bookmarks.removeTree(
 ### Parameters
 
 - `id`
-  - : A {{jsxref("string")}} specifying the ID of the folder node to be deleted along with its descendants.
+  - : A {{jsxref("String")}} specifying the ID of the folder node to be deleted along with its descendants.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -23,7 +23,7 @@ let searching = browser.bookmarks.search(
 ### Parameters
 
 - `query`
-  - : A {{jsxref("String")}} or {{jsxref("object")}} describing the query to perform.
+  - : A {{jsxref("String")}} or {{jsxref("Object")}} describing the query to perform.
 
     If `query` is a **string**, it consists of zero or more space-delimited search terms. Each search term matches if it is a substring in the bookmark's URL or title. Matching is case-insensitive. For a bookmark to match the query, all the query's search terms must be matched.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/search/index.md
@@ -23,20 +23,20 @@ let searching = browser.bookmarks.search(
 ### Parameters
 
 - `query`
-  - : A {{jsxref("string")}} or {{jsxref("object")}} describing the query to perform.
+  - : A {{jsxref("String")}} or {{jsxref("object")}} describing the query to perform.
 
     If `query` is a **string**, it consists of zero or more space-delimited search terms. Each search term matches if it is a substring in the bookmark's URL or title. Matching is case-insensitive. For a bookmark to match the query, all the query's search terms must be matched.
 
     If `query` is an **object**, it consists of zero or more of 3 properties: `query`, `title`, and `url`, which are described below. For a bookmark to match the query, all the properties' terms must be matched.
     - `query` {{optional_inline}}
-      - : A {{jsxref("string")}} specifying one or more terms to match against; the format is identical to the string form of the `query` parameter. If this isn't a string, an exception is thrown.
+      - : A {{jsxref("String")}} specifying one or more terms to match against; the format is identical to the string form of the `query` parameter. If this isn't a string, an exception is thrown.
     - `url` {{optional_inline}}
-      - : A {{jsxref("string")}} that must exactly match the bookmark's URL. Matching is case-insensitive, and trailing slashes are ignored.
+      - : A {{jsxref("String")}} that must exactly match the bookmark's URL. Matching is case-insensitive, and trailing slashes are ignored.
 
         If you pass an invalid URL, the function will throw an exception.
 
     - `title` {{optional_inline}}
-      - : A {{jsxref("string")}} that must exactly match the bookmark tree node's title. Matching is case-sensitive.
+      - : A {{jsxref("String")}} that must exactly match the bookmark tree node's title. Matching is case-sensitive.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -25,13 +25,13 @@ let updating = browser.bookmarks.update(
 ### Parameters
 
 - `id`
-  - : A {{jsxref("string")}} specifying the ID of the bookmark or bookmark folder to update.
+  - : A {{jsxref("String")}} specifying the ID of the bookmark or bookmark folder to update.
 - `changes`
   - : An {{jsxref("object")}} specifying the changes to apply, with some combination of the following fields. Any items not specified aren't changed in the referenced bookmark or folder:
     - `title` {{optional_inline}}
-      - : A {{jsxref("string")}} containing the new title of the bookmark, or the new name of the folder if `id` refers to a folder.
+      - : A {{jsxref("String")}} containing the new title of the bookmark, or the new name of the folder if `id` refers to a folder.
     - `url` {{optional_inline}}
-      - : A {{jsxref("string")}} providing a new URL for the bookmark.
+      - : A {{jsxref("String")}} providing a new URL for the bookmark.
 
 ### Return value
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/update/index.md
@@ -27,7 +27,7 @@ let updating = browser.bookmarks.update(
 - `id`
   - : A {{jsxref("String")}} specifying the ID of the bookmark or bookmark folder to update.
 - `changes`
-  - : An {{jsxref("object")}} specifying the changes to apply, with some combination of the following fields. Any items not specified aren't changed in the referenced bookmark or folder:
+  - : An {{jsxref("Object")}} specifying the changes to apply, with some combination of the following fields. Any items not specified aren't changed in the referenced bookmark or folder:
     - `title` {{optional_inline}}
       - : A {{jsxref("String")}} containing the new title of the bookmark, or the new name of the folder if `id` refers to a folder.
     - `url` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -10,7 +10,7 @@ A `Permissions` object represents a collection of permissions.
 
 ## Type
 
-An {{jsxref("object")}} with these properties:
+An {{jsxref("Object")}} with these properties:
 
 - `origins` {{optional_inline}}
   - : An array of [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns), representing [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions).

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
@@ -16,7 +16,7 @@ If the value of this property changes, the [progress](/en-US/docs/Web/API/Backgr
 
 ## Value
 
-A {{jsxref("number")}}.
+A {{jsxref("Number")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
@@ -14,7 +14,7 @@ The **`downloadTotal`** read-only property of the {{domxref("BackgroundFetchRegi
 
 ## Value
 
-A {{jsxref("number")}}.
+A {{jsxref("Number")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/backgroundfetchregistration/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/index.md
@@ -34,7 +34,7 @@ _Also inherits properties from its parent, {{domxref("EventTarget")}}._
 - {{domxref("BackgroundFetchRegistration.failureReason")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string with a value that indicates a reason for a background fetch failure. Can be one of the following values: `""`, `"aborted"`, `"bad-status"`, `"fetch-error"`, `"quota-exceeded"`, `"download-total-exceeded"`.
 - {{domxref("BackgroundFetchRegistration.recordsAvailable")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : A {{jsxref("boolean")}} indicating whether the `recordsAvailable` flag is set.
+  - : A {{jsxref("Boolean")}} indicating whether the `recordsAvailable` flag is set.
 
 ## Instance methods
 

--- a/files/en-us/web/api/backgroundfetchregistration/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/index.md
@@ -22,13 +22,13 @@ _Also inherits properties from its parent, {{domxref("EventTarget")}}._
 - {{domxref("BackgroundFetchRegistration.id")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing the background fetch's ID.
 - {{domxref("BackgroundFetchRegistration.uploadTotal")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : A {{jsxref("number")}} containing the total number of bytes to be uploaded.
+  - : A {{jsxref("Number")}} containing the total number of bytes to be uploaded.
 - {{domxref("BackgroundFetchRegistration.uploaded")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : A {{jsxref("number")}} containing the size in bytes successfully sent, initially `0`.
+  - : A {{jsxref("Number")}} containing the size in bytes successfully sent, initially `0`.
 - {{domxref("BackgroundFetchRegistration.downloadTotal")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : A {{jsxref("number")}} containing the total size in bytes of this download. This is the value set when the background fetch was registered, or `0`.
+  - : A {{jsxref("Number")}} containing the total size in bytes of this download. This is the value set when the background fetch was registered, or `0`.
 - {{domxref("BackgroundFetchRegistration.downloaded")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : A {{jsxref("number")}} containing the size in bytes that has been downloaded, initially `0`.
+  - : A {{jsxref("Number")}} containing the size in bytes that has been downloaded, initially `0`.
 - {{domxref("BackgroundFetchRegistration.result")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an empty string initially, on completion either the string `"success"` or `"failure"`.
 - {{domxref("BackgroundFetchRegistration.failureReason")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
@@ -14,7 +14,7 @@ The **`recordsAvailable`** read-only property of the {{domxref("BackgroundFetchR
 
 ## Value
 
-A {{jsxref("boolean")}}.
+A {{jsxref("Boolean")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploaded/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/uploaded/index.md
@@ -16,7 +16,7 @@ If the value of this property changes, the [progress](/en-US/docs/Web/API/Backgr
 
 ## Value
 
-A {{jsxref("number")}}.
+A {{jsxref("Number")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.md
@@ -14,7 +14,7 @@ The **`uploadTotal`** read-only property of the {{domxref("BackgroundFetchRegist
 
 ## Value
 
-A {{jsxref("number")}}.
+A {{jsxref("Number")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.md
@@ -27,7 +27,7 @@ An array of objects containing the changed cookie(s). Each object contains the f
 - `expires`
   - : A timestamp, given as {{glossary("Unix time")}} in milliseconds, containing the expiration date of the cookie.
 - `secure`
-  - : A {{jsxref("boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
+  - : A {{jsxref("Boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
 - `sameSite`
   - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values:
     - `"strict"`

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.md
@@ -27,7 +27,7 @@ An array of objects containing the deleted cookie(s). Each object contains the f
 - `expires`
   - : A timestamp, given as {{glossary("Unix time")}} in milliseconds, containing the expiration date of the cookie.
 - `secure`
-  - : A {{jsxref("boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
+  - : A {{jsxref("Boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
 - `sameSite`
   - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values:
     - `"strict"`

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
@@ -25,7 +25,7 @@ An array of objects containing the changed cookie(s). Each object contains the f
 - `expires`
   - : A timestamp, given as [Unix time](/en-US/docs/Glossary/Unix_time) in milliseconds, containing the expiration date of the cookie.
 - `secure`
-  - : A {{jsxref("boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
+  - : A {{jsxref("Boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
 - `sameSite`
   - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values:
     - `"strict"`

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
@@ -25,7 +25,7 @@ An array of objects containing the deleted cookie(s). Each object contains the f
 - `expires`
   - : A timestamp, given as [Unix time](/en-US/docs/Glossary/Unix_time) in milliseconds, containing the expiration date of the cookie.
 - `secure`
-  - : A {{jsxref("boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
+  - : A {{jsxref("Boolean")}} indicating whether the cookie is used only in a secure context (HTTPS rather than HTTP).
 - `sameSite`
   - : One of the following [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) values:
     - `"strict"`

--- a/files/en-us/web/api/gpubuffer/destroy/index.md
+++ b/files/en-us/web/api/gpubuffer/destroy/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpubuffer/mapasync/index.md
+++ b/files/en-us/web/api/gpubuffer/mapasync/index.md
@@ -43,7 +43,7 @@ mapAsync(mode, offset, size)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to {{jsxref("Undefined")}} when the `GPUBuffer`'s content is ready to be accessed.
+A {{jsxref("Promise")}} that resolves to {{jsxref("undefined")}} when the `GPUBuffer`'s content is ready to be accessed.
 
 ### Validation
 

--- a/files/en-us/web/api/gpubuffer/unmap/index.md
+++ b/files/en-us/web/api/gpubuffer/unmap/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpucommandencoder/clearbuffer/index.md
+++ b/files/en-us/web/api/gpucommandencoder/clearbuffer/index.md
@@ -30,7 +30,7 @@ clearBuffer(buffer, offset, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucommandencoder/copybuffertobuffer/index.md
+++ b/files/en-us/web/api/gpucommandencoder/copybuffertobuffer/index.md
@@ -37,7 +37,7 @@ copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucommandencoder/copybuffertotexture/index.md
+++ b/files/en-us/web/api/gpucommandencoder/copybuffertotexture/index.md
@@ -59,7 +59,7 @@ copyBufferToTexture(source, destination, copySize)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucommandencoder/copytexturetobuffer/index.md
+++ b/files/en-us/web/api/gpucommandencoder/copytexturetobuffer/index.md
@@ -60,7 +60,7 @@ copyTextureToBuffer(source, destination, copySize)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
+++ b/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
@@ -55,7 +55,7 @@ A copy texture object has the following structure:
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucommandencoder/insertdebugmarker/index.md
+++ b/files/en-us/web/api/gpucommandencoder/insertdebugmarker/index.md
@@ -26,7 +26,7 @@ insertDebugMarker(markerLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpucommandencoder/popdebuggroup/index.md
+++ b/files/en-us/web/api/gpucommandencoder/popdebuggroup/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucommandencoder/pushdebuggroup/index.md
+++ b/files/en-us/web/api/gpucommandencoder/pushdebuggroup/index.md
@@ -26,7 +26,7 @@ pushDebugGroup(groupLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpucommandencoder/resolvequeryset/index.md
+++ b/files/en-us/web/api/gpucommandencoder/resolvequeryset/index.md
@@ -32,7 +32,7 @@ resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucommandencoder/writetimestamp/index.md
+++ b/files/en-us/web/api/gpucommandencoder/writetimestamp/index.md
@@ -32,7 +32,7 @@ writeTimestamp(querySet, queryIndex)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroups/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroups/index.md
@@ -33,7 +33,7 @@ dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroupsindirect/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/dispatchworkgroupsindirect/index.md
@@ -40,7 +40,7 @@ dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucomputepassencoder/end/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/end/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucomputepassencoder/insertdebugmarker/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/insertdebugmarker/index.md
@@ -26,7 +26,7 @@ insertDebugMarker(markerLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpucomputepassencoder/popdebuggroup/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/popdebuggroup/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpucomputepassencoder/pushdebuggroup/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/pushdebuggroup/index.md
@@ -26,7 +26,7 @@ pushDebugGroup(groupLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpucomputepassencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/setbindgroup/index.md
@@ -40,7 +40,7 @@ If a {{jsxref("Uint32Array")}} value is specified for `dynamicOffsets`, both of 
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/gpucomputepassencoder/setpipeline/index.md
+++ b/files/en-us/web/api/gpucomputepassencoder/setpipeline/index.md
@@ -24,7 +24,7 @@ setPipeline(pipeline)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpudevice/pusherrorscope/index.md
+++ b/files/en-us/web/api/gpudevice/pusherrorscope/index.md
@@ -32,7 +32,7 @@ pushErrorScope(filter)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpuqueryset/destroy/index.md
+++ b/files/en-us/web/api/gpuqueryset/destroy/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
+++ b/files/en-us/web/api/gpuqueue/copyexternalimagetotexture/index.md
@@ -77,7 +77,7 @@ copyExternalImageToTexture(source, destination, copySize)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
+++ b/files/en-us/web/api/gpuqueue/onsubmittedworkdone/index.md
@@ -63,7 +63,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}}.
+A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/gpuqueue/submit/index.md
+++ b/files/en-us/web/api/gpuqueue/submit/index.md
@@ -24,7 +24,7 @@ submit(commandBuffers)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpuqueue/writebuffer/index.md
+++ b/files/en-us/web/api/gpuqueue/writebuffer/index.md
@@ -34,7 +34,7 @@ writeBuffer(buffer, bufferOffset, data, dataOffset, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/gpuqueue/writetexture/index.md
+++ b/files/en-us/web/api/gpuqueue/writetexture/index.md
@@ -59,7 +59,7 @@ writeTexture(destination, data, dataLayout, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderbundleencoder/draw/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/draw/index.md
@@ -36,7 +36,7 @@ draw(vertexCount, instanceCount, firstVertex, firstInstance)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderbundleencoder/drawindexed/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/drawindexed/index.md
@@ -39,7 +39,7 @@ drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderbundleencoder/drawindexedindirect/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/drawindexedindirect/index.md
@@ -45,7 +45,7 @@ drawIndexedIndirect(indirectBuffer, indirectOffset)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderbundleencoder/drawindirect/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/drawindirect/index.md
@@ -44,7 +44,7 @@ drawIndirect(indirectBuffer, indirectOffset)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderbundleencoder/insertdebugmarker/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/insertdebugmarker/index.md
@@ -29,7 +29,7 @@ insertDebugMarker(markerLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderbundleencoder/popdebuggroup/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/popdebuggroup/index.md
@@ -28,7 +28,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderbundleencoder/pushdebuggroup/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/pushdebuggroup/index.md
@@ -29,7 +29,7 @@ pushDebugGroup(groupLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setbindgroup/index.md
@@ -43,7 +43,7 @@ If a {{jsxref("Uint32Array")}} value is specified for `dynamicOffsets`, both of 
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/gpurenderbundleencoder/setindexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setindexbuffer/index.md
@@ -39,7 +39,7 @@ setIndexBuffer(buffer, indexFormat, offset, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderbundleencoder/setpipeline/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setpipeline/index.md
@@ -27,7 +27,7 @@ setPipeline(pipeline)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderbundleencoder/setvertexbuffer/index.md
@@ -33,7 +33,7 @@ setVertexBuffer(slot, buffer, offset, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/beginocclusionquery/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/beginocclusionquery/index.md
@@ -24,7 +24,7 @@ beginOcclusionQuery(queryIndex)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/draw/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/draw/index.md
@@ -33,7 +33,7 @@ draw(vertexCount, instanceCount, firstVertex, firstInstance)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderpassencoder/drawindexed/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/drawindexed/index.md
@@ -36,7 +36,7 @@ drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderpassencoder/drawindexedindirect/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/drawindexedindirect/index.md
@@ -42,7 +42,7 @@ drawIndexedIndirect(indirectBuffer, indirectOffset)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/drawindirect/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/drawindirect/index.md
@@ -41,7 +41,7 @@ drawIndirect(indirectBuffer, indirectOffset)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/end/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/end/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/endocclusionquery/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/endocclusionquery/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/executebundles/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/executebundles/index.md
@@ -27,7 +27,7 @@ executeBundles(bundles)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/insertdebugmarker/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/insertdebugmarker/index.md
@@ -26,7 +26,7 @@ insertDebugMarker(markerLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderpassencoder/popdebuggroup/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/popdebuggroup/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/pushdebuggroup/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/pushdebuggroup/index.md
@@ -26,7 +26,7 @@ pushDebugGroup(groupLabel)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setbindgroup/index.md
@@ -40,7 +40,7 @@ If a {{jsxref("Uint32Array")}} value is specified for `dynamicOffsets`, both of 
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/gpurenderpassencoder/setblendconstant/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setblendconstant/index.md
@@ -39,7 +39,7 @@ setBlendConstant(color)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderpassencoder/setindexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setindexbuffer/index.md
@@ -36,7 +36,7 @@ setIndexBuffer(buffer, indexFormat, offset, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/setpipeline/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setpipeline/index.md
@@ -24,7 +24,7 @@ setPipeline(pipeline)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/setscissorrect/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setscissorrect/index.md
@@ -33,7 +33,7 @@ setScissorRect(x, y, width, height)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/setstencilreference/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setstencilreference/index.md
@@ -27,7 +27,7 @@ setStencilReference(reference)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/gpurenderpassencoder/setvertexbuffer/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setvertexbuffer/index.md
@@ -30,7 +30,7 @@ setVertexBuffer(slot, buffer, offset, size)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gpurenderpassencoder/setviewport/index.md
+++ b/files/en-us/web/api/gpurenderpassencoder/setviewport/index.md
@@ -37,7 +37,7 @@ setViewport(x, y, width, height, minDepth, maxDepth)
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ### Validation
 

--- a/files/en-us/web/api/gputexture/destroy/index.md
+++ b/files/en-us/web/api/gputexture/destroy/index.md
@@ -23,7 +23,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("Undefined")}}).
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/hiddevice/index.md
+++ b/files/en-us/web/api/hiddevice/index.md
@@ -18,7 +18,7 @@ The **`HIDDevice`** interface of the [WebHID API](/en-US/docs/Web/API/WebHID_API
 This interface also inherits properties from {{domxref("EventTarget")}}.
 
 - {{domxref("HIDDevice.opened")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns a {{jsxref("boolean")}}, true if the device has an open connection.
+  - : Returns a {{jsxref("Boolean")}}, true if the device has an open connection.
 - {{domxref("HIDDevice.vendorId")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the vendorId of the HID device.
 - {{domxref("HIDDevice.productId")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/imagedecoder/complete/index.md
+++ b/files/en-us/web/api/imagedecoder/complete/index.md
@@ -12,7 +12,7 @@ The **`complete`** read-only property of the {{domxref("ImageDecoder")}} interfa
 
 ## Value
 
-A {{jsxref("boolean")}}, `true` if buffering is complete.
+A {{jsxref("Boolean")}}, `true` if buffering is complete.
 
 ## Examples
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -24,7 +24,7 @@ decode(options)
     - `frameIndex` {{optional_inline}}
       - : An integer representing the index of the frame to decode. Defaults to `0` (the first frame).
     - `completeFramesOnly` {{optional_inline}}
-      - : A {{jsxref("boolean")}} defaulting to `true`.
+      - : A {{jsxref("Boolean")}} defaulting to `true`.
         When `true`, the `Promise` returned by the method resolves only when the image is fully decoded.
         When `false`, the method will return a new `Promise` that may resolve with a partially decoded image.
         The method can be called repeatedly until `result.complete` is true, with each step providing an image with the next available level of detail.
@@ -36,7 +36,7 @@ A {{jsxref("Promise")}} that resolves with an object containing the following me
 - `image`
   - : A {{domxref("VideoFrame")}} containing the decoded image.
 - `complete`
-  - : A {{jsxref("boolean")}}, if `true` indicates that `image` contains the final full-detail output.
+  - : A {{jsxref("Boolean")}}, if `true` indicates that `image` contains the final full-detail output.
 
 ### Exceptions
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -31,7 +31,7 @@ decode(options)
 
 ### Return value
 
-A {{jsxref("promise")}} that resolves with an object containing the following members:
+A {{jsxref("Promise")}} that resolves with an object containing the following members:
 
 - `image`
   - : A {{domxref("VideoFrame")}} containing the decoded image.

--- a/files/en-us/web/api/imagedecoder/istypesupported_static/index.md
+++ b/files/en-us/web/api/imagedecoder/istypesupported_static/index.md
@@ -23,7 +23,7 @@ ImageDecoder.isTypeSupported(type)
 
 ### Return value
 
-A {{jsxref("promise")}} that resolves with a boolean value indicating whether images with a format of `type` can be decoded by the API.
+A {{jsxref("Promise")}} that resolves with a boolean value indicating whether images with a format of `type` can be decoded by the API.
 
 ## Examples
 

--- a/files/en-us/web/api/imagetrack/animated/index.md
+++ b/files/en-us/web/api/imagetrack/animated/index.md
@@ -12,7 +12,7 @@ The **`animated`** property of the {{domxref("ImageTrack")}} interface returns `
 
 ## Value
 
-A {{jsxref("boolean")}}, if `true` this is an animated track.
+A {{jsxref("Boolean")}}, if `true` this is an animated track.
 
 ## Examples
 

--- a/files/en-us/web/api/imagetrack/index.md
+++ b/files/en-us/web/api/imagetrack/index.md
@@ -14,13 +14,13 @@ The **`ImageTrack`** interface of the {{domxref('WebCodecs API','','','true')}} 
 ## Instance properties
 
 - {{domxref("ImageTrack.animated")}} {{ReadOnlyInline}}
-  - : Returns a {{jsxref("boolean")}} indicating whether the track is animated and therefore has multiple frames.
+  - : Returns a {{jsxref("Boolean")}} indicating whether the track is animated and therefore has multiple frames.
 - {{domxref("ImageTrack.frameCount")}} {{ReadOnlyInline}}
   - : Returns an integer indicating the number of frames in the track.
 - {{domxref("ImageTrack.repetitionCount")}} {{ReadOnlyInline}}
   - : Returns an integer indicating the number of times that the animation repeats.
 - {{domxref("ImageTrack.selected")}} {{ReadOnlyInline}}
-  - : Returns a {{jsxref("boolean")}} indicating whether the track is selected for decoding.
+  - : Returns a {{jsxref("Boolean")}} indicating whether the track is selected for decoding.
 
 ## Specifications
 

--- a/files/en-us/web/api/imagetrack/selected/index.md
+++ b/files/en-us/web/api/imagetrack/selected/index.md
@@ -12,7 +12,7 @@ The **`selected`** property of the {{domxref("ImageTrack")}} interface returns `
 
 ## Value
 
-A {{jsxref("boolean")}}, if `true` the track is selected for decoding.
+A {{jsxref("Boolean")}}, if `true` the track is selected for decoding.
 
 ## Examples
 

--- a/files/en-us/web/api/imagetracklist/index.md
+++ b/files/en-us/web/api/imagetracklist/index.md
@@ -12,7 +12,7 @@ The **`ImageTrackList`** interface of the {{domxref('WebCodecs API','','','true'
 ## Instance properties
 
 - {{domxref("ImageTrackList.ready")}} {{ReadOnlyInline}}
-  - : Returns a {{jsxref("promise")}} that resolves once the `ImageTrackList` has been populated with {{domxref("ImageTrack","tracks")}}.
+  - : Returns a {{jsxref("Promise")}} that resolves once the `ImageTrackList` has been populated with {{domxref("ImageTrack","tracks")}}.
 - {{domxref("ImageTrackList.length")}} {{ReadOnlyInline}}
   - : Returns an integer indicating the length of the `ImageTrackList`.
 - {{domxref("ImageTrackList.selectedIndex")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/mediadevices/devicechange_event/index.md
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.md
@@ -177,7 +177,7 @@ function updateDeviceList() {
 {{domxref("MediaDevices.enumerateDevices", "enumerateDevices()")}} on the
 {{domxref("MediaDevices")}} object referenced in the
 {{domxref("navigator.mediaDevices")}} property, as well as the code that's run when the
-{{jsxref("promise")}} returned by `enumerateDevices()` is fulfilled. The
+{{jsxref("Promise")}} returned by `enumerateDevices()` is fulfilled. The
 fulfillment handler is called when the device list is ready. The list is passed into the
 fulfillment handler as an array of {{domxref("MediaDeviceInfo")}} objects, each
 describing one media input or output device.

--- a/files/en-us/web/api/navigator/setappbadge/index.md
+++ b/files/en-us/web/api/navigator/setappbadge/index.md
@@ -20,7 +20,7 @@ setAppBadge(contents)
 ### Parameters
 
 - `contents` {{optional_inline}}
-  - : A {{jsxref("number")}} which will be used as the value of the badge. If `contents` is `0` then the badge will be set to `nothing`, indicating a cleared badge.
+  - : A {{jsxref("Number")}} which will be used as the value of the badge. If `contents` is `0` then the badge will be set to `nothing`, indicating a cleared badge.
 
 ### Return value
 

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -145,7 +145,7 @@ Capturing audio is always optional, and even when web content requests a stream 
 
 ## Using the captured stream
 
-The {{jsxref("promise")}} returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} resolves to a {{domxref("MediaStream")}} that contains at least one video stream that contains the screen or screen area, and which is adjusted or filtered based upon the constraints specified when `getDisplayMedia()` was called.
+The {{jsxref("Promise")}} returned by {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}} resolves to a {{domxref("MediaStream")}} that contains at least one video stream that contains the screen or screen area, and which is adjusted or filtered based upon the constraints specified when `getDisplayMedia()` was called.
 
 ### Potential risks
 
@@ -232,7 +232,7 @@ async function startCapture() {
 }
 ```
 
-After clearing the contents of the log in order to get rid of any leftover text from the previous attempt to connect, `startCapture()` calls {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}, passing into it the constraints object defined by `displayMediaOptions`. Using {{jsxref("Operators/await", "await")}}, the following line of code does not get executed until after the {{jsxref("promise")}} returned by `getDisplayMedia()` resolves. Upon resolution, the promise returns a {{domxref("MediaStream")}}, which will stream the contents of the screen, window, or other region selected by the user.
+After clearing the contents of the log in order to get rid of any leftover text from the previous attempt to connect, `startCapture()` calls {{domxref("MediaDevices.getDisplayMedia", "getDisplayMedia()")}}, passing into it the constraints object defined by `displayMediaOptions`. Using {{jsxref("Operators/await", "await")}}, the following line of code does not get executed until after the {{jsxref("Promise")}} returned by `getDisplayMedia()` resolves. Upon resolution, the promise returns a {{domxref("MediaStream")}}, which will stream the contents of the screen, window, or other region selected by the user.
 
 The stream is connected to the {{HTMLElement("video")}} element by storing the returned `MediaStream` into the element's {{domxref("HTMLMediaElement.srcObject", "srcObject")}}.
 

--- a/files/en-us/web/api/textdecoderstream/fatal/index.md
+++ b/files/en-us/web/api/textdecoderstream/fatal/index.md
@@ -8,7 +8,7 @@ browser-compat: api.TextDecoderStream.fatal
 
 {{APIRef("Encoding API")}}{{AvailableInWorkers}}
 
-The **`fatal`** read-only property of the {{domxref("TextDecoderStream")}} interface is a {{jsxref("boolean")}} indicating if the error mode of the `TextDecoderStream` object is set to `fatal`.
+The **`fatal`** read-only property of the {{domxref("TextDecoderStream")}} interface is a {{jsxref("Boolean")}} indicating if the error mode of the `TextDecoderStream` object is set to `fatal`.
 
 If the property is `true` then a decoder will throw a {{jsxref("TypeError")}} if it encounters malformed data while decoding.
 If `false` the decoder will substitute the invalid data with the replacement character `U+FFFD` (�).
@@ -16,7 +16,7 @@ The value of the property is set in the [`TextDecoderStream()` constructor](/en-
 
 ## Value
 
-A {{jsxref("boolean")}} which will return `true` if the error mode is set to "fatal".
+A {{jsxref("Boolean")}} which will return `true` if the error mode is set to "fatal".
 Otherwise it returns `false`, indicating that the error mode is "replacement".
 
 ## Examples

--- a/files/en-us/web/api/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/index.md
@@ -21,9 +21,9 @@ It implements the same shape as a {{domxref("TransformStream")}}, allowing it to
 - {{DOMxRef("TextDecoderStream.encoding")}} {{ReadOnlyInline}}
   - : An encoding.
 - {{DOMxRef("TextDecoderStream.fatal")}} {{ReadOnlyInline}}
-  - : A {{jsxref("boolean")}} indicating if the error mode is fatal.
+  - : A {{jsxref("Boolean")}} indicating if the error mode is fatal.
 - {{DOMxRef("TextDecoderStream.ignoreBOM")}} {{ReadOnlyInline}}
-  - : A {{jsxref("boolean")}} indicating whether the byte order mark is ignored.
+  - : A {{jsxref("Boolean")}} indicating whether the byte order mark is ignored.
 - {{DOMxRef("TextDecoderStream.readable")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("ReadableStream")}} instance controlled by this object.
 - {{DOMxRef("TextDecoderStream.writable")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
@@ -26,7 +26,7 @@ isHTML(value)
 
 ### Return value
 
-A {{jsxref("boolean")}} that is true if the object is a valid {{domxref("TrustedHTML")}} object.
+A {{jsxref("Boolean")}} that is true if the object is a valid {{domxref("TrustedHTML")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
@@ -26,7 +26,7 @@ isScript(value)
 
 ### Return value
 
-A {{jsxref("boolean")}} that is true if the object is a valid {{domxref("TrustedScript")}} object.
+A {{jsxref("Boolean")}} that is true if the object is a valid {{domxref("TrustedScript")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
@@ -26,7 +26,7 @@ isScriptURL(value)
 
 ### Return value
 
-A {{jsxref("boolean")}} that is true if the object is a valid {{domxref("TrustedScriptURL")}} object.
+A {{jsxref("Boolean")}} that is true if the object is a valid {{domxref("TrustedScriptURL")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/urlpattern/exec/index.md
+++ b/files/en-us/web/api/urlpattern/exec/index.md
@@ -37,7 +37,7 @@ Omitted parts are treated as empty strings.
 
 ### Return value
 
-An {{jsxref("object")}} that defines the matching elements and groups, or `null` if the passed inputs do not match the pattern.
+An {{jsxref("Object")}} that defines the matching elements and groups, or `null` if the passed inputs do not match the pattern.
 
 The object has the following properties:
 

--- a/files/en-us/web/api/urlpattern/test/index.md
+++ b/files/en-us/web/api/urlpattern/test/index.md
@@ -37,7 +37,7 @@ Omitted parts are treated as empty strings.
 
 ### Return value
 
-A {{jsxref("boolean")}}.
+A {{jsxref("Boolean")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/usbdevice/claiminterface/index.md
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.claimInterface
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`claimInterface()`** method of the
-{{domxref("USBDevice")}} interface returns a {{jsxref("promise")}} that resolves when
+{{domxref("USBDevice")}} interface returns a {{jsxref("Promise")}} that resolves when
 the requested interface is claimed for exclusive access.
 
 ## Syntax
@@ -28,7 +28,7 @@ claimInterface(interfaceNumber)
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/usbdevice/clearhalt/index.md
+++ b/files/en-us/web/api/usbdevice/clearhalt/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.clearHalt
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`clearHalt()`** method of the {{domxref("USBDevice")}}
-interface returns a {{jsxref("promise")}} that resolves when a halt condition is
+interface returns a {{jsxref("Promise")}} that resolves when a halt condition is
 cleared. A halt condition is when a data transfer to or from the device has a status
 of `'stall'`, which requires the web page (the _host_ system, in USB
 terminology) to clear that condition. See the for details.
@@ -33,7 +33,7 @@ clearHalt(direction, endpointNumber)
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/usbdevice/close/index.md
+++ b/files/en-us/web/api/usbdevice/close/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.close
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`close()`** method of the {{domxref("USBDevice")}}
-interface returns a {{jsxref("promise")}} that resolves when all open interfaces are
+interface returns a {{jsxref("Promise")}} that resolves when all open interfaces are
 released and the device session has ended.
 
 ## Syntax
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/configurations/index.md
+++ b/files/en-us/web/api/usbdevice/configurations/index.md
@@ -11,12 +11,12 @@ browser-compat: api.USBDevice.configurations
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`configurations`** read only property of the
-{{domxref("USBDevice")}} interface an {{jsxref("array")}} of device-specific interfaces
+{{domxref("USBDevice")}} interface an {{jsxref("Array")}} of device-specific interfaces
 for controlling a paired USB device.
 
 ## Value
 
-An {{jsxref("array")}} of {{domxref("USBConfiguration")}} objects.
+An {{jsxref("Array")}} of {{domxref("USBConfiguration")}} objects.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/controltransferin/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferin/index.md
@@ -38,7 +38,7 @@ controlTransferIn(setup, length)
 
 ### Return value
 
-{{jsxref("promise")}} that resolves with a {{domxref("USBInTransferResult")}}.
+{{jsxref("Promise")}} that resolves with a {{domxref("USBInTransferResult")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/controltransferout/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.md
@@ -40,7 +40,7 @@ controlTransferOut(setup, data)
 
 ### Return value
 
-A {{jsxref("promise")}} that resolves with a {{domxref("USBOutTransferResult")}}.
+A {{jsxref("Promise")}} that resolves with a {{domxref("USBOutTransferResult")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/index.md
+++ b/files/en-us/web/api/usbdevice/index.md
@@ -16,7 +16,7 @@ The **`USBDevice`** interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API
 - {{domxref("USBDevice.configuration")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{domxref("USBConfiguration")}} object for the currently selected interface for a paired USB device.
 - {{domxref("USBDevice.configurations")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : An {{jsxref("array")}} of device-specific interfaces for controlling a paired USB device.
+  - : An {{jsxref("Array")}} of device-specific interfaces for controlling a paired USB device.
 - {{domxref("USBDevice.deviceClass")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : One of three properties that identify USB devices for the purpose of loading a USB driver that will work with that device. The other two properties are `USBDevice.deviceSubclass` and `USBDevice.deviceProtocol`.
 - {{domxref("USBDevice.deviceProtocol")}} {{ReadOnlyInline}} {{Experimental_Inline}}

--- a/files/en-us/web/api/usbdevice/open/index.md
+++ b/files/en-us/web/api/usbdevice/open/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.open
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`open()`** method of the {{domxref("USBDevice")}}
-interface returns a {{jsxref("promise")}} that resolves when a device session has
+interface returns a {{jsxref("Promise")}} that resolves when a device session has
 started.
 
 ## Syntax
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/opened/index.md
+++ b/files/en-us/web/api/usbdevice/opened/index.md
@@ -16,7 +16,7 @@ paired USB device. A device must be opened before it can be controlled by a web 
 
 ## Value
 
-A {{jsxref("boolean")}}.
+A {{jsxref("Boolean")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/usbdevice/releaseinterface/index.md
+++ b/files/en-us/web/api/usbdevice/releaseinterface/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.releaseInterface
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`releaseInterface()`** method of the
-{{domxref("USBDevice")}} interface returns a {{jsxref("promise")}} that resolves when a
+{{domxref("USBDevice")}} interface returns a {{jsxref("Promise")}} that resolves when a
 claimed interface is released from exclusive access.
 
 ## Syntax
@@ -27,7 +27,7 @@ releaseInterface(interfaceNumber)
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/reset/index.md
+++ b/files/en-us/web/api/usbdevice/reset/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.reset
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`reset()`** method of the {{domxref("USBDevice")}}
-interface returns a {{jsxref("promise")}} that resolves when the device is reset and all
+interface returns a {{jsxref("Promise")}} that resolves when the device is reset and all
 app operations canceled and their promises rejected.
 
 ## Syntax
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
+++ b/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.selectAlternateInterface
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`selectAlternateInterface()`** method of the
-{{domxref("USBDevice")}} interface returns a {{jsxref("promise")}} that resolves when
+{{domxref("USBDevice")}} interface returns a {{jsxref("Promise")}} that resolves when
 the specified alternative endpoint is selected.
 
 ## Syntax
@@ -30,7 +30,7 @@ selectAlternateInterface(interfaceNumber, alternateSetting)
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/selectconfiguration/index.md
+++ b/files/en-us/web/api/usbdevice/selectconfiguration/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.selectConfiguration
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`selectConfiguration()`** method of the
-{{domxref("USBDevice")}} interface returns a {{jsxref("promise")}} that resolves when
+{{domxref("USBDevice")}} interface returns a {{jsxref("Promise")}} that resolves when
 the specified configuration is selected.
 
 ## Syntax
@@ -27,7 +27,7 @@ selectConfiguration(configurationValue)
 
 ### Return value
 
-A {{jsxref("promise")}}.
+A {{jsxref("Promise")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/transferin/index.md
+++ b/files/en-us/web/api/usbdevice/transferin/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.transferIn
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`transferIn()`** method of the {{domxref("USBDevice")}}
-interface returns a {{jsxref("promise")}} that resolves with a
+interface returns a {{jsxref("Promise")}} that resolves with a
 {{domxref("USBInTransferResult")}} when bulk or interrupt data is received from the USB
 device.
 
@@ -31,7 +31,7 @@ transferIn(endpointNumber, length)
 
 ### Return value
 
-A {{jsxref("promise")}} that resolves with a {{domxref("USBInTransferResult")}}.
+A {{jsxref("Promise")}} that resolves with a {{domxref("USBInTransferResult")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/usbdevice/transferout/index.md
+++ b/files/en-us/web/api/usbdevice/transferout/index.md
@@ -11,7 +11,7 @@ browser-compat: api.USBDevice.transferOut
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{SecureContext_Header}}{{AvailableInWorkers}}
 
 The **`transferOut()`** method of the {{domxref("USBDevice")}}
-interface returns a {{jsxref("promise")}} that resolves with a
+interface returns a {{jsxref("Promise")}} that resolves with a
 {{domxref("USBOutTransferResult")}} when bulk or interrupt data is sent to the USB
 device.
 
@@ -30,7 +30,7 @@ transferOut(endpointNumber, data)
 
 ### Return value
 
-A {{jsxref("promise")}} that resolves with a {{domxref("USBOutTransferResult")}}.
+A {{jsxref("Promise")}} that resolves with a {{domxref("USBOutTransferResult")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -25,7 +25,7 @@ encode(frame, options)
 - `options` {{optional_inline}}
   - : An object containing the following members:
     - `keyFrame` {{optional_inline}}
-      - : A {{jsxref("boolean")}}, defaulting to `false` giving the user agent flexibility to decide if this frame should be encoded as a key frame. If `true` this indicates that the given frame must be encoded as a key frame.
+      - : A {{jsxref("Boolean")}}, defaulting to `false` giving the user agent flexibility to decide if this frame should be encoded as a key frame. If `true` this indicates that the given frame must be encoded as a key frame.
     - `vp9` {{optional_inline}}
       - : Encode options for the [VP9](/en-US/docs/Web/Media/Guides/Formats/Video_codecs#vp9) codec.
         - `quantizer`

--- a/files/en-us/web/api/webrtc_api/using_dtmf/index.md
+++ b/files/en-us/web/api/webrtc_api/using_dtmf/index.md
@@ -303,7 +303,7 @@ async function handleCallerNegotiationNeeded() {
 }
 ```
 
-Since the various methods involved in negotiating the connection return {{jsxref("promise")}}s, we can chain them together like this:
+Since the various methods involved in negotiating the connection return {{jsxref("Promise")}}s, we can chain them together like this:
 
 1. Call {{domxref("RTCPeerConnection.createOffer", "callerPC.createOffer()")}} to get an offer.
 2. Then take that offer and set the caller's local description to match by calling {{domxref("RTCPeerConnection.setLocalDescription", "callerPC.setLocalDescription()")}}.

--- a/files/en-us/web/api/workernavigator/setappbadge/index.md
+++ b/files/en-us/web/api/workernavigator/setappbadge/index.md
@@ -20,7 +20,7 @@ setAppBadge(contents)
 ### Parameters
 
 - `contents` {{optional_inline}}
-  - : A {{jsxref("number")}} which will be used as the value of the badge. If `contents` is `0` then the badge will be set to `nothing`, indicating a cleared badge.
+  - : A {{jsxref("Number")}} which will be used as the value of the badge. If `contents` is `0` then the badge will be set to `nothing`, indicating a cleared badge.
 
 ### Return value
 

--- a/files/en-us/web/api/xrsession/end/index.md
+++ b/files/en-us/web/api/xrsession/end/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-A {{jsxref("promise")}} that resolves without a value after any platform-specific steps
+A {{jsxref("Promise")}} that resolves without a value after any platform-specific steps
 related to shutting down the session have completed. You can use the promise to do
 things like update UI elements to reflect the shut down connection, trigger application
 shut down, or whatever else you might need to do.

--- a/files/en-us/web/api/xrsession/index.md
+++ b/files/en-us/web/api/xrsession/index.md
@@ -47,7 +47,7 @@ _`XRSession` provides the following methods in addition to those inherited from 
 - {{DOMxRef("XRSession.cancelAnimationFrame", "cancelAnimationFrame()")}} {{Experimental_Inline}}
   - : Removes a callback from the animation frame painting callback from `XRSession`'s set of animation frame rendering callbacks, given the identifying handle returned by a previous call to {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}}.
 - {{DOMxRef("XRSession.end", "end()")}} {{Experimental_Inline}}
-  - : Ends the WebXR session. Returns a {{jsxref("promise")}} which resolves when the session has been shut down.
+  - : Ends the WebXR session. Returns a {{jsxref("Promise")}} which resolves when the session has been shut down.
 - {{DOMxRef("XRSession.requestAnimationFrame", "requestAnimationFrame()")}} {{Experimental_Inline}}
   - : Schedules the specified method to be called the next time the {{glossary("user agent")}} is working on rendering an animation frame for the WebXR device. Returns an integer value which can be used to identify the request for the purposes of canceling the callback using `cancelAnimationFrame()`. This method is comparable to the {{domxref("Window.requestAnimationFrame()")}} method.
 - {{DOMxRef("XRSession.requestHitTestSource", "requestHitTestSource()")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.md
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.md
@@ -11,7 +11,7 @@ browser-compat: api.XRSession.requestReferenceSpace
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`requestReferenceSpace()`** method of the
-{{DOMxRef("XRSession")}} interface returns a {{JSxRef("promise")}} that resolves with
+{{DOMxRef("XRSession")}} interface returns a {{JSxRef("Promise")}} that resolves with
 an instance of either {{DOMxRef("XRReferenceSpace")}}
 or {{DOMxRef("XRBoundedReferenceSpace")}} as appropriate given the type of reference
 space requested.

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -11,7 +11,7 @@ browser-compat: api.XRSystem.requestSession
 {{APIRef("WebXR Device API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **{{domxref("XRSystem")}}** interface's
-**`requestSession()`** method returns a {{jsxref("promise")}}
+**`requestSession()`** method returns a {{jsxref("Promise")}}
 which resolves to an {{domxref("XRSession")}} object through which you can manage the
 requested type of WebXR session.
 

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor_static/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor_static/index.md
@@ -111,7 +111,7 @@ function requestNativeScaleWebGLLayer(gl, xrSession) {
 ```
 
 This starts by calling the [WebGL rendering context](/en-US/docs/Web/API/WebGLRenderingContext) function
-{{domxref("WebGLRenderingContext.makeXRCompatible", "makeXRCompatible()")}}. When the returned {{jsxref("promise")}} resolves, we proceed by
+{{domxref("WebGLRenderingContext.makeXRCompatible", "makeXRCompatible()")}}. When the returned {{jsxref("Promise")}} resolves, we proceed by
 calling `XRWebGLLayer`'s `getNativeFramebufferScaleFactor()`
 static function to get the scale factor needed to reach the native resolution, and we
 then pass that into the {{domxref("XRWebGLLayer.XRWebGLLayer", "WebGLLayer()")}}

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -110,7 +110,7 @@ btn.addEventListener("click", () => {
 
 ## do...while statement
 
-The {{jsxref("statements/do...while", "do...while")}} statement repeats until a
+The {{jsxref("Statements/do...while", "do...while")}} statement repeats until a
 specified condition evaluates to false.
 
 A `do...while` statement looks as follows:

--- a/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
@@ -35,7 +35,7 @@ A number representing the [timestamp](/en-US/docs/Web/JavaScript/Reference/Globa
 
 ## Description
 
-`Date` objects are fundamentally represented by a [timestamp](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date), and this method allows you to retrieve the timestamp. You can use this method to help assign a date and time to another {{jsxref("Date")}} object. This method is functionally equivalent to the {{jsxref("Date/valueof", "valueOf()")}} method.
+`Date` objects are fundamentally represented by a [timestamp](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date), and this method allows you to retrieve the timestamp. You can use this method to help assign a date and time to another {{jsxref("Date")}} object. This method is functionally equivalent to the {{jsxref("Date/valueOf", "valueOf()")}} method.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formatrangetoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatRangeToParts
 sidebar: jsref
 ---
 
-The **`formatRangeToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/DatetimeFormat/formatRange", "formatRange()")}}. It is useful for building custom strings from the locale-specific tokens.
+The **`formatRangeToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/DateTimeFormat/formatRange", "formatRange()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 {{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.prototype.formatRangeToParts()", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -7,7 +7,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat.formatToParts
 sidebar: jsref
 ---
 
-The **`formatToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/DatetimeFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
+The **`formatToParts()`** method of {{jsxref("Intl.DateTimeFormat")}} instances returns an array of objects representing each part of the formatted string that would be returned by {{jsxref("Intl/DateTimeFormat/format", "format()")}}. It is useful for building custom strings from the locale-specific tokens.
 
 {{InteractiveExample("JavaScript Demo: Intl.DateTimeFormat.prototype.formatToParts()", "taller")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/foreach/index.md
@@ -63,7 +63,7 @@ it is executed for values which are present but have the value `undefined`.
 
 There are no keys in `Set` objects, however, so the first two arguments are
 both **values** contained in the {{jsxref("Set")}}. This is to make it
-consistent with other `forEach()` methods for {{jsxref("Map/foreach", "Map")}} and {{jsxref("Array/forEach", "Array")}}.
+consistent with other `forEach()` methods for {{jsxref("Map/forEach", "Map")}} and {{jsxref("Array/forEach", "Array")}}.
 
 If a `thisArg` parameter is provided to `forEach()`,
 it will be passed to `callback` when invoked, for use as its

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -330,7 +330,7 @@ If you are new to JavaScript, start with the [guide](/en-US/docs/Web/JavaScript/
 
 [JavaScript classes.](/en-US/docs/Web/JavaScript/Reference/Classes)
 
-- {{jsxref("Classes/Constructor", "constructor")}}
+- {{jsxref("Classes/constructor", "constructor")}}
 - {{jsxref("Classes/extends", "extends")}}
 - [Private elements](/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements)
 - [Public class fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields)

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -611,7 +611,7 @@ Several general notes about the table:
       <td>1: comma</td>
       <td>left-to-right</td>
       <td>
-        {{jsxref("Operators/comma_operator", "Comma operator", "", 1)}}<br><code>x, y</code>
+        {{jsxref("Operators/Comma_operator", "Comma operator", "", 1)}}<br><code>x, y</code>
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
+++ b/files/en-us/web/javascript/reference/operators/operator_precedence/index.md
@@ -611,7 +611,7 @@ Several general notes about the table:
       <td>1: comma</td>
       <td>left-to-right</td>
       <td>
-        {{jsxref("Operators/Comma_Operator", "Comma operator", "", 1)}}<br><code>x, y</code>
+        {{jsxref("Operators/comma_operator", "Comma operator", "", 1)}}<br><code>x, y</code>
       </td>
     </tr>
   </tbody>

--- a/files/en-us/webassembly/index.md
+++ b/files/en-us/webassembly/index.md
@@ -75,7 +75,7 @@ The [WebAssembly guides](/en-US/docs/WebAssembly/Guides) cover topics such as hi
 - [`WebAssembly.validate()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/validate_static)
   - : The `WebAssembly.validate()` function validates a given typed array of WebAssembly binary code.
 - [`WebAssembly.Memory()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory)
-  - : A `WebAssembly.Memory` object is a resizable {{jsxref("Global_objects/ArrayBuffer", "ArrayBuffer")}} that holds the raw bytes of memory accessed by an `Instance`.
+  - : A `WebAssembly.Memory` object is a resizable {{jsxref("Global_Objects/ArrayBuffer", "ArrayBuffer")}} that holds the raw bytes of memory accessed by an `Instance`.
 - [`WebAssembly.Table()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table)
   - : A `WebAssembly.Table` object is a resizable typed array of opaque values, like function references, that are accessed by an `Instance`.
 - [`WebAssembly.Tag()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Tag)


### PR DESCRIPTION
### Description

Fixes the casing of several `{{jsxref}}` macro invocations referring to these pages:

- `undefined`
- `Promise`
- `Boolean`
- `String`
- `Number`
- `Object`
- `Array`
- …

### Motivation

Allow the `jsxref` to be case-sensitive in the future, avoiding the ambiguity in cases of `{{domxref("function")}}` vs. `{{domxref("Function")}}`.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.
