### PR TITLE
FF152 Relnote: Element.getAnimations() - options.pseudoElement

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -57,6 +57,9 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{domxref("Notification/actions","actions")}} read-only property and the [`maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) static read-only property of the {{domxref("Notification")}} interface are supported.
   These contain the notification actions set with {{domxref("ServiceWorkerRegistration.showNotification()")}}, and the platform-dependent maximum number of actions that can be set for a notification, respectively.
   ([Firefox bug 1959931](https://bugzil.la/1959931)).
+- The {{domxref("Element.getAnimations()")}} method can now accept the [`options.pseudoElement`](/en-US/docs/Web/API/Element/getAnimations#pseudoelement) parameter.
+  This provides an ergonomic way to return the animations associated with a particular pseudo element.
+  ([Firefox bug 1935557](https://bugzil.la/1935557)).
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -58,7 +58,7 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
   These contain the notification actions set with {{domxref("ServiceWorkerRegistration.showNotification()")}}, and the platform-dependent maximum number of actions that can be set for a notification, respectively.
   ([Firefox bug 1959931](https://bugzil.la/1959931)).
 - The {{domxref("Element.getAnimations()")}} method can now accept the [`options.pseudoElement`](/en-US/docs/Web/API/Element/getAnimations#pseudoelement) parameter.
-  This provides an ergonomic way to return the animations associated with a particular pseudo element.
+  This allows you to directly target a specific pseudo-element, rather than filtering the results of `{ subtree: true }`.
   ([Firefox bug 1935557](https://bugzil.la/1935557)).
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF152 adds support for the `options.pseudoElement` param to be passed to [`Element.getAnimations()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations#options) in https://bugzilla.mozilla.org/show_bug.cgi?id=1935557

This adds the release note

Related docs work can be tracked in #44160