### PR TITLE
Fix: Remove duplicate explanations for 2-value and 3-value syntax expressions

### DIFF
--- a/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
+++ b/files/en-us/web/css/guides/cascade/shorthand_properties/index.md
@@ -47,10 +47,6 @@ Shorthands handling properties related to the sides of the box, like {{cssxref("
 
 - **1-value syntax:** `border-width: 1em` — A single value represents all sides: ![Box edges with one-value syntax](border1.png)
 
-- **2-value syntax:** `border-width: 1em 2em` — The first value represents the top and bottom edges, and the second value represents the left and right edges: ![Box edges with two-value syntax](border2.png)
-
-- **3-value syntax:** `border-width: 1em 2em 3em` — The first value represents the top edge, the second value represents the left and right edges, and the third value represents the bottom edge: ![Box edges with three-value syntax](border3.png)
-
 - **2-value syntax:** `border-width: 1em 2em` — The first value represents the top and bottom sides, and the second value represents the left and right sides: ![Box edges with two-value syntax](border2.png)
 
 - **3-value syntax:** `border-width: 1em 2em 3em` — The first value represents the top side, the second value represents the left and right sides, and the third value represents the bottom side: ![Box edges with three-value syntax](border3.png)


### PR DESCRIPTION
Removed duplicate explanations for 2-value and 3-value syntax in border-width. Kept naming (side vs. edge) consistent with rest of list.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Removed two duplicate items for multi-value syntax expressions.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The list of multi-value syntax expressions had duplicate 2-value and 3-value list items. Removed for clarity and fixing unnecessary repetition.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
N/A
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
