### PR TITLE
docs: clarify HTMLMediaElement abort event example

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/abort_event/index.md
@@ -31,7 +31,9 @@ A generic {{domxref("Event")}}.
 
 ### Abort loading a media resource
 
-The following example starts loading a video resource, then aborts the load by removing the `src` attribute and calling `load()`.
+The following example demonstrates how to abort a video.
+When you press the button it starts loading a video resource.
+After a short timeout it aborts the load by removing the `src` attribute and calling the `load()` method.
 If the video resource is still loading when `load()` is called, the `abort` event fires.
 
 #### HTML

--- a/files/en-us/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/abort_event/index.md
@@ -29,22 +29,59 @@ A generic {{domxref("Event")}}.
 
 ## Examples
 
-The following example starts loading a video resource, then provides a button that stops the load.
+### Abort loading a media resource
+
+The following example starts loading a video resource, then aborts the load by removing the `src` attribute and calling `load()`.
 If the video resource is still loading when `load()` is called, the `abort` event fires.
+
+#### HTML
+
+```html
+<video controls width="250"></video>
+
+<button id="loadAndAbort">Load and abort video</button>
+
+<pre id="log"></pre>
+```
+
+#### CSS
+
+```css
+video,
+button,
+pre {
+  display: block;
+  margin-block: 1rem;
+}
+```
+
+#### JavaScript
 
 ```js
 const video = document.querySelector("video");
-const stopButton = document.querySelector("#stopBtn");
+const loadAndAbortButton = document.querySelector("#loadAndAbort");
+const log = document.querySelector("#log");
 
 video.addEventListener("abort", () => {
-  console.log("Video loading aborted");
+  log.textContent += "Video loading aborted\n";
 });
 
-stopButton.addEventListener("click", () => {
-  video.removeAttribute("src");
+loadAndAbortButton.addEventListener("click", () => {
+  log.textContent = "Loading video...\n";
+
+  video.src = `/shared-assets/videos/flower.webm?nocache=${Date.now()}`;
   video.load();
+
+  setTimeout(() => {
+    video.removeAttribute("src");
+    video.load();
+  }, 50);
 });
 ```
+
+#### Result
+
+{{EmbedLiveSample("Abort_loading_a_media_resource", "100%", 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/abort_event/index.md
@@ -28,19 +28,26 @@ A generic {{domxref("Event")}}.
 
 ## Examples
 
+The following example starts loading one video resource, then starts another load before the
+first resource has finished.
+If the first resource is still loading when `load()` is called again, the `abort` event fires.
+
 ```js
 const video = document.querySelector("video");
-const videoSrc = "https://example.org/path/to/video.webm";
+const firstVideoSrc = "https://example.org/path/to/video.webm";
+const secondVideoSrc = "https://example.org/path/to/another-video.webm";
 
 video.addEventListener("abort", () => {
-  console.log(`Abort loading: ${videoSrc}`);
+  console.log(`Aborted loading: ${firstVideoSrc}`);
 });
 
-const source = document.createElement("source");
-source.setAttribute("src", videoSrc);
-source.setAttribute("type", "video/webm");
+video.src = firstVideoSrc;
+video.load();
 
-video.appendChild(source);
+setTimeout(() => {
+  video.src = secondVideoSrc;
+  video.load();
+}, 1000);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/abort_event/index.md
@@ -8,7 +8,8 @@ browser-compat: api.HTMLMediaElement.abort_event
 
 {{APIRef("HTML DOM")}}
 
-The **`abort`** event is fired when the resource was not fully loaded, but not as the result of an error.
+The **`abort`** event is fired when media resource loading is stopped before completion, but not as the result of an error.
+This is usually achieved by removing the `src` attribute or setting it to the empty string (`""`), then calling `load()`.
 
 This event is not cancelable and does not bubble.
 
@@ -28,26 +29,21 @@ A generic {{domxref("Event")}}.
 
 ## Examples
 
-The following example starts loading one video resource, then starts another load before the
-first resource has finished.
-If the first resource is still loading when `load()` is called again, the `abort` event fires.
+The following example starts loading a video resource, then provides a button that stops the load.
+If the video resource is still loading when `load()` is called, the `abort` event fires.
 
 ```js
 const video = document.querySelector("video");
-const firstVideoSrc = "https://example.org/path/to/video.webm";
-const secondVideoSrc = "https://example.org/path/to/another-video.webm";
+const stopButton = document.querySelector("#stopBtn");
 
 video.addEventListener("abort", () => {
-  console.log(`Aborted loading: ${firstVideoSrc}`);
+  console.log("Video loading aborted");
 });
 
-video.src = firstVideoSrc;
-video.load();
-
-setTimeout(() => {
-  video.src = secondVideoSrc;
+stopButton.addEventListener("click", () => {
+  video.removeAttribute("src");
   video.load();
-}, 1000);
+});
 ```
 
 ## Specifications


### PR DESCRIPTION
### Summary
- Clarifies when the HTMLMediaElement abort event can fire
- Updates the example so it starts one media load and then starts another before the first finishes

### Related issue
Fixes #44222

### Testing
- markdownlint-cli2 files/en-us/web/api/htmlmediaelement/abort_event/index.md
- prettier -c files/en-us/web/api/htmlmediaelement/abort_event/index.md
- cspell --config .vscode/cspell.json files/en-us/web/api/htmlmediaelement/abort_event/index.md
- MDN pre-commit hook