### PR TITLE
Remove a language specifier from the IndexedDB link in the MVC article

### DIFF
--- a/files/en-us/glossary/mvc/index.md
+++ b/files/en-us/glossary/mvc/index.md
@@ -41,7 +41,7 @@ You might however also want to just update the view to display the data in a dif
 
 ## MVC on the web
 
-As a web developer, this pattern will probably be quite familiar even if you've never consciously used it before. Your data model is probably contained in some kind of database (be it a traditional server-side database like MySQL, or a client-side solution such as [IndexedDB \[en-US\]](/en-US/docs/Web/API/IndexedDB_API).) Your app's controlling code is probably written in HTML/JavaScript, and your user interface is probably written using HTML/CSS/whatever else you like. This sounds very much like MVC, but MVC makes these components follow a more rigid pattern.
+As a web developer, this pattern will probably be quite familiar even if you've never consciously used it before. Your data model is probably contained in some kind of database (be it a traditional server-side database like MySQL, or a client-side solution such as [IndexedDB](/en-US/docs/Web/API/IndexedDB_API).) Your app's controlling code is probably written in HTML/JavaScript, and your user interface is probably written using HTML/CSS/whatever else you like. This sounds very much like MVC, but MVC makes these components follow a more rigid pattern.
 
 In the early days of the Web, MVC architecture was mostly implemented on the server-side, with the client requesting updates via forms or links, and receiving updated views back to display in the browser. However, these days, more of the logic is pushed to the client with the advent of client-side data stores, and the [Fetch API](/en-US/docs/Web/API/Fetch_API) enabling partial page updates as required.
 


### PR DESCRIPTION
### Description

Removed a language specifier ("[en-US]") in the text of a IndexedDB link.

### Motivation

This language specifier is not used in any other links in the article (or any other MDN articles) so I wanted to unify the look.

### Additional details

[The public MVC link](https://developer.mozilla.org/en-US/docs/Glossary/MVC#mvc_on_the_web)

The link also says "[en-US]" in the [german version](https://developer.mozilla.org/de/docs/Glossary/MVC#mvc_im_web).

<img width="964" height="538" alt="image" src="https://github.com/user-attachments/assets/a5917664-6df5-4197-b975-40d1516e23ac" />



### Related issues and pull requests

None
