### PR TITLE
FF152 Relnote/ExprFeat: MediaCapabilities.{en|de}codingInfo() webrtc …

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -497,6 +497,23 @@ See [Firefox bug 1602129](https://bugzil.la/1602129) for our progress on this AP
 
 The following experimental features include those found in media APIs such as the [WebRTC API](/en-US/docs/Web/API/WebRTC_API), the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API), the [Media Source Extensions API](/en-US/docs/Web/API/Media_Source_Extensions_API), the [Encrypted Media Extensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API), and the [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API).
 
+#### Checking browser support for encoding/decoding media for WebRTC
+
+The `webrtc` type can now be passed as an option for [`MediaCapabilities.decodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc).
+This allows developers to check how well a user agent can decode or encode a particular configuration for WebRTC.
+Support for the non-standard [`transmission`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#transmission) type, which was used as an alias for `webrtc`, is removed.
+([Firefox bug 1825286](https://bugzil.la/1825286)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 152           | No                  |
+| Developer Edition | 152           | No                  |
+| Beta              | 152           | No                  |
+| Release           | 152           | No                  |
+
+- `media.mediacapabilities.webrtc.enabled`
+  - : Set to `true` to enable.
+
 #### HTMLMediaElement properties: audioTracks and videoTracks
 
 Enabling this feature adds the {{domxref("HTMLMediaElement.audioTracks")}} and {{domxref("HTMLMediaElement.videoTracks")}} properties to all HTML media elements. However, because Firefox doesn't currently support multiple audio and video tracks, the most common use cases for these properties don't work, so they're both disabled by default. See [Firefox bug 1057233](https://bugzil.la/1057233) for more details.

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -497,7 +497,7 @@ See [Firefox bug 1602129](https://bugzil.la/1602129) for our progress on this AP
 
 The following experimental features include those found in media APIs such as the [WebRTC API](/en-US/docs/Web/API/WebRTC_API), the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API), the [Media Source Extensions API](/en-US/docs/Web/API/Media_Source_Extensions_API), the [Encrypted Media Extensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API), and the [Media Capture and Streams API](/en-US/docs/Web/API/Media_Capture_and_Streams_API).
 
-#### Checking browser support for encoding/decoding media for WebRTC
+#### Checking browser support for encoding/decoding WebRTC media
 
 The `webrtc` type can now be passed as an option for [`MediaCapabilities.decodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc).
 This allows developers to check how well a user agent can decode or encode a particular configuration for WebRTC.

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -98,6 +98,6 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **Check if a media encoding/decoding configuration is supported for WebRTC**: `media.mediacapabilities.webrtc.enabled`
 
-  The `webrtc` type can now be passed as an option for [`MediaCapabilities.decodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc) in order to check if the configuration can be used for WebRTC.
-  This replaces the non-standard [`transmission`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#transmission) that was previously used as an alias in Firefox.
+  The `webrtc` type can now be passed as an option for [`MediaCapabilities.decodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc) to check if an encoding/decoding configuration can be used for WebRTC.
+  This replaces the non-standard [`transmission`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#transmission) type, which was previously used as an alias in Firefox.
   ([Firefox bug 1825286](https://bugzil.la/1825286)).

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -95,3 +95,9 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 These features are shipping in Firefox 152 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+
+- **Check if a media encoding/decoding configuration is supported for WebRTC**: `media.mediacapabilities.webrtc.enabled`
+
+  The `webrtc` type can now be passed as an option for [`MediaCapabilities.decodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc) in order to check if the configuration can be used for WebRTC.
+  This replaces the non-standard [`transmission`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#transmission) that was previously used as an alias in Firefox.
+  ([Firefox bug 1825286](https://bugzil.la/1825286)).

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -85,7 +85,7 @@ All supported audio codecs are reported to be power efficient.
 ```js
 // Create media configuration to be tested
 const mediaConfig = {
-  type: "record", // or "webrtc"
+  type: "record",
   video: {
     contentType: "video/webm;codecs=vp8.0", // valid content type
     width: 1920, // width of the video

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -28,7 +28,7 @@ encodingInfo(configuration)
         - `webrtc`
           - : Represents a configuration meant to be transmitted over electronic means (e.g., using {{domxref("RTCPeerConnection")}}). **Note:** Firefox uses `transmission` for this type, and `webrtc` does not work.
         - `transmission` {{non-standard_inline}}
-          - : The synonym of `webrtc` to be used in Firefox.
+          - : A synonym of `webrtc` (used in Firefox).
 
     - `video`
       - : Configuration object for a video media source.
@@ -80,10 +80,12 @@ All supported audio codecs are reported to be power efficient.
 
 ## Examples
 
+### Setting a media configuration
+
 ```js
 // Create media configuration to be tested
 const mediaConfig = {
-  type: "record", // or 'transmission'
+  type: "record", // or "webrtc"
   video: {
     contentType: "video/webm;codecs=vp8.0", // valid content type
     width: 1920, // width of the video


### PR DESCRIPTION
FF152 adds support for the `configuration.type.webrtc` option to be passed to [`MediaCapabilities.decodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc) , and removes the non-standard "alias" `transmission` that has been around since FF63ish. The addition is behind the flag `media.mediacapabilities.webrtc.enabled`. Bug is https://bugzilla.mozilla.org/show_bug.cgi?id=1825286

This adds a release note, experimental features section, and very very minor change to the docs themeselves. Because this is behind a preference I haven't updated the docs to purge the "you must use transmission" stuff.

Related docs work can be tracked in #44174

