### PR TITLE
docs: remove broken Web Storage pitfalls link

### DIFF
--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -24,7 +24,8 @@ localStorage.setItem("colorSetting", "#a4509b");
 ```
 
 > [!NOTE]
-> It's recommended to use the Web Storage API (`setItem`, `getItem`, `removeItem`, `key`, `length`) to prevent the pitfalls associated with using plain objects as key-value stores.
+> You should always use the Web Storage API (`setItem()`, `getItem()`, `removeItem()`, `key`, `length`) instead of direct object property access such as `localStorage.key = value` or `localStorage["key"] = value`.
+> This avoids colliding with built-in storage members like `clear()` or `getItem()`, avoids surprising results from inherited properties, and reduces prototype-pollution risk when working with untrusted keys.
 
 The two mechanisms within Web Storage are as follows:
 

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -24,7 +24,7 @@ localStorage.setItem("colorSetting", "#a4509b");
 ```
 
 > [!NOTE]
-> It's recommended to use the Web Storage API (`setItem`, `getItem`, `removeItem`, `key`, `length`) to prevent the [pitfalls](https://2ality.com/2012/01/objects-as-maps.html) associated with using plain objects as key-value stores.
+> It's recommended to use the Web Storage API (`setItem`, `getItem`, `removeItem`, `key`, `length`) to prevent the pitfalls associated with using plain objects as key-value stores.
 
 The two mechanisms within Web Storage are as follows:
 

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -25,7 +25,7 @@ localStorage.setItem("colorSetting", "#a4509b");
 
 > [!NOTE]
 > You should always use the Web Storage API (`setItem()`, `getItem()`, `removeItem()`, `key`, `length`) instead of direct object property access such as `localStorage.key = value` or `localStorage["key"] = value`.
-> This avoids colliding with built-in storage members like `clear()` or `getItem()`, avoids surprising results from inherited properties, and reduces prototype-pollution risk when working with untrusted keys.
+> This avoids the pitfalls of passing an object, such as colliding with native built-in methods (like `.clear()` or `.getItem()`), unexpected data leaks from prototype inheritance, and security vulnerabilities like prototype pollution when handling untrusted user input.
 
 The two mechanisms within Web Storage are as follows:
 


### PR DESCRIPTION
## Summary
- remove the broken external pitfalls hyperlink from the Web Storage API guide note
- keep the recommendation text intact without pointing to a 404 page

## Validation
- git diff --check

Closes #44251
