### PR TITLE
FF152 Relnote: Devtools toggle for HTML comments

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -16,7 +16,11 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Changes for web developers
 
-<!-- ### Developer Tools -->
+### Developer Tools
+
+- The developer tools now have a "Show comments" option to toggle the display of HTML comment nodes in the Inspector.
+  This option can be found in the [Settings panel](https://firefox-source-docs.mozilla.org/devtools-user/settings/index.html#settings-inspector).
+  ([Firefox bug 1455294](https://bugzil.la/1455294)).
 
 <!-- ### HTML -->
 


### PR DESCRIPTION
FF152 adds a toggle for HTML comments in the inspector ("Show comments" in [Settings panel](https://firefox-source-docs.mozilla.org/devtools-user/settings/index.html#settings-inspector). This adds the release note.

Related docs work can be tracked in #44170