### PR TITLE
FF152 Relnote: with  { type: "text" } supported

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -445,6 +445,22 @@ This includes all the instance methods on `Intl.Locale` that are prefixed with "
 - `javascript.options.experimental.intl_locale_info`
   - : Set to `true` to enable on Nightly.
 
+### Text module import
+
+The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) allows importing a module's source as a string value.
+The media type of the response is ignored, and the content is parsed as text even if the source contains scripts or other executable code.
+([Firefox bug 2024854](https://bugzil.la/2024854)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 152           | No                  |
+| Developer Edition | 152           | No                  |
+| Beta              | 152           | No                  |
+| Release           | 152           | No                  |
+
+- `javascript.options.experimental.import_text`
+  - : Set to `true` to enable.
+
 ### Multiple import maps
 
 Support for [multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps).

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -448,7 +448,7 @@ This includes all the instance methods on `Intl.Locale` that are prefixed with "
 ### Text module import
 
 The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) allows importing a module's source as a string value.
-The media type of the response is ignored, and the content is parsed as text even if the source contains scripts or other executable code.
+The import ignores the media type of the response: the content is parsed as text even if the source contains scripts or other executable code.
 ([Firefox bug 2024854](https://bugzil.la/2024854)).
 
 | Release channel   | Version added | Enabled by default? |

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -448,7 +448,7 @@ This includes all the instance methods on `Intl.Locale` that are prefixed with "
 ### Text module import
 
 The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) allows importing a module's source as a string value.
-The import ignores the media type of the response: the content is parsed as text even if the source contains scripts or other executable code.
+The media type of the response is ignored, and the content is parsed as text even if the source contains scripts or other executable code.
 ([Firefox bug 2024854](https://bugzil.la/2024854)).
 
 | Release channel   | Version added | Enabled by default? |

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -127,3 +127,9 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
   The [TC39 Intl.Locale info proposal](https://github.com/tc39/proposal-intl-locale-info) is now supported on nightly builds if the preference is enabled.
   This includes all the [`Intl.Locale` instance methods prefixed with "get"](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale#instance_methods).
   ([Firefox bug 1693576](https://bugzil.la/1693576)).
+
+- **Text module import**: `javascript.options.experimental.import_text`
+
+  The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) is now supported for importing a text module into a string value.
+  This can be used to ensure that a module served with the media type of `text/plain` is imported as text, even if it contains JavaScript or some other format.
+  ([Firefox bug 2024854](https://bugzil.la/2024854)).

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -130,6 +130,6 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **Text module import**: `javascript.options.experimental.import_text`
 
-  The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) is now supported for importing a text module into a string value.
-  This can be used to ensure that a module served with the media type of `text/plain` is imported as text, even if it contains JavaScript or some other format.
+  The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) allows importing a module's source as a string value.
+  The media type of the response is ignored, and the content is parsed as text even if the source contains scripts or other executable code.
   ([Firefox bug 2024854](https://bugzil.la/2024854)).


### PR DESCRIPTION
FF152 adds suppport for the `text` import attribute with value `"text"` in https://bugzilla.mozilla.org/show_bug.cgi?id=2024854

This adds the release note and experimental feature update.

Related work can be tracked in #44166
