### PR TITLE
FF152 Relnote TC39 Iterator includes proposal

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -414,7 +414,7 @@ When enabled, the [`href`](/en-US/docs/Web/MathML/Reference/Global_attributes/hr
 
 ### TC39 Iterator includes proposal
 
-Support for the [`Iterator.prototype.includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes) method, which allows testing of whether an `Iterator` instance will return a specified value.
+The [`Iterator.prototype.includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes) method tests whether an `Iterator` instance will produce a specified value.
 The comparison uses the [SameValueZero algorithm](/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness#same-value-zero_equality).
 This algorithm is similar to strict equality `===` (where `-0` and `+0` are considered equal), but differs in that {{jsxref("NaN")}} is considered equal to itself.
 ([Firefox bug 2025779](https://bugzil.la/2025779)).

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -412,6 +412,23 @@ When enabled, the [`href`](/en-US/docs/Web/MathML/Reference/Global_attributes/hr
 
 ## JavaScript
 
+### TC39 Iterator includes proposal
+
+Support for the [`Iterator.prototype.includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes) method, which allows testing of whether an `Iterator` instance will return a specified value.
+The comparison uses the [SameValueZero algorithm](/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness#same-value-zero_equality).
+This algorithm is similar to strict equality `===` (where `-0` and `+0` are considered equal), but differs in that {{jsxref("NaN")}} is considered equal to itself.
+([Firefox bug 2025779](https://bugzil.la/2025779)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 152           | No                  |
+| Developer Edition | 152           | No                  |
+| Beta              | 152           | No                  |
+| Release           | 152           | No                  |
+
+- `javascript.options.experimental.iterator_includes`
+  - : Set to `true` to enable.
+
 ### Multiple import maps
 
 Support for [multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps).

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -104,5 +104,5 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **TC39 Iterator includes proposal**: `javascript.options.experimental.iterator_includes`
 
-  The [`Iterator.prototype.includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes) method is supported for testing whether the iterator will return a specified value.
+  The [`Iterator.prototype.includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes) method tests whether the iterator will produce a specified value.
   ([Firefox bug 2025779](https://bugzil.la/2025779)).

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -101,3 +101,8 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
   The `webrtc` type can now be passed as an option for [`MediaCapabilities.decodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc) to check if an encoding/decoding configuration can be used for WebRTC.
   This replaces the non-standard [`transmission`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#transmission) type, which was previously used as an alias in Firefox.
   ([Firefox bug 1825286](https://bugzil.la/1825286)).
+
+- **TC39 Iterator includes proposal**: `javascript.options.experimental.iterator_includes`
+
+  The [`Iterator.prototype.includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes) method is supported for testing whether the iterator will return a specified value.
+  ([Firefox bug 2025779](https://bugzil.la/2025779)).


### PR DESCRIPTION
FF152 adds support for the [TC39 Iterator proposal](https://github.com/tc39/proposal-iterator-includes) in https://bugzilla.mozilla.org/show_bug.cgi?id=2025779 behind pref `javascript.options.experimental.iterator_includes`

This adds a release note and an experimental features entry.
The docs are being done in a separate PR.

Related docs work can be tracked in #44158