### PR TITLE
FF152 ExprFeat/Relnote: TC39 Intl.Locale info

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -429,6 +429,22 @@ This algorithm is similar to strict equality `===` (where `-0` and `+0` are cons
 - `javascript.options.experimental.iterator_includes`
   - : Set to `true` to enable.
 
+### TC39 Intl.Locale info proposal
+
+The [TC39 Intl.Locale info proposal](https://github.com/tc39/proposal-intl-locale-info) is now supported.
+This includes all the instance methods on `Intl.Locale` that are prefixed with "get" — {{jsxref("Intl/Locale/getCalendars", "Intl.Locale.prototype.getCalendars()")}}, {{jsxref("Intl/Locale/getCollations", "Intl.Locale.prototype.getCollations()")}}, {{jsxref("Intl/Locale/getHourCycles", "Intl.Locale.prototype.getHourCycles()")}}, {{jsxref("Intl/Locale/getNumberingSystems", "Intl.Locale.prototype.getNumberingSystems()")}}, {{jsxref("Intl/Locale/getTextInfo", "Intl.Locale.prototype.getTextInfo()")}}, {{jsxref("Intl/Locale/getTimeZones", "Intl.Locale.prototype.getTimeZones()")}}, {{jsxref("Intl/Locale/getWeekInfo", "Intl.Locale.prototype.getWeekInfo()")}}.
+([Firefox bug 1693576](https://bugzil.la/1693576)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 152           | No                  |
+| Developer Edition | NA            | -                   |
+| Beta              | NA            | -                   |
+| Release           | NA            | -                   |
+
+- `javascript.options.experimental.intl_locale_info`
+  - : Set to `true` to enable on Nightly.
+
 ### Multiple import maps
 
 Support for [multiple import maps](/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#merging_multiple_import_maps).

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -438,9 +438,9 @@ This includes all the instance methods on `Intl.Locale` that are prefixed with "
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
 | Nightly           | 152           | No                  |
-| Developer Edition | NA            | -                   |
-| Beta              | NA            | -                   |
-| Release           | NA            | -                   |
+| Developer Edition | —             | —                   |
+| Beta              | —             | —                   |
+| Release           | —             | —                   |
 
 - `javascript.options.experimental.intl_locale_info`
   - : Set to `true` to enable on Nightly.

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -117,3 +117,9 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
   The [`Iterator.prototype.includes()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes) method tests whether the iterator will produce a specified value.
   ([Firefox bug 2025779](https://bugzil.la/2025779)).
+
+- **TC39 Intl.Locale info proposal**: `javascript.options.experimental.intl_locale_info`
+
+  The [TC39 Intl.Locale info proposal](https://github.com/tc39/proposal-intl-locale-info) is now supported on nightly builds if the preference is enabled.
+  This includes all the [`Intl.Locale` instance methods prefixed with "get"](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale#instance_methods).
+  ([Firefox bug 1693576](https://bugzil.la/1693576)).


### PR DESCRIPTION
FF152 adds support for the [TC39 Intl.Locale info proposal](https://github.com/tc39/proposal-intl-locale-info) in https://bugzilla.mozilla.org/show_bug.cgi?id=1693576, behind the pref `javascript.options.experimental.intl_locale_info` and **only** in nightly.

This adds an update to experimental features and release note pages.

Related docs can be tracked in #44172

