### PR TITLE
chore(deps): run `npm audit fix`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8045,13 +8045,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {


### PR DESCRIPTION
### Description

Result of running `npm audit fix` in each directory with `package-lock.json`.

### Motivation

Resolve vulnerabilities that may potentially affect us.

### Additional details

See: https://docs.npmjs.com/cli/commands/npm-audit

#### `/`

**Before:**

```
# npm audit report

cross-spawn  <6.0.6
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix --force`
Will install imagemin-mozjpeg@7.0.0, which is a breaking change
node_modules/execa/node_modules/cross-spawn
  execa  0.5.0 - 0.9.0
  Depends on vulnerable versions of cross-spawn
  node_modules/execa
    bin-build  *
    Depends on vulnerable versions of download
    Depends on vulnerable versions of execa
    Depends on vulnerable versions of tempfile
    node_modules/bin-build
      gifsicle  >=3.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/gifsicle
        imagemin-gifsicle  >=6.0.0
        Depends on vulnerable versions of gifsicle
        node_modules/imagemin-gifsicle
      mozjpeg  >=4.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/mozjpeg
        imagemin-mozjpeg  >=8.0.0
        Depends on vulnerable versions of mozjpeg
        node_modules/imagemin-mozjpeg
      pngquant-bin  >=3.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/pngquant-bin
        imagemin-pngquant  >=5.1.0
        Depends on vulnerable versions of pngquant-bin
        node_modules/imagemin-pngquant
    bin-check  >=4.1.0
    Depends on vulnerable versions of execa
    node_modules/bin-check
      bin-wrapper  >=0.4.0
      Depends on vulnerable versions of bin-check
      Depends on vulnerable versions of bin-version-check
      Depends on vulnerable versions of download
      node_modules/bin-wrapper

file-type  13.0.0 - 21.3.0
Severity: moderate
file-type affected by infinite loop in ASF parser on malformed input with zero-size sub-header - https://github.com/advisories/GHSA-5v7r-6r5c-r473
fix available via `npm audit fix --force`
Will install imagemin@7.0.1, which is a breaking change
node_modules/imagemin/node_modules/file-type
  imagemin  >=8.0.0
  Depends on vulnerable versions of file-type
  node_modules/imagemin

got  <=11.8.3
Severity: high
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
Depends on vulnerable versions of cacheable-request
fix available via `npm audit fix --force`
Will install imagemin-mozjpeg@7.0.0, which is a breaking change
node_modules/bin-wrapper/node_modules/got
node_modules/got
  download  >=4.0.0
  Depends on vulnerable versions of got
  node_modules/bin-wrapper/node_modules/download
  node_modules/download

http-cache-semantics  <4.1.1
Severity: high
http-cache-semantics vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-rc47-6667-2j5j
fix available via `npm audit fix --force`
Will install imagemin-mozjpeg@7.0.0, which is a breaking change
node_modules/http-cache-semantics
  cacheable-request  0.1.0 - 2.1.4
  Depends on vulnerable versions of http-cache-semantics
  node_modules/cacheable-request

insane  *
Severity: moderate
insane vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-w455-mfq9-hf74
No fix available
node_modules/insane
  @mdn/fred  *
  Depends on vulnerable versions of @mozilla/glean
  Depends on vulnerable versions of insane
  node_modules/@mdn/fred

path-to-regexp  8.0.0 - 8.3.0
Severity: high
path-to-regexp vulnerable to Denial of Service via sequential optional groups - https://github.com/advisories/GHSA-j3q9-mxjg-w52f
path-to-regexp vulnerable to Regular Expression Denial of Service via multiple wildcards - https://github.com/advisories/GHSA-27v5-c462-wpq7
fix available via `npm audit fix`
node_modules/path-to-regexp

semver-regex  <=3.1.3
Severity: high
semver-regex Regular Expression Denial of Service (ReDOS) - https://github.com/advisories/GHSA-44c6-4v22-4mhx
Regular expression denial of service in semver-regex - https://github.com/advisories/GHSA-4x5v-gmq8-25ch
fix available via `npm audit fix --force`
Will install imagemin-mozjpeg@7.0.0, which is a breaking change
node_modules/semver-regex
  find-versions  <=3.2.0
  Depends on vulnerable versions of semver-regex
  node_modules/find-versions
    bin-version  <=4.0.0
    Depends on vulnerable versions of find-versions
    node_modules/bin-version
      bin-version-check  <=4.0.0
      Depends on vulnerable versions of bin-version
      node_modules/bin-version-check

uuid  <11.1.1
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
fix available via `npm audit fix --force`
Will install imagemin-mozjpeg@7.0.0, which is a breaking change
node_modules/tempfile/node_modules/uuid
node_modules/uuid
  @mozilla/glean  *
  Depends on vulnerable versions of uuid
  node_modules/@mozilla/glean
  tempfile  <=4.0.0
  Depends on vulnerable versions of uuid
  node_modules/tempfile

27 vulnerabilities (8 moderate, 19 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.
```

**After:**

```
# npm audit report

cross-spawn  <6.0.6
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix --force`
Will install imagemin-pngquant@5.0.1, which is a breaking change
node_modules/execa/node_modules/cross-spawn
  execa  0.5.0 - 0.9.0
  Depends on vulnerable versions of cross-spawn
  node_modules/execa
    bin-build  *
    Depends on vulnerable versions of download
    Depends on vulnerable versions of execa
    Depends on vulnerable versions of tempfile
    node_modules/bin-build
      gifsicle  >=3.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/gifsicle
        imagemin-gifsicle  >=6.0.0
        Depends on vulnerable versions of gifsicle
        node_modules/imagemin-gifsicle
      mozjpeg  >=4.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/mozjpeg
        imagemin-mozjpeg  >=8.0.0
        Depends on vulnerable versions of mozjpeg
        node_modules/imagemin-mozjpeg
      pngquant-bin  >=3.0.0
      Depends on vulnerable versions of bin-build
      Depends on vulnerable versions of bin-wrapper
      node_modules/pngquant-bin
        imagemin-pngquant  >=5.1.0
        Depends on vulnerable versions of pngquant-bin
        node_modules/imagemin-pngquant
    bin-check  >=4.1.0
    Depends on vulnerable versions of execa
    node_modules/bin-check
      bin-wrapper  >=0.4.0
      Depends on vulnerable versions of bin-check
      Depends on vulnerable versions of bin-version-check
      Depends on vulnerable versions of download
      node_modules/bin-wrapper

file-type  13.0.0 - 21.3.0
Severity: moderate
file-type affected by infinite loop in ASF parser on malformed input with zero-size sub-header - https://github.com/advisories/GHSA-5v7r-6r5c-r473
fix available via `npm audit fix --force`
Will install imagemin@7.0.1, which is a breaking change
node_modules/imagemin/node_modules/file-type
  imagemin  >=8.0.0
  Depends on vulnerable versions of file-type
  node_modules/imagemin

got  <=11.8.3
Severity: high
Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
Depends on vulnerable versions of cacheable-request
fix available via `npm audit fix --force`
Will install imagemin-pngquant@5.0.1, which is a breaking change
node_modules/bin-wrapper/node_modules/got
node_modules/got
  download  >=4.0.0
  Depends on vulnerable versions of got
  node_modules/bin-wrapper/node_modules/download
  node_modules/download

http-cache-semantics  <4.1.1
Severity: high
http-cache-semantics vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-rc47-6667-2j5j
fix available via `npm audit fix --force`
Will install imagemin-pngquant@5.0.1, which is a breaking change
node_modules/http-cache-semantics
  cacheable-request  0.1.0 - 2.1.4
  Depends on vulnerable versions of http-cache-semantics
  node_modules/cacheable-request

insane  *
Severity: moderate
insane vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-w455-mfq9-hf74
No fix available
node_modules/insane
  @mdn/fred  *
  Depends on vulnerable versions of @mozilla/glean
  Depends on vulnerable versions of insane
  node_modules/@mdn/fred

semver-regex  <=3.1.3
Severity: high
semver-regex Regular Expression Denial of Service (ReDOS) - https://github.com/advisories/GHSA-44c6-4v22-4mhx
Regular expression denial of service in semver-regex - https://github.com/advisories/GHSA-4x5v-gmq8-25ch
fix available via `npm audit fix --force`
Will install imagemin-pngquant@5.0.1, which is a breaking change
node_modules/semver-regex
  find-versions  <=3.2.0
  Depends on vulnerable versions of semver-regex
  node_modules/find-versions
    bin-version  <=4.0.0
    Depends on vulnerable versions of find-versions
    node_modules/bin-version
      bin-version-check  <=4.0.0
      Depends on vulnerable versions of bin-version
      node_modules/bin-version-check

uuid  <11.1.1
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
fix available via `npm audit fix --force`
Will install imagemin-pngquant@5.0.1, which is a breaking change
node_modules/tempfile/node_modules/uuid
node_modules/uuid
  @mozilla/glean  *
  Depends on vulnerable versions of uuid
  node_modules/@mozilla/glean
  tempfile  <=4.0.0
  Depends on vulnerable versions of uuid
  node_modules/tempfile

26 vulnerabilities (8 moderate, 18 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.
```

**Diff:**

```diff
--- before
+++ after
@@ -4,7 +4,7 @@
 Severity: high
 Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
 fix available via `npm audit fix --force`
-Will install imagemin-mozjpeg@7.0.0, which is a breaking change
+Will install imagemin-pngquant@5.0.1, which is a breaking change
 node_modules/execa/node_modules/cross-spawn
   execa  0.5.0 - 0.9.0
   Depends on vulnerable versions of cross-spawn
@@ -59,7 +59,7 @@
 Got allows a redirect to a UNIX socket - https://github.com/advisories/GHSA-pfrx-2q88-qq97
 Depends on vulnerable versions of cacheable-request
 fix available via `npm audit fix --force`
-Will install imagemin-mozjpeg@7.0.0, which is a breaking change
+Will install imagemin-pngquant@5.0.1, which is a breaking change
 node_modules/bin-wrapper/node_modules/got
 node_modules/got
   download  >=4.0.0
@@ -71,7 +71,7 @@
 Severity: high
 http-cache-semantics vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-rc47-6667-2j5j
 fix available via `npm audit fix --force`
-Will install imagemin-mozjpeg@7.0.0, which is a breaking change
+Will install imagemin-pngquant@5.0.1, which is a breaking change
 node_modules/http-cache-semantics
   cacheable-request  0.1.0 - 2.1.4
   Depends on vulnerable versions of http-cache-semantics
@@ -87,19 +87,12 @@
   Depends on vulnerable versions of insane
   node_modules/@mdn/fred
 
-path-to-regexp  8.0.0 - 8.3.0
-Severity: high
-path-to-regexp vulnerable to Denial of Service via sequential optional groups - https://github.com/advisories/GHSA-j3q9-mxjg-w52f
-path-to-regexp vulnerable to Regular Expression Denial of Service via multiple wildcards - https://github.com/advisories/GHSA-27v5-c462-wpq7
-fix available via `npm audit fix`
-node_modules/path-to-regexp
-
 semver-regex  <=3.1.3
 Severity: high
 semver-regex Regular Expression Denial of Service (ReDOS) - https://github.com/advisories/GHSA-44c6-4v22-4mhx
 Regular expression denial of service in semver-regex - https://github.com/advisories/GHSA-4x5v-gmq8-25ch
 fix available via `npm audit fix --force`
-Will install imagemin-mozjpeg@7.0.0, which is a breaking change
+Will install imagemin-pngquant@5.0.1, which is a breaking change
 node_modules/semver-regex
   find-versions  <=3.2.0
   Depends on vulnerable versions of semver-regex
@@ -115,7 +108,7 @@
 Severity: moderate
 uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
 fix available via `npm audit fix --force`
-Will install imagemin-mozjpeg@7.0.0, which is a breaking change
+Will install imagemin-pngquant@5.0.1, which is a breaking change
 node_modules/tempfile/node_modules/uuid
 node_modules/uuid
   @mozilla/glean  *
@@ -125,7 +118,7 @@
   Depends on vulnerable versions of uuid
   node_modules/tempfile
 
-27 vulnerabilities (8 moderate, 19 high)
+26 vulnerabilities (8 moderate, 18 high)
 
 To address issues that do not require attention, run:
   npm audit fix
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->