### PR TITLE
chore(jsondata): add `Handler_methods` L10n key

### DIFF
--- a/files/jsondata/L10n-Common.json
+++ b/files/jsondata/L10n-Common.json
@@ -47,6 +47,16 @@
     "zh-CN": "指南",
     "zh-TW": "指南"
   },
+  "Handler_methods": {
+    "de": "Handler-Methoden",
+    "en-US": "Handler methods",
+    "es": "Métodos del manejador",
+    "fr": "Méthodes du gestionnaire",
+    "ja": "ハンドラーメソッド",
+    "ko": "처리기 메서드",
+    "ru": "Методы обработчика",
+    "zh-CN": "处理器方法"
+  },
   "Implemented_by": {
     "de": "Implementiert von",
     "en-US": "Implemented by",


### PR DESCRIPTION
### Description

Add a `Handler_methods` entry to `L10n-Common.json` with translations for `de`, `en-US`, `es`, `fr`, `ja`, `ko`, `ru`, `zh-CN`.

### Motivation

Used by rari's JS reference sidebar for a new "Handler methods" group on `Proxy/*` pages (see mdn/rari#728). Without this key, `l10n_json_data` returns an error and the affected sidebar build fails.

### Additional details

Translations were sourced from established usage in the existing `Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/**` pages of `translated-content` and `translated-content-de`. Each mirrors the locale's existing "X methods" pattern (e.g. `Instance_methods` → "Méthodes d'instance" ⇒ "Méthodes du gestionnaire"; German "Handler-Funktionen" ⇒ "Handler-Methoden").

`pt-BR` and `zh-TW` are omitted because the source content is not translated in those locales; they will fall back to `en-US`.

### Related issues and pull requests

Related to mdn/rari#728.