### PR TITLE
Update index.md: refer to 'column' and fix solution

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
@@ -346,7 +346,7 @@ th {
 }
 
 /* There's no need to specify the width of the other columns
-   explicitly: The 4th column has an explicit width of 40% set, and
+   explicitly: The 4th column has a width of 40% set, and
    the remaining columns will get the remaining 60% equally
    distributed between them (20% each) */
 tr :nth-of-type(4) {

--- a/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
@@ -345,7 +345,7 @@ th {
   border-bottom: 1px solid #999999;
 }
 
-/* There’s no need to explicitly specify the width of the other
+/* There's no need to specify the width of the other
    columns: The 4th column has an explicit width of 40% and the
    remaining columns will get the remaining width of 60% equally
    distributed to them (20% each) */

--- a/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
@@ -345,9 +345,9 @@ th {
   border-bottom: 1px solid #999999;
 }
 
-/* There's no need to specify the width of the other
-   columns explicitly: The 4th column has an explicit width of 40% set, and the
-   remaining columns will get the remaining 60% equally
+/* There's no need to specify the width of the other columns
+   explicitly: The 4th column has an explicit width of 40% set, and
+   the remaining columns will get the remaining 60% equally
    distributed between them (20% each) */
 tr :nth-of-type(4) {
   width: 40%;

--- a/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
@@ -205,7 +205,7 @@ Specifically:
 2. Make the table's top and bottom borders `1px` thick, solid, and colored `#999999`.
 3. Give the table header cells and normal cells `0.6em` of padding, and make their content vertically aligned to the top of the cells.
 4. Give the table header cells a bottom border that is `1px` thick, solid, and colored `#999999`.
-5. Give all of the table rows a width of `20%`, except for the fourth row, which should have a width of `40%`.
+5. Give all of the table columns a width of `20%`, except for the fourth column, which should have a width of `40%`.
 6. Inside the table body, there are four rows. The second cell inside each of these rows contains text for an `rgb()` color. Give each one of these cells a background color that corresponds to its text.
 7. Create zebra stripes: Give each odd-numbered row a background color of `#eeeeee`, inside the table body only.
 8. Give the caption padding of `1em`, an italic font style, and letter spacing of `1px`.
@@ -345,10 +345,10 @@ th {
   border-bottom: 1px solid #999999;
 }
 
-tr {
-  width: 20%;
-}
-
+/* There’s no need to explicitly specify the width of the other
+   columns: The 4th column has an explicit width of 40% and the
+   remaining columns will get the remaining width of 60% equally
+   distributed to them (20% each) */
 tr :nth-of-type(4) {
   width: 40%;
 }

--- a/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
@@ -346,7 +346,7 @@ th {
 }
 
 /* There's no need to specify the width of the other
-   columns: The 4th column has an explicit width of 40% and the
+   columns explicitly: The 4th column has an explicit width of 40% set, and the
    remaining columns will get the remaining width of 60% equally
    distributed to them (20% each) */
 tr :nth-of-type(4) {

--- a/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
@@ -347,7 +347,7 @@ th {
 
 /* There's no need to specify the width of the other
    columns explicitly: The 4th column has an explicit width of 40% set, and the
-   remaining columns will get the remaining width of 60% equally
+   remaining columns will get the remaining 60% equally
    distributed to them (20% each) */
 tr :nth-of-type(4) {
   width: 40%;

--- a/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/home_color_scheme_search/index.md
@@ -348,7 +348,7 @@ th {
 /* There's no need to specify the width of the other
    columns explicitly: The 4th column has an explicit width of 40% set, and the
    remaining columns will get the remaining 60% equally
-   distributed to them (20% each) */
+   distributed between them (20% each) */
 tr :nth-of-type(4) {
   width: 40%;
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

The instructions referred to setting _row_ widths, which doesn't make sense. I think it should be _column_ widths.

Also the solution set row widths to 20% which doesn't make sense.

I don't think it's necessary to explicitly set the default column width to 20%. All we need to do is explicitly set the 4th column to 40%, and the others will get the remaining 60% distributed to them equally (20% each to the other 3 columns).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The instructions are confusing, i.e. referring to rows rather than columns. Part of the solution looks wrong i.e. setting a `tr` width of 20% (I removed this).

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
