### PR TITLE
Document missing label and sessionTypes members on MediaKeySystemAccess.getConfiguration()

### DIFF
--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
@@ -25,14 +25,15 @@ The **`getConfiguration()`** method of the {{domxref("MediaKeySystemAccess")}} i
   - : Indicates whether the ability to persist state is required.
 - `sessionTypes` {{ReadOnlyInline}}
   - : An array of strings indicating the session types that are supported by the configuration.
-        Permitted values include:
-        - `temporary`
-          - : A session for which the license, key(s) and record of or data related to the session are not persisted.
-            The application does not need to manage such storage.
-            Implementations must support this option, and it is the default.
-        - `persistent-license`
-          - : A session for which the license (and potentially other data related to the session) will be persisted.
-            A record of the license and associated keys persists even if the license is destroyed, providing an attestation that the license and key(s) it contains are no longer usable by the client.
+
+    Permitted values include:
+    - `temporary`
+      - : A session for which the license, key(s) and record of or data related to the session are not persisted.
+        The application does not need to manage such storage.
+        Implementations must support this option, and it is the default.
+    - `persistent-license`
+      - : A session for which the license (and potentially other data related to the session) will be persisted.
+        A record of the license and associated keys persists even if the license is destroyed, providing an attestation that the license and key(s) it contains are no longer usable by the client.
 
 ## Syntax
 

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
@@ -11,7 +11,8 @@ browser-compat: api.MediaKeySystemAccess.getConfiguration
 The **`getConfiguration()`** method of the {{domxref("MediaKeySystemAccess")}} interface returns an object with the supported combination of the following configuration options:
 
 - `label` {{ReadOnlyInline}}
-  - : A string identifying the configuration, preserved as-is from the configuration passed to {{domxref("Navigator.requestMediaKeySystemAccess()")}}. Defaults to the empty string.
+  - : A string identifying the configuration, preserved as-is from the configuration passed to {{domxref("Navigator.requestMediaKeySystemAccess()")}}.
+    Defaults to the empty string (`""`).
 - `initDataTypes` {{ReadOnlyInline}}
   - : Returns a list of supported initialization data type names. An initialization data type is a string indicating the format of the initialization data.
 - `audioCapabilities` {{ReadOnlyInline}}
@@ -23,7 +24,15 @@ The **`getConfiguration()`** method of the {{domxref("MediaKeySystemAccess")}} i
 - `persistentState` {{ReadOnlyInline}}
   - : Indicates whether the ability to persist state is required.
 - `sessionTypes` {{ReadOnlyInline}}
-  - : An array of strings indicating the session types that must be supported, such as `"temporary"` or `"persistent-license"`.
+  - : An array of strings indicating the session types that are supported by the configuration.
+        Permitted values include:
+        - `temporary`
+          - : A session for which the license, key(s) and record of or data related to the session are not persisted.
+            The application does not need to manage such storage.
+            Implementations must support this option, and it is the default.
+        - `persistent-license`
+          - : A session for which the license (and potentially other data related to the session) will be persisted.
+            A record of the license and associated keys persists even if the license is destroyed, providing an attestation that the license and key(s) it contains are no longer usable by the client.
 
 ## Syntax
 

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
@@ -10,6 +10,8 @@ browser-compat: api.MediaKeySystemAccess.getConfiguration
 
 The **`getConfiguration()`** method of the {{domxref("MediaKeySystemAccess")}} interface returns an object with the supported combination of the following configuration options:
 
+- `label` {{ReadOnlyInline}}
+  - : A string identifying the configuration, preserved as-is from the configuration passed to {{domxref("Navigator.requestMediaKeySystemAccess()")}}. Defaults to the empty string.
 - `initDataTypes` {{ReadOnlyInline}}
   - : Returns a list of supported initialization data type names. An initialization data type is a string indicating the format of the initialization data.
 - `audioCapabilities` {{ReadOnlyInline}}
@@ -20,6 +22,8 @@ The **`getConfiguration()`** method of the {{domxref("MediaKeySystemAccess")}} i
   - : Indicates whether a persistent distinctive identifier is required.
 - `persistentState` {{ReadOnlyInline}}
   - : Indicates whether the ability to persist state is required.
+- `sessionTypes` {{ReadOnlyInline}}
+  - : An array of strings indicating the session types that must be supported, such as `"temporary"` or `"persistent-license"`.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Adds the two missing dictionary members — `label` and `sessionTypes` — to the list of configuration options returned by `MediaKeySystemAccess.getConfiguration()`. The `MediaKeySystemConfiguration` page redirects to this page, so it's the canonical docs location for the dictionary members.

### Motivation

The W3C [Encrypted Media Extensions specification](https://www.w3.org/TR/encrypted-media/#mediakeysystemconfiguration-dictionary) defines seven members on `MediaKeySystemConfiguration`, but only five were documented here. `label` and `sessionTypes` were missing, leaving readers without docs for two real properties that the returned object exposes.

The new entries are inserted in spec order: `label` at the top (it's the first member in the IDL), `sessionTypes` at the bottom (it's the last).

### Additional details

- Spec: <https://www.w3.org/TR/encrypted-media/#mediakeysystemconfiguration-dictionary>
- `label` per spec: preserved as-is from input; default empty string.
- `sessionTypes` per spec: sequence of strings indicating required session types (e.g. `"temporary"`, `"persistent-license"`).

### Related issues and pull requests

Fixes #44211.