### PR TITLE
Note that non-zero letter-spacing disables optional ligatures

### DIFF
--- a/files/en-us/web/css/reference/properties/letter-spacing/index.md
+++ b/files/en-us/web/css/reference/properties/letter-spacing/index.md
@@ -83,6 +83,9 @@ letter-spacing: unset;
 
     Percentage values are calculated relative to the width of the space character of the font applied to the text.
 
+    > [!NOTE]
+    > When `letter-spacing` is non-zero, user agents do not apply optional ligatures (such as the `liga` and `clig` OpenType features controlled by {{cssxref("font-variant-ligatures")}}). See the [CSS Text](https://www.w3.org/TR/css-text-3/#letter-spacing-property) specification.
+
 ## Accessibility
 
 A large positive or negative `letter-spacing` value will make the word(s) the styling is applied to unreadable. For text styled with a very large positive value, the letters will be so far apart that the word(s) will appear like a series of individual, unconnected letters. For text styled with a very large negative value, the letters can overlap each other to the point where the word(s) may be unrecognizable.

--- a/files/en-us/web/css/reference/properties/letter-spacing/index.md
+++ b/files/en-us/web/css/reference/properties/letter-spacing/index.md
@@ -84,7 +84,6 @@ letter-spacing: unset;
     Percentage values are calculated relative to the width of the space character of the font applied to the text.
 
     > [!NOTE]
-    > [!NOTE]
     > When `letter-spacing` is non-zero, user agents do not apply optional ligatures, such as the `liga` (standard ligatures) and `clig` (contextual ligatures) OpenType features normally controlled by {{cssxref("font-variant-ligatures")}}.
     > These features can be explicitly re-enabled with {{cssxref("font-feature-settings")}}.
 

--- a/files/en-us/web/css/reference/properties/letter-spacing/index.md
+++ b/files/en-us/web/css/reference/properties/letter-spacing/index.md
@@ -84,7 +84,9 @@ letter-spacing: unset;
     Percentage values are calculated relative to the width of the space character of the font applied to the text.
 
     > [!NOTE]
-    > When `letter-spacing` is non-zero, user agents do not apply optional ligatures (such as the `liga` and `clig` OpenType features controlled by {{cssxref("font-variant-ligatures")}}). See the [CSS Text](https://www.w3.org/TR/css-text-3/#letter-spacing-property) specification.
+    > [!NOTE]
+    > When `letter-spacing` is non-zero, user agents do not apply optional ligatures, such as the `liga` (standard ligatures) and `clig` (contextual ligatures) OpenType features normally controlled by {{cssxref("font-variant-ligatures")}}.
+    > These features can be explicitly re-enabled with {{cssxref("font-feature-settings")}}.
 
 ## Accessibility
 


### PR DESCRIPTION
### Description

Adds a note under the `<length-percentage>` value for `letter-spacing` saying that any non-zero value disables optional ligatures.

### Motivation

Per CSS Text 3, when `letter-spacing` is non-zero, user agents do not apply optional ligatures. The property page didn't mention this, so authors hitting unexpected glyph rendering had no easy way to find out why from MDN.

### Additional details

Spec: https://www.w3.org/TR/css-text-3/#letter-spacing-property
Cross-link goes to `font-variant-ligatures`, which is where the affected OpenType features (`liga`, `clig`, etc.) are documented.

### Related issues and pull requests

Fixes #44218.