### PR TITLE
Add relnote for adoptedStyleSheets in content scripts (bug 1751346)

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -76,6 +76,8 @@ Firefox 153 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 <!-- ### Other -->
 
+- Extension content scripts can now read and modify constructed stylesheets in {{domxref("document.adoptedStyleSheets")}} and {{domxref("ShadowRoot.adoptedStyleSheets")}}, without `.wrappedJSObject`. ([Firefox bug 1751346](https://bugzil.la/1751346))
+
 ## Experimental web features
 
 These features are shipping in Firefox 153 but are disabled by default.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Add Firefox 153 release note entry to document support for adoptedStyleSheets in content scripts.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
I have encountered multiple extension developers online and offline that were impacted by a quirk in `adoptedStyleSheets` support in Firefox's content scripts. I fixed the issue in https://bugzilla.mozilla.org/show_bug.cgi?id=1751346, and it is worth calling out this fix so extensions can stop using their current work arounds.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1751346

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
