### PR TITLE
updated the nightly version for attr() types

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -296,7 +296,7 @@ The {{cssxref("attr")}} CSS function now supports [`<attr-type>`](/en-US/docs/We
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 149           | No                  |
+| Nightly           | 152           | Yes                 |
 | Developer Edition | 149           | No                  |
 | Beta              | 149           | No                  |
 | Release           | 149           | No                  |


### PR DESCRIPTION
### Description

- Updated the enabled by default and version number for `attr() types`

### Motivation

- Working on [MDN issue #44173](https://github.com/mdn/content/issues/44173)

### Related issues and pull requests

- N/A