### PR TITLE
[Editorial review] BiDi - Add pages for browsingContext module, part 2: context lifecycle command and events

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
@@ -1,0 +1,138 @@
+---
+title: "`browsingContext.contextCreated` event"
+short-title: contextCreated
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.contextCreated_event
+sidebar: webdriver
+---
+
+The `browsingContext.contextCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a new context is created in the browser.
+
+## Event data
+
+The `params` field in the event notification is a context object with the following properties:
+
+- `children`
+  - : An array of context objects that represents child contexts.
+    This event does not include child contexts ([`maxDepth`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#maxdepth) is `0`).
+    To retrieve the children of a context, use [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `clientWindow`
+  - : A string that contains the ID of the [client window](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#client_windows) that contains this context.
+- `context`
+  - : A string that contains the ID of the newly created context.
+- `originalOpener`
+  - : A string that contains the ID of the context that originally opened this context.
+    The value is `null` if the context was opened directly (not by another context).
+- `parent`
+  - : A string that contains the ID of the parent context.
+    The value is `null` if the context has no parent (that is, it is a [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context)).
+- `url`
+  - : A string that contains the URL of the context, including the fragment, at the time it was created.
+    For newly created contexts, the value is `"about:blank"` because the event fires before any navigation has occurred and content has loaded.
+    For existing contexts at subscription time, the value reflects their current URL.
+- `userContext`
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) associated with this context.
+
+## Description
+
+When you subscribe to this event, the browser immediately fires the event recursively for all contexts that already exist at the time of subscription, starting from top-level contexts down through their children.
+
+If the [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) was scoped to specific contexts using the [`contexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe#contexts) parameter, only child contexts created within those contexts will fire the event.
+
+## Examples
+
+### Receiving an event for a new tab
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextCreated` active, consider a scenario where your automation script creates a new tab using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create). The browser sends the following notification when the tab is created:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.contextCreated",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "children": null,
+    "originalOpener": null,
+    "url": "about:blank",
+    "userContext": "default",
+    "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+    "parent": null
+  }
+}
+```
+
+### Receiving an event for a child context
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextCreated` active, consider a scenario where a page containing an `<iframe>` loads. The browser sends the following notification for the new child context:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.contextCreated",
+  "params": {
+    "context": "6442450945",
+    "children": null,
+    "originalOpener": null,
+    "url": "about:blank",
+    "userContext": "default",
+    "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+    "parent": "93ee5bd6-d256-4608-a002-9a8995cc0e5f"
+  }
+}
+```
+
+### Identifying the opener of a context
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), consider a scenario where two tabs are already open: Tab 1 at `https://example.com/page1.html`, and Tab 2 at `https://example.com/page2.html`, which was opened from Tab 1 using `window.open()`. When you subscribe to `browsingContext.contextCreated`, the browser fires events for the two existing contexts. The `originalOpener` field in Tab 2's notification identifies the context that opened it.
+
+The browser sends the following notification for Tab 1:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.contextCreated",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "children": null,
+    "originalOpener": null,
+    "url": "https://example.com/page1.html",
+    "userContext": "default",
+    "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+    "parent": null
+  }
+}
+```
+
+This is immediately followed by the notification for Tab 2:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.contextCreated",
+  "params": {
+    "context": "32ed30da-24ad-459d-8f0d-660526e92d96",
+    "children": null,
+    "originalOpener": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "url": "https://example.com/page2.html",
+    "userContext": "default",
+    "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+    "parent": null
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed) event
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
@@ -11,10 +11,10 @@ The `browsingContext.contextCreated` [event](/en-US/docs/Web/WebDriver/Reference
 
 ## Event data
 
-The `params` field in the event notification is a context object with the following properties:
+The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following properties:
 
 - `children`
-  - : An array of context objects that represents child contexts.
+  - : An array of [context objects](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) that represents child contexts.
     This event does not include child contexts ([`maxDepth`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#maxdepth) is `0`).
     To retrieve the children of a context, use [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `clientWindow`
@@ -44,7 +44,9 @@ If the [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/s
 
 ### Receiving an event for a new tab
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextCreated` active, consider a scenario where your automation script creates a new tab using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create). The browser sends the following notification when the tab is created:
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextCreated` active.
+
+When your automation script creates a tab using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create), the browser sends the following notification:
 
 ```json
 {
@@ -64,7 +66,9 @@ With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_
 
 ### Receiving an event for a child context
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextCreated` active, consider a scenario where a page containing an `<iframe>` loads. The browser sends the following notification for the new child context:
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextCreated` active.
+
+Suppose a page containing an `<iframe>` loads. The browser sends the following notification for the new child context:
 
 ```json
 {
@@ -84,7 +88,9 @@ With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_
 
 ### Identifying the opener of a context
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), consider a scenario where two tabs are already open: Tab 1 at `https://example.com/page1.html`, and Tab 2 at `https://example.com/page2.html`, which was opened from Tab 1 using `window.open()`. When you subscribe to `browsingContext.contextCreated`, the browser fires events for the two existing contexts. The `originalOpener` field in Tab 2's notification identifies the context that opened it.
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new).
+
+Consider a scenario where two tabs are already open: Tab 1 at `https://example.com/page1.html`, and Tab 2 at `https://example.com/page2.html`, which was opened from Tab 1 using `window.open()`. When you subscribe to `browsingContext.contextCreated`, the browser fires events for the two existing contexts. The `originalOpener` field in Tab 2's notification identifies the context that opened it.
 
 The browser sends the following notification for Tab 1:
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
@@ -1,0 +1,114 @@
+---
+title: "`browsingContext.contextDestroyed` event"
+short-title: contextDestroyed
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.contextDestroyed_event
+sidebar: webdriver
+---
+
+The `browsingContext.contextDestroyed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a context is discarded from the browser, such as when a tab is closed or when an `<iframe>` is removed from the DOM.
+
+## Event data
+
+The `params` field in the event notification is a context object with the following properties, describing the discarded context and its subtree:
+
+- `children`
+  - : An array of context objects that represents child contexts.
+    This event includes the full subtree of child contexts that were discarded ([`maxDepth`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#maxdepth) is `null`).
+    An empty array indicates that the context had no children.
+- `clientWindow`
+  - : A string that contains the ID of the [client window](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#client_windows) that contained this context.
+- `context`
+  - : A string that contains the ID of the discarded context.
+- `originalOpener`
+  - : A string that contains the ID of the context that originally opened this context.
+    The value is `null` if the context was opened directly (not by another context).
+- `parent`
+  - : A string that contains the ID of the parent context.
+    The value is `null` if the context had no parent (that is, it was a [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context)).
+    This field is present only for the top-level context in the event data.
+- `url`
+  - : A string that contains the URL of the context, including the fragment, at the time it was discarded.
+- `userContext`
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) associated with this context.
+
+## Description
+
+If the [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) was scoped to specific contexts using the [`contexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe#contexts) parameter, the discarded context's ID is automatically removed from that subscription's scope after the event is emitted.
+
+If the discarded context was the only context in the subscription's scope, the subscription itself is automatically removed.
+
+## Examples
+
+### Receiving an event when a tab is closed
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextDestroyed` active, consider a scenario where your automation script closes a tab using [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close). The browser sends the following notification when the tab is closed:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.contextDestroyed",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "children": [],
+    "originalOpener": null,
+    "url": "https://example.com/",
+    "userContext": "default",
+    "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+    "parent": null
+  }
+}
+```
+
+### Receiving an event when a tab with child frames is closed
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextDestroyed` active, consider a scenario where a tab that contains two `<iframe>`s is closed. The browser sends the following notification, which includes the full subtree in the `children` field:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.contextDestroyed",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "children": [
+      {
+        "context": "6442450945",
+        "children": [],
+        "originalOpener": null,
+        "url": "https://example.com/frame1.html",
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386"
+      },
+      {
+        "context": "15032385537",
+        "children": [],
+        "originalOpener": null,
+        "url": "https://example.com/frame2.html",
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386"
+      }
+    ],
+    "originalOpener": null,
+    "url": "https://example.com/",
+    "userContext": "default",
+    "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+    "parent": null
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated) event
+- [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
@@ -11,10 +11,10 @@ The `browsingContext.contextDestroyed` [event](/en-US/docs/Web/WebDriver/Referen
 
 ## Event data
 
-The `params` field in the event notification is a context object with the following properties, describing the discarded context and its subtree:
+The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following properties, describing the discarded context and its subtree:
 
 - `children`
-  - : An array of context objects that represents child contexts.
+  - : An array of [context objects](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) that represents child contexts.
     This event includes the full subtree of child contexts that were discarded ([`maxDepth`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#maxdepth) is `null`).
     An empty array indicates that the context had no children.
 - `clientWindow`
@@ -43,7 +43,9 @@ If the discarded context was the only context in the subscription's scope, the s
 
 ### Receiving an event when a tab is closed
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextDestroyed` active, consider a scenario where your automation script closes a tab using [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close). The browser sends the following notification when the tab is closed:
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextDestroyed` active.
+
+When your automation script closes a tab using [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close), the browser sends the following notification:
 
 ```json
 {
@@ -63,7 +65,9 @@ With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_
 
 ### Receiving an event when a tab with child frames is closed
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextDestroyed` active, consider a scenario where a tab that contains two `<iframe>`s is closed. The browser sends the following notification, which includes the full subtree in the `children` field:
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.contextDestroyed` active.
+
+Suppose a tab that contains two `<iframe>`s is closed. The browser sends the following notification, which includes the full subtree in the `children` field:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
@@ -24,7 +24,7 @@ The `params` field contains:
 
 - `maxDepth` {{optional_inline}}
   - : A non-negative integer that specifies the maximum depth of the tree to return.
-    If not included, the full tree is returned.
+    If not included, which is equivalent to the value `null`, the full tree is returned.
     A value of `0` returns only the root context itself.
     For example, if a top-level context contains an `<iframe>`, which itself contains another `<iframe>`, then a `maxDepth` of `0` returns only the top-level context; a `maxDepth` of `1` returns the top-level context and the first `<iframe>`, but not the nested one.
 - `root` {{optional_inline}}
@@ -106,26 +106,26 @@ The `contexts` array lists the two top-level contexts. The `<iframe>` inside Tab
           {
             "context": "6442450945", // The <iframe>
             "children": [], // No child contexts
-            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
             "originalOpener": null,
             "url": "https://example.com/frame.html",
-            "userContext": "default"
+            "userContext": "default",
+            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386"
           }
         ],
-        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
         "originalOpener": null,
-        "parent": null,
         "url": "https://example.com/page1.html",
-        "userContext": "default"
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "parent": null
       },
       {
         "context": "32ed30da-24ad-459d-8f0d-660526e92d96", // Tab 2
         "children": [], // No child contexts
-        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
         "originalOpener": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
-        "parent": null,
         "url": "https://example.com/page2.html",
-        "userContext": "default"
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "parent": null
       }
     ]
   }
@@ -161,17 +161,17 @@ The browser responds with Tab 1 and its immediate child. The `children` field fo
           {
             "context": "6442450945",
             "children": null,
-            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
             "originalOpener": null,
             "url": "https://example.com/frame.html",
-            "userContext": "default"
+            "userContext": "default",
+            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386"
           }
         ],
-        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
         "originalOpener": null,
-        "parent": null,
         "url": "https://example.com/page1.html",
-        "userContext": "default"
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "parent": null
       }
     ]
   }
@@ -204,11 +204,11 @@ The browser responds as follows:
       {
         "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
         "children": null,
-        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
         "originalOpener": null,
-        "parent": null,
         "url": "https://example.com/page1.html",
-        "userContext": "default"
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "parent": null
       }
     ]
   }
@@ -241,26 +241,26 @@ The browser responds with the full context tree. The `originalOpener` field iden
           {
             "context": "6442450945",
             "children": [],
-            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
             "originalOpener": null,
             "url": "https://example.com/frame.html",
-            "userContext": "default"
+            "userContext": "default",
+            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386"
           }
         ],
-        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
         "originalOpener": null, // Opened directly
-        "parent": null,
         "url": "https://example.com/page1.html",
-        "userContext": "default"
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "parent": null
       },
       {
         "context": "32ed30da-24ad-459d-8f0d-660526e92d96",
         "children": [],
-        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
         "originalOpener": "93ee5bd6-d256-4608-a002-9a8995cc0e5f", // Opened by Tab 1
-        "parent": null,
         "url": "https://example.com/page2.html",
-        "userContext": "default"
+        "userContext": "default",
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "parent": null
       }
     ]
   }

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
@@ -1,0 +1,284 @@
+---
+title: "`browsingContext.getTree` command"
+short-title: getTree
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browsingContext.getTree
+sidebar: webdriver
+---
+
+The `browsingContext.getTree` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module returns the tree of all [top-level contexts](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) or the subtree starting with the specified context.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browsingContext.getTree",
+  "params": {}
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `maxDepth` {{optional_inline}}
+  - : A non-negative integer that specifies the maximum depth of the tree to return.
+    If not included, the full tree is returned.
+    A value of `0` returns only the root context itself.
+    For example, if a top-level context contains an `<iframe>`, which itself contains another `<iframe>`, then a `maxDepth` of `0` returns only the top-level context; a `maxDepth` of `1` returns the top-level context and the first `<iframe>`, but not the nested one.
+- `root` {{optional_inline}}
+  - : A string that contains the ID of the context to use as the root of the returned tree.
+    Context IDs are returned by commands such as [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) or events such as [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated).
+    If not included, all [top-level contexts](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) are returned.
+
+### Return value
+
+The `result` object in the response contains the following fields:
+
+- `contexts`
+  - : An array of context objects, each representing the properties of a context. Each object has the following fields:
+    - `children`
+      - : An array of context objects that represents the child contexts of this context. Each child object has the same structure, with its own `children` array, making this a recursive representation of the context tree.
+        An empty array indicates that the context has no children, while a `null` value indicates that children are excluded from the response, such as when the `maxDepth` limit is reached.
+    - `clientWindow`
+      - : A string that contains the ID of the [client window](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#client_windows) that contains this context.
+    - `context`
+      - : A string that contains the ID of the context.
+    - `originalOpener`
+      - : A string that contains the ID of the context that originally opened this context.
+        The value is `null` if the context was opened directly (not by another context).
+
+        > [!NOTE]
+        > `originalOpener` is set once at the time the context is created, never changes, and always retains the opener's context ID. This differs from the JavaScript [`window.opener`](/en-US/docs/Web/API/Window/opener) property, which references the window that opened the current window — it becomes `null` if the [`rel=noopener`](/en-US/docs/Web/HTML/Attributes/rel/noopener) attribute is used on the link or if the [`noopener`](/en-US/docs/Web/API/Window/open#noopener) window feature is specified in {{domxref("window.open()")}}.
+
+    - `parent` {{optional_inline}}
+      - : A string that contains the ID of the parent context.
+        The value is `null` if the context has no parent.
+        This field is present only for the root-level items in the returned array.
+    - `url`
+      - : A string that contains the URL of the context, including the fragment.
+    - `userContext`
+      - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) associated with this context.
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
+- `no such frame`
+  - : No context with the given `root` ID is found.
+
+## Examples
+
+### Getting all top-level contexts
+
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), consider a scenario where two tabs are open in the browser: the first tab at `https://example.com/page1.html` has an `<iframe>` loading `https://example.com/frame.html`, and the second tab shows `https://example.com/page2.html`:
+
+```plain
+Browser
+├── https://example.com/page1.html (Tab 1)
+│   └── https://example.com/frame.html (<iframe>)
+└── https://example.com/page2.html (Tab 2)
+```
+
+Send the following message to get the full context tree:
+
+```json
+{
+  "id": 1,
+  "method": "browsingContext.getTree",
+  "params": {}
+}
+```
+
+The `contexts` array lists the two top-level contexts. The `<iframe>` inside Tab 1 appears nested under its `children`. The browser responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "contexts": [
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f", // Tab 1
+        "children": [
+          // Tab 1 has one child <iframe>
+          {
+            "context": "6442450945", // The <iframe>
+            "children": [], // No child contexts
+            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+            "originalOpener": null,
+            "url": "https://example.com/frame.html",
+            "userContext": "default"
+          }
+        ],
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "originalOpener": null,
+        "parent": null,
+        "url": "https://example.com/page1.html",
+        "userContext": "default"
+      },
+      {
+        "context": "32ed30da-24ad-459d-8f0d-660526e92d96", // Tab 2
+        "children": [], // No child contexts
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "originalOpener": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "parent": null,
+        "url": "https://example.com/page2.html",
+        "userContext": "default"
+      }
+    ]
+  }
+}
+```
+
+### Getting a subtree from a specific context
+
+Using the same setup as in the previous example, to get only Tab 1 and its immediate child context, send the following message with Tab 1's context ID as `root` and `maxDepth` set to `1`:
+
+```json
+{
+  "id": 2,
+  "method": "browsingContext.getTree",
+  "params": {
+    "root": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "maxDepth": 1
+  }
+}
+```
+
+The browser responds with Tab 1 and its immediate child. The `children` field for the iframe is `null`; the `maxDepth` setting of `1` limits the response to one level below the root, so the iframe's own children are not included:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "contexts": [
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "children": [
+          {
+            "context": "6442450945",
+            "children": null,
+            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+            "originalOpener": null,
+            "url": "https://example.com/frame.html",
+            "userContext": "default"
+          }
+        ],
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "originalOpener": null,
+        "parent": null,
+        "url": "https://example.com/page1.html",
+        "userContext": "default"
+      }
+    ]
+  }
+}
+```
+
+In this example, if the `root` parameter of the `browsingContext.getTree` message were set to the iframe's context ID (`"6442450945"`), the iframe's `parent` field in the response would be `"93ee5bd6-d256-4608-a002-9a8995cc0e5f"` (Tab 1's context ID) rather than `null`.
+
+To limit the lookup to only the root context with no children, set `maxDepth` to `0`:
+
+```json
+{
+  "id": 3,
+  "method": "browsingContext.getTree",
+  "params": {
+    "root": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "maxDepth": 0
+  }
+}
+```
+
+The browser responds as follows:
+
+```json
+{
+  "id": 3,
+  "type": "success",
+  "result": {
+    "contexts": [
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "children": null,
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "originalOpener": null,
+        "parent": null,
+        "url": "https://example.com/page1.html",
+        "userContext": "default"
+      }
+    ]
+  }
+}
+```
+
+### Identifying the opener of a context
+
+Expanding on the same setup, consider that Tab 2 (`https://example.com/page2.html`) was opened from Tab 1 (`https://example.com/page1.html`) using `window.open()`. Send the following message to see how this relationship is conveyed in the response:
+
+```json
+{
+  "id": 4,
+  "method": "browsingContext.getTree",
+  "params": {}
+}
+```
+
+The browser responds with the full context tree. The `originalOpener` field identifies the context that opened Tab 2:
+
+```json
+{
+  "id": 4,
+  "type": "success",
+  "result": {
+    "contexts": [
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "children": [
+          {
+            "context": "6442450945",
+            "children": [],
+            "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+            "originalOpener": null,
+            "url": "https://example.com/frame.html",
+            "userContext": "default"
+          }
+        ],
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "originalOpener": null, // Opened directly
+        "parent": null,
+        "url": "https://example.com/page1.html",
+        "userContext": "default"
+      },
+      {
+        "context": "32ed30da-24ad-459d-8f0d-660526e92d96",
+        "children": [],
+        "clientWindow": "08c697a1-2664-447d-9c88-52bcee3bb386",
+        "originalOpener": "93ee5bd6-d256-4608-a002-9a8995cc0e5f", // Opened by Tab 1
+        "parent": null,
+        "url": "https://example.com/page2.html",
+        "userContext": "default"
+      }
+    ]
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) command
+- [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close) command
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
+- [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated) event
+- [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
@@ -12,15 +12,25 @@ The `browsingContext.getTree` [command](/en-US/docs/Web/WebDriver/Reference/BiDi
 ## Syntax
 
 ```json-nolint
+/* Without optional parameters */
 {
   "method": "browsingContext.getTree",
   "params": {}
+}
+
+/* With optional parameters */
+{
+  "method": "browsingContext.getTree",
+  "params": {
+    "maxDepth": 1,
+    "root": "93ee5bd6-d256-4608-a002-9a8995cc0e5f"
+  }
 }
 ```
 
 ### Parameters
 
-The `params` field contains:
+The `params` field can contain:
 
 - `maxDepth` {{optional_inline}}
   - : A non-negative integer that specifies the maximum depth of the tree to return.
@@ -50,7 +60,7 @@ The `result` object in the response contains the following fields:
         The value is `null` if the context was opened directly (not by another context).
 
         > [!NOTE]
-        > `originalOpener` is set once at the time the context is created, never changes, and always retains the opener's context ID. This differs from the JavaScript [`window.opener`](/en-US/docs/Web/API/Window/opener) property, which references the window that opened the current window — it becomes `null` if the [`rel=noopener`](/en-US/docs/Web/HTML/Attributes/rel/noopener) attribute is used on the link or if the [`noopener`](/en-US/docs/Web/API/Window/open#noopener) window feature is specified in {{domxref("window.open()")}}.
+        > `originalOpener` is set once when the context is created. It never changes and always retains the opener's context ID. This differs from the JavaScript [`window.opener`](/en-US/docs/Web/API/Window/opener) property, which references the window that opened the current window — it becomes `null` if the [`rel=noopener`](/en-US/docs/Web/HTML/Attributes/rel/noopener) attribute is used on the link or if the [`noopener`](/en-US/docs/Web/API/Window/open#noopener) window feature is specified in {{domxref("window.open()")}}.
 
     - `parent` {{optional_inline}}
       - : A string that contains the ID of the parent context.
@@ -147,7 +157,7 @@ Using the same setup as in the previous example, to get only Tab 1 and its immed
 }
 ```
 
-The browser responds with Tab 1 and its immediate child. The `children` field for the iframe is `null`; the `maxDepth` setting of `1` limits the response to one level below the root, so the iframe's own children are not included:
+The browser responds with Tab 1 and its immediate child. The `children` field for the iframe is `null`; the `maxDepth` setting of `1` limits the response to one level below the root, so the `<iframe>`'s own children are not included:
 
 ```json
 {
@@ -178,7 +188,7 @@ The browser responds with Tab 1 and its immediate child. The `children` field fo
 }
 ```
 
-In this example, if the `root` parameter of the `browsingContext.getTree` message were set to the iframe's context ID (`"6442450945"`), the iframe's `parent` field in the response would be `"93ee5bd6-d256-4608-a002-9a8995cc0e5f"` (Tab 1's context ID) rather than `null`.
+In this example, if the `root` parameter of the `browsingContext.getTree` message were set to the iframe's context ID (`"6442450945"`), the `<iframe>`'s `parent` field in the response would be `"93ee5bd6-d256-4608-a002-9a8995cc0e5f"` (Tab 1's context ID) rather than `null`.
 
 To limit the lookup to only the root context with no children, set `maxDepth` to `0`:
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -33,9 +33,6 @@ Calling [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Mod
 - [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate)
 - [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close)
 - [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create)
-
-## Commands
-
 - [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree)
 
 ## Events

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -34,6 +34,15 @@ Calling [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Mod
 - [`browsingContext.close`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/close)
 - [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create)
 
+## Commands
+
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree)
+
+## Events
+
+- [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated)
+- [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed)
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
@@ -30,7 +30,9 @@ The `params` field in the event notification is an object with the following fie
 
 ### Receiving an event when a file picker dialog opens
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `input.fileDialogOpened` active, consider a scenario where a page has an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element that accepts a single file and your script calls [`click()`](/en-US/docs/Web/API/HTMLElement/click) on it. The browser sends the following notification when the file picker dialog opens:
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `input.fileDialogOpened` active.
+
+Suppose your page has an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element that accepts a single file and your script calls [`click()`](/en-US/docs/Web/API/HTMLElement/click) on the `<input>`. The browser sends the following notification when the file picker dialog opens:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/filedialogopened/index.md
@@ -30,7 +30,7 @@ The `params` field in the event notification is an object with the following fie
 
 ### Receiving an event when a file picker dialog opens
 
-Consider a scenario where a page has an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element that accepts a single file and your script calls [`click()`](/en-US/docs/Web/API/HTMLElement/click) on it. With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `input.fileDialogOpened` active, the browser sends a notification when the file picker dialog opens:
+With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `input.fileDialogOpened` active, consider a scenario where a page has an [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file) element that accepts a single file and your script calls [`click()`](/en-US/docs/Web/API/HTMLElement/click) on it. The browser sends the following notification when the file picker dialog opens:
 
 ```json
 {

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -47,6 +47,15 @@ sidebar:
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/create
             code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree
+            code: true
+          - type: section
+            link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext#events
+            title: Events
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed
+            code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/input


### PR DESCRIPTION
### Description

This PR adds the second set of pages related to the context life cycle:
  - `browsingContext.getTree`
  - `browsingContext.contextCreated`
  - `browsingContext.contextDestroyed`

Other pages updated include:
- `browsingContext` module landing page: Added list items for the three new pages
    (the base content updates to this file are in the [part 1 set](https://github.com/mdn/content/pull/44121)) 
- `input.fileDialogOpened`: Added "active session" to the example intro for consistency


### Spec links

- https://w3c.github.io/webdriver-bidi/#command-browsingContext-getTree
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-contextCreated
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-contextDestroyed

### Related issue

Doc issue: mdn/mdn#339