### PR TITLE
Update HTMLMediaElement abort event description and example (#44222)

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/abort_event/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLMediaElement.abort_event
 
 {{APIRef("HTML DOM")}}
 
-The **`abort`** event is fired when the resource was not fully loaded, but not as the result of an error.
+The **`abort`** event is fired when the loading of a media resource is canceled before it completes, but not as the result of an error. Common triggers include the user pressing the browser's stop button, or the page changing or clearing the element's `src` while the load is in progress.
 
 This event is not cancelable and does not bubble.
 
@@ -30,17 +30,19 @@ A generic {{domxref("Event")}}.
 
 ```js
 const video = document.querySelector("video");
-const videoSrc = "https://example.org/path/to/video.webm";
 
 video.addEventListener("abort", () => {
-  console.log(`Abort loading: ${videoSrc}`);
+  console.log("Video loading was aborted.");
 });
 
-const source = document.createElement("source");
-source.setAttribute("src", videoSrc);
-source.setAttribute("type", "video/webm");
+// Start loading a video.
+video.setAttribute("src", "https://example.org/path/to/video.webm");
 
-video.appendChild(source);
+// While the load is still in progress, changing `src` to a different
+// resource (or clearing it) cancels the in-progress load and fires the
+// `abort` event. The user pressing the browser's stop button has the
+// same effect.
+video.setAttribute("src", "https://example.org/path/to/other-video.webm");
 ```
 
 ## Specifications


### PR DESCRIPTION
The existing example on `HTMLMediaElement: abort_event` appends a `<source>` element to a `<video>`, which does not fire the `abort` event. Per @hamishwillee on #44222, abort is fired for user-intended cancellation of a media load — typically the browser's stop button, or changing/clearing `src` mid-load.

Changes:

- Description now states when the event fires, with the common triggers.
- Example replaced with one that actually fires `abort`: start loading a video, then change `src` to a different resource. Comment notes that clearing `src` or the browser's stop button have the same effect.

Closes #44222.