### PR TITLE
Element.getAttribute(): document entity decoding in returned values

### DIFF
--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -56,6 +56,19 @@ const lang = div1.getAttribute("lang");
 When called on an HTML element in a DOM flagged as an HTML document,
 `getAttribute()` lower-cases its argument before proceeding.
 
+### Character entities in attribute values
+
+HTML character entities in an attribute's source markup (for example, `&lt;`, `&amp;`, or `&#x3C;`) are decoded by the HTML parser when the document is parsed, so `getAttribute()` returns the decoded value, not the original source. Given:
+
+```html
+<div id="example" data-payload="&lt;b&gt;hi&lt;/b&gt;"></div>
+```
+
+calling `document.getElementById("example").getAttribute("data-payload")` returns the string `"<b>hi</b>"`.
+
+> [!WARNING]
+> Treating the return value as already-escaped HTML is unsafe. If you read an attribute that holds untrusted data and then assign it to {{domxref("Element.innerHTML", "innerHTML")}} or insert it into the document as markup, any HTML entities the source author used to escape special characters will already be decoded, and the result can be exploited for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS). Use {{domxref("Node.textContent", "textContent")}} (or another text-safe API) for untrusted data instead of `innerHTML`.
+
 ### Retrieving nonce values
 
 For security reasons, [CSP](/en-US/docs/Web/HTTP/Guides/CSP) nonces from non-script

--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -56,9 +56,11 @@ const lang = div1.getAttribute("lang");
 When called on an HTML element in a DOM flagged as an HTML document,
 `getAttribute()` lower-cases its argument before proceeding.
 
-### Character entities in attribute values
+### Decoded character references in attribute values
 
-HTML character entities in an attribute's source markup (for example, `&lt;`, `&amp;`, or `&#x3C;`) are decoded by the HTML parser when the document is parsed, so `getAttribute()` returns the decoded value, not the original source. Given:
+HTML [character references](/en-US/docs/Glossary/Character_reference) in an attribute's source markup (for example, `&lt;`, `&amp;`, or `&#x3C;`) are decoded by the HTML parser when the document is parsed, so `getAttribute()` returns the decoded value, not the original source.
+
+Given:
 
 ```html
 <div id="example" data-payload="&lt;b&gt;hi&lt;/b&gt;"></div>
@@ -66,8 +68,9 @@ HTML character entities in an attribute's source markup (for example, `&lt;`, `&
 
 calling `document.getElementById("example").getAttribute("data-payload")` returns the string `"<b>hi</b>"`.
 
-> [!WARNING]
-> Treating the return value as already-escaped HTML is unsafe. If you read an attribute that holds untrusted data and then assign it to {{domxref("Element.innerHTML", "innerHTML")}} or insert it into the document as markup, any HTML entities the source author used to escape special characters will already be decoded, and the result can be exploited for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS). Use {{domxref("Node.textContent", "textContent")}} (or another text-safe API) for untrusted data instead of `innerHTML`.
+Treating the return value from `getAttribute()` as already-escaped HTML is unsafe. If you read an attribute that holds untrusted data and then assign it to {{domxref("Element.innerHTML", "innerHTML")}} or insert it into the document as markup, any HTML references used to escape special characters will already be decoded, and the result can be exploited for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
+
+Use {{domxref("Node.textContent", "textContent")}} (or another text-safe API) for untrusted data instead of `innerHTML`.
 
 ### Retrieving nonce values
 


### PR DESCRIPTION
### Summary

Adds a "Character entities in attribute values" section to the `Element.getAttribute()` page explaining that HTML character entities in the source markup (e.g. `&lt;`) are decoded by the HTML parser, so `getAttribute()` returns the decoded value. The section also includes a `WARNING` callout about the XSS risk of feeding the return value into `innerHTML` and points readers at `textContent` for untrusted data.

### Motivation

Closes #43825.

The behavior is well-defined by the HTML parser (attribute values go through [character reference state](https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state) during tokenization, just like text content) but isn't called out anywhere on the `getAttribute()` page. As the issue reporter notes, this gap can lead developers to assume that escaping at the server side (e.g. PHP `htmlentities()`) keeps an attribute value "safe" to round-trip through JS and back into the DOM as HTML, which isn't the case.

### Verification

- Example matches Firefox 147 and Chromium-stable behavior (parsed `&lt;b&gt;hi&lt;/b&gt;` attribute returns `"<b>hi</b>"`).
- Spec reference: WHATWG HTML, [§13.2.5.72 Character reference state](https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state) — used while tokenizing attribute values when a character-reference start (`&`) is encountered.
- Cross-link to the existing [XSS guide](/en-US/docs/Web/Security/Attacks/XSS) and to `Node.textContent`.

+13 / -0, one file.