### PR TITLE
Update Promise.race documentation regarding error handling

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/all/index.md
@@ -49,6 +49,8 @@ The `Promise.all()` method is one of the [promise concurrency](/en-US/docs/Web/J
 
 `Promise.all()` will reject immediately upon **any** of the input promises rejecting. In comparison, the promise returned by {{jsxref("Promise.allSettled()")}} will wait for all input promises to complete, regardless of whether or not one rejects. Use `allSettled()` if you need the final result of every promise in the input iterable.
 
+Like other promise combinators, `Promise.all()` immediately marks all promises as "handled" when it is called (by calling their `.then()` methods). Subsequent rejections after the first rejection will be ignored, and will not trigger any `unhandledrejection` events.
+
 ## Examples
 
 ### Using Promise.all()

--- a/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/any/index.md
@@ -50,6 +50,8 @@ Unlike {{jsxref("Promise.all()")}}, which returns an _array_ of fulfillment valu
 
 Also, unlike {{jsxref("Promise.race()")}}, which returns the first _settled_ value (either fulfillment or rejection), this method returns the first _fulfilled_ value. This method ignores all rejected promises up until the first promise that fulfills.
 
+Like other promise combinators, `Promise.any()` immediately marks all promises as "handled" when it is called (by calling their `.then()` methods). Subsequent rejections after the first fulfillment will be ignored, and will not trigger any `unhandledrejection` events.
+
 ## Examples
 
 ### Using Promise.any()

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
@@ -188,6 +188,29 @@ const data = Promise.race([
 
 If the `data` promise fulfills, it will contain the data fetched from `/api`; otherwise, it will reject if `fetch` remains pending for 5 seconds and loses the race with the `setTimeout` timer.
 
+> [!NOTE]
+> Capturing and clearing the timeout handle from `setTimeout` is _not_ required. `Promise.race` will capture and discard any errors thrown by any of the losing promises, and they will not bubble up and become `unhandledRejection`s. In other words, this is not necessary:
+
+```js
+let rejectTimeoutHandle;
+const data = Promise.race([
+  fetch("/api"),
+  new Promise((resolve, reject) => {
+    // Reject after 5 seconds
+    rejectTimeoutHandle = setTimeout(() => reject(new Error("Request timed out")), 5000);
+  }),
+])
+  .then((res) => {
+    clearTimeout(rejectTimeoutHandle);
+    return res.json();
+  })
+  .catch((err) => {
+    // Clear the timeout in case the error was thrown by fetch
+    clearTimeout(rejectTimeoutHandle);
+    displayError(err);
+  });
+```
+
 ### Using Promise.race() to detect the status of a promise
 
 Because `Promise.race()` resolves to the first non-pending promise in the iterable, we can check a promise's state, including if it's pending. This example is adapted from [`promise-status-async`](https://github.com/kudla/promise-status-async/blob/master/lib/promiseState.js).

--- a/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/race/index.md
@@ -48,6 +48,8 @@ The `Promise.race()` method is one of the [promise concurrency](/en-US/docs/Web/
 
 If the iterable contains one or more non-promise values and/or an already settled promise, then `Promise.race()` will settle to the first of these values found in the iterable.
 
+Like other promise combinators, `Promise.race()` immediately marks all promises as "handled" when it is called (by calling their `.then()` methods). Subsequent rejections after the first settlement will be ignored, and will not trigger any `unhandledrejection` events.
+
 ## Examples
 
 ### Using Promise.race()
@@ -188,28 +190,7 @@ const data = Promise.race([
 
 If the `data` promise fulfills, it will contain the data fetched from `/api`; otherwise, it will reject if `fetch` remains pending for 5 seconds and loses the race with the `setTimeout` timer.
 
-> [!NOTE]
-> Capturing and clearing the timeout handle from `setTimeout` is _not_ required. `Promise.race` will capture and discard any errors thrown by any of the losing promises, and they will not bubble up and become `unhandledRejection`s. In other words, this is not necessary:
-
-```js
-let rejectTimeoutHandle;
-const data = Promise.race([
-  fetch("/api"),
-  new Promise((resolve, reject) => {
-    // Reject after 5 seconds
-    rejectTimeoutHandle = setTimeout(() => reject(new Error("Request timed out")), 5000);
-  }),
-])
-  .then((res) => {
-    clearTimeout(rejectTimeoutHandle);
-    return res.json();
-  })
-  .catch((err) => {
-    // Clear the timeout in case the error was thrown by fetch
-    clearTimeout(rejectTimeoutHandle);
-    displayError(err);
-  });
-```
+Note that there's no need to explicitly clean up the timeout rejection (such as clearing the timeout) in case the `fetch` promise finishes first. `Promise.race` will capture and discard the settlement results of the losing promises, so the `"Request timed out"` rejection will not bubble up as unhandled.
 
 ### Using Promise.race() to detect the status of a promise
 


### PR DESCRIPTION
Clarified that capturing and clearing the timeout handle is not required when using `Promise.race` to time out a request. Provided an example to illustrate this point.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Expanded the description of "Using Promise.race() to implement request timeout" to demonstrate how the timeout does _not_ need to be captured to prevent the throwing of the error: every iterable item passed to `Promise.race` that loses the race is consumed silently, so the error is thrown but does not become an `unhandledRejection`.

### Motivation

I refactored a significant chunk of code to use `Promise.race` and an auto-throwing method, then worried that the timeouts might be generating unhandled rejections; after checking the MDN, I didn't see any reference to this specific case. So I developed a "solution" that promptly created the problem I was trying to avoid.

### Additional details

None.

### Related issues and pull requests

None.