### PR TITLE
Location/WindowClient ancestorOrigins: note iframe referrerpolicy effect

### DIFF
--- a/files/en-us/web/api/location/ancestororigins/index.md
+++ b/files/en-us/web/api/location/ancestororigins/index.md
@@ -19,6 +19,9 @@ determine, for example, whenever the document is being framed by a site which yo
 expect it to be framed by. You can also use it to vary the behavior of the document
 based on what site or list of sites is framing it.
 
+> [!NOTE]
+> The [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/iframe#referrerpolicy) attribute of an embedding `<iframe>` affects this list. Setting it to `no-referrer`, or to `same-origin` when the framed document is cross-origin, redacts the origin of the document that contains the `<iframe>` from the `ancestorOrigins` list of the framed document: the origin is replaced with an opaque origin, which serializes as `"null"`.
+
 ## Value
 
 A {{domxref("DOMStringList")}}.

--- a/files/en-us/web/api/location/ancestororigins/index.md
+++ b/files/en-us/web/api/location/ancestororigins/index.md
@@ -20,7 +20,7 @@ expect it to be framed by. You can also use it to vary the behavior of the docum
 based on what site or list of sites is framing it.
 
 > [!NOTE]
-> The [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/iframe#referrerpolicy) attribute of an embedding `<iframe>` affects this list. Setting it to `no-referrer`, or to `same-origin` when the framed document is cross-origin, redacts the origin of the document that contains the `<iframe>` from the `ancestorOrigins` list of the framed document: the origin is replaced with an opaque origin, which serializes as `"null"`.
+> The [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/iframe#referrerpolicy) attribute of an embedding `<iframe>` affects this list. Setting `referrerpolicy` to `no-referrer`, or to `same-origin` when the framed document is cross-origin, redacts the origin of the document containing the `<iframe>` from the `ancestorOrigins` list of the framed document. The origin is replaced with an opaque origin, which serializes as `"null"`.
 
 ## Value
 

--- a/files/en-us/web/api/windowclient/ancestororigins/index.md
+++ b/files/en-us/web/api/windowclient/ancestororigins/index.md
@@ -15,7 +15,7 @@ The **`ancestorOrigins`** read-only property of the {{domxref("WindowClient")}} 
 The first element in the array is the origin of this window's parent, and the last element is the origin of the top-level browsing context. If this window is itself a top-level browsing context, then `ancestorOrigins` is an empty array.
 
 > [!NOTE]
-> The [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/iframe#referrerpolicy) attribute of an embedding `<iframe>` affects this list. Setting it to `no-referrer`, or to `same-origin` when the framed document is cross-origin, redacts the origin of the document that contains the `<iframe>` from the `ancestorOrigins` list of the framed document: the origin is replaced with an opaque origin, which serializes as `"null"`.
+> The [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/iframe#referrerpolicy) attribute of an embedding `<iframe>` affects this list. Setting `referrerpolicy` to `no-referrer`, or to `same-origin` when the framed document is cross-origin, redacts the origin of the document containing the `<iframe>` from the `ancestorOrigins` list of the framed document. The origin is replaced with an opaque origin, which serializes as `"null"`.
 
 ## Value
 

--- a/files/en-us/web/api/windowclient/ancestororigins/index.md
+++ b/files/en-us/web/api/windowclient/ancestororigins/index.md
@@ -14,6 +14,9 @@ The **`ancestorOrigins`** read-only property of the {{domxref("WindowClient")}} 
 
 The first element in the array is the origin of this window's parent, and the last element is the origin of the top-level browsing context. If this window is itself a top-level browsing context, then `ancestorOrigins` is an empty array.
 
+> [!NOTE]
+> The [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/iframe#referrerpolicy) attribute of an embedding `<iframe>` affects this list. Setting it to `no-referrer`, or to `same-origin` when the framed document is cross-origin, redacts the origin of the document that contains the `<iframe>` from the `ancestorOrigins` list of the framed document: the origin is replaced with an opaque origin, which serializes as `"null"`.
+
 ## Value
 
 An array of strings.


### PR DESCRIPTION
Fixes #42231.

`location.ancestorOrigins` (and `WindowClient.ancestorOrigins`) don't mention that an embedding `<iframe>`'s `referrerpolicy` can keep the embedder's origin out of the list. Setting `referrerpolicy="no-referrer"`, or `referrerpolicy="same-origin"` when the framed document is cross-origin, replaces the embedder's origin with an opaque origin (serialized as `"null"`) in the framed document's `ancestorOrigins`.

Added a matching note to both pages that expose the property. Wording follows the behavior described by the reporter (@zcorpan) and the spec change in whatwg/html#11560.