### PR TITLE
FF152Relnote: PerformanceResourceTiming.{firstInterimResponse|finalRe…

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -61,7 +61,7 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 ### APIs
 
 - The {{domxref("PerformanceResourceTiming.firstInterimResponseStart","firstInterimResponseStart")}} and {{domxref("PerformanceResourceTiming.finalResponseHeadersStart","finalResponseHeadersStart")}} properties of the {{domxref("PerformanceResourceTiming")}} interface are supported.
-  These can be used to measure how long it takes to the browser to receive interim HTTP responses and the final HTTP response after sending a request, respectively.
+  These can be used to measure how long it takes for the browser to receive interim HTTP responses and the final HTTP response after sending a request, respectively.
   ([Firefox bug 2006340](https://bugzil.la/2006340)).
 
 #### DOM

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -60,6 +60,10 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
+- The {{domxref("PerformanceResourceTiming.firstInterimResponseStart","firstInterimResponseStart")}} and {{domxref("PerformanceResourceTiming.finalResponseHeadersStart","finalResponseHeadersStart")}} properties of the {{domxref("PerformanceResourceTiming")}} interface are supported.
+  These can be used to measure how long it takes to the browser to receive interim HTTP responses and the final HTTP response after sending a request, respectively.
+  ([Firefox bug 2006340](https://bugzil.la/2006340)).
+
 #### DOM
 
 - The {{domxref("Notification/actions","actions")}} read-only property and the [`maxActions`](/en-US/docs/Web/API/Notification/maxActions_static) static read-only property of the {{domxref("Notification")}} interface are supported.

--- a/files/en-us/web/api/performanceresourcetiming/finalresponseheadersstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/finalresponseheadersstart/index.md
@@ -8,15 +8,13 @@ browser-compat: api.PerformanceResourceTiming.finalResponseHeadersStart
 
 {{APIRef("Performance API")}}{{AvailableInWorkers}}
 
-The **`finalResponseHeadersStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives the first byte of the final document response (for example, 200 OK) from the server.
+The **`finalResponseHeadersStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives the first byte of the final document response (for example, {{httpstatus(200, "200 OK")}}) from the server.
 
 This differs from **{{domxref("PerformanceResourceTiming.requestStart", "requestStart")}}** (which may also be represented as **{{domxref("PerformanceResourceTiming.firstInterimResponseStart", "firstInterimResponseStart")}}**), as this starts from the first bytes of any response including interim responses (for example, 103 Early Hints) with the final response coming potentially much later.
 
 When there are no interim responses, `requestStart` is the same as `finalResponseHeadersStart` and `firstInterimResponseStart` is 0.
 
 There is no _end_ property for `finalResponseHeadersStart`.
-
-## Value
 
 The `finalResponseHeadersStart` property can have the following values:
 

--- a/files/en-us/web/api/performanceresourcetiming/finalresponseheadersstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/finalresponseheadersstart/index.md
@@ -16,6 +16,8 @@ When there are no interim responses, `requestStart` is the same as `finalRespons
 
 There is no _end_ property for `finalResponseHeadersStart`.
 
+## Value
+
 The `finalResponseHeadersStart` property can have the following values:
 
 - A {{domxref("DOMHighResTimeStamp")}} immediately after the browser receives the first bytes of the final response from the server.

--- a/files/en-us/web/api/performanceresourcetiming/firstinterimresponsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/firstinterimresponsestart/index.md
@@ -8,7 +8,7 @@ browser-compat: api.PerformanceResourceTiming.firstInterimResponseStart
 
 {{APIRef("Performance API")}}{{AvailableInWorkers}}
 
-The **`firstInterimResponseStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives the first byte of the interim 1xx response (for example, 100 Continue or 103 Early Hints) from the server.
+The **`firstInterimResponseStart`** read-only property returns a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after the browser receives the first byte of the interim 1xx response (for example, {{httpstatus(100, "100 Continue")}} or {{httpstatus(103, "103 Early Hints")}}) from the server.
 
 There is no _end_ property for `firstInterimResponseStart`.
 


### PR DESCRIPTION
…sponseHeader}Start

FF152 supports [`PerformanceResourceTiming.finalResponseHeadersStart`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/finalResponseHeadersStart) and [`PerformanceResourceTiming.firstInterimResponseStart`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/firstInterimResponseStart) in https://bugzilla.mozilla.org/show_bug.cgi?id=2006340

This adds a release note, along with a tiny update to cross link a few status codes from those docs.

Related docs work can be tracked in #44168
