### PR TITLE
FF150 Relnote HighlightRegistry: highlightsFromPoint()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -52,6 +52,12 @@ No notable changes.
   This allows the method to return the node containing the caret from within a shadow DOM, provided its associated {{domxref("ShadowRoot")}} was passed as an option.
   ([Firefox bug 1914596](https://bugzil.la/1914596)).
 
+- The {{domxref("HighlightRegistry.highlightsFromPoint()")}} method is now supported, providing an mechanism for web pages to get information about all the [CSS custom highlights](/en-US/docs/Web/API/CSS_Custom_Highlight_API) at a particular point.
+  This includes highlights that are inside shadow roots, provided the associated {{domxref("ShadowRoot")}} instance was passed to the method.
+  ([Firefox bug 1917991](https://bugzil.la/1917991)).
+
+  highlightsFromPoint() allows web pages to interact with CSS Highlights by returning all Highlights at a given point.
+
 - The {{domxref("CSSFontFaceDescriptors")}} interface is now supported, and an instance of this type is returned by the {{domxref("CSSFontFaceRule.style")}} property. ([Firefox bug 2019904](https://bugzil.la/2019904)).
 
 - The non-standard {{domxref("Document/caretRangeFromPoint","caretRangeFromPoint()")}} method of the {{domxref("Document")}} interface is now supported. ([Firefox bug 1550635](https://bugzil.la/1550635)).

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -56,8 +56,6 @@ No notable changes.
   This includes highlights that are inside shadow roots, provided the associated {{domxref("ShadowRoot")}} instance was passed to the method.
   ([Firefox bug 1917991](https://bugzil.la/1917991)).
 
-  highlightsFromPoint() allows web pages to interact with CSS Highlights by returning all Highlights at a given point.
-
 - The {{domxref("CSSFontFaceDescriptors")}} interface is now supported, and an instance of this type is returned by the {{domxref("CSSFontFaceRule.style")}} property. ([Firefox bug 2019904](https://bugzil.la/2019904)).
 
 - The non-standard {{domxref("Document/caretRangeFromPoint","caretRangeFromPoint()")}} method of the {{domxref("Document")}} interface is now supported. ([Firefox bug 1550635](https://bugzil.la/1550635)).

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -52,7 +52,7 @@ No notable changes.
   This allows the method to return the node containing the caret from within a shadow DOM, provided its associated {{domxref("ShadowRoot")}} was passed as an option.
   ([Firefox bug 1914596](https://bugzil.la/1914596)).
 
-- The {{domxref("HighlightRegistry.highlightsFromPoint()")}} method is now supported, providing an mechanism for web pages to get information about all the [CSS custom highlights](/en-US/docs/Web/API/CSS_Custom_Highlight_API) at a particular point.
+- The {{domxref("HighlightRegistry.highlightsFromPoint()")}} method is now supported, providing an mechanism for web pages to get information about all the [CSS custom highlights](/en-US/docs/Web/API/CSS_Custom_Highlight_API) applied at a particular point.
   This includes highlights that are inside shadow roots, provided the associated {{domxref("ShadowRoot")}} instance was passed to the method.
   ([Firefox bug 1917991](https://bugzil.la/1917991)).
 

--- a/files/en-us/web/api/highlightregistry/highlightsfrompoint/index.md
+++ b/files/en-us/web/api/highlightregistry/highlightsfrompoint/index.md
@@ -30,9 +30,9 @@ highlightsFromPoint(x, y, options)
 
 ### Return value
 
-An array of `HighlightHitResult` objects representing the custom highlights applied at the point in the viewport specified by the `x` and `y` parameters.
+An array of objects representing the custom highlights applied at the point in the viewport specified by the `x` and `y` parameters.
 
-Each `HighlightHitResult` object contains the following properties:
+Each object contains the following properties:
 
 - `highlight`
   - : A {{domxref("Highlight")}} object representing the applied custom highlight.


### PR DESCRIPTION
FF150 added support for [`HighlightRegistry.highlightsFromPoint()`](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/highlightsFromPoint) in https://bugzilla.mozilla.org/show_bug.cgi?id=1917991

This adds a release note.

Related docs work can be tracked in #43969
