### PR TITLE
Improve misleading examples

### DIFF
--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -64,15 +64,15 @@ You normally create a new `URL` object by specifying the URL as a string when ca
 
 ## Usage notes
 
-The constructor takes a `url` parameter, and an optional `base` parameter to use as a base if the `url` parameter is a relative URL:
+The constructor takes a `url` parameter, and an optional `base` parameter to use as a base if the `url` parameter is a relative URL.
+
+Note that in the case below "dogs" is the filename segment (because it has no trailing slash), and the relative URL "cats" is interpreted relative to the *directory* part of the base URL, which is `http://www.example.com/animals/`. See [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references) for more information.
 
 ```js
 const url = new URL("cats", "http://www.example.com/animals/dogs");
 console.log(url.hostname); // "www.example.com"
 console.log(url.pathname); // "/animals/cats"
 ```
-
-See [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references) for how the `url` parameter is interpreted relative to `base`.
 
 The constructor will raise an exception if the URL cannot be parsed to a valid URL.
 You can either call the above code in a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block or use the {{domxref("URL.canParse_static", "canParse()")}} static method to first check the URL is valid:

--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -67,19 +67,19 @@ You normally create a new `URL` object by specifying the URL as a string when ca
 The constructor takes a `url` parameter, and an optional `base` parameter to use as a base if the `url` parameter is a relative URL:
 
 ```js
-const url = new URL("../cats", "http://www.example.com/dogs");
+const url = new URL("cats", "http://www.example.com/animals/dogs");
 console.log(url.hostname); // "www.example.com"
-console.log(url.pathname); // "/cats"
+console.log(url.pathname); // "/animals/cats"
 ```
 
 The constructor will raise an exception if the URL cannot be parsed to a valid URL.
 You can either call the above code in a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block or use the {{domxref("URL.canParse_static", "canParse()")}} static method to first check the URL is valid:
 
 ```js
-if (URL.canParse("../cats", "http://www.example.com/dogs")) {
-  const url = new URL("../cats", "http://www.example.com/dogs");
+if (URL.canParse("cats", "http://www.example.com/animals/dogs")) {
+  const url = new URL("cats", "http://www.example.com/animals/dogs");
   console.log(url.hostname); // "www.example.com"
-  console.log(url.pathname); // "/cats"
+  console.log(url.pathname); // "/animals/cats"
 } else {
   console.log("Invalid URL");
 }
@@ -89,7 +89,7 @@ URL properties can be set to construct the URL:
 
 ```js
 url.hash = "tabby";
-console.log(url.href); // "http://www.example.com/cats#tabby"
+console.log(url.href); // "http://www.example.com/animals/cats#tabby"
 ```
 
 URLs are encoded according to the rules found in {{RFC(3986)}}. For instance:

--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -66,7 +66,7 @@ You normally create a new `URL` object by specifying the URL as a string when ca
 
 The constructor takes a `url` parameter, and an optional `base` parameter to use as a base if the `url` parameter is a relative URL.
 
-Note that in the case below "dogs" is the filename segment (because it has no trailing slash), and the relative URL "cats" is interpreted relative to the *directory* part of the base URL, which is `http://www.example.com/animals/`. See [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references) for more information.
+Note that in the case below "dogs" is the filename segment (because it has no trailing slash), and the relative URL "cats" is interpreted relative to the _directory_ part of the base URL, which is `http://www.example.com/animals/`. See [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references) for more information.
 
 ```js
 const url = new URL("cats", "http://www.example.com/animals/dogs");

--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -72,6 +72,8 @@ console.log(url.hostname); // "www.example.com"
 console.log(url.pathname); // "/animals/cats"
 ```
 
+See [Resolving relative references to a URL](/en-US/docs/Web/API/URL_API/Resolving_relative_references) for how the `url` parameter is interpreted relative to `base`.
+
 The constructor will raise an exception if the URL cannot be parsed to a valid URL.
 You can either call the above code in a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block or use the {{domxref("URL.canParse_static", "canParse()")}} static method to first check the URL is valid:
 


### PR DESCRIPTION
The examples for how relative URLs are constructed, while technically correct, give a misleading impression that `../` is needed to get from `/dogs` to `/cats`, which is not the case. This replaces those examples with clearer ones.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Replaces
```
new URL("../cats", "http://www.example.com/dogs");
```
with
```
new URL("cats", "http://www.example.com/animals/dogs");
```
and adjusts anything else that needs to change as a result. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The previous example might mislead readers into thinking that relative URLs are constructed by always treating the last path element as if it ends with a trailing slash.

