### PR TITLE
chore(community): updating french team list with current names

### DIFF
--- a/files/en-us/mdn/community/translated_content/index.md
+++ b/files/en-us/mdn/community/translated_content/index.md
@@ -32,7 +32,7 @@ If you need help or have any questions, feel free to get in touch with one of th
 ### French (`fr`)
 
 - Discussions: [Matrix (`#l10n-fr`)](https://chat.mozilla.org/#/room/#l10n-fr:mozilla.org)
-- Current maintainers: [cw118](https://github.com/cw118), [SphinxKnight](https://github.com/SphinxKnight), [tristantheb](https://github.com/tristantheb)
+- Current maintainers: [cw118](https://github.com/cw118), [tristantheb](https://github.com/tristantheb)
 
 ### Japanese (`ja`)
 


### PR DESCRIPTION
### Description

SphinxKnight is no longer part of the team; he removed himself from the roster in January 2026 for personal and professional reasons.

We would like to extend our heartfelt thanks to him for all his years of participation and contributions to the Mozilla and MDN communities.

### Motivation

For more information about his departure, see his message: https://github.com/mdn/translated-content/pull/32110

### Additional details

> [!NOTE]
> He was the French team lead, which means that the [#localization-team-leads](https://github.com/orgs/mdn/teams/localization-team-leads) team currently has no one left on the French side. So please, mention the FR team ([#fr-content](https://github.com/orgs/mdn/teams/fr-content)) instead. Thanks ♥

### Related issues and pull requests

Related to: https://github.com/mdn/translated-content/pull/32110
