### PR TITLE
Rectify rules for attribute inheritance from <g>

### DIFF
--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -19,8 +19,7 @@ Transformations applied to the `<g>` element are performed on its child elements
 This element only includes global attributes.
 
 Most of the [presentation attributes](/en-US/docs/Web/SVG/Reference/Attribute#presentation_attributes) applied to the element are inherited by its children.
-However, SVG-specific element rules supersede inheritance.
-Geometric attributes specific to certain elements are ignored on a `<g>` container and **not** inherited by its children.
+However, geometric attributes are only valid as presentation attributes on their designated elements — they have no effect on a `<g>` element and are not passed to its children.
 
 These non-inherited attributes include:
 
@@ -29,7 +28,7 @@ These non-inherited attributes include:
 - {{SVGAttr("d")}}: {{SVGElement("path")}}
 - {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}: {{SVGElement("foreignObject")}}, {{SVGElement("image")}}, {{SVGElement("rect")}}, {{SVGElement("svg")}}, {{SVGElement("symbol")}}, {{SVGElement("use")}}
 
-In addition, non-presentation attributes valid on `<g>` (such as {{SVGAttr("id")}} or {{SVGAttr("class")}}) are not inherited by its children.
+Non-presentation attributes, even those that are valid on `<g>` (such as {{SVGAttr("id")}} or {{SVGAttr("class")}}), are also not inherited.
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -8,7 +8,7 @@ sidebar: svgref
 
 The **`<g>`** [SVG](/en-US/docs/Web/SVG) element is a container used to group other SVG elements.
 
-Transformations applied to the `<g>` element are performed on its child elements, and its attributes are inherited by its children. It can also group multiple elements to be referenced later with the {{SVGElement("use")}} element.
+Transformations applied to the `<g>` element are performed on its child elements, and most of its attributes are inherited by its children. It can also group multiple elements to be referenced later with the {{SVGElement("use")}} element.
 
 ## Usage context
 
@@ -17,6 +17,15 @@ Transformations applied to the `<g>` element are performed on its child elements
 ## Attributes
 
 This element only includes global attributes.
+
+Most of the [presentation attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute#presentation_attributes) applied to the element are inherited by its children.
+However, it is important to note that SVG's rules for which element supports which attribute take precedence over this inheritance rule.
+This means that geometric attributes which are specific to one or several elements will be ignored on a <g> element and not inherited by its children. Such attributes include:
+- cx and cy, which are specific to <circle> and <ellipse>
+- height, width, x and y, which are specific to <foreignObject>, <image>, <rect>, <svg>, <symbol> and <use>
+- r, which is specific to <circle>
+- rx and ry, which are specific to <ellipse> and <rect>
+- d, which is specific to <path>
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -8,7 +8,7 @@ sidebar: svgref
 
 The **`<g>`** [SVG](/en-US/docs/Web/SVG) element is a container used to group other SVG elements.
 
-Transformations applied to the `<g>` element are performed on its child elements, and most of its attributes are inherited by its children. It can also group multiple elements to be referenced later with the {{SVGElement("use")}} element.
+Transformations applied to the `<g>` element are performed on its child elements, and most of its presentation attributes are inherited by its children. It can also group multiple elements to be referenced later with the {{SVGElement("use")}} element.
 
 ## Usage context
 
@@ -19,13 +19,15 @@ Transformations applied to the `<g>` element are performed on its child elements
 This element only includes global attributes.
 
 Most of the [presentation attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute#presentation_attributes) applied to the element are inherited by its children.
-However, it is important to note that SVG's rules for which element supports which attribute take precedence over this inheritance rule.
+However, it is important to note that this inheritance rule is superseded by SVG's rules for which element supports which attribute.
 This means that geometric attributes which are specific to one or several elements will be ignored on a <g> element and not inherited by its children. Such attributes include:
 - cx and cy, which are specific to <circle> and <ellipse>
 - height, width, x and y, which are specific to <foreignObject>, <image>, <rect>, <svg>, <symbol> and <use>
 - r, which is specific to <circle>
 - rx and ry, which are specific to <ellipse> and <rect>
 - d, which is specific to <path>
+
+Other attributes taken by <g>, such as id or class, are not inherited.
 
 ## DOM Interface
 

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -18,7 +18,7 @@ Transformations applied to the `<g>` element are performed on its child elements
 
 This element only includes global attributes.
 
-Most of the [presentation attributes](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute#presentation_attributes) applied to the element are inherited by its children.
+Most of the [presentation attributes](/en-US/docs/Web/SVG/Reference/Attribute#presentation_attributes) applied to the element are inherited by its children.
 However, it is important to note that this inheritance rule is superseded by SVG's rules for which element supports which attribute.
 This means that geometric attributes which are specific to one or several elements will be ignored on a <g> element and not inherited by its children. Such attributes include:
 - cx and cy, which are specific to <circle> and <ellipse>

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -23,10 +23,11 @@ However, SVG-specific element rules supersede inheritance.
 Geometric attributes specific to certain elements are ignored on a `<g>` container and **not** inherited by its children.
 
 These non-inherited attributes include:
-* {{SVGAttr("cx")}}, {{SVGAttr("cy")}}, {{SVGAttr("r")}}: {{SVGElement("circle")}}, {{SVGElement("ellipse")}}
-* {{SVGAttr("rx")}}, {{SVGAttr("ry")}}: {{SVGElement("ellipse")}}, {{SVGElement("rect")}}
-* {{SVGAttr("d")}}: {{SVGElement("path")}}
-* {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}: {{SVGElement("foreignObject")}}, {{SVGElement("image")}}, {{SVGElement("rect")}}, {{SVGElement("svg")}}, {{SVGElement("symbol")}}, {{SVGElement("use")}}
+
+- {{SVGAttr("cx")}}, {{SVGAttr("cy")}}, {{SVGAttr("r")}}: {{SVGElement("circle")}}, {{SVGElement("ellipse")}}
+- {{SVGAttr("rx")}}, {{SVGAttr("ry")}}: {{SVGElement("ellipse")}}, {{SVGElement("rect")}}
+- {{SVGAttr("d")}}: {{SVGElement("path")}}
+- {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}: {{SVGElement("foreignObject")}}, {{SVGElement("image")}}, {{SVGElement("rect")}}, {{SVGElement("svg")}}, {{SVGElement("symbol")}}, {{SVGElement("use")}}
 
 In addition, non-presentation attributes valid on `<g>` (such as {{SVGAttr("id")}} or {{SVGAttr("class")}}) are not inherited by its children.
 

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -19,15 +19,16 @@ Transformations applied to the `<g>` element are performed on its child elements
 This element only includes global attributes.
 
 Most of the [presentation attributes](/en-US/docs/Web/SVG/Reference/Attribute#presentation_attributes) applied to the element are inherited by its children.
-However, it is important to note that this inheritance rule is superseded by SVG's rules for which element supports which attribute.
-This means that geometric attributes which are specific to one or several elements will be ignored on a <g> element and not inherited by its children. Such attributes include:
-- cx and cy, which are specific to <circle> and <ellipse>
-- height, width, x and y, which are specific to <foreignObject>, <image>, <rect>, <svg>, <symbol> and <use>
-- r, which is specific to <circle>
-- rx and ry, which are specific to <ellipse> and <rect>
-- d, which is specific to <path>
+However, SVG-specific element rules supersede inheritance.
+Geometric attributes specific to certain elements are ignored on a `<g>` container and **not** inherited by its children.
 
-Other attributes taken by <g>, such as id or class, are not inherited.
+These non-inherited attributes include:
+* {{SVGAttr("cx")}}, {{SVGAttr("cy")}}, {{SVGAttr("r")}}: {{SVGElement("circle")}}, {{SVGElement("ellipse")}}
+* {{SVGAttr("rx")}}, {{SVGAttr("ry")}}: {{SVGElement("ellipse")}}, {{SVGElement("rect")}}
+* {{SVGAttr("d")}}: {{SVGElement("path")}}
+* {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}}: {{SVGElement("foreignObject")}}, {{SVGElement("image")}}, {{SVGElement("rect")}}, {{SVGElement("svg")}}, {{SVGElement("symbol")}}, {{SVGElement("use")}}
+
+In addition, non-presentation attributes valid on `<g>` (such as {{SVGAttr("id")}} or {{SVGAttr("class")}}) are not inherited by its children.
 
 ## DOM Interface
 


### PR DESCRIPTION
### Description

Rectifies that all attributes are not inherited : first, non-presentation attributes (such as id or class) are not inherited, second, some presentation attributes that are specific to some SVG elements will be ignored on \<g>.

### Motivation

I was blocked several times wondering why my g elements refused to work with some attributes and not others.

### Additional details

https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute

See also the linked issue.

### Related issues and pull requests

fixes #44288 
