### PR TITLE
fix: correct spelling typos found by automated weekly check

### DIFF
--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -308,6 +308,7 @@ iexact
 ifchanged
 ifequal
 ifnotequal
+ifrac
 imageset
 imghp
 imgur
@@ -778,6 +779,7 @@ tabbox
 tabbrowser
 tabs-closebutton
 tabular-nums
+tagidx
 takr
 talu
 taml
@@ -934,5 +936,3 @@ xpidl
 xpinstall
 xywh
 zoomlevelchange
-tagidx
-ifrac

--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -934,3 +934,5 @@ xpidl
 xpinstall
 xywh
 zoomlevelchange
+tagidx
+ifrac

--- a/.vscode/dictionaries/proper-names.txt
+++ b/.vscode/dictionaries/proper-names.txt
@@ -703,3 +703,5 @@ Zosia
 zxcvbn
 Émanuel
 Österreich
+Picos
+Hitman

--- a/.vscode/dictionaries/proper-names.txt
+++ b/.vscode/dictionaries/proper-names.txt
@@ -259,6 +259,7 @@ Hidde
 Highrise
 Hildy
 Hiroshi
+Hitman
 hmatrjp
 Hobday
 hochan
@@ -482,6 +483,7 @@ Pereira
 Perlin
 Petrov
 Phong
+Picos
 Picryl
 Pinterest
 Pissuti
@@ -703,5 +705,3 @@ Zosia
 zxcvbn
 Émanuel
 Österreich
-Picos
-Hitman

--- a/.vscode/dictionaries/terms-abbreviations.txt
+++ b/.vscode/dictionaries/terms-abbreviations.txt
@@ -157,6 +157,7 @@ datestamped
 DBFS
 DCDM
 DCSP
+debiased
 decodability
 Deinonychus
 demi
@@ -395,6 +396,7 @@ maplike
 MBASW
 Mbit
 Mbps
+mediacapabilities
 metalness
 metastring
 microcontrollers
@@ -659,6 +661,7 @@ side-scrollers
 sideload
 sideloaded
 SIDX
+signedness
 significand
 singlecast
 singlecasts
@@ -969,6 +972,3 @@ zoomable
 ZQSD
 ZWNBSP
 ZWSP
-mediacapabilities
-debiased
-signedness

--- a/.vscode/dictionaries/terms-abbreviations.txt
+++ b/.vscode/dictionaries/terms-abbreviations.txt
@@ -969,3 +969,6 @@ zoomable
 ZQSD
 ZWNBSP
 ZWSP
+mediacapabilities
+debiased
+signedness

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -63,7 +63,7 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
-- The `recieveTime` property is now included in the metadata returned from [`RTCEncodedVideoFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/getMetadata#receivetime) and [`RTCEncodedAudioFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/getMetadata#receivetime), and can be passed to the [`RTCEncodedVideoFrame()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/RTCEncodedVideoFrame) and [`RTCEncodedAudioFrame()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/RTCEncodedAudioFrame) constructors as a property in the `options` parameter.
+- The `receiveTime` property is now included in the metadata returned from [`RTCEncodedVideoFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/getMetadata#receivetime) and [`RTCEncodedAudioFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/getMetadata#receivetime), and can be passed to the [`RTCEncodedVideoFrame()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/RTCEncodedVideoFrame) and [`RTCEncodedAudioFrame()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/RTCEncodedAudioFrame) constructors as a property in the `options` parameter.
   ([Firefox bug 2033420](https://bugzil.la/2033420)).
 
 <!-- #### Removals -->

--- a/files/en-us/webassembly/reference/exception_handling/throw_ref/index.md
+++ b/files/en-us/webassembly/reference/exception_handling/throw_ref/index.md
@@ -109,7 +109,7 @@ throw_ref
 
 A `throw_ref` instruction can be used to rethrow a previously-thrown exception, as represented by an [`exnref`](/en-US/docs/WebAssembly/Reference/Value_types/exnref) value. Values of type `exnref` are pushed onto the stack by [`catch_ref`](/en-US/docs/WebAssembly/Reference/Exception_handling/try_table/catch_ref) and [`catch_all_ref`](/en-US/docs/WebAssembly/Reference/Exception_handling/try_table/catch_all_ref) clauses.
 
-Generally, rethrowing exceptions is useful because you might want to perform an action such as cleanup or logging but then still let users know that an error ocurred.
+Generally, rethrowing exceptions is useful because you might want to perform an action such as cleanup or logging but then still let users know that an error occurred.
 
 ## See also
 

--- a/files/en-us/webassembly/reference/exception_handling/try_table/catch_all_ref/index.md
+++ b/files/en-us/webassembly/reference/exception_handling/try_table/catch_all_ref/index.md
@@ -120,7 +120,7 @@ The `catch_all_ref` clause can be included inside a [`try_table`](/en-US/docs/We
 
 The exception can then be rethrown using a [`throw_ref`](/en-US/docs/WebAssembly/Reference/Exception_handling/throw_ref) instruction.
 
-`catch_all_ref` is useful when you want to report that some kind of exception has been thrown, but you also want to rethrow the exception. You might for example want to perform an action such as cleanup or logging but then still let users know that an error ocurred.
+`catch_all_ref` is useful when you want to report that some kind of exception has been thrown, but you also want to rethrow the exception. You might for example want to perform an action such as cleanup or logging but then still let users know that an error occurred.
 
 The referenced block must declare a result type that matches the pushed `exnref`. In the example shown earlier, the block branched to when the exception is caught specifies an `exnref` type in its `result`:
 

--- a/files/en-us/webassembly/reference/exception_handling/try_table/catch_ref/index.md
+++ b/files/en-us/webassembly/reference/exception_handling/try_table/catch_ref/index.md
@@ -135,7 +135,7 @@ The `catch_ref` clause can be included inside a [`try_table`](/en-US/docs/WebAss
 
 The exception can then be rethrown using a [`throw_ref`](/en-US/docs/WebAssembly/Reference/Exception_handling/throw_ref) instruction.
 
-`catch_ref` is useful when you want to report that a specific exception type has been thrown, but you also want to rethrow the exception. You might for example want to perform an action such as cleanup or logging but then still let users know that a specific error ocurred.
+`catch_ref` is useful when you want to report that a specific exception type has been thrown, but you also want to rethrow the exception. You might for example want to perform an action such as cleanup or logging but then still let users know that a specific error occurred.
 
 The referenced block must declare a result type that matches the exception's payload and the `exnref`. In the example shown earlier, the exception type is defined with a single `i32` parameter in its `tag` definition:
 

--- a/files/en-us/webassembly/reference/javascript_interface/exception/exception/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/exception/exception/index.md
@@ -44,7 +44,7 @@ The same tag that was used to create the `Exception` is required to access the a
 
 ### Basic usage
 
-You would not normally use this contructor to manually create a Wasm exception. Instead, a `WebAssembly.Exception` object is normally created when handling Wasm exceptions, for example:
+You would not normally use this constructor to manually create a Wasm exception. Instead, a `WebAssembly.Exception` object is normally created when handling Wasm exceptions, for example:
 
 ```js
 WebAssembly.instantiateStreaming(fetch("module.wasm"), { env }).then(


### PR DESCRIPTION
Closes #44310

## Summary

Fixes actual spelling errors detected by the automated weekly spelling check:

### Typos corrected
- **recieve → receive** in 
- **ocurred → occurred** in 3 WebAssembly exception handling docs
- **contructor → constructor** in 

### Valid words added to dictionaries
- , ,  → 
- ,  → 
- ,  → 