### PR TITLE
FF152 SVGTextPathElement.side

### DIFF
--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -10,7 +10,7 @@ browser-compat: api.SVGAnimatedEnumeration.animVal
 
 The **`animVal`** read-only property of the {{domxref("SVGAnimatedEnumeration")}} interface interface represents the value of an SVG enumeration.
 
-In SVG 2 this is an alias for {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
+In SVG 2 `animVal` reflects the non-animated value of the attribute: it is the same as {{domxref("SVGAnimatedEnumeration/baseVal", "baseVal")}} .
 
 ## Value
 

--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -8,13 +8,25 @@ browser-compat: api.SVGAnimatedEnumeration.animVal
 
 {{APIRef("SVG")}}
 
-The **`animVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the current value of an SVG enumeration. If there is no animation, it is the same value as the {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
+The **`animVal`** read-only property of the {{domxref("SVGAnimatedEnumeration")}} interface interface represents the value of an SVG enumeration.
+
+In SVG 2 this is an alias for {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}.
 
 ## Value
 
-An integer containing the current value of the enumeration
+An integer representing the value of the enumeration.
+
+The allowed values depend on the attribute that is reflected.
+This value cannot be written.
+
+## Exceptions
+
+- `NoModificationAllowedError` {{domxref("DOMException")}}
+  - : Thrown if the property is set to any value.
 
 ## Examples
+
+### Basic usage
 
 ```css hidden
 html,
@@ -44,6 +56,8 @@ svg {
 <pre id="log"></pre>
 ```
 
+This snippet gets the element, and logs the `animValue` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
+
 ```js
 const clipPath1 = document.getElementById("clip1");
 const log = document.getElementById("log");
@@ -52,7 +66,6 @@ function displayLog() {
   const animValue = clipPath1.clipPathUnits.animVal;
   const baseValue = clipPath1.clipPathUnits.baseVal;
   log.textContent = `The 'clipPathUnits.animVal' is ${animValue}.\n`;
-  log.textContent += `The 'clipPathUnits.baseVal' is ${baseValue}.`;
   requestAnimationFrame(displayLog);
 }
 

--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -17,7 +17,7 @@ In SVG 2 this is an alias for {{domxref("SVGAnimatedEnumeration.baseVal", "baseV
 An integer representing the value of the enumeration.
 
 The allowed values depend on the attribute that is reflected.
-This value cannot be written.
+This property cannot be written.
 
 ## Exceptions
 

--- a/files/en-us/web/api/svganimatedenumeration/animval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/animval/index.md
@@ -10,7 +10,7 @@ browser-compat: api.SVGAnimatedEnumeration.animVal
 
 The **`animVal`** read-only property of the {{domxref("SVGAnimatedEnumeration")}} interface interface represents the value of an SVG enumeration.
 
-In SVG 2 `animVal` reflects the non-animated value of the attribute: it is the same as {{domxref("SVGAnimatedEnumeration/baseVal", "baseVal")}} .
+In SVG 2, `animVal` reflects the non-animated value of the attribute: it is the same as {{domxref("SVGAnimatedEnumeration/baseVal", "baseVal")}} .
 
 ## Value
 
@@ -56,7 +56,7 @@ svg {
 <pre id="log"></pre>
 ```
 
-This snippet gets the element, and logs the `animValue` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
+The following JavaScript gets the element, and logs the `animValue` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
 
 ```js
 const clipPath1 = document.getElementById("clip1");

--- a/files/en-us/web/api/svganimatedenumeration/baseval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/baseval/index.md
@@ -26,7 +26,7 @@ The allowed values depend on the attribute that is reflected.
 
 ### Basic usage
 
-Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with an {{domxref("SVGAnimatedEnumeration")}} object.
+Consider this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with an {{domxref("SVGAnimatedEnumeration")}} object.
 
 ```html
 <svg viewBox="0 0 100 100" width="200" height="200">
@@ -39,7 +39,7 @@ Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAtt
 </svg>
 ```
 
-This snippet gets the element, and logs the `baseVal` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
+The following JavaScript gets the element, and logs the `baseVal` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
 
 ```js
 const clipPathElt = document.getElementById("clip1");

--- a/files/en-us/web/api/svganimatedenumeration/baseval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/baseval/index.md
@@ -12,7 +12,8 @@ The **`baseVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interfac
 
 ## Value
 
-An integer representing the value of the enumeration.
+An integer representing the base value of the enumeration.
+Ths is the non-animated content value of the corresponding attribute.
 
 The allowed values depend on the attribute that is reflected.
 

--- a/files/en-us/web/api/svganimatedenumeration/baseval/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/baseval/index.md
@@ -8,13 +8,22 @@ browser-compat: api.SVGAnimatedEnumeration.baseVal
 
 {{APIRef("SVG")}}
 
-The **`baseVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface contains the initial value of an SVG enumeration.
+The **`baseVal`** property of the {{domxref("SVGAnimatedEnumeration")}} interface represents the value of an SVG enumeration.
 
 ## Value
 
-An integer containing the initial value of the enumeration
+An integer representing the value of the enumeration.
+
+The allowed values depend on the attribute that is reflected.
+
+## Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the property is set to a constant that is not in the set of defined enumerations, or to `0`, which represents the "unknown attribute" value.
 
 ## Examples
+
+### Basic usage
 
 Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with an {{domxref("SVGAnimatedEnumeration")}} object.
 

--- a/files/en-us/web/api/svganimatedenumeration/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/index.md
@@ -9,18 +9,23 @@ browser-compat: api.SVGAnimatedEnumeration
 
 The **`SVGAnimatedEnumeration`** interface describes attribute values which are constants from a particular enumeration and which can be animated.
 
+From SVG 2, both `baseVal` and `animVal` reflect the non-animated value of the attribute.
+The allowed values of its properties depend on the associated attribute.
+
 ## Instance properties
 
 - {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}
   - : An integer that is the base value of the given attribute before applying any animations.
-- {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}}
-  - : If the given attribute or property is being animated, it contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, it contains the same value as `baseVal`.
+- {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}} {{ReadOnlyInline}}
+  - : This is the same as [baseVal](#baseval).
 
 ## Instance methods
 
-The `SVGAnimatedEnumeration` interface do not provide any specific methods.
+The `SVGAnimatedEnumeration` interface does not provide any specific methods.
 
 ## Examples
+
+## Basic usage
 
 Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with a `SVGAnimatedEnumeration` object.
 
@@ -35,7 +40,8 @@ Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAtt
 </svg>
 ```
 
-This snippet gets the element, and logs the `baseVal` and `animVal` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property. As no animation is happening, they have the same value.
+This snippet gets the element, and logs the `baseVal` and `animVal` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
+These values should be the same.
 
 ```js
 const clipPathElt = document.getElementById("clip1");

--- a/files/en-us/web/api/svganimatedenumeration/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/index.md
@@ -17,7 +17,7 @@ The allowed values of its properties depend on the associated attribute.
 - {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}
   - : An integer that is the base value of the given attribute before applying any animations.
 - {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}} {{ReadOnlyInline}}
-  - : This is the same as [baseVal](#baseval).
+  - : This is the same as [baseVal](#baseval) in SVG 2.
 
 ## Instance methods
 

--- a/files/en-us/web/api/svganimatedenumeration/index.md
+++ b/files/en-us/web/api/svganimatedenumeration/index.md
@@ -17,7 +17,7 @@ The allowed values of its properties depend on the associated attribute.
 - {{domxref("SVGAnimatedEnumeration.baseVal", "baseVal")}}
   - : An integer that is the base value of the given attribute before applying any animations.
 - {{domxref("SVGAnimatedEnumeration.animVal", "animVal")}} {{ReadOnlyInline}}
-  - : This is the same as [baseVal](#baseval) in SVG 2.
+  - : This is the same as [`baseVal`](#baseval) in SVG 2.
 
 ## Instance methods
 
@@ -27,7 +27,7 @@ The `SVGAnimatedEnumeration` interface does not provide any specific methods.
 
 ## Basic usage
 
-Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with a `SVGAnimatedEnumeration` object.
+Consider this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAttr("clipPathUnits")}} is associated with a `SVGAnimatedEnumeration` object.
 
 ```html
 <svg viewBox="0 0 100 100" width="200" height="200">
@@ -40,7 +40,7 @@ Considering this snippet with a {{SVGElement("clipPath")}} element: Its {{SVGAtt
 </svg>
 ```
 
-This snippet gets the element, and logs the `baseVal` and `animVal` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
+The following JavaScript gets the element, and logs the `baseVal` and `animVal` of the {{domxref("SVGClipPathElement.clipPathUnits")}} property.
 These values should be the same.
 
 ```js

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -19,12 +19,12 @@ _This interface also inherits properties from its parent interface, {{domxref("S
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.side")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("side")}} attribute of the given element.
-    Allowed values are defined by the [`TEXTPATH_SIDETYPE_*`](#textpath_sidetype_unknown) constants defined on this interface.
+    Allowed values are specified by the [`TEXTPATH_SIDETYPE_*`](#textpath_sidetype_unknown) constants defined on this interface.
 - {{domxref("SVGTextPathElement.startOffset")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the X component of the {{SVGAttr("startOffset")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.method")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("method")}} attribute of the given element.
-    Allowed values are defined by the [`TEXTPATH_METHODTYPE_*`](#textpath_methodtype_unknown) constants defined on this interface.
+    Allowed values are specified by the [`TEXTPATH_METHODTYPE_*`](#textpath_methodtype_unknown) constants defined on this interface.
 - {{domxref("SVGTextPathElement.spacing")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("spacing")}} attribute of the given element.
     Allowed values are defined by the [`TEXTPATH_SPACINGTYPE_*`](#textpath_spacingtype_unknown) constants defined on this interface.

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -17,6 +17,8 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
 - {{domxref("SVGTextPathElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
+- {{domxref("SVGTextPathElement.side")}} {{ReadOnlyInline}}
+  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("side")}} attribute of the given {{domxref("Element.textPath","textPath")}} element.
 - {{domxref("SVGTextPathElement.startOffset")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the X component of the {{SVGAttr("startOffset")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.method")}} {{ReadOnlyInline}}
@@ -42,6 +44,97 @@ _This interface does not provide any specific methods, but implements those of i
   - : Corresponds to the value `auto`.
 - `TEXTPATH_SPACINGTYPE_EXACT` (2)
   - : Corresponds to the value `exact`.
+- `TEXTPATH_SIDETYPE_UNKNOWN` (0)
+  - : The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+- `TEXTPATH_SIDETYPE_LEFT` (1)
+  - : Corresponds to the value `left`.
+- `TEXTPATH_SIDETYPE_RIGHT` (2)
+  - : Corresponds to the value `right`.
+
+## Examples
+
+### Basic usage
+
+THIS IS FROM /en-US/docs/Web/SVG/Reference/Attribute/path#path-data
+
+```css hidden
+html,
+body,
+svg {
+  height: 100%;
+}
+```
+
+```html
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- to hide the path, it is usually wrapped in a <defs> element -->
+  <!-- <defs> -->
+  <path
+    id="MyPath"
+    fill="none"
+    stroke="red"
+    d="M10,90 Q90,90 90,45 Q90,10 50,10 Q10,10 10,40 Q10,70 45,70 Q70,70 75,50" />
+  <!-- </defs> -->
+
+  <text>
+    <textPath href="#MyPath">Quick brown fox jumps over the lazy dog.</textPath>
+  </text>
+</svg>
+```
+
+```html
+<pre id="log"></pre>
+```
+
+```css
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+```js
+// 1. Select the textPath element
+const textPathElement = document.querySelector("textPath");
+log(
+  `side .baseVal/animVal: ${textPathElement.side.baseVal}/${textPathElement.side.animVal}`,
+);
+log(
+  `method .baseVal/animVal: ${textPathElement.method.baseVal}/${textPathElement.method.animVal}`,
+);
+log(
+  `spacing .baseVal/animVal: ${textPathElement.spacing.baseVal}/${textPathElement.spacing.animVal}`,
+);
+log(
+  `startOffset .baseVal/animVal: ${textPathElement.startOffset.baseVal}/${textPathElement.startOffset.animVal}`,
+);
+log(
+  `href .baseVal/animVal: ${textPathElement.href.baseVal}/${textPathElement.href.animVal}`,
+);
+/*
+// 2. Access properties specific to SVGTextPathElement
+const hrefValue = textPathElement.href.baseVal; // Gets the reference path (e.g., "#MyPath")
+const startOffset = textPathElement.startOffset.baseVal; // Gets the start offset value
+const method = textPathElement.method.baseVal; // Gets the alignment method (e.g., align or stretch)
+const spacing = textPathElement.spacing.baseVal; // Gets the spacing method (e.g., exact or auto)
+
+// 3. Log the values to see them in action
+console.log("Associated Path Href:", hrefValue); 
+console.log("Start Offset:", startOffset);
+*/
+```
+
+{{EmbedLiveSample('Basic usage', 200, 700)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -27,7 +27,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
     Allowed values are specified by the [`TEXTPATH_METHODTYPE_*`](#textpath_methodtype_unknown) constants defined on this interface.
 - {{domxref("SVGTextPathElement.spacing")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("spacing")}} attribute of the given element.
-    Allowed values are defined by the [`TEXTPATH_SPACINGTYPE_*`](#textpath_spacingtype_unknown) constants defined on this interface.
+    Allowed values are specified by the [`TEXTPATH_SPACINGTYPE_*`](#textpath_spacingtype_unknown) constants defined on this interface.
 
 ## Instance methods
 

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -18,13 +18,16 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 - {{domxref("SVGTextPathElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.side")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("side")}} attribute of the given {{domxref("Element.textPath","textPath")}} element.
+  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("side")}} attribute of the given element.
+    Possible values are defined by the `TEXTPATH_SIDETYPE_*` constants defined on this interface.
 - {{domxref("SVGTextPathElement.startOffset")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the X component of the {{SVGAttr("startOffset")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.method")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("method")}} attribute of the given element. It takes one of the `TEXTPATH_METHODTYPE_*` constants defined on this interface.
+  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("method")}} attribute of the given element.
+    Possible values are defined by the `TEXTPATH_METHODTYPE_*` constants defined on this interface.
 - {{domxref("SVGTextPathElement.spacing")}} {{ReadOnlyInline}}
-  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("spacing")}} attribute of the given element. It takes one of the `TEXTPATH_SPACINGTYPE_*` constants defined on this interface.
+  - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("spacing")}} attribute of the given element.
+    Possible values are defined by the `TEXTPATH_SPACINGTYPE_*` constants defined on this interface.
 
 ## Instance methods
 
@@ -55,13 +58,18 @@ _This interface does not provide any specific methods, but implements those of i
 
 ### Basic usage
 
-THIS IS FROM /en-US/docs/Web/SVG/Reference/Attribute/path#path-data
+This example shows how you can read the properties of an `SVGTextPathElement`.
+
+#### HTML
+
+First we define the SVG and associated CSS to draw a path with text drawn along it (this is a near-copy of the SVG in the [`path`](/en-US/docs/Web/SVG/Reference/Attribute/path#path-data) attribute topic).
 
 ```css hidden
 html,
 body,
 svg {
-  height: 100%;
+  height: 400px;
+  width: auto; /* Keeps the aspect ratio */
 }
 ```
 
@@ -74,7 +82,6 @@ svg {
     fill="none"
     stroke="red"
     d="M10,90 Q90,90 90,45 Q90,10 50,10 Q10,10 10,40 Q10,70 45,70 Q70,70 75,50" />
-  <!-- </defs> -->
 
   <text>
     <textPath href="#MyPath">Quick brown fox jumps over the lazy dog.</textPath>
@@ -82,11 +89,18 @@ svg {
 </svg>
 ```
 
+We also add a button for cycling through the possible values of the `side` attribute, allowing us to control which side of the path the text is drawn on.
+Note that there is also hidden logging code that is not relevant to the example.
+
 ```html
+<button id="cycleBtn">Cycle side [none]</button>
+```
+
+```html hidden
 <pre id="log"></pre>
 ```
 
-```css
+```css hidden
 #log {
   height: 100px;
   overflow: scroll;
@@ -95,7 +109,7 @@ svg {
 }
 ```
 
-```js
+```js hidden
 const logElement = document.querySelector("#log");
 function log(text) {
   logElement.innerText = `${logElement.innerText}${text}\n`;
@@ -103,38 +117,78 @@ function log(text) {
 }
 ```
 
-```js
-// 1. Select the textPath element
-const textPathElement = document.querySelector("textPath");
-log(
-  `side .baseVal/animVal: ${textPathElement.side.baseVal}/${textPathElement.side.animVal}`,
-);
-log(
-  `method .baseVal/animVal: ${textPathElement.method.baseVal}/${textPathElement.method.animVal}`,
-);
-log(
-  `spacing .baseVal/animVal: ${textPathElement.spacing.baseVal}/${textPathElement.spacing.animVal}`,
-);
-log(
-  `startOffset .baseVal/animVal: ${textPathElement.startOffset.baseVal}/${textPathElement.startOffset.animVal}`,
-);
-log(
-  `href .baseVal/animVal: ${textPathElement.href.baseVal}/${textPathElement.href.animVal}`,
-);
-/*
-// 2. Access properties specific to SVGTextPathElement
-const hrefValue = textPathElement.href.baseVal; // Gets the reference path (e.g., "#MyPath")
-const startOffset = textPathElement.startOffset.baseVal; // Gets the start offset value
-const method = textPathElement.method.baseVal; // Gets the alignment method (e.g., align or stretch)
-const spacing = textPathElement.spacing.baseVal; // Gets the spacing method (e.g., exact or auto)
+#### JavaScript
 
-// 3. Log the values to see them in action
-console.log("Associated Path Href:", hrefValue); 
-console.log("Start Offset:", startOffset);
-*/
+The code below cycles the `side` attribute on the `textPath` between `none` (by removing it), `"left"`, and `"right"`.
+If the state is `none` or `"left"` the text is drawn on the left of the path, and otherwise it is drawn on the right.
+The code also updates the button text with the current state, and logs the `baseVal` for each of the properties (the `animVal` will have the same value, as we are not animating the attribute).
+
+```js
+const textPath = document.querySelector("textPath");
+const button = document.getElementById("cycleBtn");
+
+// States indicating the side of the path
+const states = ["none", "left", "right"];
+
+button.addEventListener("click", () => {
+  // Get the current state from attribute: side
+  let currentSide;
+  if (!textPath.hasAttribute("side")) {
+    currentSide = "none";
+  } else {
+    currentSide = textPath.getAttribute("side");
+  }
+
+  // Advance to the next state
+  let currentIndex = states.indexOf(currentSide);
+  let nextIndex = (currentIndex + 1) % states.length;
+  let nextState = states[nextIndex];
+
+  // Apply the state changes to the SVG
+  if (nextState === "none") {
+    textPath.removeAttribute("side");
+  } else {
+    textPath.setAttribute("side", nextState);
+  }
+
+  // Update the button text to reflect the new state
+  button.textContent = `Cycle side [${nextState}]`;
+
+  // Log the SVG properties
+  console.log(textPath.method.baseVal);
+  logPathBaseVal(nextState);
+});
 ```
 
-{{EmbedLiveSample('Basic usage', 200, 700)}}
+The code to log the `baseVal` of each of the properties is shown below.
+For just the `side` property we show how you can compare the returned value to one of the constants.
+
+```js
+function logPathBaseVal(currentSide) {
+  // Select the textPath element
+  const textPathElement = document.querySelector("textPath");
+
+  // Log the baseVal for each property
+  log(`LOG: ${currentSide}`);
+  log(` href: ${textPathElement.href.baseVal}`);
+  log(` method: ${textPathElement.method.baseVal}`);
+  log(` spacing: ${textPathElement.spacing.baseVal}`);
+  log(` startOffset: ${textPathElement.startOffset.baseVal}`);
+  const side =
+    textPath.side.baseVal == SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT
+      ? "right"
+      : "left";
+  log(` side: ${side}`);
+}
+```
+
+#### Result
+
+Press the button to cycle through the states.
+On browsers that support the `side` attribute, the text will be drawn on the right of the path when the button displays `Cycle side [right]`.
+Note that by default (and on browsers that don't support attribute) the text is drawn on the left.
+
+{{EmbedLiveSample('Basic usage', 200, 600)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -19,15 +19,15 @@ _This interface also inherits properties from its parent interface, {{domxref("S
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.side")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("side")}} attribute of the given element.
-    Possible values are defined by the `TEXTPATH_SIDETYPE_*` constants defined on this interface.
+    Allowed values are defined by the [`TEXTPATH_SIDETYPE_*`](#textpath_sidetype_unknown) constants defined on this interface.
 - {{domxref("SVGTextPathElement.startOffset")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the X component of the {{SVGAttr("startOffset")}} attribute of the given element.
 - {{domxref("SVGTextPathElement.method")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("method")}} attribute of the given element.
-    Possible values are defined by the `TEXTPATH_METHODTYPE_*` constants defined on this interface.
+    Allowed values are defined by the [`TEXTPATH_METHODTYPE_*`](#textpath_methodtype_unknown) constants defined on this interface.
 - {{domxref("SVGTextPathElement.spacing")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedEnumeration")}} corresponding to the {{SVGAttr("spacing")}} attribute of the given element.
-    Possible values are defined by the `TEXTPATH_SPACINGTYPE_*` constants defined on this interface.
+    Allowed values are defined by the [`TEXTPATH_SPACINGTYPE_*`](#textpath_spacingtype_unknown) constants defined on this interface.
 
 ## Instance methods
 
@@ -58,7 +58,7 @@ _This interface does not provide any specific methods, but implements those of i
 
 ### Basic usage
 
-This example shows how you can read the properties of an `SVGTextPathElement`.
+This example shows how you can set and get the properties of an `SVGTextPathElement`.
 
 #### HTML
 
@@ -89,11 +89,11 @@ svg {
 </svg>
 ```
 
-We also add a button for cycling through the possible values of the `side` attribute, allowing us to control which side of the path the text is drawn on.
+We also add a button for toggling the `side` property in order to change what side of the path the text is drawn on.
 Note that there is also hidden logging code that is not relevant to the example.
 
 ```html
-<button id="cycleBtn">Cycle side [none]</button>
+<button id="toggleBtn">Toggle side</button>
 ```
 
 ```html hidden
@@ -102,7 +102,7 @@ Note that there is also hidden logging code that is not relevant to the example.
 
 ```css hidden
 #log {
-  height: 100px;
+  height: 120px;
   overflow: scroll;
   padding: 0.5rem;
   border: 1px solid black;
@@ -119,74 +119,76 @@ function log(text) {
 
 #### JavaScript
 
-The code below cycles the `side` attribute on the `textPath` between `none` (by removing it), `"left"`, and `"right"`.
-If the state is `none` or `"left"` the text is drawn on the left of the path, and otherwise it is drawn on the right.
-The code also updates the button text with the current state, and logs the `baseVal` for each of the properties (the `animVal` will have the same value, as we are not animating the attribute).
+The code below toggles the `side.baseVal` property on the `textPath`, causing the text to swap sides.
+
+First we define a function to log each of the properties of the the path element, and call it to log the initial state on load.
+The `side.baseVale` property is logged first, and demonstrates how the enumerated constants may be read and interpreted (this is done in a `try...catch` block, because `side` is not supported in all browsers).
+The other properties of the text path are also logged, but as raw values of their associated `baseVal` property.
 
 ```js
 const textPath = document.querySelector("textPath");
-const button = document.getElementById("cycleBtn");
 
-// States indicating the side of the path
-const states = ["none", "left", "right"];
+function logPathBaseVal() {
+  // Log the baseVal for each property
+  log("LOG:");
 
-button.addEventListener("click", () => {
-  // Get the current state from attribute: side
-  let currentSide;
-  if (!textPath.hasAttribute("side")) {
-    currentSide = "none";
-  } else {
-    currentSide = textPath.getAttribute("side");
+  try {
+    let side;
+
+    if (textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT) {
+      side = "right";
+    } else if (
+      textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_LEFT
+    ) {
+      side = "left";
+    } else if (
+      textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_UNKNOWN
+    ) {
+      side = "unknown";
+    } else {
+      side = "unexpected value";
+    }
+    log(` Current side: ${side}`);
+  } catch {
+    log(`side property is not supported in this browser`);
   }
 
-  // Advance to the next state
-  let currentIndex = states.indexOf(currentSide);
-  let nextIndex = (currentIndex + 1) % states.length;
-  let nextState = states[nextIndex];
+  log(` href: ${textPath.href.baseVal}`);
+  log(` method: ${textPath.method.baseVal}`);
+  log(` spacing: ${textPath.spacing.baseVal}`);
+  log(` startOffset: ${textPath.startOffset.baseVal}`);
+}
 
-  // Apply the state changes to the SVG
-  if (nextState === "none") {
-    textPath.removeAttribute("side");
-  } else {
-    textPath.setAttribute("side", nextState);
-  }
-
-  // Update the button text to reflect the new state
-  button.textContent = `Cycle side [${nextState}]`;
-
-  // Log the SVG properties
-  console.log(textPath.method.baseVal);
-  logPathBaseVal(nextState);
-});
+// Log the initial state on load
+logPathBaseVal();
 ```
 
-The code to log the `baseVal` of each of the properties is shown below.
-For just the `side` property we show how you can compare the returned value to one of the constants.
+The toggle button event handler code is shown below This reads the current value of the `side.baseVal` property, and toggles the value to match the other side.
+It then logs the current state.
 
 ```js
-function logPathBaseVal(currentSide) {
-  // Select the textPath element
-  const textPathElement = document.querySelector("textPath");
+// Toggle the side when the button is clicked
+toggleBtn.addEventListener("click", () => {
+  try {
+    if (textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT) {
+      // Change to left
+      textPath.side.baseVal = SVGTextPathElement.TEXTPATH_SIDETYPE_LEFT;
+    } else {
+      // Change to right
+      textPath.side.baseVal = SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT;
+    }
 
-  // Log the baseVal for each property
-  log(`LOG: ${currentSide}`);
-  log(` href: ${textPathElement.href.baseVal}`);
-  log(` method: ${textPathElement.method.baseVal}`);
-  log(` spacing: ${textPathElement.spacing.baseVal}`);
-  log(` startOffset: ${textPathElement.startOffset.baseVal}`);
-  const side =
-    textPath.side.baseVal == SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT
-      ? "right"
-      : "left";
-  log(` side: ${side}`);
-}
+    // Log the updated state
+    logPathBaseVal();
+  } catch (e) {
+    log("Setting the side property is not supported in this browser.");
+  }
+});
 ```
 
 #### Result
 
-Press the button to cycle through the states.
-On browsers that support the `side` attribute, the text will be drawn on the right of the path when the button displays `Cycle side [right]`.
-Note that by default (and on browsers that don't support attribute) the text is drawn on the left.
+Press the button to toggle the states.
 
 {{EmbedLiveSample('Basic usage', 200, 600)}}
 

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -48,7 +48,7 @@ _This interface does not provide any specific methods, but implements those of i
 - `TEXTPATH_SPACINGTYPE_EXACT` (2)
   - : Corresponds to the value `exact`.
 - `TEXTPATH_SIDETYPE_UNKNOWN` (0)
-  - : The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+  - : The type is not one of the predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
 - `TEXTPATH_SIDETYPE_LEFT` (1)
   - : Corresponds to the value `left`.
 - `TEXTPATH_SIDETYPE_RIGHT` (2)

--- a/files/en-us/web/api/svgtextpathelement/index.md
+++ b/files/en-us/web/api/svgtextpathelement/index.md
@@ -36,19 +36,22 @@ _This interface does not provide any specific methods, but implements those of i
 ## Static properties
 
 - `TEXTPATH_METHODTYPE_UNKNOWN` (0)
-  - : The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+  - : The type is not one of predefined types.
+    It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
 - `TEXTPATH_METHODTYPE_ALIGN` (1)
   - : Corresponds to the value `align`.
 - `TEXTPATH_METHODTYPE_STRETCH` (2)
   - : Corresponds to the value `stretch`.
 - `TEXTPATH_SPACINGTYPE_UNKNOWN` (0)
-  - : The type is not one of predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+  - : The type is not one of predefined types.
+    It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
 - `TEXTPATH_SPACINGTYPE_AUTO` (1)
   - : Corresponds to the value `auto`.
 - `TEXTPATH_SPACINGTYPE_EXACT` (2)
   - : Corresponds to the value `exact`.
 - `TEXTPATH_SIDETYPE_UNKNOWN` (0)
-  - : The type is not one of the predefined types. It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
+  - : The type is not one of the predefined types.
+    It is invalid to attempt to define a new value of this type or to attempt to switch an existing value to this type.
 - `TEXTPATH_SIDETYPE_LEFT` (1)
   - : Corresponds to the value `left`.
 - `TEXTPATH_SIDETYPE_RIGHT` (2)

--- a/files/en-us/web/api/svgtextpathelement/method/index.md
+++ b/files/en-us/web/api/svgtextpathelement/method/index.md
@@ -13,13 +13,13 @@ The **`method`** read-only property of the {{domxref("SVGTextPathElement")}} int
 Note that the `method.baseVal` property reflects the {{SVGAttr("method")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 While `method` is read-only, you can use `method.baseVal` to modify the value of the corresponding attribute.
 
-In SVG 2 `side.method` also reflects the non-animated value of the attribute.
+In SVG 2, `side.method` also reflects the non-animated value of the attribute.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
 
-These static properties indicate the values that can be returned from `method.baseVal` (and `method.animVal`):
+The following static properties indicate the values that can be returned from `method.baseVal` (and `method.animVal`):
 
 - [`SVGTextPathElement.TEXTPATH_METHODTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_unknown) (0)
   - : The type is not one of the predefined types.
@@ -28,7 +28,7 @@ These static properties indicate the values that can be returned from `method.ba
 - [`SVGTextPathElement.TEXTPATH_METHODTYPE_STRETCH`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_stretch) (2)
   - : Corresponds to the value [`stretch`](/en-US/docs/Web/SVG/Reference/Attribute/method#stretch).
 
-Note that `baseVal` cannot be set to `0` (`TEXTPATH_METHODTYPE_UNKNOWN`) or any other value than those listed above.
+Note that `baseVal` cannot be set to `0` (`TEXTPATH_METHODTYPE_UNKNOWN`) or any value other than those listed above.
 `animVal` is read-only and with throw if you attempt to write to it.
 
 ## Examples

--- a/files/en-us/web/api/svgtextpathelement/method/index.md
+++ b/files/en-us/web/api/svgtextpathelement/method/index.md
@@ -11,12 +11,15 @@ browser-compat: api.SVGTextPathElement.method
 The **`method`** read-only property of the {{domxref("SVGTextPathElement")}} interface represents the method by which text should be rendered along the path.
 
 Note that the `method.baseVal` property reflects the {{SVGAttr("method")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
+While `method` is read-only, you can use `method.baseVal` to modify the value of the corresponding attribute.
+
+Note that in SVG 2, `method.animVal` is an alias of `method.baseVal`.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
 
-The object's `baseVal` and `animVal` properties can get or set the following static property values:
+These static properties indicate the values that can be returned from `method.baseVal` (and `method.animVal`):
 
 - [`SVGTextPathElement.TEXTPATH_METHODTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_unknown) (0)
   - : The type is not one of the predefined types.
@@ -24,6 +27,9 @@ The object's `baseVal` and `animVal` properties can get or set the following sta
   - : Corresponds to the value [`align`](/en-US/docs/Web/SVG/Reference/Attribute/method#align).
 - [`SVGTextPathElement.TEXTPATH_METHODTYPE_STRETCH`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_stretch) (2)
   - : Corresponds to the value [`stretch`](/en-US/docs/Web/SVG/Reference/Attribute/method#stretch).
+
+Note that `baseVal` cannot be set to `0` (`TEXTPATH_METHODTYPE_UNKNOWN`) or any other value than those listed above.
+`animVal` is read-only and with throw if you attempt to write to it.
 
 ## Examples
 

--- a/files/en-us/web/api/svgtextpathelement/method/index.md
+++ b/files/en-us/web/api/svgtextpathelement/method/index.md
@@ -8,7 +8,8 @@ browser-compat: api.SVGTextPathElement.method
 
 {{APIRef("SVG")}}
 
-The **`method`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("method")}} attribute of the given {{SVGElement("textPath")}} element. It takes one of the [`TEXTPATH_METHODTYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) defined on this interface.
+The **`method`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("method")}} attribute of the given {{SVGElement("textPath")}} element.
+Possible values are defined by the [`TEXTPATH_METHODTYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) constants defined on this interface.
 
 ## Value
 

--- a/files/en-us/web/api/svgtextpathelement/method/index.md
+++ b/files/en-us/web/api/svgtextpathelement/method/index.md
@@ -13,7 +13,7 @@ The **`method`** read-only property of the {{domxref("SVGTextPathElement")}} int
 Note that the `method.baseVal` property reflects the {{SVGAttr("method")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 While `method` is read-only, you can use `method.baseVal` to modify the value of the corresponding attribute.
 
-Note that in SVG 2, `method.animVal` is an alias of `method.baseVal`.
+In SVG 2 `side.method` also reflects the non-animated value of the attribute.
 
 ## Value
 

--- a/files/en-us/web/api/svgtextpathelement/method/index.md
+++ b/files/en-us/web/api/svgtextpathelement/method/index.md
@@ -19,7 +19,7 @@ An {{domxref("SVGAnimatedEnumeration")}} object.
 The object's `baseVal` and `animVal` properties can get or set the following static property values:
 
 - [`SVGTextPathElement.TEXTPATH_METHODTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_unknown) (0)
-  - : The type is not one of predefined types.
+  - : The type is not one of the predefined types.
 - [`SVGTextPathElement.TEXTPATH_METHODTYPE_ALIGN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_align) (1)
   - : Corresponds to the value [`align`](/en-US/docs/Web/SVG/Reference/Attribute/method#align).
 - [`SVGTextPathElement.TEXTPATH_METHODTYPE_STRETCH`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_stretch) (2)

--- a/files/en-us/web/api/svgtextpathelement/method/index.md
+++ b/files/en-us/web/api/svgtextpathelement/method/index.md
@@ -8,12 +8,22 @@ browser-compat: api.SVGTextPathElement.method
 
 {{APIRef("SVG")}}
 
-The **`method`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("method")}} attribute of the given {{SVGElement("textPath")}} element.
-Possible values are defined by the [`TEXTPATH_METHODTYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) constants defined on this interface.
+The **`method`** read-only property of the {{domxref("SVGTextPathElement")}} interface represents the method by which text should be rendered along the path.
+
+Note that the `method.baseVal` property reflects the {{SVGAttr("method")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
+
+The object's `baseVal` and `animVal` properties can get or set the following static property values:
+
+- [`SVGTextPathElement.TEXTPATH_METHODTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_unknown) (0)
+  - : The type is not one of predefined types.
+- [`SVGTextPathElement.TEXTPATH_METHODTYPE_ALIGN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_align) (1)
+  - : Corresponds to the value [`align`](/en-US/docs/Web/SVG/Reference/Attribute/method#align).
+- [`SVGTextPathElement.TEXTPATH_METHODTYPE_STRETCH`](/en-US/docs/Web/API/SVGTextPathElement#textpath_methodtype_stretch) (2)
+  - : Corresponds to the value [`stretch`](/en-US/docs/Web/SVG/Reference/Attribute/method#stretch).
 
 ## Examples
 

--- a/files/en-us/web/api/svgtextpathelement/side/index.md
+++ b/files/en-us/web/api/svgtextpathelement/side/index.md
@@ -13,7 +13,7 @@ The **`side`** read-only property of the {{domxref("SVGTextPathElement")}} inter
 The `side.baseVal` property reflects the {{SVGAttr("side")}} content attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 While `side` is read-only, you can use `side.baseVal` to modify the value of the corresponding attribute.
 
-Note that in SVG 2, `side.animVal` is an alias of `side.baseVal`.
+In SVG 2 `side.animVal` also reflects the non-animated value of the attribute.
 
 ## Value
 

--- a/files/en-us/web/api/svgtextpathelement/side/index.md
+++ b/files/en-us/web/api/svgtextpathelement/side/index.md
@@ -1,0 +1,113 @@
+---
+title: "SVGTextPathElement: side property"
+short-title: side
+slug: Web/API/SVGTextPathElement/side
+page-type: web-api-instance-property
+browser-compat: api.SVGTextPathElement.side
+---
+
+{{APIRef("SVG")}}
+
+The **`side`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("side")}} attribute of the given {{SVGElement("textPath")}} element.
+Possible values are defined by the [`TEXTPATH_SIDETYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) constants defined on this interface.
+
+## Value
+
+An {{domxref("SVGAnimatedEnumeration")}} object.
+
+## Examples
+
+Also see the [Example](/en-US/docs/Web/API/SVGTextPathElement#basic_usage) in `SVGTextPathElement`, which allows you to toggle the `side` attribute.
+
+### Accessing the `side` property
+
+This example demonstrates how you can read the `side` property.
+
+#### HTML
+
+First we define HTML and CSS for an SVG path that draws text on the right on supporting browsers.
+
+```css hidden
+html,
+body,
+svg {
+  height: 400px;
+  width: auto; /* Keeps the aspect ratio */
+}
+```
+
+```html
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- to hide the path, it is usually wrapped in a <defs> element -->
+  <!-- <defs> -->
+  <path
+    id="MyPath"
+    fill="none"
+    stroke="red"
+    d="M10,90 Q90,90 90,45 Q90,10 50,10 Q10,10 10,40 Q10,70 45,70 " />
+
+  <text>
+    <textPath href="#MyPath" side="right">This text follows a path.</textPath>
+  </text>
+</svg>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 50px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+#### JavaScript
+
+The code below logs the `baseVal` of the `side` property and uses the `TEXTPATH_SIDETYPE_RIGHT` static property to indicate whether text is drawn on the left or right of the path.
+If the `side` property isn't defined the code will throw, and we assume that text is drawn to the left.
+
+```js
+const textPath = document.querySelector("textPath");
+
+// Log right or left based on value
+try {
+  const side =
+    textPath.side.baseVal == SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT
+      ? "right"
+      : "left";
+  log(`side: ${side}`);
+} catch {
+  log(`side: left`);
+}
+```
+
+#### Result
+
+Browsers that support the `side` attribute on paths will draw the text on the right hand side of the path below and log which side the text has been drawn on.
+
+{{EmbedLiveSample('Accessing the `side` property', 200, 500)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SVGTextPathElement.side")}}
+- [`SVGTextPathElement` method types](/en-US/docs/Web/API/SVGTextPathElement#static_properties)

--- a/files/en-us/web/api/svgtextpathelement/side/index.md
+++ b/files/en-us/web/api/svgtextpathelement/side/index.md
@@ -13,13 +13,13 @@ The **`side`** read-only property of the {{domxref("SVGTextPathElement")}} inter
 The `side.baseVal` property reflects the {{SVGAttr("side")}} content attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 While `side` is read-only, you can use `side.baseVal` to modify the value of the corresponding attribute.
 
-In SVG 2 `side.animVal` also reflects the non-animated value of the attribute.
+In SVG 2, `side.animVal` also reflects the non-animated value of the attribute.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
 
-These static properties indicate the values that can be returned from `side.baseVal` (and `side.animVal`):
+The following static properties indicate the values that can be returned from `side.baseVal` (and `side.animVal`):
 
 - [`SVGTextPathElement.TEXTPATH_SIDETYPE_LEFT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_unknown) (1)
   - : The text is rendered on the left side of the path (the default).
@@ -31,7 +31,7 @@ These static properties indicate the values that can be returned from `side.base
   - : The side type is unknown or invalid.
     This value cannot be set.
 
-Note that `baseVal` cannot be set to `0` (`TEXTPATH_SIDETYPE_UNKNOWN`) or any other value than those listed above.
+Note that `baseVal` cannot be set to `0` (`TEXTPATH_SIDETYPE_UNKNOWN`) or any value other than those listed above.
 `animVal` is read-only and with throw if you attempt to write to it.
 
 ## Examples

--- a/files/en-us/web/api/svgtextpathelement/side/index.md
+++ b/files/en-us/web/api/svgtextpathelement/side/index.md
@@ -10,28 +10,35 @@ browser-compat: api.SVGTextPathElement.side
 
 The **`side`** read-only property of the {{domxref("SVGTextPathElement")}} interface represents the side of the path that the text is placed on (relative to the path direction).
 
-Note that the `side.baseVal` property reflects the {{SVGAttr("side")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
+The `side.baseVal` property reflects the {{SVGAttr("side")}} content attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
+While `side` is read-only, you can use `side.baseVal` to modify the value of the corresponding attribute.
+
+Note that in SVG 2, `side.animVal` is an alias of `side.baseVal`.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
 
-The object's `baseVal` and `animVal` properties can get or set the following static property values:
+These static properties indicate the values that can be returned from `side.baseVal` (and `side.animVal`):
 
-- [`SVGTextPathElement.TEXTPATH_SIDETYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_left) (0)
-  - : The side type is unknown or invalid.
 - [`SVGTextPathElement.TEXTPATH_SIDETYPE_LEFT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_unknown) (1)
   - : The text is rendered on the left side of the path (the default).
     This corresponds to a value of `"left"` on the SVG `side` attribute.
 - [`SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_right) (2)
   - : The text is rendered on the right side of the path.
     This corresponds to a value of `"right"` on the SVG `side` attribute.
+- [`SVGTextPathElement.TEXTPATH_SIDETYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_left) (0)
+  - : The side type is unknown or invalid.
+    This value cannot be set.
+
+Note that `baseVal` cannot be set to `0` (`TEXTPATH_SIDETYPE_UNKNOWN`) or any other value than those listed above.
+`animVal` is read-only and with throw if you attempt to write to it.
 
 ## Examples
 
 Also see the [Example](/en-US/docs/Web/API/SVGTextPathElement#basic_usage) in `SVGTextPathElement`, which allows you to toggle the `side` attribute.
 
-### Basic usage
+### Accessing the `side` property
 
 This example demonstrates how you can set and get the `side` property, and in particular its `baseVal`.
 

--- a/files/en-us/web/api/svgtextpathelement/side/index.md
+++ b/files/en-us/web/api/svgtextpathelement/side/index.md
@@ -8,24 +8,36 @@ browser-compat: api.SVGTextPathElement.side
 
 {{APIRef("SVG")}}
 
-The **`side`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("side")}} attribute of the given {{SVGElement("textPath")}} element.
-Possible values are defined by the [`TEXTPATH_SIDETYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) constants defined on this interface.
+The **`side`** read-only property of the {{domxref("SVGTextPathElement")}} interface represents the side of the path that the text is placed on (relative to the path direction).
+
+Note that the `side.baseVal` property reflects the {{SVGAttr("side")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
 
+The object's `baseVal` and `animVal` properties can get or set the following static property values:
+
+- [`SVGTextPathElement.TEXTPATH_SIDETYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_left) (0)
+  - : The side type is unknown or invalid.
+- [`SVGTextPathElement.TEXTPATH_SIDETYPE_LEFT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_unknown) (1)
+  - : The text is rendered on the left side of the path (the default).
+    This corresponds to a value of `"left"` on the SVG `side` attribute.
+- [`SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_sidetype_right) (2)
+  - : The text is rendered on the right side of the path.
+    This corresponds to a value of `"right"` on the SVG `side` attribute.
+
 ## Examples
 
 Also see the [Example](/en-US/docs/Web/API/SVGTextPathElement#basic_usage) in `SVGTextPathElement`, which allows you to toggle the `side` attribute.
 
-### Accessing the `side` property
+### Basic usage
 
-This example demonstrates how you can read the `side` property.
+This example demonstrates how you can set and get the `side` property, and in particular its `baseVal`.
 
 #### HTML
 
-First we define HTML and CSS for an SVG path that draws text on the right on supporting browsers.
+First we define HTML and CSS for an SVG path that draws text on the right on supporting browsers using the SVG `side` attribute.
 
 ```css hidden
 html,
@@ -52,6 +64,13 @@ svg {
 </svg>
 ```
 
+We also add a button for toggling the value of the `side.baseVal` property.
+Note that there is also logging code, that is hidden as it is not relevant.
+
+```html
+<button id="toggle-side">Toggle Side</button>
+```
+
 ```html hidden
 <pre id="log"></pre>
 ```
@@ -75,27 +94,67 @@ function log(text) {
 
 #### JavaScript
 
-The code below logs the `baseVal` of the `side` property and uses the `TEXTPATH_SIDETYPE_RIGHT` static property to indicate whether text is drawn on the left or right of the path.
-If the `side` property isn't defined the code will throw, and we assume that text is drawn to the left.
+The code below first gets the `side.baseVal` property and compares it to the enumerated static property values to determine (and log) which side of the path the text is drawn on.
+If the `side` property isn't defined the code will throw, and we note that the `side` property isn't supported.
 
 ```js
 const textPath = document.querySelector("textPath");
+const button = document.querySelector("#toggle-side");
 
-// Log right or left based on value
-try {
-  const side =
-    textPath.side.baseVal == SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT
-      ? "right"
-      : "left";
-  log(`side: ${side}`);
-} catch {
-  log(`side: left`);
+// Helper function to read and log the current side
+function logCurrentSide() {
+  try {
+    let side;
+
+    if (textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT) {
+      side = "right";
+    } else if (
+      textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_LEFT
+    ) {
+      side = "left";
+    } else if (
+      textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_UNKNOWN
+    ) {
+      side = "unknown";
+    } else {
+      side = "unexpected value";
+    }
+    log(`Current side: ${side}`);
+  } catch {
+    log(`side property is not supported in this browser`);
+  }
 }
+
+// Log the initial state on load
+logCurrentSide();
+```
+
+The code below shows how you can set `side.baseVal` with the enumerated static values.
+The event handler first checks the current value of `side.baseVal` and then toggles the value to the static property that matches the other side.
+
+```js
+// Toggle the side when the button is clicked
+button.addEventListener("click", () => {
+  try {
+    if (textPath.side.baseVal === SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT) {
+      // Change to left
+      textPath.side.baseVal = SVGTextPathElement.TEXTPATH_SIDETYPE_LEFT;
+    } else {
+      // Change to right
+      textPath.side.baseVal = SVGTextPathElement.TEXTPATH_SIDETYPE_RIGHT;
+    }
+
+    // Log the updated state
+    logCurrentSide();
+  } catch (e) {
+    log("Setting the side property is not supported in this browser.");
+  }
+});
 ```
 
 #### Result
 
-Browsers that support the `side` attribute on paths will draw the text on the right hand side of the path below and log which side the text has been drawn on.
+Toggle the button to move the text from one side to the other.
 
 {{EmbedLiveSample('Accessing the `side` property', 200, 500)}}
 

--- a/files/en-us/web/api/svgtextpathelement/spacing/index.md
+++ b/files/en-us/web/api/svgtextpathelement/spacing/index.md
@@ -19,7 +19,7 @@ An {{domxref("SVGAnimatedEnumeration")}} object.
 The object's `baseVal` and `animVal` properties can get or set the following static property values:
 
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_unknown) (0)
-  - : The type is not one of predefined types.
+  - : The type is not one of the predefined types.
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_AUTO`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_auto) (1)
   - : Corresponds to the value [`auto`](/en-US/docs/Web/SVG/Reference/Attribute/spacing#auto).
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_EXACT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_exact) (2)

--- a/files/en-us/web/api/svgtextpathelement/spacing/index.md
+++ b/files/en-us/web/api/svgtextpathelement/spacing/index.md
@@ -8,12 +8,22 @@ browser-compat: api.SVGTextPathElement.spacing
 
 {{APIRef("SVG")}}
 
-The **`spacing`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("spacing")}} attribute of the given {{SVGElement("textPath")}} element.
-Possible values are defined by the [`TEXTPATH_SPACINGTYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) constants defined on this interface.
+The **`spacing`** read-only property of the {{domxref("SVGTextPathElement")}} interface represents the spacing between typographic characters that are to be rendered along a path.
+
+Note that the `spacing.baseVal` property reflects the {{SVGAttr("spacing")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
+
+The object's `baseVal` and `animVal` properties can get or set the following static property values:
+
+- [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_unknown) (0)
+  - : The type is not one of predefined types.
+- [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_AUTO`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_auto) (1)
+  - : Corresponds to the value [`auto`](/en-US/docs/Web/SVG/Reference/Attribute/spacing#auto).
+- [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_EXACT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_exact) (2)
+  - : Corresponds to the value [`exact`](/en-US/docs/Web/SVG/Reference/Attribute/spacing#exact).
 
 ## Examples
 

--- a/files/en-us/web/api/svgtextpathelement/spacing/index.md
+++ b/files/en-us/web/api/svgtextpathelement/spacing/index.md
@@ -8,7 +8,8 @@ browser-compat: api.SVGTextPathElement.spacing
 
 {{APIRef("SVG")}}
 
-The **`spacing`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("spacing")}} attribute of the given {{SVGElement("textPath")}} element. It takes one of the [`TEXTPATH_SPACINGTYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) defined on this interface.
+The **`spacing`** read-only property of the {{domxref("SVGTextPathElement")}} interface reflects the {{SVGAttr("spacing")}} attribute of the given {{SVGElement("textPath")}} element.
+Possible values are defined by the [`TEXTPATH_SPACINGTYPE_*` constants](/en-US/docs/Web/API/SVGTextPathElement#static_properties) constants defined on this interface.
 
 ## Value
 
@@ -49,4 +50,5 @@ console.log(textPath.spacing.baseVal); // Output: 1 (TEXTPATH_SPACINGTYPE_AUTO)
 ## See also
 
 - {{domxref("SVGTextPathElement.method")}}
+- {{domxref("SVGTextPathElement.side")}}
 - [`SVGTextPathElement` spacing types](/en-US/docs/Web/API/SVGTextPathElement#static_properties)

--- a/files/en-us/web/api/svgtextpathelement/spacing/index.md
+++ b/files/en-us/web/api/svgtextpathelement/spacing/index.md
@@ -13,7 +13,7 @@ The **`spacing`** read-only property of the {{domxref("SVGTextPathElement")}} in
 Note that the `spacing.baseVal` property reflects the {{SVGAttr("spacing")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 While `spacing` is read-only, you can use `spacing.baseVal` to modify the value of the corresponding attribute.
 
-Note that in SVG 2, `spacing.animVal` is an alias of `spacing.baseVal`.
+In SVG 2 `spacing.animVal` also reflects the non-animated value of the attribute.
 
 ## Value
 

--- a/files/en-us/web/api/svgtextpathelement/spacing/index.md
+++ b/files/en-us/web/api/svgtextpathelement/spacing/index.md
@@ -13,13 +13,13 @@ The **`spacing`** read-only property of the {{domxref("SVGTextPathElement")}} in
 Note that the `spacing.baseVal` property reflects the {{SVGAttr("spacing")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
 While `spacing` is read-only, you can use `spacing.baseVal` to modify the value of the corresponding attribute.
 
-In SVG 2 `spacing.animVal` also reflects the non-animated value of the attribute.
+In SVG 2, `spacing.animVal` also reflects the non-animated value of the attribute.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
 
-These static properties indicate the values that can be returned from `spacing.baseVal` (and `spacing.animVal`):
+The following static properties indicate the values that can be returned from `spacing.baseVal` (and `spacing.animVal`):
 
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_unknown) (0)
   - : The type is not one of the predefined types.
@@ -29,7 +29,7 @@ These static properties indicate the values that can be returned from `spacing.b
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_EXACT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_exact) (2)
   - : Corresponds to the value [`exact`](/en-US/docs/Web/SVG/Reference/Attribute/spacing#exact).
 
-Note that `baseVal` cannot be set to `0` (`TEXTPATH_SPACINGTYPE_UNKNOWN`) or any other value than those listed above.
+Note that `baseVal` cannot be set to `0` (`TEXTPATH_SPACINGTYPE_UNKNOWN`) or any value other than those listed above.
 `animVal` is read-only and with throw if you attempt to write to it.
 
 ## Examples

--- a/files/en-us/web/api/svgtextpathelement/spacing/index.md
+++ b/files/en-us/web/api/svgtextpathelement/spacing/index.md
@@ -11,19 +11,26 @@ browser-compat: api.SVGTextPathElement.spacing
 The **`spacing`** read-only property of the {{domxref("SVGTextPathElement")}} interface represents the spacing between typographic characters that are to be rendered along a path.
 
 Note that the `spacing.baseVal` property reflects the {{SVGAttr("spacing")}} attribute of the given {{SVGElement("textPath")}} element, as an enumerated value.
+While `spacing` is read-only, you can use `spacing.baseVal` to modify the value of the corresponding attribute.
+
+Note that in SVG 2, `spacing.animVal` is an alias of `spacing.baseVal`.
 
 ## Value
 
 An {{domxref("SVGAnimatedEnumeration")}} object.
 
-The object's `baseVal` and `animVal` properties can get or set the following static property values:
+These static properties indicate the values that can be returned from `spacing.baseVal` (and `spacing.animVal`):
 
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_UNKNOWN`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_unknown) (0)
   - : The type is not one of the predefined types.
+    This value cannot be set.
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_AUTO`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_auto) (1)
   - : Corresponds to the value [`auto`](/en-US/docs/Web/SVG/Reference/Attribute/spacing#auto).
 - [`SVGTextPathElement.TEXTPATH_SPACINGTYPE_EXACT`](/en-US/docs/Web/API/SVGTextPathElement#textpath_spacingtype_exact) (2)
   - : Corresponds to the value [`exact`](/en-US/docs/Web/SVG/Reference/Attribute/spacing#exact).
+
+Note that `baseVal` cannot be set to `0` (`TEXTPATH_SPACINGTYPE_UNKNOWN`) or any other value than those listed above.
+`animVal` is read-only and with throw if you attempt to write to it.
 
 ## Examples
 

--- a/files/en-us/web/svg/reference/attribute/method/index.md
+++ b/files/en-us/web/svg/reference/attribute/method/index.md
@@ -41,3 +41,7 @@ For {{SVGElement("textPath")}}, `method` indicates the method by which text shou
 ## Specifications
 
 {{Specifications}}
+
+## See also
+
+- {{domxref("SVGTextPathElement.method")}}

--- a/files/en-us/web/svg/reference/attribute/side/index.md
+++ b/files/en-us/web/svg/reference/attribute/side/index.md
@@ -67,7 +67,7 @@ text {
 
 #### Result
 
-Browsers that support setting the `side` attribute will display text to the left (outide) and to the right (inside) of the circular text path below.
+Browsers that support setting the `side` attribute will display text to the left (outside) and to the right (inside) of the circular text path below.
 
 {{EmbedLiveSample("Basic usage", "420", "220")}}
 

--- a/files/en-us/web/svg/reference/attribute/side/index.md
+++ b/files/en-us/web/svg/reference/attribute/side/index.md
@@ -18,6 +18,12 @@ You can use this attribute with the following SVG elements:
 
 ## Example
 
+### Basic usage
+
+The following example draws two circular text paths, displaying text on the left-hand side and the right-hand side, respectively.
+
+#### HTML
+
 ```css hidden
 html,
 body,
@@ -36,10 +42,10 @@ text {
 ```html
 <svg viewBox="0 0 420 200" xmlns="http://www.w3.org/2000/svg">
   <text>
-    <textPath href="#circle1" side="left">Text left from the path</textPath>
+    <textPath href="#circle1" side="left">Text on left of path</textPath>
   </text>
   <text>
-    <textPath href="#circle2" side="right">Text right from the path</textPath>
+    <textPath href="#circle2" side="right">Text on right of path</textPath>
   </text>
 
   <circle
@@ -59,7 +65,11 @@ text {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "420", "220")}}
+#### Result
+
+Browsers that support setting the `side` attribute will display text to the left (outide) and to the right (inside) of the circular text path below.
+
+{{EmbedLiveSample("Basic usage", "420", "220")}}
 
 ## Usage notes
 
@@ -92,3 +102,7 @@ text {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("SVGTextPathElement.side")}}

--- a/files/en-us/web/svg/reference/attribute/spacing/index.md
+++ b/files/en-us/web/svg/reference/attribute/spacing/index.md
@@ -43,3 +43,7 @@ You can use this attribute with the following SVG elements:
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("SVGTextPathElement.spacing")}}


### PR DESCRIPTION
FF152 adds support for the `SVGTextPathElement.side` property and associated static constant properties. This adds docs, including live examples in the `SVGTextPathElement` and the property page. 

Also tweaked the method and spacing property docs to match the same introductory format and more clearly indicate the supported static properties in each case.

Related docs work can be tracked in #44162