### PR TITLE
FF152 Relnote: SVGTextPathElement.side

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -32,7 +32,11 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### SVG -->
+### SVG
+
+- The {{domxref("SVGTextPathElement.side")}} read-only property is now supported, indicating whether text is drawn on the left or right hand side of a text path.
+  This reflects the corresponding [`path`](/en-US/docs/Web/SVG/Reference/Attribute/path) attribute on the [`<textPath>`](/en-US/docs/Web/SVG/Reference/Element/textPath) element.
+  ([Firefox bug 2034371](https://bugzil.la/2034371)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -34,8 +34,8 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### SVG
 
-- The {{domxref("SVGTextPathElement.side")}} read-only property is now supported, indicating whether text is drawn on the left or right hand side of a text path.
-  This reflects the corresponding [`path`](/en-US/docs/Web/SVG/Reference/Attribute/path) attribute on the [`<textPath>`](/en-US/docs/Web/SVG/Reference/Element/textPath) element.
+- The {{domxref("SVGTextPathElement.side")}} read-only property is now supported, indicating whether text is drawn on the left-hand side or right-hand side of a text path.
+  This reflects the corresponding [`side`](/en-US/docs/Web/SVG/Reference/Attribute/side) attribute on the [`<textPath>`](/en-US/docs/Web/SVG/Reference/Element/textPath) element.
   ([Firefox bug 2034371](https://bugzil.la/2034371)).
 
 <!-- #### Removals -->


### PR DESCRIPTION
FF152 supports the `SVGTextPathElement.side` property in https://bugzilla.mozilla.org/show_bug.cgi?id=2034371

This adds a release note.

Related docs work can be tracked in #44162