### PR TITLE
Clarify WebTransport datagram writable support

### DIFF
--- a/files/en-us/web/api/webtransport/datagrams/index.md
+++ b/files/en-us/web/api/webtransport/datagrams/index.md
@@ -20,13 +20,21 @@ A {{domxref("WebTransportDatagramDuplexStream")}} object.
 
 ### Writing an outgoing datagram
 
-The {{domxref("WebTransportDatagramDuplexStream.writable")}} property returns a {{domxref("WritableStream")}} object that you can write data to using a writer, for transmission to the server:
+This code uses the {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}} method, if it is supported, to get a {{domxref("WebTransportDatagramsWritable")}} instance that can be used for writing data to the transport.
+Otherwise, it falls back to the {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} property {{deprecated_inline}} {{non-standard_inline}}, which returns a {{domxref("WritableStream")}} object that you can write data to using a writer, for transmission to the server:
 
 ```js
-const writer = transport.datagrams.writable.getWriter();
+const writableStream =
+  typeof transport.datagrams.createWritable === "function"
+    ? transport.datagrams.createWritable()
+    : transport.datagrams.writable; // Deprecated and non-standard.
+
+const writer = writableStream.getWriter();
 const data1 = new Uint8Array([65, 66, 67]);
 const data2 = new Uint8Array([68, 69, 70]);
+await writer.ready;
 writer.write(data1);
+await writer.ready;
 writer.write(data2);
 ```
 

--- a/files/en-us/web/api/webtransportdatagramduplexstream/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/index.md
@@ -36,13 +36,21 @@ This is accessed via the {{domxref("WebTransport.datagrams")}} property.
 
 ### Writing outgoing datagrams
 
-The {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}} property returns a {{domxref("WritableStream")}} object that you can write data to using a writer, for transmission to the server:
+This code uses the {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}} method, if it is supported, to get a {{domxref("WebTransportDatagramsWritable")}} instance that can be used for writing data to the transport.
+Otherwise, it falls back to the {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} property {{deprecated_inline}} {{non-standard_inline}}, which returns a {{domxref("WritableStream")}} object that you can write data to using a writer instead:
 
 ```js
-const writer = transport.datagrams.writable.getWriter();
+const writableStream =
+  typeof transport.datagrams.createWritable === "function"
+    ? transport.datagrams.createWritable()
+    : transport.datagrams.writable; // Deprecated and non-standard.
+
+const writer = writableStream.getWriter();
 const data1 = new Uint8Array([65, 66, 67]);
 const data2 = new Uint8Array([68, 69, 70]);
+await writer.ready;
 writer.write(data1);
+await writer.ready;
 writer.write(data2);
 ```
 


### PR DESCRIPTION
### Description

Adds explicit deprecated/non-standard markers and compatibility notes beside the WebTransport datagram examples that use `WebTransportDatagramDuplexStream.writable`.

### Motivation

The `WebTransport.datagrams` page can show Baseline support for the `datagrams` property while the outgoing datagram example uses `writable`, which has separate compatibility data, is deprecated, is non-standard, and is not supported in Safari. The added notes make that distinction visible where readers encounter the example.

### Additional details

The same outgoing datagram example appears on the `WebTransportDatagramDuplexStream` overview, so this updates both pages consistently.

### Related issues and pull requests

Partially addresses #44273

### Tests

- Prettier 3.8.3 check on the two touched pages
- MarkdownLint CLI 0.22.1 with MDN config on the two touched pages
- `git diff --check -- files/en-us/web/api/webtransport/datagrams/index.md files/en-us/web/api/webtransportdatagramduplexstream/index.md`
