### PR TITLE
docs: document Firefox base-select support

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -304,6 +304,20 @@ The {{cssxref("attr")}} CSS function now supports [`<attr-type>`](/en-US/docs/We
 - `layout.css.attr.enabled`
   - : Set to `true` to enable.
 
+### Customizable select elements
+
+The {{cssxref("appearance")}} CSS property supports the `base-select` value for {{htmlelement("select")}} elements and their {{cssxref("::picker()", "::picker(select)")}} pickers. This allows select controls and their pickers to be styled as [customizable select elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select). ([Firefox bug 1974787](https://bugzil.la/1974787)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 149           | No                  |
+| Developer Edition | 149           | No                  |
+| Beta              | 149           | No                  |
+| Release           | 149           | No                  |
+
+- `layout.css.appearance-base-select.enabled`
+  - : Set to `true` to enable.
+
 ### Namespaced attributes in `attr()` CSS function
 
 The {{cssxref("attr")}} CSS function now accepts [namespaced attributes](/en-US/docs/Web/CSS/Reference/Values/attr#namespaces). This allows you to take attributes from elements of [XML](/en-US/docs/Web/XML)-based languages, such as [SVG](/en-US/docs/Web/SVG) and style them accordingly. ([Firefox bug 2014060](https://bugzil.la/2014060).

--- a/files/en-us/mozilla/firefox/releases/149/index.md
+++ b/files/en-us/mozilla/firefox/releases/149/index.md
@@ -126,6 +126,10 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
   The [`color-mix()`](/en-US/docs/Web/CSS/Reference/Values/color_value/color-mix) CSS function now supports multiple [`<color>`](/en-US/docs/Web/CSS/Reference/Values/color_value) values, rather than just two. This allows you to mix many colors and set the percentages of each. ([Firefox bug 2007772](https://bugzil.la/2007772)).
 
+- **Customizable select elements**: `layout.css.appearance-base-select.enabled`
+
+  The {{cssxref("appearance")}} CSS property now supports the `base-select` value for {{htmlelement("select")}} elements and their {{cssxref("::picker()", "::picker(select)")}} pickers. This enables styling select controls and their pickers as [customizable select elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select). ([Firefox bug 1974787](https://bugzil.la/1974787)).
+
 - **Media-based pseudo-classes**: `dom.media.pseudo-classes.enabled`
 
   The media-based pseudo-classes {{cssxref(":buffering")}}, {{cssxref(":muted")}}, {{cssxref(":paused")}}, {{cssxref(":playing")}}, {{cssxref(":seeking")}}, {{cssxref(":stalled")}}, and {{cssxref(":volume-locked")}} allow you to style {{htmlelement("audio")}} and {{htmlelement("video")}} elements based on their current state, such as playing or paused. ([Firefox bug 1707584](https://bugzil.la/1707584), [Firefox bug 2014512](https://bugzil.la/2014512)).


### PR DESCRIPTION
### Problem
mdn/content#44299 asks for Firefox documentation for `appearance: base-select`, which shipped in Firefox 149 behind `layout.css.appearance-base-select.enabled`.

### Root cause
The `appearance` reference already documents `base-select`, but the Firefox 149 release notes and the persistent Experimental features page did not mention the Firefox preference.

### Solution
- Add a Firefox 149 experimental-web-features entry for customizable select elements.
- Add a matching Experimental features table entry with the preference and channel availability.

### Tests run
- `npx --yes prettier@3.8.3 --config .prettierrc.json --check files/en-us/mozilla/firefox/releases/149/index.md files/en-us/mozilla/firefox/experimental_features/index.md`
- `npx --yes --package markdownlint-cli2@0.22.1 --package markdownlint-rule-search-replace markdownlint-cli2 --config .markdownlint-cli2.jsonc files/en-us/mozilla/firefox/releases/149/index.md files/en-us/mozilla/firefox/experimental_features/index.md`
- `git diff --check`

### Notes
A companion BCD update will be opened separately.