### PR TITLE
Remove confusing reference to UTF-8 in `<wbr>`

### DIFF
--- a/files/en-us/web/html/reference/elements/wbr/index.md
+++ b/files/en-us/web/html/reference/elements/wbr/index.md
@@ -35,7 +35,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 
 ## Notes
 
-On UTF-8 encoded pages, `<wbr>` behaves like the `U+200B ZERO-WIDTH SPACE` code point. In particular, it behaves like a Unicode bidi BN code point, meaning it has no effect on {{Glossary("bidi")}}-ordering: `<div dir=rtl>123,<wbr>456</div>` displays, when not broken on two lines, `123,456` and not `456,123`.
+`<wbr>` behaves like the `U+200B ZERO-WIDTH SPACE` code point. In particular, it behaves like a Unicode bidi BN code point, meaning it has no effect on {{Glossary("bidi")}}-ordering: `<div dir=rtl>123,<wbr>456</div>` displays, when not broken on two lines, `123,456` and not `456,123`.
 
 For the same reason, the `<wbr>` element does not introduce a hyphen at the line break point. To make a hyphen appear only at the end of a line, use the soft hyphen character entity (`&shy;`) instead.
 


### PR DESCRIPTION
### Description

Whether the page is in UTF-8 or not makes no difference.

For example, with UTF-16, all of the following continue to behave identically:

```html
<div dir="rtl">123,<wbr>456</div>
<div dir="rtl">123,&#x200B;456</div>
<div dir="rtl">123,{{literal U+200B}}456</div>
```

Additionally, even with non-Unicode encodings, the first two still behave identically (with the literal U+200B being impossible to represent in those encodings).

### Motivation

Remove confusing reference

### Additional details

N/A

### Related issues and pull requests

N/A