### PR TITLE
Document Firefox Crash Reporting API Nightly support

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -465,6 +465,22 @@ These give developers more flexibility when structuring and loading JavaScript m
 
 ## APIs
 
+### Crash Reporting API
+
+The [Crash Reporting API](/en-US/docs/Web/API/CrashReport) provides a way for sites to include diagnostic data in browser crash reports sent through the [Reporting API](/en-US/docs/Web/API/Reporting_API).
+It exposes the {{domxref("Window.crashReport")}} property and the {{domxref("CrashReportContext")}} interface, which store key-value data for the current top-level browsing context.
+([Firefox bug 2036160](https://bugzil.la/2036160)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 152           | Yes                 |
+| Developer Edition | 152           | No                  |
+| Beta              | 152           | No                  |
+| Release           | 152           | No                  |
+
+- `dom.reporting.crash.enabled`
+  - : Set to `true` to enable (enabled by default in Nightly).
+
 ### Scoped custom element registries
 
 Support for [scoped custom element registries](/en-US/docs/Web/API/Web_components/Using_custom_elements#scoped_custom_element_registries) is being implemented.

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -121,9 +121,15 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Experimental web features
 
-These features are shipping in Firefox 152 but are disabled by default.
+These features are shipping in Firefox 152 but are disabled by default unless otherwise noted.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+
+- **Crash Reporting API** (Nightly): `dom.reporting.crash.enabled`
+
+  The [Crash Reporting API](/en-US/docs/Web/API/CrashReport) is now supported.
+  This exposes {{domxref("Window.crashReport")}} and {{domxref("CrashReportContext")}}, allowing pages to store key-value diagnostic data that can be included in {{domxref("CrashReport")}} objects sent through the [Reporting API](/en-US/docs/Web/API/Reporting_API).
+  ([Firefox bug 2036160](https://bugzil.la/2036160)).
 
 - **Check if a media encoding/decoding configuration is supported for WebRTC**: `media.mediacapabilities.webrtc.enabled`
 

--- a/files/en-us/web/api/crashreport/index.md
+++ b/files/en-us/web/api/crashreport/index.md
@@ -2,7 +2,7 @@
 title: CrashReport
 slug: Web/API/CrashReport
 page-type: web-api-interface
-browser-compat: api.ReportingObserver.ReportingObserver.options_parameter.types_property.crash
+browser-compat: http.headers.Reporting-Endpoints.default.receives_crash_type
 ---
 
 {{APIRef("Reporting API")}}


### PR DESCRIPTION
## Problem

Firefox 152 enables the Crash Reporting API in Nightly builds, but the MDN pages did not yet mention the Firefox preview and the `CrashReport` page pointed at a non-existent BCD key.

## Root cause

The Gecko change enables `dom.reporting.crash.enabled` for Nightly builds. The `CrashReport` page should use the existing BCD key that represents delivery of `crash` reports through the `Reporting-Endpoints` default endpoint, while the new `CrashReportContext`/`Window.crashReport` support is tracked in a companion BCD update.

## Solution

- Add Firefox 152 release notes for the Crash Reporting API Nightly preview.
- Add an Experimental features entry for `dom.reporting.crash.enabled`.
- Point the `CrashReport` page at `http.headers.Reporting-Endpoints.default.receives_crash_type`.

## Tests

- `npx --yes prettier@3.8.3 --config C:\Users\kirti\Documents\PRs\mdn-content\.prettierrc.json --check C:\Users\kirti\Documents\PRs\mdn-content\files\en-us\web\api\crashreport\index.md C:\Users\kirti\Documents\PRs\mdn-content\files\en-us\mozilla\firefox\releases\152\index.md C:\Users\kirti\Documents\PRs\mdn-content\files\en-us\mozilla\firefox\experimental_features\index.md`
- `npx --yes --package markdownlint-cli2@0.22.1 --package markdownlint-rule-search-replace@1.2.0 markdownlint-cli2 --config C:\Users\kirti\Documents\PRs\mdn-content\.markdownlint-cli2.jsonc C:\Users\kirti\Documents\PRs\mdn-content\files\en-us\web\api\crashreport\index.md C:\Users\kirti\Documents\PRs\mdn-content\files\en-us\mozilla\firefox\releases\152\index.md C:\Users\kirti\Documents\PRs\mdn-content\files\en-us\mozilla\firefox\experimental_features\index.md`
- `git diff --check`

## Related

Related docs work #44297
Companion BCD update: mdn/browser-compat-data#29782
Firefox bug: https://bugzil.la/2036160