### PR TITLE
Document Firefox 152 WebAssembly JS-PI support

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -92,7 +92,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **WebAssembly JavaScript Promise Integration (JS-PI)**: `javascript.options.wasm_js_promise_integration`
 
-  WebAssembly JavaScript Promise Integration (JS-PI) allows WebAssembly modules to interoperate with asynchronous, {{jsxref("Promise")}}-based JavaScript APIs. This lets WebAssembly code suspend while waiting for a JavaScript promise and resume when the promise settles. WebAssembly JS-PI is now available in nightly builds.
+  WebAssembly [JavaScript Promise Integration (JS-PI)](https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md) allows WebAssembly modules to interoperate with asynchronous, {{jsxref("Promise")}}-based JavaScript APIs. This lets WebAssembly code suspend while waiting for a JavaScript promise and resume when the promise settles.
   ([Firefox bug 2015877](https://bugzil.la/2015877)).
 
 - **Check if a media encoding/decoding configuration is supported for WebRTC**: `media.mediacapabilities.webrtc.enabled`

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -90,6 +90,11 @@ These features are shipping in Firefox 152 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
 
+- **WebAssembly JavaScript Promise Integration (JS-PI)**: `javascript.options.wasm_js_promise_integration`
+
+  WebAssembly JavaScript Promise Integration (JS-PI) allows WebAssembly modules to interoperate with asynchronous, {{jsxref("Promise")}}-based JavaScript APIs. This lets WebAssembly code suspend while waiting for a JavaScript promise and resume when the promise settles. WebAssembly JS-PI is now available in nightly builds.
+  ([Firefox bug 2015877](https://bugzil.la/2015877)).
+
 - **Check if a media encoding/decoding configuration is supported for WebRTC**: `media.mediacapabilities.webrtc.enabled`
 
   The `webrtc` type can now be passed as an option for [`MediaCapabilities.decodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc) to check if an encoding/decoding configuration can be used for WebRTC.


### PR DESCRIPTION
### Description

Adds Firefox 152 Nightly documentation for WebAssembly JavaScript Promise Integration (JS-PI):

- a Firefox 152 release-note entry under WebAssembly
- an Experimental web features bullet with the preference name
- an Experimental features page entry with channel availability

### Motivation

This addresses mdn/content#44167. The paired BCD update is mdn/browser-compat-data#29783.

### Tests run

- `npx --yes prettier@3.8.3 --check files/en-us/mozilla/firefox/experimental_features/index.md files/en-us/mozilla/firefox/releases/152/index.md`
- `npx --yes --package markdownlint-cli2@0.22.1 --package markdownlint-rule-search-replace markdownlint-cli2 --config .markdownlint-cli2.jsonc files/en-us/mozilla/firefox/experimental_features/index.md files/en-us/mozilla/firefox/releases/152/index.md`
- `git diff --check`