### PR TITLE
Fix HTMLFormElement target example

### DIFF
--- a/files/en-us/web/api/htmlformelement/target/index.md
+++ b/files/en-us/web/api/htmlformelement/target/index.md
@@ -19,7 +19,7 @@ A string.
 ## Examples
 
 ```js
-myForm.target = window.frames[1].name;
+myForm.target = document.querySelector("iframe[name='preview']").name;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlformelement/target/index.md
+++ b/files/en-us/web/api/htmlformelement/target/index.md
@@ -19,8 +19,7 @@ A string.
 ## Examples
 
 ```js
-const previewFrame = document.querySelector("iframe");
-myForm.target = previewFrame.name;
+myForm.target = frames[1].name;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlformelement/target/index.md
+++ b/files/en-us/web/api/htmlformelement/target/index.md
@@ -19,7 +19,7 @@ A string.
 ## Examples
 
 ```js
-myForm.target = document.frames[1].name;
+myForm.target = window.frames[1].name;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlformelement/target/index.md
+++ b/files/en-us/web/api/htmlformelement/target/index.md
@@ -19,7 +19,8 @@ A string.
 ## Examples
 
 ```js
-myForm.target = document.querySelector("iframe[name='preview']").name;
+const previewFrame = document.querySelector("iframe");
+myForm.target = previewFrame.name;
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

Replace the invalid `document.frames` example on the `HTMLFormElement.target` page with `window.frames`.

### Motivation

`document.frames` is not a valid API on modern pages, and a maintainer confirmed in the issue that the example should use `frames` or `window.frames` instead. This keeps the example accurate without changing the rest of the page.

### Additional details

Validated the edited markdown with `prettier --check` and `git diff --check`.

### Related issues and pull requests

Fixes #44330