### PR TITLE
Clarify when start tags can be marked self-closing in SVG/MathML

### DIFF
--- a/files/en-us/glossary/void_element/index.md
+++ b/files/en-us/glossary/void_element/index.md
@@ -40,7 +40,7 @@ However, some code formatters add the trailing slash character to the start tags
 
 Self-closing tags are required in void elements in {{Glossary("XML")}}, {{Glossary("XHTML")}}, and {{Glossary("SVG")}} (e.g., `<circle cx="50" cy="50" r="50" />`).
 
-In SVG and MathML, elements that cannot have any child nodes are allowed to be marked as self-closing. In such cases, if an element's start tag is marked as self-closing, the element must not have an end tag.
+In SVG and MathML, an element without any child nodes is allowed to be marked as self-closing by adding a trailing slash to its start tag. In such cases, if an element's start tag is marked as self-closing, the element must not have an end tag.
 
 > [!NOTE]
 > If a trailing `/` (slash) character in a start tag is directly preceded by an unquoted attribute value — with no space between — the slash becomes a part of the attribute value rather than being discarded by the parser. For example, the markup `<img src=http://www.example.com/logo.svg/>` results in the `src` attribute having the value `http://www.example.com/logo.svg/` — which makes the URL wrong.

--- a/files/en-us/glossary/void_element/index.md
+++ b/files/en-us/glossary/void_element/index.md
@@ -40,7 +40,7 @@ However, some code formatters add the trailing slash character to the start tags
 
 Self-closing tags are required in void elements in {{Glossary("XML")}}, {{Glossary("XHTML")}}, and {{Glossary("SVG")}} (e.g., `<circle cx="50" cy="50" r="50" />`).
 
-In SVG and MathML, an element without any child nodes is allowed to be marked as self-closing by adding a trailing slash to its start tag. In such cases, if an element's start tag is marked as self-closing, the element must not have an end tag.
+In SVG and MathML, an element without any child nodes can be marked as self-closing by adding a trailing slash to its start tag. If an element's start tag is marked as self-closing, the element must not have an end tag.
 
 > [!NOTE]
 > If a trailing `/` (slash) character in a start tag is directly preceded by an unquoted attribute value — with no space between — the slash becomes a part of the attribute value rather than being discarded by the parser. For example, the markup `<img src=http://www.example.com/logo.svg/>` results in the `src` attribute having the value `http://www.example.com/logo.svg/` — which makes the URL wrong.


### PR DESCRIPTION
### Description

Clarify when start tags can be marked self-closing in SVG/MathML.

### Motivation

Start tags can be marked self-closing for _any_ element without any child nodes, not only elements that _cannot_ have any child nodes.

### Additional details

N/A

### Related issues and pull requests

N/A
