### PR TITLE
Remove double 'are'

### DIFF
--- a/files/en-us/web/html/reference/elements/slot/index.md
+++ b/files/en-us/web/html/reference/elements/slot/index.md
@@ -21,7 +21,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   - : The slot's name.
     A _named slot_ is a `<slot>` element with a `name` attribute, while an _unnamed slot_ has no `name` attribute, and the name defaults to the empty string.
 
-    When a shadow root uses [named slot assignment](/en-US/docs/Web/HTML/Reference/Elements/template#named), top-level child elements of its host are are rendered in slots that have a matching name in their [`slot` attribute](/en-US/docs/Web/API/Element/slot).
+    When a shadow root uses [named slot assignment](/en-US/docs/Web/HTML/Reference/Elements/template#named), top-level child elements of its host are rendered in slots that have a matching name in their [`slot` attribute](/en-US/docs/Web/API/Element/slot).
     Slot names should be unique per shadow root: if you have two slots with the same name, all of the elements with a matching `slot` attribute are rendered in the _first_ slot.
     All top-level child elements that don't have a `slot` attribute are rendered in the first unnamed `<slot>` element, which is referred to as the _default slot_.
     The `name` has no effect if the shadow root uses [manual slot assignment](/en-US/docs/Web/HTML/Reference/Elements/template#manual).


### PR DESCRIPTION
### Description

Found a typo. Double are.