### PR TITLE
CSS: style property page: Remove form elements from examples

### DIFF
--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -195,10 +195,8 @@ Note that only the element's longhand CSS properties are enumerated values (the 
 ```html
 <div id="box"></div>
 
-<form name="FormName">
-  <button id="btn1">Make border 20px-wide</button>
-  <button id="btn2">Make border 5px-wide</button>
-</form>
+<button id="btn1">Make border 20px-wide</button>
+<button id="btn2">Make border 5px-wide</button>
 ```
 
 ```css
@@ -230,9 +228,7 @@ In this example, some basic style properties of an HTML paragraph element are ac
 
 ```html
 <p id="pid">Some text</p>
-<form>
-  <p><button type="button">Change text</button></p>
-</form>
+<p><button type="button">Change text</button></p>
 ```
 
 ```js


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Remove `<form>` elements from around `<button>`s in example HTML code.

### Motivation

Having `<button>` elements with `id` attributes in an example's HTML code will break if they are inside a `<form>` element, because in addition to running the bound `click` event handler, clicking the button will also attempt to submit the form,

This then results in a "400 Bad Request" error response from the playground `runner.html` page, and the rendered demo promptly vanishes.


### Additional details

There's no need for the `<form>` elements anyway, as `<button>` elements with event handlers bound to respond to `click` events are functional on their own.

Note that only one of these examples was actually affected. (The second one didn't have an `id` attribute on the `<button>` element, so the form would not submit when clicked.) Nevertheless, I chose to remove the `<form>` from both examples, because it still amounts to superfluous and unnecessary noise. Examples should be minimal for clarity.

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
