### PR TITLE
Add-reference references to the script-on-click example

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
@@ -95,6 +95,8 @@ However, if you need certain content in the background page, you can specify one
 
 You cannot specify background scripts and a background page.
 
+To support background scripts on browsers that use service workers (such as Chrome) and those that use event pages, specify both `scripts` and `service_worker` in the `background` key. The [script-on-click](https://github.com/mdn/webextensions-examples/tree/main/script-on-click) example demonstrates this cross-browser pattern.
+
 ### Initialize the extension
 
 Listen to {{WebExtAPIRef("runtime.onInstalled")}} to initialize an extension on installation. Use this event to set a state or for one-time initialization.

--- a/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/build_a_cross_browser_extension/index.md
@@ -124,7 +124,7 @@ There are also differences between the [Content Security Policy (CSP) for conten
 
 As part of its implementation of Manifest V3, Chrome replaced background pages with extension service workers. Firefox retains the use of background pages, while Safari supports background pages and service workers.
 
-For more information, see the [browser support](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support) section on the `"background"` manifest key page. This includes an example of how to implement a cross-browser script.
+For more information, see the [browser support](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support) section on the `"background"` manifest key page. This section includes an example of how to implement a cross-browser script. The [script-on-click](https://github.com/mdn/webextensions-examples/tree/main/script-on-click) example provides a complete working demonstration of this approach.
 
 ### Manifest keys
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -223,6 +223,8 @@ With this `background` configuration, this happens:
 - in Firefox, the `scripts` property is used, and an event page starts because Firefox only supports scripts for background scripts.
 - in Safari, the `scripts` property is used by default, and an event page starts.
 
+The [script-on-click](https://github.com/mdn/webextensions-examples/tree/main/script-on-click) example also provides a demonstration of this pattern.
+
 ## Examples
 
 ```json

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -159,7 +159,7 @@ The extra privileges are:
 
 The intent of this permission is to enable extensions to fulfill a common use case without granting them overly powerful permissions. Many extensions want to "do something to the current page when the user asks".
 
-For example, consider an extension that wants to run a script in the current page when the user clicks a browser action. If the `activeTab` permission did not exist, the extension would need to ask for the host permission `<all_urls>`. But this gives the extension more power than it needs: it can now execute scripts in _any tab_, _any time_ it likes, instead of just the active tab and only in response to a user action.
+For example, take an extension that wants to run a script in the current page when the user clicks a browser action. If the `activeTab` permission wasn't available, the extension would need the host permission `<all_urls>`. But this permission gives the extension more power than it needs: it can now execute scripts in any tab at any time, instead of only in the active tab in response to a user action. The [script-on-click](https://github.com/mdn/webextensions-examples/tree/main/script-on-click) example demonstrates this in action.
 
 > [!NOTE]
 > Your extension can only access the tab or data that existed when the user interaction occurred (e.g., a click). When the active tab navigates away (e.g., due to page load finishing or another event), the extension no longer has permission to access the tab.


### PR DESCRIPTION
### Description

This change adds links to the new script-on-click example in various places where background scripts and activeTab permission are documented.

### Related issues and pull requests

The example is being made available in https://github.com/mdn/webextensions-examples/pull/636

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
