### PR TITLE
Note that Attr.isConnected is always false

### DIFF
--- a/files/en-us/web/api/node/isconnected/index.md
+++ b/files/en-us/web/api/node/isconnected/index.md
@@ -17,6 +17,12 @@ returns a boolean indicating whether the node is connected
 A boolean value that is `true` if the node is connected to its relevant context object,
 and `false` if not.
 
+> [!NOTE]
+> An {{domxref("Attr")}} node always returns `false` for `isConnected`, even when its
+> {{domxref("Attr.ownerElement", "ownerElement")}} is connected. An attribute is not a
+> child of its owner element, so an `Attr` node has no parent node and its root is
+> itself rather than a document — meaning it is never considered connected.
+
 ## Examples
 
 ### Standard DOM

--- a/files/en-us/web/api/node/isconnected/index.md
+++ b/files/en-us/web/api/node/isconnected/index.md
@@ -8,22 +8,16 @@ browser-compat: api.Node.isConnected
 
 {{APIRef("DOM")}}
 
-The read-only **`isConnected`** property of the {{domxref("Node")}} interface
-returns a boolean indicating whether the node is connected
-(directly or indirectly) to a {{domxref("Document")}} object.
+The read-only **`isConnected`** property of the {{domxref("Node")}} interface returns a boolean indicating whether the node is connected (directly or indirectly) to a {{domxref("Document")}} object.
 
 ## Value
 
-A boolean value that is `true` if the node is connected to its relevant context object,
-and `false` if not.
+A boolean value that is `true` if the node is connected to its relevant context object, and `false` if not.
 
 > [!NOTE]
-> An {{domxref("Attr")}} node always returns `false` for `isConnected`, even when its
-> {{domxref("Attr.ownerElement", "ownerElement")}} is connected.
-> This is because, even though an attribute is associated with an element via `ownerElement`,
-> it is not part of the node tree — it has no parent node, and it is its own root node.
-> Since `isConnected` is only true when a node's root is a document, an `Attr` node is never
-> considered connected.
+> An {{domxref("Attr")}} node always returns `false` for `isConnected`, even when its {{domxref("Attr.ownerElement", "ownerElement")}} is connected.
+> This is because, even though an attribute is associated with an element via `ownerElement`, it is not part of the node tree — it has no parent node, and it is its own root node.
+> Since `isConnected` is only true when a node's root is a document, an `Attr` node is never considered connected.
 
 ## Examples
 

--- a/files/en-us/web/api/node/isconnected/index.md
+++ b/files/en-us/web/api/node/isconnected/index.md
@@ -19,9 +19,11 @@ and `false` if not.
 
 > [!NOTE]
 > An {{domxref("Attr")}} node always returns `false` for `isConnected`, even when its
-> {{domxref("Attr.ownerElement", "ownerElement")}} is connected. An attribute is not a
-> child of its owner element, so an `Attr` node has no parent node and its root is
-> itself rather than a document — meaning it is never considered connected.
+> {{domxref("Attr.ownerElement", "ownerElement")}} is connected.
+> This is because, even though an attribute is associated with an element via `ownerElement`,
+> it is not part of the node tree — it has no parent node, and it is its own root node.
+> Since `isConnected` is only true when a node's root is a document, an `Attr` node is never
+> considered connected.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #42933.

`isConnected` always returns `false` on an {{domxref("Attr")}} node, even when the attribute's `ownerElement` is connected to the document. This trips people up, so this adds a note explaining why.

As @caugner noted on the issue, this is consistent across Chrome, Firefox, and Safari, and is out of scope for BCD — the spec defines `isConnected` for all nodes, and since an attribute node has no parent, it has no root that is a document, so it is never "connected".

I confirmed the behavior in Chrome:

```js
const el = document.createElement("div");
el.setAttribute("data-x", "1");
const attr = el.getAttributeNode("data-x");
document.body.appendChild(el);

el.isConnected;                 // true
attr.ownerElement.isConnected;  // true
attr.isConnected;               // false
attr.parentNode;                // null
attr.getRootNode() === attr;    // true (its root is itself, not the document)
```