### PR TITLE
Clarify that deleteDatabase() blocks until open connections close

### DIFF
--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -34,9 +34,9 @@ To let it complete, close each connection. This is typically done by calling
 
 ```js
 // db is an open connection (e.g. from a previous indexedDB.open() success)
-db.onversionchange = () => {
+db.addEventListener("versionchange", () => {
   db.close();
-};
+});
 ```
 
 ## Syntax

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -19,18 +19,25 @@ the request object returned from this method, with its `result` set to
 `error` event is fired on the request object that is returned from this
 method.
 
-The deletion does not complete while other connections to the database are still open.
 When `deleteDatabase()` is called, any other open connections to this particular database
 are sent a [`versionchange`](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event,
 giving them the opportunity to close so that the deletion can proceed.
 
-> [!NOTE]
-> If a connection is not closed in response to the `versionchange` event, the deletion is
-> blocked: the request's `success` event does not fire, and a
-> [`blocked`](/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) event is fired on the
-> request instead. The deletion stays pending until every connection to the database is
-> closed. To let it complete, close each connection — for example by calling
-> {{domxref("IDBDatabase.close()")}}, typically from a `versionchange` event handler.
+If a connection is not closed in response to the `versionchange` event, the deletion is
+blocked: the request's `success` event does not fire, and a
+[`blocked`](/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) event is fired on the
+request instead. The deletion stays pending until every connection to the database is
+closed.
+
+To let it complete, close each connection. This is typically done by calling
+{{domxref("IDBDatabase.close()")}} from inside the `versionchange` event handler:
+
+```js
+// db is an open connection (e.g. from a previous indexedDB.open() success)
+db.onversionchange = () => {
+  db.close();
+};
+```
 
 ## Syntax
 

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -19,8 +19,18 @@ the request object returned from this method, with its `result` set to
 `error` event is fired on the request object that is returned from this
 method.
 
-When `deleteDatabase()` is called, any other open connections to this
-particular database will get a [versionchange](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event.
+The deletion does not complete while other connections to the database are still open.
+When `deleteDatabase()` is called, any other open connections to this particular database
+are sent a [`versionchange`](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event,
+giving them the opportunity to close so that the deletion can proceed.
+
+> [!NOTE]
+> If a connection is not closed in response to the `versionchange` event, the deletion is
+> blocked: the request's `success` event does not fire, and a
+> [`blocked`](/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) event is fired on the
+> request instead. The deletion stays pending until every connection to the database is
+> closed. To let it complete, close each connection — for example by calling
+> {{domxref("IDBDatabase.close()")}}, typically from a `versionchange` event handler.
 
 ## Syntax
 

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -42,9 +42,9 @@ If the operation is successful, the value of the request's {{domxref("IDBRequest
 
 ## Description
 
-If the database is successfully deleted, then a `success` event is fired on the request object returned from this method, with its `result` set to `undefined`. If an error occurs while the database is being deleted, then an `error` event is fired on the request object that is returned from this method.
+If the database is successfully deleted, then a `success` event is fired on the request object returned from `deleteDatabase()`, with its `result` set to `undefined`. If an error occurs during deletion, an `error` event is fired on the request object returned from this method.
 
-When `deleteDatabase()` is called, any other open connections to this particular database are sent a [`versionchange`](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event, giving them the opportunity to close so that the deletion can proceed.
+When `deleteDatabase()` is called, any other open connections to this particular database are sent a [`versionchange`](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event, allowing them to close so that the deletion can proceed.
 
 If a connection is not closed in response to the `versionchange` event, the deletion is blocked: the request's `success` event does not fire, and a [`blocked`](/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) event is fired on the request instead. The deletion stays pending until every connection to the database is closed.
 
@@ -58,6 +58,8 @@ db.addEventListener("versionchange", () => {
 ```
 
 ## Examples
+
+### Basic usage
 
 ```js
 const dbDeleteRequest = indexedDB.deleteDatabase("toDoList");

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -8,36 +8,7 @@ browser-compat: api.IDBFactory.deleteDatabase
 
 {{APIRef("IndexedDB")}} {{AvailableInWorkers}}
 
-The **`deleteDatabase()`** method of the
-{{DOMxRef("IDBFactory")}} interface requests the deletion of a database. The method
-returns an {{DOMxRef("IDBOpenDBRequest")}} object immediately, and performs the deletion
-operation asynchronously.
-
-If the database is successfully deleted, then a `success` event is fired on
-the request object returned from this method, with its `result` set to
-`undefined`. If an error occurs while the database is being deleted, then an
-`error` event is fired on the request object that is returned from this
-method.
-
-When `deleteDatabase()` is called, any other open connections to this particular database
-are sent a [`versionchange`](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event,
-giving them the opportunity to close so that the deletion can proceed.
-
-If a connection is not closed in response to the `versionchange` event, the deletion is
-blocked: the request's `success` event does not fire, and a
-[`blocked`](/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) event is fired on the
-request instead. The deletion stays pending until every connection to the database is
-closed.
-
-To let it complete, close each connection. This is typically done by calling
-{{domxref("IDBDatabase.close()")}} from inside the `versionchange` event handler:
-
-```js
-// db is an open connection (e.g. from a previous indexedDB.open() success)
-db.addEventListener("versionchange", () => {
-  db.close();
-});
-```
+The **`deleteDatabase()`** method of the {{DOMxRef("IDBFactory")}} interface requests the deletion of a database. The method returns an {{DOMxRef("IDBOpenDBRequest")}} object immediately, and performs the deletion operation asynchronously.
 
 ## Syntax
 
@@ -69,16 +40,33 @@ An {{DOMxRef("IDBOpenDBRequest")}} on which subsequent events related to this re
 
 If the operation is successful, the value of the request's {{domxref("IDBRequest.result", "result")}} property is `null`.
 
+## Description
+
+If the database is successfully deleted, then a `success` event is fired on the request object returned from this method, with its `result` set to `undefined`. If an error occurs while the database is being deleted, then an `error` event is fired on the request object that is returned from this method.
+
+When `deleteDatabase()` is called, any other open connections to this particular database are sent a [`versionchange`](/en-US/docs/Web/API/IDBDatabase/versionchange_event) event, giving them the opportunity to close so that the deletion can proceed.
+
+If a connection is not closed in response to the `versionchange` event, the deletion is blocked: the request's `success` event does not fire, and a [`blocked`](/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event) event is fired on the request instead. The deletion stays pending until every connection to the database is closed.
+
+To let it complete, close each connection. This is typically done by calling {{domxref("IDBDatabase.close()")}} from inside the `versionchange` event handler:
+
+```js
+// db is an open connection (e.g. from a previous indexedDB.open() success)
+db.addEventListener("versionchange", () => {
+  db.close();
+});
+```
+
 ## Examples
 
 ```js
-const DBDeleteRequest = window.indexedDB.deleteDatabase("toDoList");
+const dbDeleteRequest = indexedDB.deleteDatabase("toDoList");
 
-DBDeleteRequest.onerror = (event) => {
+dbDeleteRequest.onerror = (event) => {
   console.error("Error deleting database.");
 };
 
-DBDeleteRequest.onsuccess = (event) => {
+dbDeleteRequest.onsuccess = (event) => {
   console.log("Database deleted successfully");
 
   console.log(event.result); // should be undefined


### PR DESCRIPTION
Fixes #20368.

The page mentions that open connections receive a `versionchange` event, but doesn't explain the consequence: the deletion will not complete (and `success` will not fire) while any connection to the database is still open. This is a common source of confusion — people wait for `onsuccess` that never comes because a connection is left open.

This expands the existing sentence to spell out that:

- the deletion stays pending until every connection closes;
- a `blocked` event is fired on the request if a connection doesn't close in response to `versionchange`;
- closing connections (e.g. via `IDBDatabase.close()`) lets the deletion proceed.

This matches the [spec's database-deletion steps](https://www.w3.org/TR/IndexedDB/#delete-a-database) and the behavior @evanstade quoted on the issue.