### PR TITLE
Note alternatives to Emscripten in C to Wasm guide

### DIFF
--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -7,6 +7,9 @@ sidebar: webassemblysidebar
 
 When you've written a new code module in a language like C/C++, you can compile it into WebAssembly using a tool like [Emscripten](https://emscripten.org/). Let's look at how it works.
 
+> [!NOTE]
+> This guide uses Emscripten, which is the most full-featured toolchain: it emulates a C standard library, a file system, and other operating-system features that C programs commonly expect. If your code doesn't need that runtime support, you can also compile C directly to WebAssembly with a lower-level toolchain such as [Clang/LLVM](https://surma.dev/things/c-to-webassembly/) or the [WASI SDK](https://github.com/WebAssembly/wasi-sdk), which produce smaller modules with fewer dependencies.
+
 ## Emscripten Environment Setup
 
 First, let's set up the required development environment.

--- a/files/en-us/webassembly/guides/c_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/c_to_wasm/index.md
@@ -8,7 +8,7 @@ sidebar: webassemblysidebar
 When you've written a new code module in a language like C/C++, you can compile it into WebAssembly using a tool like [Emscripten](https://emscripten.org/). Let's look at how it works.
 
 > [!NOTE]
-> This guide uses Emscripten, which is the most full-featured toolchain: it emulates a C standard library, a file system, and other operating-system features that C programs commonly expect. If your code doesn't need that runtime support, you can also compile C directly to WebAssembly with a lower-level toolchain such as [Clang/LLVM](https://surma.dev/things/c-to-webassembly/) or the [WASI SDK](https://github.com/WebAssembly/wasi-sdk), which produce smaller modules with fewer dependencies.
+> This guide uses Emscripten, which is the most full-featured toolchain for compiling to WebAssembly. It emulates a C standard library, a file system, and other operating-system features that C programs commonly expect. If your code doesn't need that runtime support, you can also compile C directly to WebAssembly with a lower-level toolchain such as [Clang/LLVM](https://surma.dev/things/c-to-webassembly/) or the [WASI SDK](https://github.com/WebAssembly/wasi-sdk), both of which produce smaller modules with fewer dependencies.
 
 ## Emscripten Environment Setup
 


### PR DESCRIPTION
Fixes #20177.

The guide only mentions Emscripten, which led to the request for a pointer to lighter, more portable alternatives. Per the discussion on the issue (@Josh-Cena and @bsmth), the consensus was to keep the tutorial primarily Emscripten-based but add a note about alternatives in the introduction — so this adds a short note pointing to compiling C directly with Clang/LLVM or the WASI SDK, while noting what Emscripten provides that those don't (libc, file system, and other OS emulation).

The Clang/LLVM reference is the [surma.dev write-up](https://surma.dev/things/c-to-webassembly/) @bsmth linked in the thread.