### PR TITLE
Add optional annotation to parameters in FontFaceSet methods

### DIFF
--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -25,7 +25,7 @@ check(font, text)
 - `font`
   - : A font specification using the syntax for the CSS {{cssxref("font")}} property, for example `"italic bold 16px Roboto"`
 - `text` {{optional_inline}}
-  - : Limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html). Defaults to [a string containing a single space character (U+0020 SPACE) `" "`](https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces).
+  - : Limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html). Defaults to a string containing a single space character (`" "`).
 
 ### Return value
 

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -23,9 +23,9 @@ check(font, text)
 ### Parameters
 
 - `font`
-  - : a font specification using the syntax for the CSS {{cssxref("font")}} property, for example `"italic bold 16px Roboto"`
+  - : A font specification using the syntax for the CSS {{cssxref("font")}} property, for example `"italic bold 16px Roboto"`
 - `text` {{optional_inline}}
-  - : limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html).
+  - : Limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html). Defaults to [a string containing a single space character (U+0020 SPACE) `" "`](https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces).
 
 ### Return value
 

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -24,7 +24,7 @@ check(font, text)
 
 - `font`
   - : a font specification using the syntax for the CSS {{cssxref("font")}} property, for example `"italic bold 16px Roboto"`
-- `text`
+- `text` {{optional_inline}}
   - : limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html).
 
 ### Return value

--- a/files/en-us/web/api/fontfaceset/foreach/index.md
+++ b/files/en-us/web/api/fontfaceset/foreach/index.md
@@ -26,11 +26,11 @@ forEach(callbackFn, thisArg)
     - `set`
       - : The `FontFaceSet` which `forEach()` was called on.
 - `thisArg` {{optional_inline}}
-  - : Value to use as [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) when executing `callbackFn`.
+  - : Value to use as [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) when executing `callbackFn`. Defaults to `undefined`.
 
 ### Return value
 
-Undefined.
+{{jsxref("undefined")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontfaceset/foreach/index.md
+++ b/files/en-us/web/api/fontfaceset/foreach/index.md
@@ -25,7 +25,7 @@ forEach(callbackFn, thisArg)
       - : The current element being processed in the `FontFaceSet`. As there are no keys in a `FontFaceSet`, the value is passed for both arguments.
     - `set`
       - : The `FontFaceSet` which `forEach()` was called on.
-- `thisArg`
+- `thisArg` {{optional_inline}}
   - : Value to use as [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this) when executing `callbackFn`.
 
 ### Return value

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -21,7 +21,7 @@ load(font, text)
 
 - `font`
   - : a font specification using the CSS value syntax, e.g., "italic bold 16px Roboto"
-- `text`
+- `text` {{optional_inline}}
   - : limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html).
 
 ### Return value

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -20,9 +20,9 @@ load(font, text)
 ### Parameters
 
 - `font`
-  - : a font specification using the CSS value syntax, e.g., "italic bold 16px Roboto"
+  - : A font specification using the CSS value syntax, e.g., "italic bold 16px Roboto"
 - `text` {{optional_inline}}
-  - : limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html).
+  - : Limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html). Defaults to [a string containing a single space character (U+0020 SPACE) `" "`](https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces).
 
 ### Return value
 

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -22,7 +22,7 @@ load(font, text)
 - `font`
   - : A font specification using the CSS value syntax, e.g., "italic bold 16px Roboto"
 - `text` {{optional_inline}}
-  - : Limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html). Defaults to [a string containing a single space character (U+0020 SPACE) `" "`](https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces).
+  - : Limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html). Defaults to a string containing a single space character (`" "`).
 
 ### Return value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR updates the following pages to include the inline Optional label for their optional parameters:

- https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/check
- https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/forEach
- https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/load

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Adding the Optional label improves readability, prevents confusion about which arguments are strictly required, and maintains consistency with the rest of the MDN Web API reference pages.


### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
