### PR TITLE
FF152 AnimationEvent/TransitionEvent.animation property

### DIFF
--- a/files/en-us/web/api/animationevent/animation/index.md
+++ b/files/en-us/web/api/animationevent/animation/index.md
@@ -1,0 +1,34 @@
+---
+title: "AnimationEvent: animation property"
+short-title: animation
+slug: Web/API/AnimationEvent/animation
+page-type: web-api-instance-property
+browser-compat: api.AnimationEvent.animation
+---
+
+{{APIRef("Web Animations")}}
+
+The **`animation`** read-only property of the {{domxref("AnimationEvent")}} interface represents the animation associated with the event.
+
+## Value
+
+A {{domxref("CSSAnimation")}}, or `null`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Using CSS animations](/en-US/docs/Web/CSS/Guides/Animations/Using)
+- Animation-related CSS properties and at-rules: {{cssxref("animation")}},
+  {{cssxref("animation-delay")}}, {{cssxref("animation-direction")}},
+  {{cssxref("animation-duration")}}, {{cssxref("animation-fill-mode")}},
+  {{cssxref("animation-iteration-count")}}, {{cssxref("animation-name")}},
+  {{cssxref("animation-play-state")}}, {{cssxref("animation-timing-function")}},
+  {{cssxref("@keyframes")}}.
+- The {{domxref("AnimationEvent")}} interface it belongs to.

--- a/files/en-us/web/api/animationevent/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/animationevent/index.md
@@ -24,6 +24,9 @@ new AnimationEvent(type, options)
     It is case-sensitive and browsers set it to `animationstart`, `animationend`, or `animationiteration`.
 - `options` {{optional_inline}}
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
+    - `animation` {{optional_inline}}
+      - : A {{domxref("CSSAnimation")}} containing the animation associated with the event.
+        It defaults to `null`.
     - `animationName` {{optional_inline}}
       - : A string containing the value of the {{cssxref("animation-name")}} CSS property associated with the transition. It defaults to `""`.
     - `elapsedTime` {{optional_inline}}

--- a/files/en-us/web/api/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/index.md
@@ -20,6 +20,8 @@ The **`AnimationEvent`** interface represents events providing information relat
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
+- {{domxref("AnimationEvent.animation")}} {{ReadOnlyInline}}
+  - : A {{domxref("CSSAnimation")}} read-only property containing the animation that triggered the event, or `null`.
 - {{domxref("AnimationEvent.animationName")}} {{ReadOnlyInline}}
   - : A string containing the value of the {{cssxref("animation-name")}} that generated the animation.
 - {{domxref("AnimationEvent.elapsedTime")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/index.md
@@ -21,7 +21,7 @@ The **`AnimationEvent`** interface represents events providing information relat
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("AnimationEvent.animation")}} {{ReadOnlyInline}}
-  - : A {{domxref("CSSAnimation")}} read-only property containing the animation that triggered the event, or `null`.
+  - : A {{domxref("CSSAnimation")}} read-only property representing the animation associated with the event.
 - {{domxref("AnimationEvent.animationName")}} {{ReadOnlyInline}}
   - : A string containing the value of the {{cssxref("animation-name")}} that generated the animation.
 - {{domxref("AnimationEvent.elapsedTime")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/transitionevent/animation/index.md
+++ b/files/en-us/web/api/transitionevent/animation/index.md
@@ -1,0 +1,32 @@
+---
+title: "TransitionEvent: animation property"
+short-title: animation
+slug: Web/API/TransitionEvent/animation
+page-type: web-api-instance-property
+browser-compat: api.TransitionEvent.animation
+---
+
+{{APIRef("CSSOM")}}
+
+The **`animation`** read-only property of the {{domxref("TransitionEvent")}} interface represents the animation associated with the event.
+
+## Value
+
+A {{domxref("CSSTransition")}}, or `null`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Using CSS transitions](/en-US/docs/Web/CSS/Guides/Transitions/Using)
+- CSS properties: {{cssxref("transition")}}, {{cssxref("transition-delay")}},
+  {{cssxref("transition-duration")}}, {{cssxref("transition-property")}},
+  {{cssxref("transition-timing-function")}}
+- CSS at-rules: {{cssxref("@starting-style")}}
+- The {{domxref("TransitionEvent")}} interface it belongs to.

--- a/files/en-us/web/api/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/index.md
@@ -21,7 +21,7 @@ The **`TransitionEvent`** interface represents events providing information rela
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("TransitionEvent.animation")}} {{ReadOnlyInline}}
-  - : A {{domxref("CSSTransition")}} read-only property containing animation that triggered the transition, or `null`.
+  - : A {{domxref("CSSTransition")}} read-only property containing the animation associated with the event.
 - {{domxref("TransitionEvent.propertyName")}} {{ReadOnlyInline}}
   - : A string containing the name CSS property associated with the transition.
 - {{domxref("TransitionEvent.elapsedTime")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/index.md
@@ -20,6 +20,8 @@ The **`TransitionEvent`** interface represents events providing information rela
 
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
+- {{domxref("TransitionEvent.animation")}} {{ReadOnlyInline}}
+  - : A {{domxref("CSSTransition")}} read-only property containing animation that triggered the transition, or `null`.
 - {{domxref("TransitionEvent.propertyName")}} {{ReadOnlyInline}}
   - : A string containing the name CSS property associated with the transition.
 - {{domxref("TransitionEvent.elapsedTime")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/transitionevent/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/transitionevent/index.md
@@ -25,7 +25,7 @@ new TransitionEvent(type, options)
 - `options` {{optional_inline}}
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
     - `animation` {{optional_inline}}
-      - : A {{domxref("CSSTransition")}} containing the animation associated with the transition.
+      - : A {{domxref("CSSTransition")}} representing the animation associated with the event.
         It defaults to `null`.
     - `propertyName` {{optional_inline}}
       - : A string containing the name of the CSS property associated with the transition.

--- a/files/en-us/web/api/transitionevent/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/transitionevent/index.md
@@ -24,6 +24,9 @@ new TransitionEvent(type, options)
     It is case-sensitive and browsers set it to `transitionrun`, `transitionstart`, `transitionend`, or `transitioncancel`.
 - `options` {{optional_inline}}
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, can have the following properties:
+    - `animation` {{optional_inline}}
+      - : A {{domxref("CSSTransition")}} containing the animation associated with the transition.
+        It defaults to `null`.
     - `propertyName` {{optional_inline}}
       - : A string containing the name of the CSS property associated with the transition.
         It defaults to `""`.


### PR DESCRIPTION
FF152 added support for `AnimationEvent.animation` and `TransitionEvent.animation` in https://bugzilla.mozilla.org/show_bug.cgi?id=1929118

This adds docs for those events.

Related docs work can be tracked in #44164