### PR TITLE
Security main page

### DIFF
--- a/files/en-us/web/api/screen_capture_api/index.md
+++ b/files/en-us/web/api/screen_capture_api/index.md
@@ -112,7 +112,7 @@ A site can also specify a desire to use the [Captured Surface Control API](/en-U
 
 The default allowlist for both directives is `self`, which permits any content within the same origin use Screen Capture.
 
-These methods are considered [powerful features](/en-US/docs/Web/Security#secure_contexts_and_feature_permissions), which means that even if permission is allowed via a `Permissions-Policy`, the user will still be prompted for permission to use them. The [Permissions API](/en-US/docs/Web/API/Permissions_API) can be used to query the aggregate permission (from both the website and the user) for using the listed features.
+These methods are considered _powerful features_, which means that even if permission is allowed via a `Permissions-Policy`, the user will still be prompted for permission to use them. The [Permissions API](/en-US/docs/Web/API/Permissions_API) can be used to query the aggregate permission (from both the website and the user) for using the listed features.
 
 In addition, the specification requires that a user has recently interacted with the page to use these features — this means that [transient activation](/en-US/docs/Glossary/Transient_activation) is required. See the individual method pages for more details.
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -44,6 +44,8 @@ In this page we'll introduce each of these sections and list the guides they con
 
 - **Follow good [operational security practices](/en-US/docs/Web/Security/Defenses/Operational_security)**: control access to your project's source code, handle secrets securely, and control your dependencies.
 
+See also the [Secure Web Application Guidelines](https://w3c-cg.github.io/swag/docs/swag.html).
+
 ## Attacks
 
 The [Attacks](/en-US/docs/Web/Security/Attacks) section includes guides to common attacks on websites. An attack is a specific technique that an attacker can use to harm websites or their users.

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -18,27 +18,34 @@ The [Attacks](/en-US/docs/Web/Security/Attacks) section includes guides to commo
 
 In this section, each guide describes an attack, or in some cases a class of related attacks. Each guide explains how the attack works, the conditions in which a website is vulnerable to it, and the methods to defend against it.
 
-The attacks described include, among others:
+The attacks described include:
 
-- [Cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS)
+- [Clickjacking](/en-US/docs/Web/Security/Attacks/Clickjacking)
 - [Cross-site request forgery (CSRF)](/en-US/docs/Web/Security/Attacks/CSRF)
-- [Phishing](/en-US/docs/Web/Security/Attacks/phishing)
+- [Cross-site leaks (XS-Leaks)](/en-US/docs/Web/Security/Attacks/XS-Leaks)
+- [Cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS)
+- [Insecure Direct Object Reference (IDOR)](/en-US/docs/Web/Security/Attacks/IDOR)
+- [Manipulator in the Middle (MITM)](/en-US/docs/Web/Security/Attacks/MITM)
+- [Phishing](/en-US/docs/Web/Security/Attacks/Phishing)
+- [Prototype pollution](/en-US/docs/Web/Security/Attacks/Prototype_pollution)
+- [Server Side Request Forgery (SSRF)](/en-US/docs/Web/Security/Attacks/SSRF)
+- [Subdomain takeover](/en-US/docs/Web/Security/Attacks/Subdomain_takeover)
 - [Supply chain attacks](/en-US/docs/Web/Security/Attacks/Supply_chain_attacks)
 
 ## Defenses
 
 The [Defenses](/en-US/docs/Web/Security/Defenses) section includes guides to features or practices that you can use to protect yourself against various attacks. In general, there's a many-to-many relationship between attack and defenses. That is, a single defense can protect against multiple attacks, and defending against a single attack may require multiple defenses, so as to provide defense in depth.
 
-Defenses include features that browsers provide, such as:
+In this section we document the following defenses:
 
-- [Transport Layer Security (TLS)](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security)
-- [The same-origin policy](/en-US/docs/Web/Security/Defenses/Same-origin_policy)
-- [Subresource Integrity](/docs/Web/Security/Defenses/Subresource_Integrity)
-
-Defense also include practices you can follow, such as:
-
+- [Certificate transparency](/en-US/docs/Web/Security/Defenses/Certificate_Transparency)
+- [Mixed content blocking](/en-US/docs/Web/Security/Defenses/Mixed_content)
 - [Operational security](/en-US/docs/Web/Security/Defenses/Operational_security)
-- [Input validation](/en-US/docs/Web/Security/Defenses/Input_validation)
+- [Same-origin policy](/en-US/docs/Web/Security/Defenses/Same-origin_policy)
+- [Secure contexts](/en-US/docs/Web/Security/Defenses/Secure_Contexts)
+- [Subresource integrity](/en-US/docs/Web/Security/Defenses/Subresource_Integrity)
+- [Transport Layer Security (TLS)](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security)
+- [User activation](/en-US/docs/Web/Security/Defenses/User_activation)
 
 Note that not all defenses are described in this section: some, such as [CSP](2/en-US/docs/Web/HTTP/Guides/CSP) or [trusted types](/en-US/docs/Web/API/Trusted_Types_API), are described inside the technology area of which they are a part.
 
@@ -57,13 +64,9 @@ If users can log into your website, there are typically things logged-in users c
 In this set of guides we'll look at the main techniques available for authenticating users on the web, and good practices for them. We describe four methods:
 
 - [Passwords](/en-US/docs/Web/Security/Authentication/Passwords)
-  - : Passwords are the most well-known authentication method. They have many well-known security weaknesses, and in this article we'll explain the best practices to minimize the risks of using them: however, some threats don't have effective defenses.
 - [One-time passwords (OTP)](/en-US/docs/Web/Security/Authentication/OTP)
-  - : A one-time password is a generated code that is specific to a single login attempt. These are often used in combination with another method such as a password.
 - [Federated identity](/en-US/docs/Web/Security/Authentication/Federated_identity)
-  - : In a federated identity system, a website delegates authentication to a third party, which is called an _identity provider_. When the user tries to sign into the website, the website asks the identity provider to identify the user, and if the identification is successful, logs the user in.
 - [Passkeys](/en-US/docs/Web/Security/Authentication/Passkeys)
-  - : Passkeys enable websites to authenticate users without the user having to enter any passwords or other secret codes on the site itself. They rely on a module called an _authenticator_, that's in, or attached to, the user's device.
 
 In this section we also outline good practices for [session management](/en-US/docs/Web/Security/Authentication/Session_management), which is how a website remembers the signed-in status of a user.
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -19,7 +19,7 @@ The documentation is organized into four main sections:
 - [Threat modeling](/en-US/docs/Web/Security/Threat_modeling)
 - [Authentication](/en-US/docs/Web/Security/Authentication)
 
-In this page we'll introduce each of these sections and list the guides they contain. 
+In this page we'll introduce each of these sections and list the guides they contain.
 
 ## Core security practices
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -72,7 +72,7 @@ In this section we also outline good practices for [session management](/en-US/d
 
 ## HTTP Observatory
 
-The [HTTP Observatory](https://developer.mozilla.org/en-US/observatory) tool enables you to scan your website to check whether it's following certain good security practices. Our [Practical security implementation guides](/en-US/docs/Web/Security/Practical_implementation_guides) provide explanations of how to implement these practices, and the threats they defend against.
+The [HTTP Observatory](/en-US/observatory) tool enables you to scan your website to check whether it's following certain good security practices. Our [Practical security implementation guides](/en-US/docs/Web/Security/Practical_implementation_guides) provide explanations of how to implement these practices, and the threats they defend against.
 
 ## See also
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -51,9 +51,11 @@ Note that not all defenses are described in this section: some, such as [CSP](2/
 
 ## Threat modeling
 
-The [Threat modeling](/en-US/docs/Web/Security/Threat_modeling) section introduces a process that web developers can follow to develop a structured representation of the potential threats that their site faces, based on the features it provides and the way these features are implemented.
+Not all websites are vulnerable to all attacks: which attacks a developer needs to worry about depends on the features that the site provides and how they are implemented.
 
-That is, threat modeling helps you understand which attacks you need to defend against.
+[Threat modeling](/en-US/docs/Web/Security/Threat_modeling) is a process that web developers can follow to develop a structured representation of the potential threats that their site faces, and the corresponding defenses that they should employ.
+
+That is, threat modeling helps you understand which attacks you need to defend against, and how to defend against them.
 
 ## Authentication
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -1,176 +1,78 @@
 ---
-title: Security on the web
+title: Security
 short-title: Security
 slug: Web/Security
 page-type: landing-page
 sidebar: security
 ---
 
-Websites contain several different types of information. Some of it is non-sensitive, for example the copy shown on the public pages. Some of it is sensitive, for example customer usernames, passwords, and banking information, or internal algorithms and private product information.
+Web security is the practice of protecting websites and their users from damage caused by malicious third parties, who are generally called _attackers_.
 
-Sensitive information needs to be protected, and that is the focus of web security. If that information fell into the wrong hands, it could be used to:
+The kind of damage done can be reputational, financial, or even physical. It can target data that should be kept private to users, or actions that should be only made available to particular users. The motivations of attackers might be financial, political, or personal.
 
-- Put companies at a competitive disadvantage by sharing their information with competitors.
-- Disable or hijack their services, again causing serious problems with their operation.
-- Put their customer's [privacy](/en-US/docs/Web/Privacy) at risk, making them vulnerable to profiling, targeting, loss of data, identity theft, or even financial loss.
+In this part of MDN we've written guides to help web developers understand how to protect their websites, and their users, against these attacks.
 
-Modern browsers already have several features to protect users' security on the web, but developers also need to use best practices and code carefully to ensure that their websites are secure. Even simple bugs in your code can result in vulnerabilities that bad actors can exploit to steal data and gain unauthorized control over services.
+## Attacks
 
-This article provides an introduction to web security, including conceptual information to help you understand website vulnerabilities and practical guides on how to secure them.
+The [Attacks](/en-US/docs/Web/Security/Attacks) section includes guides to common attacks on websites. An attack is a specific technique that an attacker can use to harm websites or their users.
 
-## Relationship between security and privacy
+In this section, each guide describes an attack, or in some cases a class of related attacks. Each guide explains how the attack works, the conditions in which a website is vulnerable to it, and the methods to defend against it.
 
-Security and privacy are distinct yet closely related topics. It is worth knowing the differences between the two and how they relate.
+The attacks described include, among others:
 
-- **Security** is the act of keeping private data and systems protected against unauthorized access. This includes both company (internal) data and user and partner (external) data.
+- [Cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS)
+- [Cross-site request forgery (CSRF)](/en-US/docs/Web/Security/Attacks/CSRF)
+- [Phishing](/en-US/docs/Web/Security/Attacks/phishing)
+- [Supply chain attacks](/en-US/docs/Web/Security/Attacks/Supply_chain_attacks)
 
-- **Privacy** refers to the act of giving users control over how their data is collected, stored, and used, while also ensuring that it is not used irresponsibly. For example, you should let your users know what data you are collecting from them, the parties with whom it will be shared, and how it will be used. Users must be given a chance to consent to your privacy policy, have access to their data you store, and delete it if they choose to.
+## Defenses
 
-Good security is essential for good privacy. You could follow all the advice listed in our [Privacy on the web](/en-US/docs/Web/Privacy) guide, but acting with integrity and having a robust privacy policy are futile if your site is not secure and attackers can just steal data anyway.
+The [Defenses](/en-US/docs/Web/Security/Defenses) section includes guides to features or practices that you can use to protect yourself against various attacks. In general, there's a many-to-many relationship between attack and defenses. That is, a single defense can protect against multiple attacks, and defending against a single attack may require multiple defenses, so as to provide defense in depth.
 
-## Security features provided by browsers
+Defenses include features that browsers provide, such as:
 
-Web browsers follow a strict security model that enforces strong security for content, connections between the browser and the server, and data transportation. This section looks at the features that underpin this model.
+- [Transport Layer Security (TLS)](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security)
+- [The same-origin policy](/en-US/docs/Web/Security/Defenses/Same-origin_policy)
+- [Subresource Integrity](/docs/Web/Security/Defenses/Subresource_Integrity)
 
-### Same-origin policy and CORS
+Defense also include practices you can follow, such as:
 
-[Same-origin policy](/en-US/docs/Web/Security/Defenses/Same-origin_policy) is a fundamental security mechanism of the web that restricts how a document or a script loaded from one {{Glossary("origin")}} can interact with a resource from another origin. It helps isolate potentially malicious documents, reducing possible attack vectors.
+- [Operational security](/en-US/docs/Web/Security/Defenses/Operational_security)
+- [Input validation](/en-US/docs/Web/Security/Defenses/Input_validation)
 
-In general, documents from one origin cannot make requests to other origins. This makes sense because you don't want sites to be able to interfere with one another and access unauthorized data.
+Note that not all defenses are described in this section: some, such as [CSP](2/en-US/docs/Web/HTTP/Guides/CSP) or [trusted types](/en-US/docs/Web/API/Trusted_Types_API), are described inside the technology area of which they are a part.
 
-However, you might want to relax this restriction in some circumstances; for example, if you have multiple websites that interact with each other, you may allow them to request resources from one another using [`fetch()`](/en-US/docs/Web/API/Window/fetch). This can be permitted using [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/Guides/CORS), an HTTP-header-based mechanism that allows a server to indicate any origins (domain, scheme, or port) other than its own from which a browser should permit loading resources.
+## Threat modeling
 
-### HTTP model for communication
+The [Threat modeling](/en-US/docs/Web/Security/Threat_modeling) section introduces a process that web developers can follow to develop a structured representation of the potential threats that their site faces, based on the features it provides and the way these features are implemented.
 
-The [HTTP](/en-US/docs/Web/HTTP) protocol is used by web browsers and servers to communicate with one another, request resources, provide responses (for example, providing a requested resource or detailing why a request failed), and provide security features for that communication.
+That is, threat modeling helps you understand which attacks you need to defend against.
 
-Transport Layer Security (TLS) provides security and privacy by encrypting data during transport over the network and is the technology behind the [HTTPS](/en-US/docs/Glossary/HTTPS) protocol. TLS is good for privacy because it stops third parties from being able to intercept transmitted data and use it maliciously.
+## Authentication
 
-All browsers are moving towards requiring HTTPS by default; this is practically the case already because you can't do much on the web without this protocol.
+Authentication is the process of verifying that an entity — such as a user of a website — is who they claim to be. You'll most likely need to think about authentication if you want users to sign into your website.
 
-Related topics:
+If users can log into your website, there are typically things logged-in users can do, or data they can access, that you don't want to make generally available. This makes user account access one of the most valuable targets for attackers.
 
-- [Transport layer security](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security) (TLS)
-  - : The TLS protocol is the standard for enabling two networked applications or devices to exchange information privately and robustly. Applications that use TLS can choose their security parameters, which can have a substantial impact on the security and reliability of data.
-- [HTTP Strict-Transport-Security](/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security)
-  - : The `Strict-Transport-Security` [HTTP](/en-US/docs/Web/HTTP) header lets a website specify that it may only be accessed using HTTPS.
-- [Certificate Transparency](/en-US/docs/Web/Security/Defenses/Certificate_Transparency)
-  - : Certificate Transparency (CT) is an open framework designed to protect against and monitor for certificate misissuance. Newly issued certificates are 'logged' to publicly run, often independent CT logs. These provide append-only, cryptographically assured records of issued TLS certificates.
-- [Mixed content](/en-US/docs/Web/Security/Defenses/Mixed_content)
-  - : An HTTPS page that includes content fetched using [cleartext](/en-US/docs/Glossary/Plaintext) HTTP is called a **mixed content** page. Pages like this are only partially encrypted, leaving the unencrypted content accessible to sniffers and man-in-the-middle attackers.
+In this set of guides we'll look at the main techniques available for authenticating users on the web, and good practices for them. We describe four methods:
 
-### Secure contexts and feature permissions
+- [Passwords](/en-US/docs/Web/Security/Authentication/Passwords)
+  - : Passwords are the most well-known authentication method. They have many well-known security weaknesses, and in this article we'll explain the best practices to minimize the risks of using them: however, some threats don't have effective defenses.
+- [One-time passwords (OTP)](/en-US/docs/Web/Security/Authentication/OTP)
+  - : A one-time password is a generated code that is specific to a single login attempt. These are often used in combination with another method such as a password.
+- [Federated identity](/en-US/docs/Web/Security/Authentication/Federated_identity)
+  - : In a federated identity system, a website delegates authentication to a third party, which is called an _identity provider_. When the user tries to sign into the website, the website asks the identity provider to identify the user, and if the identification is successful, logs the user in.
+- [Passkeys](/en-US/docs/Web/Security/Authentication/Passkeys)
+  - : Passkeys enable websites to authenticate users without the user having to enter any passwords or other secret codes on the site itself. They rely on a module called an _authenticator_, that's in, or attached to, the user's device.
 
-Browsers control the usage of "powerful features" in different ways. These "powerful features" include generating system notifications on a website, using a user's webcam to get access to a media stream, manipulating the system GPU, and using web payments. If a site could just use the APIs that control such features without restriction, malicious developers could attempt to do the following:
+In this section we also outline good practices for [session management](/en-US/docs/Web/Security/Authentication/Session_management), which is how a website remembers the signed-in status of a user.
 
-- Annoy users with unneeded notifications and other UI features.
-- Turn their webcam on without warning to spy on them.
-- Clog up their browser/system to create {{glossary("denial of service", "Denial of Service")}} (DoS) attacks.
-- Steal data or money.
+## HTTP Observatory
 
-These "powerful features" are controlled in the following ways:
-
-- Usage of such features is permitted only in [secure contexts](/en-US/docs/Web/Security/Defenses/Secure_Contexts). A secure context is a {{domxref("Window", "window")}} or a {{domxref("WorkerGlobalScope", "worker")}} for which there is reasonable confidence that the content has been delivered securely (via HTTPS/TLS). In a secure context, the potential for communication with contexts that are **not** secure is limited. Secure contexts also help to prevent [man-in-the-middle attackers](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) from accessing powerful features.
-
-  To see a list of web platform features available only in secure contexts, see [Features restricted to secure contexts](/en-US/docs/Web/Security/Defenses/Secure_Contexts/features_restricted_to_secure_contexts).
-
-- The usage of these features is gated behind a system of user permissions: users have to explicitly opt-in to providing access to such features, meaning that they can't be used automatically. User permission requests happen automatically, and you can query the state of an API permission by using the [Permissions API](/en-US/docs/Web/API/Permissions_API).
-
-- Several other browser features can be used only in response to a user action such as clicking a button, meaning that they need to be invoked from inside an appropriate event handler. This is called **transient activation**. See [Features gated by user activation](/en-US/docs/Web/Security/Defenses/User_activation) for more information.
-
-## High-level security considerations
-
-There are many aspects of web security that need to be thought about on the server- and client-side. This section focuses mainly on client-side security considerations. You can find a useful summary of security from a server-side perspective, which also includes descriptions of common attacks to watch out for, at [Website security](/en-US/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security) (part of our [Server-side website programming](/en-US/docs/Learn_web_development/Extensions/Server-side) learning module).
-
-### Store client-side data responsibly
-
-Handling data responsibly is largely concerned with cutting down on [third-party cookie](/en-US/docs/Web/Privacy/Guides/Third-party_cookies) usage and being careful about the data you store and share with them. Traditionally, web developers have used cookies to store all kinds of data, and it has been easy for attackers to exploit this tendency. As a result, browsers have started to limit what you can do with cross-site cookies, with the aim of removing access to them altogether in the future.
-
-You should prepare for the removal of cross-site cookies by limiting the amount of tracking activities you rely on and/or by implementing the persistence of the desired information in other ways. See [Transitioning from third-party cookies](/en-US/docs/Web/Privacy/Guides/Third-party_cookies#transitioning_from_third-party_cookies) for more information.
-
-### Protect user identity and manage logins
-
-When implementing a secure solution that involves data collection, particularly if the data is sensitive such as log-in credentials, it makes sense to use a reputable solution. For example, any respectable server-side framework will have built-in features to protect against common vulnerabilities. You could also consider using a specialized product for your purpose, for example an identity provider solution or a secure online survey provider.
-
-If you want to roll your own solution for collecting user data, make sure you understand all aspects and requirements. Hire an experienced server-side developer and/or security engineer to implement the system, and ensure it is tested thoroughly. Use {{glossary("multi-factor authentication")}} (MFA) to provide better protection. Consider using a dedicated API such as [Web Authentication](/en-US/docs/Web/API/Web_Authentication_API) or [Federated Credential Management](/en-US/docs/Web/API/FedCM_API) to streamline the client-side of the app.
-
-Here are some other tips for providing secure logins:
-
-- When collecting user login information, enforce strong passwords so that your user's account details cannot be easily guessed. Weak passwords are one of the main causes of security breaches. In addition, encourage your users to use a password manager so that they can use more complex passwords, don't need to worry about remembering them, and won't create a security risk by writing them down. See also our article on [password authentication](/en-US/docs/Web/Security/Authentication/Passwords).
-- You should also educate your users about **phishing**. Phishing is the act of sending a message to a user (for example, an email or an SMS) containing a link to a site that looks like a site they use every day but isn't. The link is accompanied by a message designed to trick users into entering their username and password on the site so it can be stolen and then used by an attacker for malicious purposes.
-
-  > [!NOTE]
-  > Some phishing sites can be very sophisticated and hard to distinguish from a real website. You should therefore educate your users to not trust random links in emails and SMS messages. If they receive a message along the lines of "Urgent, you need to log in now to resolve an issue", they should go to the site directly in a new tab and try logging in directly rather than clicking the link in the message. Or they could phone or email you to discuss the message they received.
-
-- Protect against brute force attacks on login pages with {{glossary("rate limit", "rate limiting")}}, account lockouts after a certain number of unsuccessful attempts, and [CAPTCHA challenges](https://en.wikipedia.org/wiki/CAPTCHA).
-- Manage user login sessions with unique [session IDs](https://en.wikipedia.org/wiki/Session_ID), and automatically log out users after periods of inactivity.
-
-### Don't include sensitive data in URL query strings
-
-As a general rule, you shouldn't [include sensitive data in URL query strings](https://owasp.org/www-community/vulnerabilities/Information_exposure_through_query_strings_in_url) because if a third party intercepts the URL (for example, via the {{httpheader("Referer")}} HTTP header), they could steal that information. Even more serious is the fact that these URLs can be indexed by public web crawlers, HTTP proxies, and archiving tools such as the [internet archive](https://web.archive.org/), meaning that your sensitive data could persist on publicly accessible resources.
-
-Use `POST` requests rather than `GET` requests to avoid these issues. Our article [Referer header policy: Privacy and security concerns](/en-US/docs/Web/Privacy/Guides/Referer_header:_privacy_and_security_concerns) describes in more detail the privacy and security risks associated with the `Referer` header, and offers advice on mitigating those risks.
-
-> [!NOTE]
-> Steering away from transmitting sensitive data in URLs via `GET` requests can also help protect against {{glossary("CSRF", "cross-site request forgery")}} and [replay attacks](https://en.wikipedia.org/wiki/Replay_attack).
-
-### Enforce usage policies
-
-Consider using web platform features like [Content Security Policy](/en-US/docs/Web/HTTP/Guides/CSP) (CSP) and [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) to enforce a set of feature and resource usage rules on your website that make it harder to introduce vulnerabilities.
-
-CSP allows you to add a layer of security by, for example, allowing images or scripts to be loaded only from specific trusted origins. This helps to detect and mitigate certain types of attacks, including Cross-Site Scripting ({{Glossary("Cross-site_scripting", "XSS")}}) and data injection attacks. These attacks involve a range of malicious activities, including data theft, site defacement, and distribution of malware.
-
-Permissions policy works in a similar way, except that it is more concerned with allowing or blocking access to specific "powerful features" ([as mentioned earlier](#secure_contexts_and_feature_permissions)).
-
-> [!NOTE]
-> Such policies are very useful to help keep sites secure, especially when you are using a lot of third-party code on your site. However, keep in mind that if you block usage of a feature that a third-party script relies on to work, you may end up breaking your site's functionality.
-
-### Maintain data integrity
-
-Following on from the previous section, when you allow feature and resource usage on your site, you should try to ensure that resources have not been tampered with.
-
-Related topics:
-
-- [Subresource integrity](/en-US/docs/Web/Security/Defenses/Subresource_Integrity)
-  - : **Subresource Integrity** (SRI) is a security feature that enables browsers to verify that resources they fetch (for example, from a {{Glossary("CDN")}}) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match.
-- [HTTP Access-Control-Allow-Origin](/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin)
-  - : The **`Access-Control-Allow-Origin`** response header indicates whether the response can be shared with requesting code from the given {{glossary("origin")}}.
-- [HTTP X-Content-Type-Options](/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options)
-  - : The **`X-Content-Type-Options`** response header is a marker used by the server to indicate that the [MIME types](/en-US/docs/Web/HTTP/Guides/MIME_types) advertised in the {{HTTPHeader("Content-Type")}} headers should not be changed and must be followed. This header is a way to opt out of [MIME type sniffing](/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing), or, in other words, to specify that the MIME types are deliberately configured.
-
-### Sanitize form input
-
-As a general rule, don't trust anything that users enter into forms. Filling out forms online is complicated and tedious, and it is easy for users to enter incorrect data or data in the wrong format. In addition, malicious folks are skilled in the art of entering specific strings of executable code into form fields (for example, SQL or JavaScript). If you're not careful about handling such inputs, they could either execute harmful code on your site or delete your databases. See [SQL injection](/en-US/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security#sql_injection) for a good example of how this could happen.
-
-To protect against this, you should thoroughly sanitize data entered into your forms:
-
-- You should implement client-side validation to inform users when they have entered data in the wrong format. You can do this using built-in HTML form validation features, or you can write your own validation code. See [Client-side form validation](/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation) for more information.
-- You should use output encoding when displaying user input in an application UI to safely display data exactly as a user typed it in and avoid it being executed as code. See [Output encoding](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding) for more information.
-
-You can't rely on client-side validation alone for security — it should be combined with server-side validation. Client-side validation enhances the user experience by providing instant validation feedback without having to wait for a round trip to the server. However, client-side validation is easy for a malicious party to bypass (for example, by turning off JavaScript in the browser to bypass JavaScript-based validation).
-
-Any reputable server-side framework will provide functionality for validating form submissions. In addition, a common best practice is to escape any special characters that form part of executable syntax, thereby making any entered code no longer executable and treated as plain text.
-
-### Protect against clickjacking
-
-In a [clickjacking](/en-US/docs/Web/Security/Attacks/Clickjacking) attack, a user is fooled into clicking a UI element that performs an action different from what the user expects, often resulting in the user's confidential information being passed to a malicious third party. This risk is inherent in embedded third-party content, so make sure you trust what is being embedded into your site. Additionally, be aware that clickjacking can be combined with phishing techniques. You can read about phishing in the previous section [Protect user identity and manage logins](#protect_user_identity_and_manage_logins).
-
-The following features can help guard against clickjacking:
-
-- [HTTP X-Frame-Options](/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options)
-  - : The **`X-Frame-Options`** [HTTP](/en-US/docs/Web/HTTP) response header can be used to indicate whether a browser should be allowed to render a page in a [`<frame>`](/en-US/docs/Web/HTML/Reference/Elements/frame), [`<iframe>`](/en-US/docs/Web/HTML/Reference/Elements/iframe), [`<embed>`](/en-US/docs/Web/HTML/Reference/Elements/embed) or [`<object>`](/en-US/docs/Web/HTML/Reference/Elements/object). Sites can use this to avoid clickjacking attacks, by ensuring that their content is not embedded into other sites.
-- [CSP: frame-ancestors](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors)
-  - : The HTTP {{HTTPHeader("Content-Security-Policy")}} (CSP) **`frame-ancestors`** directive specifies valid parents that may embed a page using {{HTMLElement("frame")}}, {{HTMLElement("iframe")}}, {{HTMLElement("object")}}, or {{HTMLElement("embed")}}.
-
-## Practical security implementation guides
-
-To get comprehensive instructions for implementing security features effectively on websites and to ensure you're following best practices, see our set of [Practical security implementation guides](/en-US/docs/Web/Security/Practical_implementation_guides).
-
-Some of these guides are directly related to the [HTTP Observatory](/en-US/observatory) tool. Observatory performs security audits on a website and provides a grade and score along with recommendations for fixing the security issues it finds. These guides explain how to resolve issues surfaced by the MDN Observatory tests: the tool links to the relevant guide for each issue, helping guide you towards an effective resolution. Interestingly, Mozilla's internal developer teams use this guidance when implementing websites to ensure that security best practices are applied.
+The [HTTP Observatory](https://developer.mozilla.org/en-US/observatory) tool enables you to scan your website to check whether it's following certain good security practices. Our [Practical security implementation guides](/en-US/docs/Web/Security/Practical_implementation_guides) provide explanations of how to implement these practices, and the threats they defend against.
 
 ## See also
 
 - [Privacy on the web](/en-US/docs/Web/Privacy)
 - [Learn: Website security](/en-US/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security)
-- [Mozilla Security Blog](https://blog.mozilla.org/security/)
 - [OWASP Cheat Sheet series](https://cheatsheetseries.owasp.org/index.html)

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -19,11 +19,11 @@ The documentation is organized into four main sections:
 - [Threat modeling](/en-US/docs/Web/Security/Threat_modeling)
 - [Authentication](/en-US/docs/Web/Security/Authentication)
 
-In this page we'll introduce each of these sections and list the guides they contain.
+In this page we'll introduce each of these sections and list the guides they contain. First though, we'll list the core security practices that web developers should follow.
 
 ## Core security practices
 
-Before we cover the separate aspects of website security, this section provides the core security practices that we think all web developers should follow.
+Web security can be overwhelming: there are a lot of potential threats, defenses are often complex and multilayered, and the set of threats you need to consider are highly dependent on what exactly your website is doing. In this section we'll summarize what we think are the most important things you can do, that will offer protection against most of the threats you will encounter.
 
 - **Use [HTTPS](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security)** to serve all your site's pages and subresources.
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -12,6 +12,28 @@ The kind of damage done can be reputational, financial, or even physical. It can
 
 In this part of MDN we've written guides to help web developers understand how to protect their websites, and their users, against these attacks.
 
+Before listing these detailed guides, though, we'll summarize the most important security practices:
+
+- **Use [HTTPS](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security)** to serve all your site's pages and subresources.
+
+- **Set a [Content Security Policy (CSP)](/en-US/docs/Web/HTTP/Guides/CSP)** for your site.
+  - If possible, set a [strict CSP](/en-US/docs/Web/HTTP/Guides/CSP#strict_csp), but if not, at least set a policy that [disallows inline JavaScript](/en-US/docs/Web/HTTP/Guides/CSP#inline_javascript).
+  - Set the [`frame-ancestors`](/en-US/docs/Web/HTTP/Guides/CSP#clickjacking_protection) CSP directive, to control whether pages can be embedded in nested browsing contexts.
+
+  - Set the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Guides/CSP#requiring_trusted_types) CSP directive, to help ensure that content has been sanitized before it is passed to potentially dangerous APIs.
+
+- **Control cross-origin requests**: consider whether and in which circumstances you want to allow other {{glossary("origin", "origins")}} to make requests to your site, and use [fetch metadata](/en-US/docs/Web/HTTP/Guides/Fetch_metadata) to control this.
+
+- **Limit access to any cookies** your site sets: in particular, [set the `SameSite` attribute to `Strict` if possible, or `Lax` otherwise](/en-US/docs/Web/Security/Attacks/CSRF#defense_in_depth_samesite_cookies).
+
+- **Handle input securely**: if your site accepts input from the user or another system, [validate it](/en-US/docs/Web/Security/Defenses/Input_validation). Before integrating any input into your site's pages, perform [output encoding](/en-US/docs/Web/Security/Attacks/XSS#output_encoding) or [sanitization](/en-US/docs/Web/Security/Attacks/XSS#sanitization).
+
+- **Use [Subresource Integrity](/en-US/docs/Web/Security/Defenses/Subresource_Integrity)** for any scripts that you load from external sources (such as {{glossary("CDN", "CDNs")}}).
+
+- **Use strong authentication methods**: if you authenticate users on your site, don't use [passwords](/en-US/docs/Web/Security/Authentication/Passwords) alone. [Passkeys](/en-US/docs/Web/Security/Authentication/Passkeys) are the most secure authentication method, but if you can't use them, then [time-based one-time passwords (TOTP)](/en-US/docs/Web/Security/Authentication/OTP#totp) are more secure than traditional passwords.
+
+- **Follow good [operational security practices](/en-US/docs/Web/Security/Defenses/Operational_security)**: control access to your project's source code, handle secrets securely, and control your dependencies.
+
 ## Attacks
 
 The [Attacks](/en-US/docs/Web/Security/Attacks) section includes guides to common attacks on websites. An attack is a specific technique that an attacker can use to harm websites or their users.

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -77,6 +77,7 @@ The [Defenses](/en-US/docs/Web/Security/Defenses) section includes guides to fea
 In this section we document the following defenses:
 
 - [Certificate transparency](/en-US/docs/Web/Security/Defenses/Certificate_Transparency)
+- [Input validation](/en-US/docs/Web/Security/Defenses/Input_validation)
 - [Mixed content blocking](/en-US/docs/Web/Security/Defenses/Mixed_content)
 - [Operational security](/en-US/docs/Web/Security/Defenses/Operational_security)
 - [Same-origin policy](/en-US/docs/Web/Security/Defenses/Same-origin_policy)

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -16,7 +16,7 @@ In this part of MDN we've written guides to help web developers understand how t
 
 The [Attacks](/en-US/docs/Web/Security/Attacks) section includes guides to common attacks on websites. An attack is a specific technique that an attacker can use to harm websites or their users.
 
-In this section, each guide describes an attack, or in some cases a class of related attacks. Each guide explains how the attack works, the conditions in which a website is vulnerable to it, and the methods to defend against it.
+Each guide covers a specific attack (or class of related attacks), explaining how it works, the conditions under which a website becomes vulnerable, and how to defend against it.
 
 The attacks described include:
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -19,7 +19,11 @@ The documentation is organized into four main sections:
 - [Threat modeling](/en-US/docs/Web/Security/Threat_modeling)
 - [Authentication](/en-US/docs/Web/Security/Authentication)
 
-In this page we'll introduce each of these sections and list the guides they contain. Before we do this, though, we'll state what we think are the core security practices that web developers should follow.
+In this page we'll introduce each of these sections and list the guides they contain. 
+
+## Core security practices
+
+Before we cover the separate aspects of website security, this section provides the core security practices that we think all web developers should follow.
 
 - **Use [HTTPS](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security)** to serve all your site's pages and subresources.
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -31,7 +31,10 @@ In this page we'll introduce each of these sections and list the guides they con
 
 - **Control cross-origin requests**: consider whether and in which circumstances you want to allow other {{glossary("origin", "origins")}} to make requests to your site, and use [fetch metadata](/en-US/docs/Web/HTTP/Guides/Fetch_metadata) to control this.
 
-- **Limit access to any cookies your site sets**: in particular, [set the `SameSite` attribute to `Strict` if possible, or `Lax` otherwise](/en-US/docs/Web/Security/Attacks/CSRF#defense_in_depth_samesite_cookies).
+- **Limit access to any cookies your site sets**. In particular:
+  - Set the [`SameSite`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesite) attribute to `Strict` if possible, or `Lax` otherwise.
+  - Set the [`Secure`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#secure) and [`HttpOnly`](/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#httponly) attributes, if possible.
+  - Minimize the lifetime of cookies that are used to represent logged-in users.
 
 - **Handle input securely**: if your site accepts input from the user or another system, [validate it](/en-US/docs/Web/Security/Defenses/Input_validation). Before integrating any input into your site's pages, perform [output encoding](/en-US/docs/Web/Security/Attacks/XSS#output_encoding) or [sanitization](/en-US/docs/Web/Security/Attacks/XSS#sanitization).
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -31,7 +31,7 @@ In this page we'll introduce each of these sections and list the guides they con
 
 - **Control cross-origin requests**: consider whether and in which circumstances you want to allow other {{glossary("origin", "origins")}} to make requests to your site, and use [fetch metadata](/en-US/docs/Web/HTTP/Guides/Fetch_metadata) to control this.
 
-- **Limit access to any cookies** your site sets: in particular, [set the `SameSite` attribute to `Strict` if possible, or `Lax` otherwise](/en-US/docs/Web/Security/Attacks/CSRF#defense_in_depth_samesite_cookies).
+- **Limit access to any cookies your site sets**: in particular, [set the `SameSite` attribute to `Strict` if possible, or `Lax` otherwise](/en-US/docs/Web/Security/Attacks/CSRF#defense_in_depth_samesite_cookies).
 
 - **Handle input securely**: if your site accepts input from the user or another system, [validate it](/en-US/docs/Web/Security/Defenses/Input_validation). Before integrating any input into your site's pages, perform [output encoding](/en-US/docs/Web/Security/Attacks/XSS#output_encoding) or [sanitization](/en-US/docs/Web/Security/Attacks/XSS#sanitization).
 

--- a/files/en-us/web/security/index.md
+++ b/files/en-us/web/security/index.md
@@ -12,7 +12,14 @@ The kind of damage done can be reputational, financial, or even physical. It can
 
 In this part of MDN we've written guides to help web developers understand how to protect their websites, and their users, against these attacks.
 
-Before listing these detailed guides, though, we'll summarize the most important security practices:
+The documentation is organized into four main sections:
+
+- [Attacks](/en-US/docs/Web/Security/Attacks)
+- [Defenses](/en-US/docs/Web/Security/Defenses)
+- [Threat modeling](/en-US/docs/Web/Security/Threat_modeling)
+- [Authentication](/en-US/docs/Web/Security/Authentication)
+
+In this page we'll introduce each of these sections and list the guides they contain. Before we do this, though, we'll state what we think are the core security practices that web developers should follow.
 
 - **Use [HTTPS](/en-US/docs/Web/Security/Defenses/Transport_Layer_Security)** to serve all your site's pages and subresources.
 


### PR DESCRIPTION
This rewrites the top-level security page. I've made it much more like an index of the pages in this section. I felt a bit bad removing a lot of the guide-type content here, but really it's very incomplete and outdated, so I don't think it is very useful.


