### PR TITLE
Fix mismatched left inset value in sticky positioning description

### DIFF
--- a/files/en-us/web/css/reference/properties/position/index.md
+++ b/files/en-us/web/css/reference/properties/position/index.md
@@ -465,7 +465,7 @@ dd + dd {
 
 #### Sticky position with all the inset boundaries set
 
-The following example demonstrates an element's behavior when all inset boundaries are set. Here, we have two light bulb emojis in a paragraph. The light bulbs use sticky positioning, and the inset boundaries are specified as 50px from the top, 100px from the right, 50px from the bottom, and 50px from the left. A gray background on the parent div element marks the inset area.
+The following example demonstrates an element's behavior when all inset boundaries are set. Here, we have two light bulb emojis in a paragraph. The light bulbs use sticky positioning, and the inset boundaries are specified as 50px from the top, 100px from the right, 50px from the bottom, and 100px from the left. A gray background on the parent div element marks the inset area.
 
 ##### HTML
 

--- a/files/en-us/web/css/reference/properties/position/index.md
+++ b/files/en-us/web/css/reference/properties/position/index.md
@@ -465,7 +465,7 @@ dd + dd {
 
 #### Sticky position with all the inset boundaries set
 
-The following example demonstrates an element's behavior when all inset boundaries are set. Here, we have two light bulb emojis in a paragraph. The light bulbs use sticky positioning, and the inset boundaries are specified as 50px from the top, 100px from the right, 50px from the bottom, and 100px from the left. A gray background on the parent div element marks the inset area.
+The following example demonstrates an element's behavior when all inset boundaries are set. Here, we have two light bulb emojis in a paragraph. The light bulbs use sticky positioning, and the inset boundaries are specified as 50px from the top and bottom, and 100px from the left and right. A gray background on the parent div element marks the inset area.
 
 ##### HTML
 


### PR DESCRIPTION
### Description

Corrected the left inset value in the sticky positioning documentation example from 50px to 100px.

### Motivation

The descriptive text stated the left boundary was 50px, but the accompanying CSS uses the shorthand `inset: 50px 100px;` (which sets both left and right to 100px). This change ensures the explanation  matches the code behavior.

### Additional details

None.

### Related issues and pull requests

None.