### PR TITLE
Bug 2044712 methods to get contextual identities icons and colors

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/getsupportedcolors/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/getsupportedcolors/index.md
@@ -1,0 +1,54 @@
+---
+title: contextualIdentities.getSupportedColors()
+slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/getSupportedColors
+page-type: webextension-api-function
+browser-compat: webextensions.api.contextualIdentities.getSupportedColors
+sidebar: addonsidebar
+---
+
+Returns the colors supported by the browser for contextual identities.
+
+## Syntax
+
+```js-nolint
+let colors = browser.contextualIdentities.getSupportedColors()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with an array of objects, one for each supported color. Each object has these properties:
+
+- `color`
+  - : `string`. The name of the color (for example, `"blue"`). This is the value used in the `color` property of {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}}.
+- `colorCode`
+  - : `string`. A hex code for the color (for example, `"#37adff"`).
+
+If the contextual identities feature is not enabled, the promise is rejected with an error message.
+
+## Examples
+
+Retrieve all supported colors and log their names and hex codes:
+
+```js
+function onGot(colors) {
+  for (const { color, colorCode } of colors) {
+    console.log(`${color}: ${colorCode}`);
+  }
+}
+
+function onError(error) {
+  console.error(error);
+}
+
+browser.contextualIdentities.getSupportedColors().then(onGot, onError);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/getsupportedicons/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/getsupportedicons/index.md
@@ -1,0 +1,54 @@
+---
+title: contextualIdentities.getSupportedIcons()
+slug: Mozilla/Add-ons/WebExtensions/API/contextualIdentities/getSupportedIcons
+page-type: webextension-api-function
+browser-compat: webextensions.api.contextualIdentities.getSupportedIcons
+sidebar: addonsidebar
+---
+
+Returns the icons supported by the browser for contextual identities.
+
+## Syntax
+
+```js-nolint
+let icons = browser.contextualIdentities.getSupportedIcons()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with an array of objects, one for each supported icon. Each object has these properties:
+
+- `icon`
+  - : `string`. The name of the icon (for example, `"fingerprint"`). This is the value used in the `icon` property of {{WebExtAPIRef("contextualIdentities.ContextualIdentity")}}.
+- `iconUrl`
+  - : `string`. A `resource://` URL pointing to the icon's SVG file (for example, `"resource://usercontext-content/fingerprint.svg"`).
+
+If the contextual identities feature is not enabled, the promise is rejected with an error message.
+
+## Examples
+
+Retrieve all supported icons and log their names and URLs:
+
+```js
+function onGot(icons) {
+  for (const { icon, iconUrl } of icons) {
+    console.log(`${icon}: ${iconUrl}`);
+  }
+}
+
+function onError(error) {
+  console.error(error);
+}
+
+browser.contextualIdentities.getSupportedIcons().then(onGot, onError);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contextualidentities/index.md
@@ -37,6 +37,10 @@ To use this API you need to include the "contextualIdentities" and "cookies" [pe
   - : Creates a new contextual identity.
 - {{WebExtAPIRef("contextualIdentities.get()")}}
   - : Retrieves a contextual identity, given its cookie store ID.
+- {{WebExtAPIRef("contextualIdentities.getSupportedColors()")}}
+  - : Returns the colors supported for contextual identities.
+- {{WebExtAPIRef("contextualIdentities.getSupportedIcons()")}}
+  - : Returns the icons supported for contextual identities.
 - {{WebExtAPIRef("contextualIdentities.move()")}}
   - : Moves one or more contextual identities within the list of contextual identities.
 - {{WebExtAPIRef("contextualIdentities.query()")}}

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -72,11 +72,12 @@ Firefox 153 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
+- Adds the {{WebExtAPIRef("contextualIdentities.getSupportedColors()")}} and {{WebExtAPIRef("contextualIdentities.getSupportedIcons()")}} methods to retrieve the colors and icons available for contextual identities (containers). ([Firefox bug 2044712](https://bugzil.la/2044712))
+- Extension content scripts can now read and modify constructed stylesheets in {{domxref("document.adoptedStyleSheets")}} and {{domxref("ShadowRoot.adoptedStyleSheets")}}, without `.wrappedJSObject`. ([Firefox bug 1751346](https://bugzil.la/1751346))
+
 <!-- ### Removals -->
 
 <!-- ### Other -->
-
-- Extension content scripts can now read and modify constructed stylesheets in {{domxref("document.adoptedStyleSheets")}} and {{domxref("ShadowRoot.adoptedStyleSheets")}}, without `.wrappedJSObject`. ([Firefox bug 1751346](https://bugzil.la/1751346))
 
 ## Experimental web features
 


### PR DESCRIPTION
### Description

Addresses the dev-docs-needed requirements of [Bug 2044712](https://bugzilla.mozilla.org/show_bug.cgi?id=2044712) "Expose colors and icons to extensions" including:

- a release note
- methods 'getSupportedColors()' and `getSupportedIcons()`

### Related issues and pull requests

BCD is provided in mdn/browser-compat-data#29814.
