### PR TITLE
Clarify that timeRemaining() is an estimate and not a fixed countdown (#37250)

### DIFF
--- a/files/en-us/web/api/idledeadline/timeremaining/index.md
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.md
@@ -17,6 +17,9 @@ example, if the callback finishes a task and has another one to begin, it can ca
 there isn't, the callback can just return immediately, or look for other work to do with
 the remaining time.
 
+> [!NOTE]
+> The value returned by `timeRemaining()` is an estimate of how much time the user agent believes is available before the next latency-critical task needs to run. This estimate is not fixed and can suddenly drop to 0 if higher-priority work arrives. Developers should not assume the value always decreases linearly like a countdown timer.
+
 By the time `timeRemaining()` reaches 0, it is suggested that the callback
 should return control to the user agent's event loop.
 

--- a/files/en-us/web/api/idledeadline/timeremaining/index.md
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.md
@@ -9,7 +9,7 @@ browser-compat: api.IdleDeadline.timeRemaining
 {{APIRef("Background Tasks")}}
 
 The **`timeRemaining()`** method
-on the {{domxref("IdleDeadline")}} interface returns the estimated number of
+of the {{domxref("IdleDeadline")}} interface returns the estimated number of
 milliseconds the user agent will remain idle for. The callback can call this method at
 any time to determine how much time it can continue to work before it must return. For
 example, if the callback finishes a task and has another one to begin, it can call
@@ -17,11 +17,11 @@ example, if the callback finishes a task and has another one to begin, it can ca
 there isn't, the callback can just return immediately, or look for other work to do with
 the remaining time.
 
+By the time `timeRemaining()` reaches `0`, it is suggested that the callback
+should return control to the user agent's event loop.
+
 > [!NOTE]
 > The value returned by `timeRemaining()` is an estimate of how much time the user agent believes is available before the next latency-critical task needs to run. This estimate is not fixed and can suddenly drop to 0 if higher-priority work arrives. For example, the browser's estimate can change in the middle of an idle callback if the user clicks. Developers should not assume the value always decreases linearly like a countdown timer.
-
-By the time `timeRemaining()` reaches 0, it is suggested that the callback
-should return control to the user agent's event loop.
 
 ## Syntax
 

--- a/files/en-us/web/api/idledeadline/timeremaining/index.md
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.md
@@ -10,7 +10,7 @@ browser-compat: api.IdleDeadline.timeRemaining
 
 The **`timeRemaining()`** method
 on the {{domxref("IdleDeadline")}} interface returns the estimated number of
-milliseconds remaining in the current idle period. The callback can call this method at
+milliseconds the user agent will remain idle for. The callback can call this method at
 any time to determine how much time it can continue to work before it must return. For
 example, if the callback finishes a task and has another one to begin, it can call
 `timeRemaining()` to see if there's enough time to complete the next task. If
@@ -18,7 +18,7 @@ there isn't, the callback can just return immediately, or look for other work to
 the remaining time.
 
 > [!NOTE]
-> The value returned by `timeRemaining()` is an estimate of how much time the user agent believes is available before the next latency-critical task needs to run. This estimate is not fixed and can suddenly drop to 0 if higher-priority work arrives. Developers should not assume the value always decreases linearly like a countdown timer.
+> The value returned by `timeRemaining()` is an estimate of how much time the user agent believes is available before the next latency-critical task needs to run. This estimate is not fixed and can suddenly drop to 0 if higher-priority work arrives. For example, the browser's estimate can change in the middle of an idle callback if the user clicks. Developers should not assume the value always decreases linearly like a countdown timer.
 
 By the time `timeRemaining()` reaches 0, it is suggested that the callback
 should return control to the user agent's event loop.


### PR DESCRIPTION
### Description

Adds a note to the `IdleDeadline.timeRemaining()` documentation clarifying that the returned value is an estimate of available idle time and should not be treated as a fixed countdown.

### Motivation

The current documentation may imply that `timeRemaining()` continuously counts down during an idle period. However, the browser's estimate can change and may suddenly drop to `0` when higher-priority (latency-critical) work arrives. This update helps readers better understand the behavior of the API and avoid incorrect assumptions when scheduling background tasks.

### Additional details

The note was added to the introduction section of the page and is based on the discussion in the linked issue regarding how browsers determine remaining idle time.

### Related issues and pull requests

Fixes #37250
