### PR TITLE
[Editorial review] BiDi - Add pages for navigation commands of browsingContext module

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
@@ -29,8 +29,7 @@ The `params` field contains:
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `promptUnload` {{optional_inline}}
   - : A boolean that indicates whether the browser runs [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) event handlers before closing the context.
-    The default value is `false`.
-    - `false`: The specified context closes immediately without running `beforeunload` event handlers.
+    - `false`: The specified context closes immediately without running `beforeunload` event handlers. This is the default.
     - `true`: The browser runs `beforeunload` event handlers before closing the specified context.
       Any resulting prompt is handled as defined by the `unhandledPromptBehavior` capability specified via the [`session.new`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#unhandledpromptbehavior) command.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -26,8 +26,7 @@ The `params` field contains:
 
 - `background` {{optional_inline}}
   - : A boolean that indicates whether the context is created in the background or the foreground.
-    The default value is `false`.
-    - `false`: The context is brought to the foreground and receives focus after it is created.
+    - `false`: The context is brought to the foreground and receives focus after it is created. This is the default.
     - `true`: The context is created in the background. See [`browsingContext.activate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/activate) to bring it to the foreground and give it focus.
 - `referenceContext` {{optional_inline}}
   - : A string that contains the ID of an existing [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) that is used to position the new context.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigate/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigate/index.md
@@ -70,7 +70,7 @@ The `result` object in the response contains the following fields:
 
 Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new).
 
-Suppose you create a new tab using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create). Using the context ID of that tab, send the following message to navigate it to, say, `https://example.com/page.html`:
+Suppose you create a new tab using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create). Using the context ID of that tab, send the following message to navigate it to `https://example.com/page.html`:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigate/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigate/index.md
@@ -139,7 +139,6 @@ The browser responds as follows, once the document and all its subresources have
 - [`browsingContext.traverseHistory`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/traverseHistory) command
 - [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
 - [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
-- [`browsingContext.navigationAborted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationAborted) event
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
 - [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
 - [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
-- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigate/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigate/index.md
@@ -1,0 +1,145 @@
+---
+title: "`browsingContext.navigate` command"
+short-title: navigate
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browsingContext.navigate
+sidebar: webdriver
+---
+
+The `browsingContext.navigate` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module navigates the specified [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) to the given URL.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browsingContext.navigate",
+  "params": {
+    "context": "<contextId>",
+    "url": "<url>"
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID of the context to be navigated.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `url`
+  - : A string that contains the destination URL.
+- `wait` {{optional_inline}}
+  - : A keyword that specifies the stage of document loading at which the command returns (the stages correspond to those of the [`document.readyState`](/en-US/docs/Web/API/Document/readyState) property).
+    It can take one of the following values:
+    - `"complete"`
+      - : The command returns when the document and all its subresources have finished loading.
+        Use this value when your automation needs to interact with page content — for example, to click a button or read text — before sending further commands.
+    - `"interactive"`
+      - : The command returns when the document has been parsed and is ready for interaction.
+        Use this value when you need the DOM to be available but don't need images or other subresources to finish loading.
+    - `"none"`
+      - : The command returns once the navigation has committed, that is, the browser has accepted the URL and begun loading the new page, but page content is not yet available.
+        This is also the default behavior when `wait` is omitted.
+        Use this value when you only need to initiate the navigation and track its progress through navigation events.
+
+### Return value
+
+The `result` object in the response contains the following fields:
+
+- `navigation`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) that uniquely identifies this navigation. A new UUID is generated for each `browsingContext.navigate` command.
+    If you are subscribed to navigation events such as [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted), the event includes this same UUID, letting you match the event back to this specific navigate call.
+- `url`
+  - : A string that contains the URL of the loaded document, including the fragment.
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
+    This error is also returned if the `url` parameter is not a valid URL.
+- `no such frame`
+  - : No context with the given context ID is found.
+- `unknown error`
+  - : A navigation failure occurred, such as a network error or an aborted navigation.
+
+## Examples
+
+### Navigating to a URL
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new).
+
+Suppose you create a new tab using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create). Using the context ID of that tab, send the following message to navigate it to, say, `https://example.com/page.html`:
+
+```json
+{
+  "id": 1,
+  "method": "browsingContext.navigate",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "url": "https://example.com/page.html"
+  }
+}
+```
+
+The browser responds as follows with the navigation ID and the URL of the loaded document:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "navigation": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "url": "https://example.com/page.html"
+  }
+}
+```
+
+### Navigating and waiting for the page to fully load
+
+Suppose you want to navigate a context to `https://example.com/form.html` and wait until the page has fully loaded before continuing. Send the following message:
+
+```json
+{
+  "id": 2,
+  "method": "browsingContext.navigate",
+  "params": {
+    "context": "d84e9b52-c4a1-4f88-b537-613c8a5b9e2d",
+    "url": "https://example.com/form.html",
+    "wait": "complete"
+  }
+}
+```
+
+The browser responds as follows, once the document and all its subresources have finished loading:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "navigation": "b2c3d4e5-f6a7-8901-bcde-f01234567890",
+    "url": "https://example.com/form.html"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command
+- [`browsingContext.traverseHistory`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/traverseHistory) command
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
+- [`browsingContext.navigationAborted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationAborted) event
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/reload/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/reload/index.md
@@ -1,0 +1,171 @@
+---
+title: "`browsingContext.reload` command"
+short-title: reload
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browsingContext.reload
+sidebar: webdriver
+---
+
+The `browsingContext.reload` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module reloads the specified [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts).
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browsingContext.reload",
+  "params": {
+    "context": "<contextId>"
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID of the context to reload.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `ignoreCache` {{optional_inline}}
+  - : A boolean that indicates whether the browser bypasses the HTTP cache when reloading.
+    - `false`: The browser may use cached resources when reloading. This is the default.
+    - `true`: The browser reloads the page without using cached resources, fetching all content from the network.
+- `wait` {{optional_inline}}
+  - : A keyword that specifies the stage of document loading at which the command returns (the stages correspond to those of the [`document.readyState`](/en-US/docs/Web/API/Document/readyState) property).
+    It can take one of the following values:
+    - `"complete"`
+      - : The command returns when the document and all its subresources have finished loading.
+        Use this value when your automation needs to interact with page content — for example, to click a button or read text — before sending further commands.
+    - `"interactive"`
+      - : The command returns when the document has been parsed and is ready for interaction.
+        Use this value when you need the DOM to be available but don't need images or other subresources to finish loading.
+    - `"none"`
+      - : The command returns once the navigation has committed, that is, the browser has begun reloading the page, but page content is not yet available.
+        This is also the default behavior when `wait` is omitted.
+        Use this value when you only need to initiate the reload and track its progress through navigation events.
+
+### Return value
+
+The `result` object in the response contains the following fields:
+
+- `navigation`
+  - : A string that contains the ID ([UUID](/en-US/docs/Glossary/UUID)) that uniquely identifies this navigation. A new UUID is generated for each `browsingContext.reload` command.
+    If you are subscribed to navigation events such as [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted), the event includes this same UUID, letting you match the event back to this specific reload call.
+- `url`
+  - : A string that contains the URL of the reloaded document, including the fragment.
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
+- `no such frame`
+  - : No context with the given context ID is found.
+- `unknown error`
+  - : A navigation failure occurred, such as a network error or an aborted reload.
+
+## Examples
+
+### Reloading a page
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new).
+
+Suppose a tab has `https://example.com/` loaded. Using the context ID of that tab, send the following message to reload it:
+
+```json
+{
+  "id": 1,
+  "method": "browsingContext.reload",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa"
+  }
+}
+```
+
+The browser responds as follows with the navigation ID and the URL of the reloaded document:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "navigation": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "url": "https://example.com/"
+  }
+}
+```
+
+### Bypassing the cache while reloading a page
+
+Suppose a tab has `https://example.com/` loaded and you want to force the browser to fetch all resources from the network, bypassing the cache. Using the context ID of that tab, send the following message:
+
+```json
+{
+  "id": 2,
+  "method": "browsingContext.reload",
+  "params": {
+    "context": "d84e9b52-c4a1-4f88-b537-613c8a5b9e2d",
+    "ignoreCache": true
+  }
+}
+```
+
+The browser reloads the page and responds once the navigation has committed:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "navigation": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    "url": "https://example.com/"
+  }
+}
+```
+
+### Waiting for a page to finish loading while reloading it
+
+Suppose a tab has `https://example.com/` loaded and you want to reload it, but not continue until the page has fully loaded. Using the context ID of that tab, send the following message:
+
+```json
+{
+  "id": 3,
+  "method": "browsingContext.reload",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "wait": "complete"
+  }
+}
+```
+
+The browser responds as follows, once the document and all its subresources have finished loading:
+
+```json
+{
+  "id": 3,
+  "type": "success",
+  "result": {
+    "navigation": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+    "url": "https://example.com/"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) command
+- [`browsingContext.traverseHistory`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/traverseHistory) command
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
+- [`browsingContext.navigationAborted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationAborted) event
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/reload/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/reload/index.md
@@ -165,7 +165,6 @@ The browser responds as follows, once the document and all its subresources have
 - [`browsingContext.traverseHistory`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/traverseHistory) command
 - [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
 - [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
-- [`browsingContext.navigationAborted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationAborted) event
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
 - [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
 - [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
-- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/traversehistory/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/traversehistory/index.md
@@ -1,0 +1,120 @@
+---
+title: "`browsingContext.traverseHistory` command"
+short-title: traverseHistory
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/traverseHistory
+page-type: webdriver-command
+browser-compat: webdriver.bidi.browsingContext.traverseHistory
+sidebar: webdriver
+---
+
+The `browsingContext.traverseHistory` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module navigates back or forward in the session history of the specified [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context), similar to a user clicking the browser's back and forward buttons.
+
+## Syntax
+
+```json-nolint
+{
+  "method": "browsingContext.traverseHistory",
+  "params": {
+    "context": "<contextId>",
+    "delta": <integer>
+  }
+}
+```
+
+### Parameters
+
+The `params` field contains:
+
+- `context`
+  - : A string that contains the ID of the [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context) whose session history is to be navigated.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+- `delta`
+  - : An integer that specifies the number of history entries to move in the session history.
+    A positive value moves the context forward in history; a negative value moves it backward.
+
+### Return value
+
+The `result` field in the response is an empty object (`{}`). The command returns once the traversal has been queued, before the resulting navigation is complete.
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A required parameter is missing or has an invalid type.
+    This error is also returned when the specified `context` is not a [top-level context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#top-level_context).
+- `no such frame`
+  - : No context with the given context ID is found.
+- `no such history entry`
+  - : The position in the session history specified by `delta` does not exist.
+
+## Examples
+
+### Navigating back in history
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new).
+
+Suppose you created a tab using [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) and navigated it through several pages using [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate): from `https://example.com/page1.html` to `https://example.com/page2.html`, and then to `https://example.com/page3.html`. To navigate two history entries back, that is, to skip `https://example.com/page2.html` and land at `https://example.com/page1.html`, send the following message:
+
+```json
+{
+  "id": 1,
+  "method": "browsingContext.traverseHistory",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "delta": -2
+  }
+}
+```
+
+The browser queues the history traversal and responds as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {}
+}
+```
+
+### Navigating forward in history
+
+Continuing from the previous example, to navigate one history entry forward, landing at `https://example.com/page2.html`, send the following message:
+
+```json
+{
+  "id": 2,
+  "method": "browsingContext.traverseHistory",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "delta": 1
+  }
+}
+```
+
+The browser queues the history traversal and responds as follows:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {}
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) command
+- [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command
+- [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
+- [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
+- [`browsingContext.navigationAborted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationAborted) event
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/traversehistory/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/traversehistory/index.md
@@ -116,7 +116,7 @@ The browser queues the history traversal and responds as follows:
 - [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command
 - [`browsingContext.create`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/create) command
 - [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree) command
-- [`browsingContext.navigationAborted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationAborted) event
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
 - [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
 - [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
-- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
+- [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/traversehistory/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/traversehistory/index.md
@@ -34,7 +34,9 @@ The `params` field contains:
 
 ### Return value
 
-The `result` field in the response is an empty object (`{}`). The command returns once the traversal has been queued, before the resulting navigation is complete.
+The `result` field in the response is an empty object (`{}`).
+The command returns once the traversal has been queued, before the resulting navigation is complete.
+The [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated) event fires when the traversal is complete.
 
 ### Errors
 

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -49,6 +49,12 @@ sidebar:
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree
             code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/traverseHistory
+            code: true
           - type: section
             link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext#events
             title: Events


### PR DESCRIPTION
### Description

This PR adds pages for navigation commands:
  - `browsingContext.navigate`
  - `browsingContext.reload`
  - `browsingContext.traverseHistory`


### Spec links

- https://w3c.github.io/webdriver-bidi/#command-browsingContext-navigate
- https://w3c.github.io/webdriver-bidi/#command-browsingContext-reload
- https://w3c.github.io/webdriver-bidi/#command-browsingContext-traverseHistory

### Related issue

Doc issue: mdn/mdn#339