### PR TITLE
BiDi docs: Fix fields to be in alphabetical order

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -36,8 +36,6 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 
 The `params` field contains:
 
-- `context`
-  - : A string that contains the ID of the context in which to perform the actions. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 - `actions`
   - : An array of objects, each representing an input source and the actions to perform for that source.
     Each such object represents the outer `actions` object, which in turn, contains an outer `type` (input source type can be `"key"`, `"pointer"`, or `"wheel"`) and an inner `actions` array.
@@ -48,29 +46,25 @@ The `params` field contains:
     This allows combining input sources, for example, holding <kbd>Shift</kbd> while clicking.
 
     Each outer `actions` object has the following fields:
-    - `id`
-      - : A string that uniquely identifies this input source within the action sequence, for example, `"mouse1"` or `"keyboard1"`.
-    - `type`
-      - : A string (the outer `type`) that identifies the type of input source. Accepted values are `"none"`, `"key"`, `"pointer"`, and `"wheel"`.
     - `actions`
       - : An array of objects (the inner `actions`), each representing an action for the input source specified in the outer [`type`](#type) field.
 
         Each inner `actions` object has an inner `type` field that specifies the operation to perform and additional fields that depend on it.
         The inner `type` accepts the following values:
-        - `"pause"`: Waits for the given duration before the next step.
         - `"keyDown"`: Simulates pressing a key.
         - `"keyUp"`: Simulates releasing a key.
+        - `"pause"`: Waits for the given duration before the next step.
         - `"pointerDown"`: Simulates pressing a pointer button.
-        - `"pointerUp"`: Simulates releasing a pointer button.
         - `"pointerMove"`: Simulates moving the pointer.
+        - `"pointerUp"`: Simulates releasing a pointer button.
         - `"scroll"`: Simulates a mouse wheel scroll.
 
         The following table shows, for each outer `type` value, the valid values for the inner `type`:
 
         | Outer `type` values | Accepted inner `type` values                               |
         | ------------------- | ---------------------------------------------------------- |
-        | `"none"`            | `"pause"`                                                  |
         | `"key"`             | `"pause"`, `"keyDown"`, `"keyUp"`                          |
+        | `"none"`            | `"pause"`                                                  |
         | `"pointer"`         | `"pause"`, `"pointerDown"`, `"pointerUp"`, `"pointerMove"` |
         | `"wheel"`           | `"pause"`, `"scroll"`                                      |
 
@@ -78,16 +72,22 @@ The `params` field contains:
 
         | Inner `type` values    | Fields available in the inner `actions` object                                                                |
         | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
-        | `"pause"`              | [`duration`](#duration)                                                                                       |
         | `"keyDown"`, `"keyUp"` | [`value`](#value)                                                                                             |
+        | `"pause"`              | [`duration`](#duration)                                                                                       |
         | `"pointerDown"`        | [`button`](#button), [pointer properties](#pointer_properties)                                                |
-        | `"pointerUp"`          | [`button`](#button)                                                                                           |
         | `"pointerMove"`        | [`x`](#x), [`y`](#y), [`duration`](#duration), [`origin`](#origin), [pointer properties](#pointer_properties) |
+        | `"pointerUp"`          | [`button`](#button)                                                                                           |
         | `"scroll"`             | [`x`](#x), [`y`](#y), [`deltaX`](#deltax), [`deltaY`](#deltay), [`duration`](#duration), [`origin`](#origin)  |
 
-    The outer `actions` object also supports the following field:
+    - `id`
+      - : A string that uniquely identifies this input source within the action sequence, for example, `"mouse1"` or `"keyboard1"`.
     - `parameters` {{optional_inline}}
       - : An object with a `pointerType` field that specifies the pointer device type. Accepted values are `"mouse"` (default), `"pen"`, or `"touch"`. This field is valid only when the outer [`type`](#type) is `"pointer"`.
+    - `type`
+      - : A string (the outer `type`) that identifies the type of input source. Accepted values are `"none"`, `"key"`, `"pointer"`, and `"wheel"`.
+
+- `context`
+  - : A string that contains the ID of the context in which to perform the actions. Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
 The following fields are available in each inner `actions` object, depending on the inner `type`:
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
@@ -58,8 +58,6 @@ The `alwaysMatch` and `firstMatch` objects can include the following features:
 
 The following fields in the `result` object of the response describe the characteristics of the created session:
 
-- `sessionId`
-  - : A string that contains the unique identifier for the newly created session.
 - `capabilities`
   - : An object that describes the capabilities that were negotiated and are active for the session. It includes the following fields:
     - [`acceptInsecureCerts`](/en-US/docs/Web/WebDriver/Reference/Capabilities/acceptInsecureCerts)
@@ -70,16 +68,19 @@ The following fields in the `result` object of the response describe the charact
       - : A string that contains the version of the browser.
     - `platformName`
       - : A string that contains the name of the operating system.
+    - `proxy` {{optional_inline}}
+      - : An object that describes the active proxy configuration.
+        An empty object (`{}`) indicates no proxy is configured.
     - `setWindowRect`
       - : A boolean that indicates whether the browser window can be resized and repositioned using the [Set Window Rect](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetWindowRect) command.
-    - `userAgent`
-      - : A string that contains the browser's user agent string (for example, `"Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0"`).
-    - `proxy` {{optional_inline}}
-      - : An object that describes the active proxy configuration. An empty object (`{}`) indicates no proxy is configured.
     - `unhandledPromptBehavior` {{optional_inline}}
       - : An object that describes the default behavior when a user prompt (such as an `alert`, `confirm`, or `prompt` dialog) is encountered during a command. This field is present only when specified in the `capabilities` parameter.
+    - `userAgent`
+      - : A string that contains the browser's user agent string (for example, `"Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0"`).
     - [`webSocketUrl`](/en-US/docs/Web/WebDriver/Reference/Capabilities/webSocketUrl) {{optional_inline}}
       - : A string that contains the WebSocket URL for the session.
+- `sessionId`
+  - : A string that contains the unique identifier for the newly created session.
 
 The browser may also return vendor-specific capabilities prefixed with a browser identifier (for example, `moz:buildID` for Firefox).
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/status/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/status/index.md
@@ -28,14 +28,12 @@ None. However, you must include the `params` field and set it to an empty object
 
 The following fields in the `result` object of the response describe the current status of the browser:
 
-- `ready`
-  - : A boolean that indicates whether the browser is ready to create new sessions.
-    - `true`
-      - : The browser is ready to create a new session.
-    - `false`
-      - : The browser cannot accept new sessions because it already has an active session or is otherwise in a state where creating a session would fail.
 - `message`
   - : A string with information about the browser's current status.
+- `ready`
+  - : A boolean that indicates whether the browser is ready to create new sessions.
+    - `false`: The browser cannot accept new sessions because it already has an active session or is otherwise in a state where creating a session would fail.
+    - `true`: The browser is ready to create a new session.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/status/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/status/index.md
@@ -32,8 +32,8 @@ The following fields in the `result` object of the response describe the current
   - : A string with information about the browser's current status.
 - `ready`
   - : A boolean that indicates whether the browser is ready to create new sessions.
-    - `false`: The browser cannot accept new sessions because it already has an active session or is otherwise in a state where creating a session would fail.
     - `true`: The browser is ready to create a new session.
+    - `false`: The browser cannot accept new sessions because it already has an active session or is otherwise in a state where creating a session would fail.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
@@ -24,8 +24,6 @@ The `session.subscribe` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
 
 The `params` field contains:
 
-- `events`
-  - : An array of one or more event name strings. Use a module name (for example, `"log"`) to subscribe to all events in that module or a specific event name (for example, `"log.entryAdded"`) to subscribe to only that event.
 - `contexts` {{optional_inline}}
   - : An array of one or more context ID strings, each corresponding to a tab or frame.
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
@@ -34,6 +32,9 @@ The `params` field contains:
 
     This field cannot be used if `userContexts` is also specified.
 
+- `events`
+  - : An array of one or more event name strings.
+    Use a module name (for example, `"log"`) to subscribe to all events in that module or a specific event name (for example, `"log.entryAdded"`) to subscribe to only that event.
 - `userContexts` {{optional_inline}}
   - : An array of one or more user context ID strings, each corresponding to a browser context or container.
     User context IDs are returned by commands such as [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext) or [`browser.getUserContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/getUserContexts).

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/unsubscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/unsubscribe/index.md
@@ -37,12 +37,12 @@ To unsubscribe using event name:
 
 The `params` field contains one of the following fields:
 
-- `subscriptions`
-  - : An array of one or more subscription IDs that specifies the subscriptions to cancel, including both global and context-scoped subscriptions.
 - `events`
   - : An array of one or more strings that specifies event names for canceling subscriptions.
     Each string can be either a specific event name (for example, `"log.entryAdded"`) or a module name (for example, `"log"`) that unsubscribes the client from all events in that module.
     Only global subscriptions can be removed using event names; those created using [`contexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe#contexts) or [`userContexts`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe#usercontexts) cannot be.
+- `subscriptions`
+  - : An array of one or more subscription IDs that specifies the subscriptions to cancel, including both global and context-scoped subscriptions.
 
 ### Return value
 


### PR DESCRIPTION
### Description

As a follow-up to fix the feedback in https://github.com/mdn/content/pull/44121#pullrequestreview-4409452141, this PR updates the parameter and return value field ordering to be alphabetical across BiDi reference pages.

A few other things to note:
 - `session.status`: Also fixed `true` and `false` sub-items from a DL to inline bullet format
 - `input.performActions`: Reordered the top-level parameters, outer and inner `actions` sub-fields, and also the entries in the two tables


