### PR TITLE
Clarify Array map NodeList example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -268,7 +268,7 @@ console.log(Array.prototype.map.call(arrayLike, (x) => x ** 2));
 // [ 4, 9, 16 ]
 ```
 
-This example shows how to iterate through a collection of objects collected by `querySelectorAll`. Because `querySelectorAll` returns a `NodeList` (which is a collection of objects), `Array.prototype.map.call()` is used to return an array containing the values of all the selected `option` elements:
+This example shows how to iterate through a collection of objects collected by `querySelectorAll()`, returning an array containing the values of all the selected `option` elements. Because `querySelectorAll()` returns a `NodeList`, which is an array-like object without the `map()` method, we use `Array.prototype.map.call()`, passing `elems` as the `this` value and the callback as the second argument.
 
 ```js
 const elems = document.querySelectorAll("select option:checked");

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -268,7 +268,7 @@ console.log(Array.prototype.map.call(arrayLike, (x) => x ** 2));
 // [ 4, 9, 16 ]
 ```
 
-This example shows how to iterate through a collection of objects collected by `querySelectorAll`. This is because `querySelectorAll` returns a `NodeList` (which is a collection of objects). In this case, we return all the selected `option`s' values on the screen:
+This example shows how to iterate through a collection of objects collected by `querySelectorAll`. Because `querySelectorAll` returns a `NodeList` (which is a collection of objects), `Array.prototype.map.call()` is used to return an array containing the values of all the selected `option` elements:
 
 ```js
 const elems = document.querySelectorAll("select option:checked");


### PR DESCRIPTION
## Summary

Clarifies the `Array.prototype.map()` example that uses `querySelectorAll()` with a `NodeList`.

## Changes

- Rewords the example explanation to say that `Array.prototype.map.call()` returns an array of selected `option` values.
- Removes wording that implied the values are shown on the screen.

## Why this helps readers

The code example creates an array; it does not render output to the page. This clarification helps beginners understand what the example actually returns and why `Array.prototype.map.call()` is used with a `NodeList`.

## Testing/checks performed

- `corepack npm exec --package prettier -- prettier -c files/en-us/web/javascript/reference/global_objects/array/map/index.md`
- `git diff --check`

Note: `corepack npm ci` was retried with Node.js `v24.16.0`. It no longer fails due to the Node.js version requirement, but it still did not complete locally because the `@mdn/rari` postinstall step exited with code 13 while downloading/unpacking the Rari binary.

## Note

This is a focused documentation improvement to one JavaScript reference page.