### PR TITLE
Clarify CSS split navigation auto margin

### DIFF
--- a/files/en-us/web/css/how_to/layout_cookbook/split_navigation/index.md
+++ b/files/en-us/web/css/how_to/layout_cookbook/split_navigation/index.md
@@ -56,7 +56,7 @@ This pattern combines auto margins with flexbox to split the items.
 
 An auto margin absorbs all available space in the direction it is applied. This is how centering a block with auto margins works — you have a margin on each side of the block trying to take up all of the space, thus pushing the block into the middle.
 
-In this case the left auto margin takes up any available space and pushes the item over to the right. You could apply the class `push` to any item in the list.
+In this case, the left auto margin on the `.push` item takes up any available space before that item, pushing it and the items that follow it over to the right. You could apply the class `push` to any item in the list.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Clarifies the CSS split navigation cookbook explanation for using an auto margin with flexbox.

## Changes

- Rewords the explanation of the `.push` item in the split navigation example.
- Makes it clearer that `margin-left: auto` absorbs space before that flex item and moves it, along with following items, to the right.

## Why this helps readers

The example relies on a flex item with an auto left margin to split the navigation. This wording makes the relationship between the `.push` class and the resulting layout clearer for readers who are learning flexbox patterns.

## Testing/checks performed

- `corepack npm exec --package prettier -- prettier -c files/en-us/web/css/how_to/layout_cookbook/split_navigation/index.md`
- `git diff --check`

Note: `corepack npm ci` was retried with Node.js `v24.16.0`. It no longer fails due to the Node.js version requirement, but it still did not complete locally because the `@mdn/rari` postinstall step exited with code 13 while unpacking the Rari binary.

## Note

This is a focused documentation improvement to one CSS layout cookbook page.