### PR TITLE
Clarify HTTP 429 Retry-After example

### DIFF
--- a/files/en-us/web/http/reference/status/429/index.md
+++ b/files/en-us/web/http/reference/status/429/index.md
@@ -32,7 +32,7 @@ Host: example.com
 ```
 
 In this example, server-wide rate limiting is active when a client exceeds a set threshold of requests per minute.
-A 429 response is returned with a {{HTTPHeader("Retry-After")}} header that indicates that requests will be allowed for this client again in 60 minutes:
+A 429 response is returned with a {{HTTPHeader("Retry-After")}} header that indicates requests will be allowed for this client again after 3600 seconds (60 minutes):
 
 ```http
 HTTP/1.1 429 Too Many Requests


### PR DESCRIPTION
## Summary

Clarifies the `Retry-After` value in the HTTP `429 Too Many Requests` example.

## Changes

- Rewords the example explanation to connect `Retry-After: 3600` with its duration in seconds.
- Keeps the existing 60-minute explanation while making the header value easier to interpret.

## Why this helps readers

The example uses the numeric `Retry-After` form, which is expressed in seconds. Explicitly connecting `3600` seconds to 60 minutes helps readers understand how the response header maps to the retry delay.

## Testing/checks performed

- `corepack npm exec --package prettier -- prettier -c files/en-us/web/http/reference/status/429/index.md`
- `git diff --check`

Note: `corepack npm ci` was retried with Node.js `v24.16.0`. It no longer fails due to the Node.js version requirement, but it still did not complete locally because the `@mdn/rari` postinstall step exited with code 13 while unpacking the Rari binary.

## Note

This is a focused documentation improvement to one HTTP status code reference page.