### PR TITLE
WebTransportDatagramsWritable and friends

### DIFF
--- a/files/en-us/web/api/webtransport/createsendgroup/index.md
+++ b/files/en-us/web/api/webtransport/createsendgroup/index.md
@@ -33,7 +33,7 @@ A {{domxref("WebTransportSendGroup")}} object.
 
 The **`createSendGroup()`** method creates a new `WebTransportSendGroup` associated with the `WebTransport` object on which it is called.
 
-The `WebTransportSendGroup` is used to group together streams and datagrams created on the same `WebTransport`, for the purpose of controlling their relative priority for sending queued bytes.
+The `WebTransportSendGroup` object is used to group streams and/or datagrams created on the same `WebTransport`, to control their relative priority for sending queued bytes.
 Within the same group, bytes on higher-priority streams and datagrams are sent before bytes from lower-priority ones.
 
 The returned `WebTransportSendGroup` is not initially associated with any streams or datagrams.

--- a/files/en-us/web/api/webtransport/createsendgroup/index.md
+++ b/files/en-us/web/api/webtransport/createsendgroup/index.md
@@ -1,0 +1,76 @@
+---
+title: "WebTransport: createSendGroup() method"
+short-title: createSendGroup()
+slug: Web/API/WebTransport/createSendGroup
+page-type: web-api-instance-method
+browser-compat: api.WebTransport.createSendGroup
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`createSendGroup()`** method of the {{domxref("WebTransport")}} interface creates and returns a {{domxref("WebTransportSendGroup")}}.
+
+## Syntax
+
+```js-nolint
+createSendGroup()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{domxref("WebTransportSendGroup")}} object.
+
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the transport's state is `"closed"` or `"failed"`.
+
+## Description
+
+The **`createSendGroup()`** method creates a new `WebTransportSendGroup` associated with the `WebTransport` object on which it is called.
+
+The `WebTransportSendGroup` is used to group together streams and/or datagrams created on the same `WebTransport`, for the purpose of controlling their relative priority for sending queued bytes.
+Within the same group, bytes on higher-priority streams and datagrams are sent before bytes from lower-priority ones.
+
+The returned `WebTransportSendGroup` is not initially associated with any streams or datagrams.
+You can associate it with a stream or datagram writable by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards — see `WebTransportSendStream.sendGroup` and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
+
+## Examples
+
+### Basic usage
+
+This example creates a send group, then associates a unidirectional stream and the connection's outgoing datagram stream with it, giving each a `sendOrder` that defines their relative priority.
+
+```js
+const sendGroup = transport.createSendGroup();
+
+const stream = await transport.createUnidirectionalStream({
+  sendGroup,
+  sendOrder: 1,
+});
+
+// Higher sendOrder: queued bytes on this stream are sent first
+const datagrams = transport.datagrams.createWritable({
+  sendGroup,
+  sendOrder: 2,
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransport/createsendgroup/index.md
+++ b/files/en-us/web/api/webtransport/createsendgroup/index.md
@@ -37,7 +37,10 @@ The `WebTransportSendGroup` is used to group together streams and datagrams crea
 Within the same group, bytes on higher-priority streams and datagrams are sent before bytes from lower-priority ones.
 
 The returned `WebTransportSendGroup` is not initially associated with any streams or datagrams.
-You can associate it with a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards — see `WebTransportSendStream.sendGroup` and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+You can associate it with a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} object in a couple of different ways:
+
+- By passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}}.
+- By setting the object's `sendGroup` property afterwards — see `WebTransportSendStream.sendGroup` and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
 
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 

--- a/files/en-us/web/api/webtransport/createsendgroup/index.md
+++ b/files/en-us/web/api/webtransport/createsendgroup/index.md
@@ -37,7 +37,7 @@ The `WebTransportSendGroup` is used to group together streams and/or datagrams c
 Within the same group, bytes on higher-priority streams and datagrams are sent before bytes from lower-priority ones.
 
 The returned `WebTransportSendGroup` is not initially associated with any streams or datagrams.
-You can associate it with a stream or datagram writable by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards — see `WebTransportSendStream.sendGroup` and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+You can associate it with a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards — see `WebTransportSendStream.sendGroup` and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
 
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 
@@ -72,5 +72,5 @@ const datagrams = transport.datagrams.createWritable({
 
 ## See also
 
-- {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}

--- a/files/en-us/web/api/webtransport/createsendgroup/index.md
+++ b/files/en-us/web/api/webtransport/createsendgroup/index.md
@@ -33,7 +33,7 @@ A {{domxref("WebTransportSendGroup")}} object.
 
 The **`createSendGroup()`** method creates a new `WebTransportSendGroup` associated with the `WebTransport` object on which it is called.
 
-The `WebTransportSendGroup` is used to group together streams and/or datagrams created on the same `WebTransport`, for the purpose of controlling their relative priority for sending queued bytes.
+The `WebTransportSendGroup` is used to group together streams and datagrams created on the same `WebTransport`, for the purpose of controlling their relative priority for sending queued bytes.
 Within the same group, bytes on higher-priority streams and datagrams are sent before bytes from lower-priority ones.
 
 The returned `WebTransportSendGroup` is not initially associated with any streams or datagrams.

--- a/files/en-us/web/api/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/index.md
@@ -39,6 +39,8 @@ The **`WebTransport`** interface of the {{domxref("WebTransport API", "WebTransp
   - : Closes an ongoing WebTransport session.
 - {{domxref("WebTransport.createBidirectionalStream", "createBidirectionalStream()")}}
   - : Asynchronously opens a bidirectional stream ({{domxref("WebTransportBidirectionalStream")}}) that can be used to read from and write to the server.
+- {{domxref("WebTransport.createSendGroup", "createSendGroup()")}}
+  - : Returns a {{domxref("WebTransportSendGroup")}} that can be used to group together streams and datagrams so that their relative sending priority can be prioritized.
 - {{domxref("WebTransport.createUnidirectionalStream", "createUnidirectionalStream()")}}
   - : Asynchronously opens a unidirectional stream ({{domxref("WritableStream")}}) that can be used to write to the server.
 - {{domxref("WebTransport.getStats", "getStats()")}}

--- a/files/en-us/web/api/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/index.md
@@ -40,7 +40,7 @@ The **`WebTransport`** interface of the {{domxref("WebTransport API", "WebTransp
 - {{domxref("WebTransport.createBidirectionalStream", "createBidirectionalStream()")}}
   - : Asynchronously opens a bidirectional stream ({{domxref("WebTransportBidirectionalStream")}}) that can be used to read from and write to the server.
 - {{domxref("WebTransport.createSendGroup", "createSendGroup()")}}
-  - : Returns a {{domxref("WebTransportSendGroup")}} that can be used to group together streams and datagrams so that their relative sending priority can be prioritized.
+  - : Returns a {{domxref("WebTransportSendGroup")}} that can be used to group together streams and datagrams so that their relative sending priority can be controlled as a set.
 - {{domxref("WebTransport.createUnidirectionalStream", "createUnidirectionalStream()")}}
   - : Asynchronously opens a unidirectional stream ({{domxref("WritableStream")}}) that can be used to write to the server.
 - {{domxref("WebTransport.getStats", "getStats()")}}

--- a/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
@@ -1,0 +1,103 @@
+---
+title: "WebTransportDatagramDuplexStream: createWritable() method"
+short-title: createWritable()
+slug: Web/API/WebTransportDatagramDuplexStream/createWritable
+page-type: web-api-instance-method
+browser-compat: api.WebTransportDatagramDuplexStream.createWritable
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`createWritable()`** method of the {{domxref("WebTransportDatagramDuplexStream")}} interface returns a {{domxref("WebTransportDatagramsWritable")}} instance that can be used to write outgoing datagrams to the transport.
+
+It should be used instead of the deprecated {{domxref("WebTransportDatagramDuplexStream/writable","writable")}} property on platforms where it is defined.
+
+## Syntax
+
+```js-nolint
+createWritable()
+createWritable(options)
+```
+
+### Parameters
+
+- `options` {{optional_inline}}
+  - : An object that may have the following properties:
+    - `sendGroup` {{optional_inline}}
+      - : A {{domxref("WebTransportSendGroup")}} that the returned stream's datagrams should be grouped under for the purposes of `sendOrder` prioritization, or `null` if they should be part of the default group.
+        The default value is `null`.
+    - `sendOrder` {{optional_inline}}
+      - : An integer value that, if specified, opts the returned stream's datagrams in to participating in strict per-group send-order prioritization.
+        Within the stream's `sendGroup`, bytes queued on higher-priority streams and datagrams are sent ahead of those from lower-priority ones.
+        The default value is `0`.
+
+### Return value
+
+A {{domxref("WebTransportDatagramsWritable")}} instance (this is a {{domxref("WritableStream")}}).
+
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the transport's state is `"closed"` or `"failed"`, or if `sendGroup` is specified (non-null) and is associated with a different `WebTransport`.
+
+## Description
+
+The **`createWritable()`** method is used to create a {{domxref("WebTransportDatagramsWritable")}} instance for writing outgoing datagrams.
+
+The method allows you to specify a `sendGroup` for specifying the group of streams and datagrams that this stream belongs to, and a `sendOrder` that sets the relative priority of this stream within that group.
+Within a group, bytes queued on higher-priority streams and datagrams are sent before any bytes from lower-priority ones.
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
+
+The transmission is unreliable, meaning while you can define the priory order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
+
+## Examples
+
+### Basic usage
+
+This code shows how you can use the `createWritable()` method to get a `WebTransportDatagramDuplexStream` and use it to send data.
+
+First we define a function to to wrap our stream creation and closing code.
+This first constructs a `WebTransport`, and uses it with `createWritable()` to create a writable stream.
+Note that because `createWritable()` is not supported on all browsers, the code falls back to the {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}} property for creating the writable.
+
+`getWriter()` is then called on writable to create a writer.
+Because datagram delivery is unreliable, queued outgoing datagrams that aren't sent in time are dropped.
+For this reason, the code awaits the writer's {{domxref("WritableStreamDefaultWriter.ready", "ready")}} promise before each write, so that datagrams are only written once the underlying transport is ready to send them.
+It also catches any errors from `write()`, since a rejection means that a particular datagram was not sent.
+
+```js
+async function sendDatagrams(url, datagrams, writableOptions = {}) {
+  const wt = new WebTransport(url);
+  const writable =
+    typeof wt.datagrams.createWritable === "function"
+      ? wt.datagrams.createWritable(writableOptions)
+      : wt.datagrams.writable;
+  const writer = writable.getWriter();
+  for (const bytes of datagrams) {
+    await writer.ready;
+    writer.write(bytes).catch(() => {});
+  }
+  await writer.close();
+}
+```
+
+This code shows how you might use the above method, passing a `sendOrder` priority of `1` for in the `null` send group for this stream:
+
+```js
+const url = "https://example.com/webtransport";
+const datagrams = [new Uint8Array([65, 66, 67]), new Uint8Array([68, 69, 70])];
+await sendDatagrams(url, datagrams, { sendOrder: 1 });
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
@@ -10,7 +10,7 @@ browser-compat: api.WebTransportDatagramDuplexStream.createWritable
 
 The **`createWritable()`** method of the {{domxref("WebTransportDatagramDuplexStream")}} interface returns a {{domxref("WebTransportDatagramsWritable")}} instance that can be used to write outgoing datagrams to the transport.
 
-It should be used instead of the deprecated {{domxref("WebTransportDatagramDuplexStream/writable","writable")}} property where it is supported.
+It should be used instead of the deprecated {{domxref("WebTransportDatagramDuplexStream.writable","writable")}} property where it is supported.
 
 ## Syntax
 

--- a/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
@@ -27,7 +27,7 @@ createWritable(options)
       - : A {{domxref("WebTransportSendGroup")}} that the returned stream's datagrams should be grouped under for the purposes of `sendOrder` prioritization, or `null` if they should be part of the default group.
         The default value is `null`.
     - `sendOrder` {{optional_inline}}
-      - : An integer value that, if specified, opts the returned stream's datagrams in to participating in strict per-group send-order prioritization.
+      - : An integer value specifying the send priority of the returned stream's datagrams.
         Within the stream's `sendGroup`, bytes queued on higher-priority streams and datagrams are sent ahead of those from lower-priority ones.
         The default value is `0`.
 
@@ -48,7 +48,7 @@ The method allows you to specify a `sendGroup` for specifying the group of strea
 Within a group, bytes queued on higher-priority streams and datagrams are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 
-The transmission is unreliable, meaning while you can define the priory order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
+The transmission is unreliable, meaning while you can define the priority order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
 
 ## Examples
 
@@ -56,11 +56,11 @@ The transmission is unreliable, meaning while you can define the priory order, t
 
 This code shows how you can use the `createWritable()` method to get a `WebTransportDatagramDuplexStream` and use it to send data.
 
-First we define a function to to wrap our stream creation and closing code.
+First we define a function to wrap our stream creation and closing code.
 This first constructs a `WebTransport`, and uses it with `createWritable()` to create a writable stream.
-Note that because `createWritable()` is not supported on all browsers, the code falls back to the {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}} property for creating the writable.
+Note that because `createWritable()` is not supported on all browsers, the code falls back to the {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} property for creating the writable.
 
-`getWriter()` is then called on writable to create a writer.
+`getWriter()` is then called on `writable` to create a writer.
 Because datagram delivery is unreliable, queued outgoing datagrams that aren't sent in time are dropped.
 For this reason, the code awaits the writer's {{domxref("WritableStreamDefaultWriter.ready", "ready")}} promise before each write, so that datagrams are only written once the underlying transport is ready to send them.
 It also catches any errors from `write()`, since a rejection means that a particular datagram was not sent.
@@ -68,6 +68,7 @@ It also catches any errors from `write()`, since a rejection means that a partic
 ```js
 async function sendDatagrams(url, datagrams, writableOptions = {}) {
   const wt = new WebTransport(url);
+  await wt.ready;
   const writable =
     typeof wt.datagrams.createWritable === "function"
       ? wt.datagrams.createWritable(writableOptions)
@@ -77,11 +78,10 @@ async function sendDatagrams(url, datagrams, writableOptions = {}) {
     await writer.ready;
     writer.write(bytes).catch(() => {});
   }
-  await writer.close();
 }
 ```
 
-This code shows how you might use the above method, passing a `sendOrder` priority of `1` for in the `null` send group for this stream:
+This code shows how you might use the above method, passing a `sendOrder` priority of `1` in the `null` send group for this stream:
 
 ```js
 const url = "https://example.com/webtransport";
@@ -99,5 +99,5 @@ await sendDatagrams(url, datagrams, { sendOrder: 1 });
 
 ## See also
 
-- {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}

--- a/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
@@ -58,7 +58,7 @@ This code shows how you can use the `createWritable()` method to get a `WebTrans
 
 First we define a function to wrap our stream creation code.
 This first constructs a `WebTransport`, and uses it with `createWritable()` to create a writable stream.
-Note that because `createWritable()` is not supported on all browsers, the code falls back to the {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} property for creating the writable.
+Note that because `createWritable()` is not supported on all browsers, the code falls back to the {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}} property for creating the writable.
 
 `getWriter()` is then called on `writable` to create a writer.
 Because datagram delivery is unreliable, queued outgoing datagrams that aren't sent in time are dropped.

--- a/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
@@ -10,7 +10,7 @@ browser-compat: api.WebTransportDatagramDuplexStream.createWritable
 
 The **`createWritable()`** method of the {{domxref("WebTransportDatagramDuplexStream")}} interface returns a {{domxref("WebTransportDatagramsWritable")}} instance that can be used to write outgoing datagrams to the transport.
 
-It should be used instead of the deprecated {{domxref("WebTransportDatagramDuplexStream/writable","writable")}} property on platforms where it is defined.
+It should be used instead of the deprecated {{domxref("WebTransportDatagramDuplexStream/writable","writable")}} property where it is supported.
 
 ## Syntax
 
@@ -33,7 +33,7 @@ createWritable(options)
 
 ### Return value
 
-A {{domxref("WebTransportDatagramsWritable")}} instance (this is a {{domxref("WritableStream")}}).
+A {{domxref("WebTransportDatagramsWritable")}} object, which extends {{domxref("WritableStream")}}.
 
 ### Exceptions
 
@@ -44,19 +44,19 @@ A {{domxref("WebTransportDatagramsWritable")}} instance (this is a {{domxref("Wr
 
 The **`createWritable()`** method is used to create a {{domxref("WebTransportDatagramsWritable")}} instance for writing outgoing datagrams.
 
-The method allows you to specify a `sendGroup` for specifying the group of streams and datagrams that this stream belongs to, and a `sendOrder` that sets the relative priority of this stream within that group.
+The method allows you to specify a `sendGroup` that defines the group of streams and datagrams that this stream belongs to, and a `sendOrder` that sets the relative priority of this stream within that group.
 Within a group, bytes queued on higher-priority streams and datagrams are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 
-The transmission is unreliable, meaning while you can define the priority order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
+The transmission is unreliable, meaning that even though you can define the priority order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
 
 ## Examples
 
 ### Basic usage
 
-This code shows how you can use the `createWritable()` method to get a `WebTransportDatagramDuplexStream` and use it to send data.
+This code shows how you can use the `createWritable()` method to get a `WebTransportDatagramsWritable` and use it to send data.
 
-First we define a function to wrap our stream creation and closing code.
+First we define a function to wrap our stream creation code.
 This first constructs a `WebTransport`, and uses it with `createWritable()` to create a writable stream.
 Note that because `createWritable()` is not supported on all browsers, the code falls back to the {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} property for creating the writable.
 
@@ -81,7 +81,7 @@ async function sendDatagrams(url, datagrams, writableOptions = {}) {
 }
 ```
 
-This code shows how you might use the above method, passing a `sendOrder` priority of `1` in the `null` send group for this stream:
+This code shows how you might use the above method, passing a `sendOrder` of `1` in the default send group:
 
 ```js
 const url = "https://example.com/webtransport";

--- a/files/en-us/web/api/webtransportdatagramduplexstream/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/index.md
@@ -32,6 +32,11 @@ This is accessed via the {{domxref("WebTransport.datagrams")}} property.
 - {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
   - : Returns a {{domxref("WritableStream")}} instance that can be used to write outgoing datagrams to the stream.
 
+## Instance methods
+
+- {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}}
+  - : Returns a {{domxref("WebTransportDatagramsWritable")}} instance that can be used to write outgoing datagrams to the stream.
+
 ## Examples
 
 ### Writing outgoing datagrams

--- a/files/en-us/web/api/webtransportdatagramduplexstream/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/index.md
@@ -29,7 +29,7 @@ This is accessed via the {{domxref("WebTransport.datagrams")}} property.
   - : Gets or sets the maximum age for outgoing datagrams, in milliseconds. Returns `null` if no maximum age has been set.
 - {{domxref("WebTransportDatagramDuplexStream.readable", "readable")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("ReadableStream")}} instance that can be used to read incoming datagrams from the stream.
-- {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
+- {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
   - : Returns a {{domxref("WritableStream")}} instance that can be used to write outgoing datagrams to the stream.
 
 ## Instance methods
@@ -48,7 +48,7 @@ Otherwise, it falls back to the {{domxref("WebTransportDatagramDuplexStream/writ
 const writableStream =
   typeof transport.datagrams.createWritable === "function"
     ? transport.datagrams.createWritable()
-    : transport.datagrams.writable; // Deprecated and non-standard.
+    : transport.datagrams.writable; // Deprecated and non-standard
 
 const writer = writableStream.getWriter();
 const data1 = new Uint8Array([65, 66, 67]);

--- a/files/en-us/web/api/webtransportdatagramduplexstream/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/index.md
@@ -22,14 +22,14 @@ This is accessed via the {{domxref("WebTransport.datagrams")}} property.
 - {{domxref("WebTransportDatagramDuplexStream.incomingMaxAge", "incomingMaxAge")}}
   - : Gets or sets the maximum age for incoming datagrams, in milliseconds. Returns `null` if no maximum age has been set.
 - {{domxref("WebTransportDatagramDuplexStream.maxDatagramSize", "maxDatagramSize")}} {{ReadOnlyInline}}
-  - : Returns the maximum allowable size of outgoing datagrams, in bytes, that can be written to {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}}.
+  - : Returns the maximum allowable size of outgoing datagrams, in bytes, that can be written to {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}}.
 - {{domxref("WebTransportDatagramDuplexStream.outgoingHighWaterMark", "outgoingHighWaterMark")}}
   - : Gets or sets the high water mark for outgoing chunks of data — this is the maximum size, in chunks, that the outgoing {{domxref("WritableStream")}}'s internal queue can reach before it is considered full. See [Internal queues and queuing strategies](/en-US/docs/Web/API/Streams_API/Concepts#internal_queues_and_queuing_strategies) for more information.
 - {{domxref("WebTransportDatagramDuplexStream.outgoingMaxAge", "outgoingMaxAge")}}
   - : Gets or sets the maximum age for outgoing datagrams, in milliseconds. Returns `null` if no maximum age has been set.
 - {{domxref("WebTransportDatagramDuplexStream.readable", "readable")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("ReadableStream")}} instance that can be used to read incoming datagrams from the stream.
-- {{domxref("WebTransportDatagramDuplexStream.writable", "writable")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
+- {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} {{ReadOnlyInline}} {{deprecated_inline}} {{non-standard_inline}}
   - : Returns a {{domxref("WritableStream")}} instance that can be used to write outgoing datagrams to the stream.
 
 ## Instance methods

--- a/files/en-us/web/api/webtransportdatagramduplexstream/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/index.md
@@ -22,7 +22,7 @@ This is accessed via the {{domxref("WebTransport.datagrams")}} property.
 - {{domxref("WebTransportDatagramDuplexStream.incomingMaxAge", "incomingMaxAge")}}
   - : Gets or sets the maximum age for incoming datagrams, in milliseconds. Returns `null` if no maximum age has been set.
 - {{domxref("WebTransportDatagramDuplexStream.maxDatagramSize", "maxDatagramSize")}} {{ReadOnlyInline}}
-  - : Returns the maximum allowable size of outgoing datagrams, in bytes, that can be written to {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}}.
+  - : Returns the maximum allowable size of outgoing datagrams, in bytes, that can be written to a {{domxref("WebTransportDatagramsWritable")}} obtained via {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}}, or the deprecated {{domxref("WebTransportDatagramDuplexStream/writable", "writable")}} property.
 - {{domxref("WebTransportDatagramDuplexStream.outgoingHighWaterMark", "outgoingHighWaterMark")}}
   - : Gets or sets the high water mark for outgoing chunks of data — this is the maximum size, in chunks, that the outgoing {{domxref("WritableStream")}}'s internal queue can reach before it is considered full. See [Internal queues and queuing strategies](/en-US/docs/Web/API/Streams_API/Concepts#internal_queues_and_queuing_strategies) for more information.
 - {{domxref("WebTransportDatagramDuplexStream.outgoingMaxAge", "outgoingMaxAge")}}

--- a/files/en-us/web/api/webtransportdatagramswritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/index.md
@@ -28,7 +28,7 @@ _Inherits methods from its parent interface, {{domxref("WritableStream")}}._
 
 ## Description
 
-In addition to the functionality of a standard `WritableStream`, the interface provides the `sendGroup` property that indicates the group of streams and datagrams that this stream belongs to, and the `sendOrder` property that indicates the relative priority of this stream within that group.
+In addition to the functionality of a standard `WritableStream`, the `WebTransportDatagramsWritable` interface provides the `sendGroup` property that indicates the group of streams and datagrams that this stream belongs to, and the `sendOrder` property that indicates the relative priority of this stream within that group.
 Within a group, bytes queued on higher-priority streams and datagrams are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 

--- a/files/en-us/web/api/webtransportdatagramswritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/index.md
@@ -35,7 +35,7 @@ Different groups are expected to be treated as equals for the purposes of bandwi
 Objects of this type are not constructed directly.
 Instead, an instance is returned by the {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}} method of {{domxref("WebTransportDatagramDuplexStream")}}, which can be accessed using the {{domxref("WebTransport.datagrams")}} property.
 
-The transmission is unreliable, meaning while you can define the priority order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
+The transmission is unreliable, meaning that even though you can define the priority order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportdatagramswritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/index.md
@@ -51,5 +51,5 @@ See {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable
 
 ## See also
 
-- {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}

--- a/files/en-us/web/api/webtransportdatagramswritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/index.md
@@ -1,0 +1,55 @@
+---
+title: WebTransportDatagramsWritable
+slug: Web/API/WebTransportDatagramsWritable
+page-type: web-api-interface
+browser-compat: api.WebTransportDatagramsWritable
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`WebTransportDatagramsWritable`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} is a specialized {{domxref("WritableStream")}} that can be used to write outgoing datagrams to a {{domxref("WebTransport")}} connection.
+
+`WebTransportDatagramsWritable` is a [transferable object](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects).
+
+{{InheritanceDiagram}}
+
+## Instance properties
+
+_Also inherits properties from its parent interface, {{domxref("WritableStream")}}._
+
+- {{domxref("WebTransportDatagramsWritable.sendGroup")}}
+  - : Gets or sets a {{domxref("WebTransportSendGroup")}} that the stream's datagrams are grouped under for the purposes of `sendOrder` prioritization.
+- {{domxref("WebTransportDatagramsWritable.sendOrder")}}
+  - : Gets or sets an integer indicating the priority of this stream relative to other streams and datagrams in the same `sendGroup`.
+
+## Instance methods
+
+_Inherits methods from its parent interface, {{domxref("WritableStream")}}._
+
+## Description
+
+In addition to the functionality of a standard `WritableStream`, the interface provides the `sendGroup` property that indicates the group of streams and datagrams that this stream belongs to, and the `sendOrder` property that indicates the relative priority of this stream within that group.
+Within a group, bytes queued on higher-priority streams and datagrams are sent before any bytes from lower-priority ones.
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
+
+Objects of this type are not constructed directly.
+Instead, an instance is returned by the {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}} method of {{domxref("WebTransportDatagramDuplexStream")}}, which can be accessed using the {{domxref("WebTransport.datagrams")}} property.
+
+The transmission is unreliable, meaning while you can define the priority order, there is no guarantee that every datagram will be sent, or that they will arrive in any particular order.
+
+## Examples
+
+See {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}} for an example showing how to create a `WebTransportDatagramsWritable` and use it to write outgoing datagrams.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
@@ -49,5 +49,5 @@ writer.write(data).catch(() => {});
 
 ## See also
 
-- {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}

--- a/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
@@ -8,7 +8,7 @@ browser-compat: api.WebTransportDatagramsWritable.sendGroup
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
-The **`sendGroup`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets a {{domxref("WebTransportSendGroup")}} that the streams are grouped under for the purposes of {{domxref("WebTransportDatagramsWritable.sendOrder", "sendOrder")}} prioritization.
+The **`sendGroup`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets the {{domxref("WebTransportSendGroup")}} that this `WebTransportDatagramsWritable` is grouped under for the purposes of {{domxref("WebTransportDatagramsWritable.sendOrder", "sendOrder")}} prioritization.
 
 Within a group, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
@@ -21,7 +21,7 @@ A `WebTransportSendGroup` object, or `null` for the default send group.
 
 ### Basic usage
 
-The example below creates a send group using {{domxref("WebTransport.createSendGroup()")}} method, and then uses it with a `sendOrder` value, to prioritize the datagrams written to the stream relative to other streams and datagrams that are part of the same group:
+The example below creates a send group using the {{domxref("WebTransport.createSendGroup()")}} method, and then uses it with a `sendOrder` value, to prioritize the datagrams written to the stream relative to other streams and datagrams that are part of the same group:
 
 ```js
 const sendGroup = transport.createSendGroup();

--- a/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
@@ -1,0 +1,53 @@
+---
+title: "WebTransportDatagramsWritable: sendGroup property"
+short-title: sendGroup
+slug: Web/API/WebTransportDatagramsWritable/sendGroup
+page-type: web-api-instance-property
+browser-compat: api.WebTransportDatagramsWritable.sendGroup
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`sendGroup`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets a {{domxref("WebTransportSendGroup")}} that the streams are grouped under for the purposes of {{domxref("WebTransportDatagramsWritable.sendOrder", "sendOrder")}} prioritization.
+
+Within a group, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
+
+## Value
+
+A `WebTransportSendGroup` object, or `null` for the default send group.
+
+## Examples
+
+### Basic usage
+
+The example below creates a send group using {{domxref("WebTransport.createSendGroup()")}} method, and then uses it with a `sendOrder` value, to prioritize the datagrams written to the stream relative to other streams and datagrams that are part of the same group:
+
+```js
+const sendGroup = transport.createSendGroup();
+
+const writable = transport.datagrams.createWritable({
+  sendGroup,
+  sendOrder: 1,
+});
+
+console.log(writable.sendGroup === sendGroup); // true
+
+const writer = writable.getWriter();
+const data = new Uint8Array([65, 66, 67]);
+await writer.ready;
+writer.write(data).catch(() => {});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
@@ -15,7 +15,7 @@ Different groups are expected to be treated as equals for the purposes of bandwi
 
 ## Value
 
-A `WebTransportSendGroup` object, or `null` for the default send group.
+A `WebTransportSendGroup` object, or `null` to specify the default send group.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
@@ -1,0 +1,55 @@
+---
+title: "WebTransportDatagramsWritable: sendOrder property"
+short-title: sendOrder
+slug: Web/API/WebTransportDatagramsWritable/sendOrder
+page-type: web-api-instance-property
+browser-compat: api.WebTransportDatagramsWritable.sendOrder
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`sendOrder`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets an integer that, if set to a non-zero value, opts the stream in to participating in strict send-order prioritization within a send group.
+
+Within a {{domxref("WebTransportDatagramsWritable.sendGroup", "sendGroup")}}, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
+
+## Value
+
+An integer indicating the relative priority of this stream's datagrams when sending bytes.
+The default value is `0`.
+
+## Examples
+
+### Basic usage
+
+The example below shows how you can set the initial `sendOrder` when calling {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}} to create the writable stream, read the value back from the stream, and then change it:
+
+```js
+const writable = transport.datagrams.createWritable({
+  sendOrder: 1, // Set initial send order
+});
+
+console.log(`Send order: ${writable.sendOrder}`); // Send order: 1
+
+const writer = writable.getWriter();
+const data = new Uint8Array([65, 66, 67]);
+await writer.ready;
+writer.write(data).catch(() => {});
+
+// Increase the priority of this stream's datagrams
+writable.sendOrder = 2;
+console.log(`Send order: ${writable.sendOrder}`); // Send order: 2
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
@@ -8,9 +8,9 @@ browser-compat: api.WebTransportDatagramsWritable.sendOrder
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
-The **`sendOrder`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets an integer indicating the priority of this stream's datagrams relative to other streams and datagrams in the same `sendGroup`.
+The **`sendOrder`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets an integer indicating the priority of this stream's datagrams relative to other streams and datagrams in the same {{domxref("WebTransportDatagramsWritable.sendGroup", "sendGroup")}}.
 
-Within a {{domxref("WebTransportDatagramsWritable.sendGroup", "sendGroup")}}, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
+Within a `sendGroup`, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 
 ## Value

--- a/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
@@ -8,7 +8,7 @@ browser-compat: api.WebTransportDatagramsWritable.sendOrder
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
-The **`sendOrder`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets an integer that, if set to a non-zero value, opts the stream in to participating in strict send-order prioritization within a send group.
+The **`sendOrder`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets an integer indicating the priority of this stream's datagrams relative to other streams and datagrams in the same `sendGroup`.
 
 Within a {{domxref("WebTransportDatagramsWritable.sendGroup", "sendGroup")}}, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
@@ -51,5 +51,5 @@ console.log(`Send order: ${writable.sendOrder}`); // Send order: 2
 
 ## See also
 
-- {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}

--- a/files/en-us/web/api/webtransportsendgroup/getstats/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/getstats/index.md
@@ -60,5 +60,5 @@ console.log(`Bytes sent but not yet acknowledged: ${bytesNotAcknowledged}`);
 
 ## See also
 
-- {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}

--- a/files/en-us/web/api/webtransportsendgroup/getstats/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/getstats/index.md
@@ -1,0 +1,64 @@
+---
+title: "WebTransportSendGroup: getStats() method"
+short-title: getStats()
+slug: Web/API/WebTransportSendGroup/getStats
+page-type: web-api-instance-method
+browser-compat: api.WebTransportSendGroup.getStats
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`getStats()`** method of the {{domxref("WebTransportSendGroup")}} interface returns a {{jsxref("Promise")}} that resolves to an object that contains statistics aggregated across all of the {{domxref("WebTransportSendStream")}} and {{domxref("WebTransportDatagramsWritable")}} objects that are currently associated with this group.
+That is, every stream and datagram writable whose `sendGroup` is set to this `WebTransportSendGroup`.
+
+## Syntax
+
+```js-nolint
+getStats()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves to an object containing aggregated statistics for the group's members.
+The returned object has the following properties:
+
+- `bytesAcknowledged`
+  - : A positive integer indicating the number of bytes written to the group's members that have been sent and acknowledged as received by the server, using QUIC's ACK mechanism.
+    Only sequential bytes up to, but not including, the first non-acknowledged byte of each member, are counted.
+    This number can only increase and is always less than or equal to `bytesSent`.
+- `bytesSent`
+  - : A positive integer indicating the number of bytes written to the group's members that have been sent at least once (but not necessarily acknowledged).
+    This number can only increase, and is always less than or equal to `bytesWritten`.
+    Note that this count does not include bytes sent as network overhead (such as packet headers).
+- `bytesWritten`
+  - : A positive integer indicating the number of bytes successfully written to the group's members.
+    This number can only increase.
+
+## Examples
+
+### Basic usage
+
+The code snippet below uses `await` to wait on the {{jsxref("Promise")}} returned by `getStats()`, then logs the number of bytes that have been sent across the group's members but not yet acknowledged:
+
+```js
+const stats = await sendGroup.getStats();
+const bytesNotAcknowledged = stats.bytesSent - stats.bytesAcknowledged;
+console.log(`Bytes sent but not yet acknowledged: ${bytesNotAcknowledged}`);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportsendgroup/getstats/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/getstats/index.md
@@ -8,7 +8,7 @@ browser-compat: api.WebTransportSendGroup.getStats
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
-The **`getStats()`** method of the {{domxref("WebTransportSendGroup")}} interface returns a {{jsxref("Promise")}} that resolves to an object that contains statistics aggregated across all of the {{domxref("WebTransportSendStream")}} and {{domxref("WebTransportDatagramsWritable")}} objects that are currently associated with this group.
+The **`getStats()`** method of the {{domxref("WebTransportSendGroup")}} interface returns a {{jsxref("Promise")}} that resolves to an object containing statistics aggregated across all of the {{domxref("WebTransportSendStream")}} and {{domxref("WebTransportDatagramsWritable")}} objects currently associated with this group.
 That is, every stream and datagram writable whose `sendGroup` is set to this `WebTransportSendGroup`.
 
 ## Syntax
@@ -42,7 +42,7 @@ The returned object has the following properties:
 
 ### Basic usage
 
-The code snippet below uses `await` to wait on the {{jsxref("Promise")}} returned by `getStats()`, then logs the number of bytes that have been sent across the group's members but not yet acknowledged:
+The code snippet below uses [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) to wait on the {{jsxref("Promise")}} returned by `getStats()`, then logs the number of bytes that have been sent across the group's members but not yet acknowledged:
 
 ```js
 const stats = await sendGroup.getStats();

--- a/files/en-us/web/api/webtransportsendgroup/getstats/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/getstats/index.md
@@ -28,7 +28,7 @@ The returned object has the following properties:
 
 - `bytesAcknowledged`
   - : A positive integer indicating the number of bytes written to the group's members that have been sent and acknowledged as received by the server, using QUIC's ACK mechanism.
-    Only sequential bytes up to, but not including, the first non-acknowledged byte of each member, are counted.
+    Only sequential bytes up to, but not including, the first unacknowledged byte of each member, are counted.
     This number can only increase and is always less than or equal to `bytesSent`.
 - `bytesSent`
   - : A positive integer indicating the number of bytes written to the group's members that have been sent at least once (but not necessarily acknowledged).

--- a/files/en-us/web/api/webtransportsendgroup/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/index.md
@@ -22,13 +22,13 @@ The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "
 
 Unlike for {{domxref("WritableStream")}} instances, for which the priority at which bytes are sent on different streams is implementation-dependent, a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} allows you to set the priority at which bytes will be sent on each instance relative to others in the same `sendGroup`.
 A send group is created using the {{domxref("WebTransport.createSendGroup", "createSendGroup()")}} method, and the relative priority is defined by the `sendOrder` property of `WebTransportDatagramsWritable` or `WebTransportSendStream` instances.
-Different groups are expected to be treated as equals during bandwidth allocation — though again, the precise way bandwidth is divided between groups depends on the implementation.
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 
 A `WebTransportSendGroup` is created using the `createSendGroup()` method of the {{domxref("WebTransport")}} interface.
 You can then associate it with a `WebTransportDatagramsWritable` or `WebTransportSendStream` by:
 
- - Passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}}.
- - Setting the object's `sendGroup` property afterwards, for example using {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+- Passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}}.
+- Setting the object's `sendGroup` property afterwards, for example using {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportsendgroup/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/index.md
@@ -16,23 +16,16 @@ The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "
 ## Instance methods
 
 - {{domxref("WebTransportSendGroup.getStats", "getStats()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with statistics aggregated across all of the streams and datagram writables currently associated with this group.
+  - : Returns a {{jsxref("Promise")}} that resolves with statistics aggregated across all of the {{domxref("WebTransportSendStream")}} and {{domxref("WebTransportDatagramsWritable")}} objects currently associated with this group.
 
 ## Description
 
-By default, the relative order in which a user agent sends queued bytes from different streams and datagrams is implementation-defined.
+Unlike for {{domxref("WritableStream")}} instances, for which the priority at which bytes are sent on different streams is implementation-dependent, a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} allows you to set the priority at which bytes will be sent on each instance relative to others in the same `sendGroup`.
+A send group is defined using the `WebTransportSendGroup` interface, and the relative priority is defined by the `sendOrder` property of `WebTransportDatagramsWritable` or `WebTransportSendStream` instances.
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though again the precise way bandwidth is divided between groups depends on the implementation.
 
-http://localhost:5042/en-US/docs/Web/API/WebTransportDatagramsWritable
-
-A `WebTransportSendGroup` allows you to gropu
-
-relative send order (within the group)
-
-Associating two or more streams and/or datagrams with the same `WebTransportSendGroup`, and giving each a `sendOrder` value, allows their priorities to be compared directly: queued bytes belonging to the group member with the highest `sendOrder` are sent first, ahead of other members of the same group that have a lower value. The relative priority of streams and datagrams that belong to different groups (or that have no group at all) remains implementation-defined.
-
-A `WebTransportSendGroup` is created using the `createSendGroup()` method of the {{domxref("WebTransport")}} interface. You can then associate it with a stream or datagram writable by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards, for example {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
-
-The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} represents a group of streams and datagrams whose relative send priority can be compared and prioritized as a set, based on the `sendOrder` value of each member.
+A `WebTransportSendGroup` is created using the `createSendGroup()` method of the {{domxref("WebTransport")}} interface.
+You can then associate it with a `WebTransportDatagramsWritable` or `WebTransportSendStream` by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards, for example {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
 
 ## Examples
 
@@ -67,5 +60,5 @@ const datagrams = transport.datagrams.createWritable({
 
 ## See also
 
-- {{domxref("Streams API", "Streams API", "", "nocode")}}
 - [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
+- {{domxref("Streams API", "Streams API", "", "nocode")}}

--- a/files/en-us/web/api/webtransportsendgroup/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/index.md
@@ -1,0 +1,71 @@
+---
+title: WebTransportSendGroup
+slug: Web/API/WebTransportSendGroup
+page-type: web-api-interface
+browser-compat: api.WebTransportSendGroup
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} represents a group of streams and datagrams whose relative send priority is prioritized as a set, based on the `sendOrder` value of each member.
+
+`WebTransportSendGroup` is a [transferable object](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects).
+
+{{InheritanceDiagram}}
+
+## Instance methods
+
+- {{domxref("WebTransportSendGroup.getStats", "getStats()")}}
+  - : Returns a {{jsxref("Promise")}} that resolves with statistics aggregated across all of the streams and datagram writables currently associated with this group.
+
+## Description
+
+By default, the relative order in which a user agent sends queued bytes from different streams and datagrams is implementation-defined.
+
+http://localhost:5042/en-US/docs/Web/API/WebTransportDatagramsWritable
+
+A `WebTransportSendGroup` allows you to gropu
+
+relative send order (within the group)
+
+Associating two or more streams and/or datagrams with the same `WebTransportSendGroup`, and giving each a `sendOrder` value, allows their priorities to be compared directly: queued bytes belonging to the group member with the highest `sendOrder` are sent first, ahead of other members of the same group that have a lower value. The relative priority of streams and datagrams that belong to different groups (or that have no group at all) remains implementation-defined.
+
+A `WebTransportSendGroup` is created using the `createSendGroup()` method of the {{domxref("WebTransport")}} interface. You can then associate it with a stream or datagram writable by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards, for example {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+
+The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} represents a group of streams and datagrams whose relative send priority can be compared and prioritized as a set, based on the `sendOrder` value of each member.
+
+## Examples
+
+### Basic usage
+
+The example below creates a send group, then associates a unidirectional stream and the connection's outgoing datagram stream with it, giving each a `sendOrder` so that their relative priority can be compared:
+
+```js
+const sendGroup = transport.createSendGroup();
+
+const stream = await transport.createUnidirectionalStream({
+  sendGroup,
+  sendOrder: 1,
+});
+
+const datagrams = transport.datagrams.createWritable({
+  sendGroup,
+  sendOrder: 2,
+});
+
+// Queued bytes for datagrams are sent ahead of those for stream, as the
+// two share a send group and datagrams has been given the higher sendOrder.
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportsendgroup/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/index.md
@@ -16,22 +16,26 @@ The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "
 ## Instance methods
 
 - {{domxref("WebTransportSendGroup.getStats", "getStats()")}}
-  - : Returns a {{jsxref("Promise")}} that resolves with statistics aggregated across all of the {{domxref("WebTransportSendStream")}} and {{domxref("WebTransportDatagramsWritable")}} objects currently associated with this group.
+  - : Returns a {{jsxref("Promise")}} that resolves with an object containing statistics aggregated across all of the {{domxref("WebTransportSendStream")}} and {{domxref("WebTransportDatagramsWritable")}} objects currently associated with this group.
 
 ## Description
 
 Unlike for {{domxref("WritableStream")}} instances, for which the priority at which bytes are sent on different streams is implementation-dependent, a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} allows you to set the priority at which bytes will be sent on each instance relative to others in the same `sendGroup`.
 A send group is created using the {{domxref("WebTransport.createSendGroup", "createSendGroup()")}} method, and the relative priority is defined by the `sendOrder` property of `WebTransportDatagramsWritable` or `WebTransportSendStream` instances.
-Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though again the precise way bandwidth is divided between groups depends on the implementation.
+Different groups are expected to be treated as equals during bandwidth allocation — though again, the precise way bandwidth is divided between groups depends on the implementation.
 
 A `WebTransportSendGroup` is created using the `createSendGroup()` method of the {{domxref("WebTransport")}} interface.
-You can then associate it with a `WebTransportDatagramsWritable` or `WebTransportSendStream` by passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}} — or by setting the object's `sendGroup` property afterwards, for example {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+You can then associate it with a `WebTransportDatagramsWritable` or `WebTransportSendStream` by:
+
+ - Passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}}.
+ - Setting the object's `sendGroup` property afterwards, for example using {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
 
 ## Examples
 
 ### Basic usage
 
-The example below creates a send group, then associates a unidirectional stream and the connection's outgoing datagram stream with it, giving each a `sendOrder` so that their relative priority can be compared:
+The example below creates a send group, then associates a unidirectional stream and the connection's outgoing datagram stream with it, giving each a `sendOrder`.
+Bytes on the datagram stream will be prioritized ahead of any bytes on the unidirectional stream, because they are both in the same `sendGroup` and the datagram stream has a higher `sendOrder`.
 
 ```js
 const sendGroup = transport.createSendGroup();
@@ -45,9 +49,6 @@ const datagrams = transport.datagrams.createWritable({
   sendGroup,
   sendOrder: 2,
 });
-
-// Queued bytes for datagrams are sent ahead of those for stream, as the
-// two share a send group and datagrams has been given the higher sendOrder.
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webtransportsendgroup/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/index.md
@@ -7,7 +7,7 @@ browser-compat: api.WebTransportSendGroup
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
 
-The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} represents a group of streams and datagrams whose relative send priority is prioritized as a set, based on the `sendOrder` value of each member.
+The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "WebTransport API", "", "nocode")}} represents a group of streams and datagrams, within which relative send priority is determined by the `sendOrder` value of each member.
 
 `WebTransportSendGroup` is a [transferable object](/en-US/docs/Web/API/Web_Workers_API/Transferable_objects).
 
@@ -21,7 +21,7 @@ The **`WebTransportSendGroup`** interface of the {{domxref("WebTransport API", "
 ## Description
 
 Unlike for {{domxref("WritableStream")}} instances, for which the priority at which bytes are sent on different streams is implementation-dependent, a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} allows you to set the priority at which bytes will be sent on each instance relative to others in the same `sendGroup`.
-A send group is defined using the `WebTransportSendGroup` interface, and the relative priority is defined by the `sendOrder` property of `WebTransportDatagramsWritable` or `WebTransportSendStream` instances.
+A send group is created using the {{domxref("WebTransport.createSendGroup", "createSendGroup()")}} method, and the relative priority is defined by the `sendOrder` property of `WebTransportDatagramsWritable` or `WebTransportSendStream` instances.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though again the precise way bandwidth is divided between groups depends on the implementation.
 
 A `WebTransportSendGroup` is created using the `createSendGroup()` method of the {{domxref("WebTransport")}} interface.

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -2475,7 +2475,9 @@
         "WebTransport",
         "WebTransportBidirectionalStream",
         "WebTransportDatagramDuplexStream",
+        "WebTransportDatagramsWritable",
         "WebTransportReceiveStream",
+        "WebTransportSendGroup",
         "WebTransportSendStream",
         "WebTransportError"
       ],


### PR DESCRIPTION
This documents most of the new `WebTransport` support for prioritizing streams/datagrams within a `sendGroup` based on `sendOrder` for the respective stream objects - such as `WebTransportDatagramsWritable`. This is recently implemented in Safari.

I started on this when reviewing #44317 because that wants to refer to an undocumented method I needed to understand. Talking about pulling a thread...

Anyway, I believe this is correct and useful. The only thing missing is the stream equivalent of `WebTransportDatagramsWritable` - `WebTransportSendStream`.

Fixes #44273