### PR TITLE
Fix STIX Two installation instructions for MathML fonts

### DIFF
--- a/files/en-us/web/mathml/guides/fonts/index.md
+++ b/files/en-us/web/mathml/guides/fonts/index.md
@@ -50,15 +50,17 @@ Install the _STIX Two Math_ font as follows:
 ### Linux
 
 Below, you can find commands to execute on popular Linux distributions
-in order to install the _Latin Modern Math_ and _STIX Two Math_ fonts from your
-package manager. Alternative approaches are also provided if your Linux
-distribution does not provide dedicated packages for these fonts.
+in order to install math fonts from your package manager. Alternative
+approaches are also provided if your Linux distribution does not provide
+dedicated packages for these fonts.
 
 #### Debian-based distributions (including Ubuntu and Mint)
 
 ```bash
-sudo apt-get install fonts-lmodern fonts-stix
+sudo apt-get install fonts-lmodern
 ```
+
+The Debian `fonts-stix` package installs STIX 1.x fonts, not _STIX Two Math_.
 
 #### Fedora-based distributions
 

--- a/files/en-us/web/mathml/guides/fonts/index.md
+++ b/files/en-us/web/mathml/guides/fonts/index.md
@@ -60,7 +60,8 @@ dedicated packages for these fonts.
 sudo apt-get install fonts-lmodern
 ```
 
-The Debian `fonts-stix` package installs STIX 1.x fonts, not _STIX Two Math_.
+> [!NOTE]
+> The Debian `fonts-stix` package installs STIX 1.x fonts, not _STIX Two Math_.
 
 #### Fedora-based distributions
 


### PR DESCRIPTION
## Summary

Fixes the MathML fonts guide so it no longer claims that the Debian `fonts-stix` package installs STIX Two Math.

## Issue fixed

Fixes #38089

## What changed

- Removed `fonts-stix` from the Debian-based installation command.
- Adjusted the Linux package-manager introduction so it does not claim every listed command installs both Latin Modern Math and STIX Two Math.
- Added a short note that Debian's `fonts-stix` package installs STIX 1.x fonts, not STIX Two Math.

## Why this is correct

The issue reports that Debian's `fonts-stix` package provides STIX 1.x rather than STIX Two. This change avoids recommending that package as a STIX Two Math installation method and does not add any unverified replacement package.

## Testing/checks performed

- `corepack npm exec --package prettier -- prettier -c files/en-us/web/mathml/guides/fonts/index.md`
- `git diff --check`
- `corepack npm ci` attempted locally

Note: `corepack npm ci` still did not complete locally because the `@mdn/rari` postinstall step exited with code 13 while unpacking the Rari binary.

## Note

This change is intentionally small and issue-focused.