### PR TITLE
fix(html): remove methods row from HTML technical summary

### DIFF
--- a/files/en-us/web/html/reference/elements/input/button/index.md
+++ b/files/en-us/web/html/reference/elements/input/button/index.md
@@ -367,10 +367,6 @@ draw();
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>None</td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role"><code>button</code></a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/checkbox/index.md
+++ b/files/en-us/web/html/reference/elements/input/checkbox/index.md
@@ -410,12 +410,6 @@ otherCheckbox.addEventListener("change", () => {
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/checkbox_role"><code>checkbox</code></a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/color/index.md
+++ b/files/en-us/web/html/reference/elements/input/color/index.md
@@ -236,12 +236,6 @@ The final result looks like this:
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/date/index.md
+++ b/files/en-us/web/html/reference/elements/input/date/index.md
@@ -273,14 +273,6 @@ input:valid + span::after {
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}},
-        {{domxref("HTMLInputElement.stepUp", "stepUp()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/datetime-local/index.md
+++ b/files/en-us/web/html/reference/elements/input/datetime-local/index.md
@@ -275,14 +275,6 @@ The valid range included all times between the `min` and `max` values; the time 
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}},
-        {{domxref("HTMLInputElement.stepUp", "stepUp()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/email/index.md
+++ b/files/en-us/web/html/reference/elements/input/email/index.md
@@ -400,12 +400,6 @@ As an added touch, the {{HTMLElement("label")}} element is used to establish a l
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         with no <code>list</code> attribute:

--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -475,12 +475,6 @@ The example looks like this; have a play:
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/hidden/index.md
+++ b/files/en-us/web/html/reference/elements/input/hidden/index.md
@@ -160,10 +160,6 @@ Even though the hidden input cannot be seen at all, its data is still submitted.
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>None.</td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/image/index.md
+++ b/files/en-us/web/html/reference/elements/input/image/index.md
@@ -342,10 +342,6 @@ Here, `object-position` is configured to draw the image in the top-right corner 
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>None.</td>
-    </tr>
-     <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role"><code>button</code></a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/month/index.md
+++ b/files/en-us/web/html/reference/elements/input/month/index.md
@@ -518,14 +518,6 @@ function populateYears() {
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}},
-        {{domxref("HTMLInputElement.stepUp", "stepUp()")}}.
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/number/index.md
+++ b/files/en-us/web/html/reference/elements/input/number/index.md
@@ -465,14 +465,6 @@ After declaring a few variables, an event listener is added to the `button` to c
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.stepUp", "stepUp()")}},
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/spinbutton_role">spinbutton</a></code>

--- a/files/en-us/web/html/reference/elements/input/password/index.md
+++ b/files/en-us/web/html/reference/elements/input/password/index.md
@@ -315,15 +315,6 @@ ssn.oninput = (event) => {
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.setRangeText", "setRangeText()")}},
-        and
-        {{domxref("HTMLInputElement.setSelectionRange", "setSelectionRange()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/radio/index.md
+++ b/files/en-us/web/html/reference/elements/input/radio/index.md
@@ -347,12 +347,6 @@ Notice that when clicking on a radio button, there's a nice, smooth fade out/in 
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}}
-      </td>
-    </tr>
-     <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/radio_role">radio</a></code>

--- a/files/en-us/web/html/reference/elements/input/range/index.md
+++ b/files/en-us/web/html/reference/elements/input/range/index.md
@@ -350,13 +350,6 @@ See [Creating vertical form controls](/en-US/docs/Web/CSS/Guides/Writing_modes/V
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}}
-        and {{domxref("HTMLInputElement.stepUp", "stepUp()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/slider_role">slider</a></code>

--- a/files/en-us/web/html/reference/elements/input/reset/index.md
+++ b/files/en-us/web/html/reference/elements/input/reset/index.md
@@ -176,10 +176,6 @@ We've included basic examples above. There isn't really anything more to say abo
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>None</td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role"><code>button</code></a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/search/index.md
+++ b/files/en-us/web/html/reference/elements/input/search/index.md
@@ -457,14 +457,6 @@ You can see a good example of a search form used in context at our [website-aria
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.setRangeText", "setRangeText()")}},
-        {{domxref("HTMLInputElement.setSelectionRange", "setSelectionRange()")}}.
-      </td>
-    </tr>
-     <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         with no <code>list</code> attribute:

--- a/files/en-us/web/html/reference/elements/input/submit/index.md
+++ b/files/en-us/web/html/reference/elements/input/submit/index.md
@@ -197,10 +197,6 @@ We've included basic examples above. There isn't really anything more to say abo
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>None</td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role"><code>button</code></a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/tel/index.md
+++ b/files/en-us/web/html/reference/elements/input/tel/index.md
@@ -518,14 +518,6 @@ input:valid + span::after {
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.setRangeText", "setRangeText()")}},
-        {{domxref("HTMLInputElement.setSelectionRange", "setSelectionRange()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         with no <code>list</code> attribute:

--- a/files/en-us/web/html/reference/elements/input/text/index.md
+++ b/files/en-us/web/html/reference/elements/input/text/index.md
@@ -427,15 +427,6 @@ You can see good examples of text inputs used in context in our [Your first HTML
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.setRangeText", "setRangeText()")}}
-        and
-        {{domxref("HTMLInputElement.setSelectionRange", "setSelectionRange()")}}.
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         with no <code>list</code> attribute:

--- a/files/en-us/web/html/reference/elements/input/time/index.md
+++ b/files/en-us/web/html/reference/elements/input/time/index.md
@@ -364,15 +364,6 @@ If you try to submit the form with an incomplete time (or with a time outside th
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}},
-        and
-        {{domxref("HTMLInputElement.stepUp", "stepUp()")}}.
-      </td>
-    </tr>
-     <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>

--- a/files/en-us/web/html/reference/elements/input/url/index.md
+++ b/files/en-us/web/html/reference/elements/input/url/index.md
@@ -374,15 +374,6 @@ Check the [Pattern validation](#pattern_validation) and [Using URL inputs](#usin
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.setRangeText", "setRangeText()")}}
-        and
-        {{domxref("HTMLInputElement.setSelectionRange", "setSelectionRange()")}}.
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td>
         with no <code>list</code> attribute:

--- a/files/en-us/web/html/reference/elements/input/week/index.md
+++ b/files/en-us/web/html/reference/elements/input/week/index.md
@@ -386,14 +386,6 @@ function populateWeeks() {
       <td><p>{{domxref("HTMLInputElement")}}</p></td>
     </tr>
     <tr>
-      <td><strong>Methods</strong></td>
-      <td>
-        {{domxref("HTMLInputElement.select", "select()")}},
-        {{domxref("HTMLInputElement.stepDown", "stepDown()")}},
-        and {{domxref("HTMLInputElement.stepUp", "stepUp()")}}
-      </td>
-    </tr>
-    <tr>
       <td><strong>Implicit ARIA Role</strong></td>
       <td><a href="https://w3c.github.io/html-aria/#dfn-no-corresponding-role">no corresponding role</a></td>
     </tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Remove the "methods" row from the HTML technical summary 
<!-- ✍️ Summarize your changes in one or two sentences. -->


<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
Fixes #44298
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
