### PR TITLE
CSS `font` semi-shorthand property

### DIFF
--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -72,8 +72,6 @@ section {
 }
 ```
 
-As with any shorthand property, any individual value that is not specified is set to its corresponding initial value (possibly overriding values previously set using non-shorthand properties). Though not directly settable by `font`, the longhands {{cssxref("font-size-adjust")}} and {{cssxref("font-kerning")}} are also reset to their initial values.
-
 ## Constituent properties
 
 This property is a shorthand for the following CSS properties:
@@ -105,9 +103,57 @@ font: ultra-condensed small-caps 1.2em "Fira Sans", sans-serif;
 font: caption;
 ```
 
-The `font` property may be specified as either a single keyword, which will select a system font, or as a shorthand for various font-related properties.
+### Values
 
-If `font` is specified as a system keyword, it must be one of: `caption`, `icon`, `menu`, `message-box`, `small-caption`, `status-bar`.
+The `font` shorthand property is either multiple data-types specifying the various font-related properties or a single `<system-font-family-name>` keyword:
+
+- `<'font-style'>`
+  - : See the {{cssxref("font-style")}} CSS property. Defaults to `normal`.
+- `<font-variant>`
+  - : Either the `normal` or `small-caps` value of the {{cssxref("font-variant")}} property. Defaults to `normal`.
+- `<'font-weight'>`
+  - : See the {{cssxref("font-weight")}} CSS property. Defaults to `normal`.
+- `<'font-stretch'>`
+  - : See the {{cssxref("font-stretch")}} CSS property. Defaults to `normal`.
+- `<'font-size'>`
+  - : See the {{cssxref("font-size")}} CSS property. Required value.
+- `<'line-height'>`
+  - : See the {{cssxref("line-height")}} CSS property. Defaults to `normal`.
+- `<'font-family'>`
+  - : See the {{cssxref("font-family")}} CSS property. Required value.
+ 
+
+- `<system-font-family-name>`
+  - : A single keyword representing a system font, including:
+    - `caption`
+      - : The system font used for captioned controls (e.g., buttons, drop-downs, etc.).
+    - `icon`
+      - : The system font used to label icons.
+    - `menu`
+      - : The system font used in menus (e.g., dropdown menus and menu lists).
+    - `message-box`
+      - : The system font used in dialog boxes.
+    - `small-caption`
+      - : The system font used for labeling small controls.
+    - `status-bar`
+      - : The system font used in window status bars.
+
+    There are several non-standard values are implemented with prefixes. Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`. Webkit add `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with seveal `-apple-system-*` prefixed keywords. Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
+
+ 
+## Description
+
+Depending on its value, the `font` property value is either a single keyword reresenting a system-font-family-name or multiple longhand property value used to set all the different properties of an element's font.
+
+### System font declarations
+
+If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to either `caption`, `icon`, `menu`, `message-box`, `small-caption` or `status-bar`. These values are only treated as keywords when they occur as the full property value.
+
+System fonts can only be set with the `font` property. The single keyword value, such as `font: icon` sets the font family, size, weight, style, etc. to the values the browser defined for the named system font.  The browser values can all be changed with longhand declarations coming after the `font` declaration. Setting any font components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration: `font: icon small` is invalid.
+
+If a `<system-font-family-name>` keyword appears anywhere in the value other than as the first component, the keyword is treated as an {{cssxref("ident")}} representing a `font-family` name. For example, the declaration `font: small icon` sets the `font-family` to a font named `icon`, a non-system font which may or may not exist, while also setting `font-size: small` and resetting all the other shorthand component properties to their initial value.
+
+### As a shorthand
 
 If `font` is specified as a shorthand for several font-related properties, then:
 
@@ -117,50 +163,40 @@ If `font` is specified as a shorthand for several font-related properties, then:
 
 - it may optionally include values for:
   - {{cssxref("font-style")}}
-  - {{cssxref("font-variant")}}
+  - {{cssxref("font-variant")}}, limited to `normal` or `small-caps`
   - {{cssxref("font-weight")}}
   - {{cssxref("font-stretch")}}
   - {{cssxref("line-height")}}
 
-- `font-style`, `font-variant` and `font-weight` must precede `font-size`.
-- `font-variant` may only specify the values defined in CSS 2.1, that is `normal` and `small-caps`.
-- `font-stretch` may only be a single keyword value.
-- `line-height` must immediately follow `font-size`, preceded by "/", like this: `16px/3`.
-- `font-family` must be the last value specified.
+As with any shorthand property, any of the longhand component properties not  value that is not specified is set to its initial value, possibly overriding values previously set using non-shorthand properties. In addition, the shorthand resets the following properties to their initial values that can not be set by the shorthand:
 
-### Values
+- {{cssxref("font-feature-settings")}}
+- {{cssxref("font-kerning")}}
+- {{cssxref("font-language-override")}}
+- {{cssxref("font-optical-sizing")}}
+- {{cssxref("font-size-adjust")}}
+- {{cssxref("font-variant-alternates")}}
+- {{cssxref("font-variant-caps (css3 and above)")}}
+- {{cssxref("font-variant-east-asian")}}
+- {{cssxref("font-variant-emoji")}}
+- {{cssxref("font-variant-ligatures")}}
+- {{cssxref("font-variant-numeric")}}
+- {{cssxref("font-variant-position")}}
+- {{cssxref("font-variation-settings")}}
 
-- `<'font-style'>`
-  - : See the {{cssxref("font-style")}} CSS property.
-- `<'font-variant'>`
-  - : See the {{cssxref("font-variant")}} CSS property.
-- `<'font-weight'>`
-  - : See the {{cssxref("font-weight")}} CSS property.
-- `<'font-stretch'>`
-  - : See the {{cssxref("font-stretch")}} CSS property.
-- `<'font-size'>`
-  - : See the {{cssxref("font-size")}} CSS property.
-- `<'line-height'>`
-  - : See the {{cssxref("line-height")}} CSS property.
-- `<'font-family'>`
-  - : See the {{cssxref("font-family")}} CSS property.
+### Shorthand property order
 
-#### System font values
+The order of some of the longhand values within the shorthand `font` declaration is partially important and must therefore follow a few rules:
 
-- `caption`
-  - : The system font used for captioned controls (e.g., buttons, drop-downs, etc.).
-- `icon`
-  - : The system font used to label icons.
-- `menu`
-  - : The system font used in menus (e.g., dropdown menus and menu lists).
-- `message-box`
-  - : The system font used in dialog boxes.
-- `small-caption`
-  - : The system font used for labeling small controls.
-- `status-bar`
-  - : The system font used in window status bars.
-- Prefixed system font keywords
-  - : Browsers often implement several more, prefixed, keywords: Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
+- The `font-style`, `font-variant` and `font-weight` compoents must precede the `font-size` value.
+- The valid values for the `font-variant` component are limited `normal` or `small-caps`.
+- The `font-stretch` may only be a single keyword value; {{cssxref("percentage")}} values are not valid within the shorthand.
+- A `line-height` can only be included if `font-size` is included. If present, the `line-height` must immediately follow the `font-size`, with the two values separated by a forward slash (`/`), for example: `16px / 3`.
+- The `font-family` must be the last value specified.
+
+### The `font-variant` component
+
+The `<font-variant>` component of the shorthand is limited to the two values supported in CSS 2.1, including `normal` and `small-caps`. While no other values are supported, the shorthand `font` declaration resets the {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("ffont-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}} properties to `normal`.
 
 ## Formal definition
 
@@ -172,35 +208,54 @@ If `font` is specified as a shorthand for several font-related properties, then:
 
 ## Examples
 
-### Setting font properties
+### Basic usage
+
+This example defines the `font` for all {{htmlelement("p")}} elements. We set the `font-size` to `12px` and the `line-height` to `14px`, separating them with a forward slash (`/`). We know which {{cssxref("length")}} refers to each component because of the rule: "If present, the `line-height` must immediately follow the `font-size`, with the two values separated by a forward slash (`/`)". The declaration also sets the `font-family` to `sans-serif`.
 
 ```css
-/* Set the font size to 12px and the line height to 14px.
-   Set the font family to sans-serif */
 p {
-  font: 12px/14px sans-serif;
-}
-
-/* Set the font size to 80% of the parent element
-   or default value (if no parent element present).
-   Set the font family to sans-serif */
-p {
-  font: 80% sans-serif;
-}
-
-/* Set the font weight to bold,
-   the font-style to italic,
-   the font size to large,
-   and the font family to serif. */
-p {
-  font: bold italic large serif;
-}
-
-/* Use the same font as the status bar of the window */
-p {
-  font: status-bar;
+  font: 12px / 14px sans-serif;
 }
 ```
+
+```html hidden
+<p>This is a paragraph of sans-serif text. The font-size is small, at just 12px. If this text wraps, the line height is pretty tight at 14px, so this may be difficult to read.</p>
+```
+
+{{ EmbedLiveSample('basic usage','100%', '100')}}
+
+### Multiple properties
+
+In this example, we set the `font-weight` to `bold`, the `font-style` to `italic`, the `font-size` to `large`, the `line-height` to `1.6`, and the `font-family` to `serif`.
+
+```css
+p {
+  font: bold italic large / 1.6 serif;
+}
+```
+
+```html hidden
+<p>In this example, we set the font weight to bold, the font style to italic, the font size to large, the line height to 1.6, and the font family to serif.</p>
+```
+
+{{ EmbedLiveSample(' Multiple properties','100%', '100')}}
+
+### System font
+
+This example demonstrates using the `font` property to set a system font. We set the paragraph's font to have the same `font-family`, `line-height`, `font-size`, etc., as the status bar of the window, then we set the `line-height` to `1.6`.
+
+```css
+p {
+  font: status-bar;
+  line-height: 1.6;
+}
+```
+
+```html hidden
+<p>Take a look at your status bar. The font of this text should look the same.</p>
+```
+
+{{ EmbedLiveSample('System font','100%', '100')}}
 
 ### Live sample
 
@@ -527,4 +582,4 @@ document.querySelectorAll("input[type='radio']").forEach((el) => {
 
 - {{cssxref("font-style")}}
 - {{cssxref("font-weight")}}
-- [Learn: Fundamental text and font styling](/en-US/docs/Learn_web_development/Core/Text_styling/Fundamentals)
+- [System font stack](https://css-tricks.com/snippets/css/system-font-stack/) on CSS-Tricks (2017) 

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -121,7 +121,6 @@ The `font` shorthand property is either multiple data-types specifying the vario
   - : See the {{cssxref("line-height")}} CSS property. Defaults to `normal`.
 - `<'font-family'>`
   - : See the {{cssxref("font-family")}} CSS property. Required value.
- 
 
 - `<system-font-family-name>`
   - : A single keyword representing a system font, including:
@@ -140,7 +139,6 @@ The `font` shorthand property is either multiple data-types specifying the vario
 
     There are several non-standard values are implemented with prefixes. Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`. Webkit add `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with seveal `-apple-system-*` prefixed keywords. Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
 
- 
 ## Description
 
 Depending on its value, the `font` property value is either a single keyword reresenting a system-font-family-name or multiple longhand property value used to set all the different properties of an element's font.
@@ -149,7 +147,7 @@ Depending on its value, the `font` property value is either a single keyword rer
 
 If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to either `caption`, `icon`, `menu`, `message-box`, `small-caption` or `status-bar`. These values are only treated as keywords when they occur as the full property value.
 
-System fonts can only be set with the `font` property. The single keyword value, such as `font: icon` sets the font family, size, weight, style, etc. to the values the browser defined for the named system font.  The browser values can all be changed with longhand declarations coming after the `font` declaration. Setting any font components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration: `font: icon small` is invalid.
+System fonts can only be set with the `font` property. The single keyword value, such as `font: icon` sets the font family, size, weight, style, etc. to the values the browser defined for the named system font. The browser values can all be changed with longhand declarations coming after the `font` declaration. Setting any font components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration: `font: icon small` is invalid.
 
 If a `<system-font-family-name>` keyword appears anywhere in the value other than as the first component, the keyword is treated as an {{cssxref("ident")}} representing a `font-family` name. For example, the declaration `font: small icon` sets the `font-family` to a font named `icon`, a non-system font which may or may not exist, while also setting `font-size: small` and resetting all the other shorthand component properties to their initial value.
 
@@ -168,7 +166,7 @@ If `font` is specified as a shorthand for several font-related properties, then:
   - {{cssxref("font-stretch")}}
   - {{cssxref("line-height")}}
 
-As with any shorthand property, any of the longhand component properties not  value that is not specified is set to its initial value, possibly overriding values previously set using non-shorthand properties. In addition, the shorthand resets the following properties to their initial values that can not be set by the shorthand:
+As with any shorthand property, any of the longhand component properties not value that is not specified is set to its initial value, possibly overriding values previously set using non-shorthand properties. In addition, the shorthand resets the following properties to their initial values that can not be set by the shorthand:
 
 - {{cssxref("font-feature-settings")}}
 - {{cssxref("font-kerning")}}
@@ -219,7 +217,11 @@ p {
 ```
 
 ```html hidden
-<p>This is a paragraph of sans-serif text. The font-size is small, at just 12px. If this text wraps, the line height is pretty tight at 14px, so this may be difficult to read.</p>
+<p>
+  This is a paragraph of sans-serif text. The font-size is small, at just 12px.
+  If this text wraps, the line height is pretty tight at 14px, so this may be
+  difficult to read.
+</p>
 ```
 
 {{ EmbedLiveSample('basic usage','100%', '100')}}
@@ -235,7 +237,10 @@ p {
 ```
 
 ```html hidden
-<p>In this example, we set the font weight to bold, the font style to italic, the font size to large, the line height to 1.6, and the font family to serif.</p>
+<p>
+  In this example, we set the font weight to bold, the font style to italic, the
+  font size to large, the line height to 1.6, and the font family to serif.
+</p>
 ```
 
 {{ EmbedLiveSample(' Multiple properties','100%', '100')}}
@@ -252,7 +257,9 @@ p {
 ```
 
 ```html hidden
-<p>Take a look at your status bar. The font of this text should look the same.</p>
+<p>
+  Take a look at your status bar. The font of this text should look the same.
+</p>
 ```
 
 {{ EmbedLiveSample('System font','100%', '100')}}
@@ -582,4 +589,4 @@ document.querySelectorAll("input[type='radio']").forEach((el) => {
 
 - {{cssxref("font-style")}}
 - {{cssxref("font-weight")}}
-- [System font stack](https://css-tricks.com/snippets/css/system-font-stack/) on CSS-Tricks (2017) 
+- [System font stack](https://css-tricks.com/snippets/css/system-font-stack/) on CSS-Tricks (2017)

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -123,7 +123,7 @@ The value is either a shorthand specifying the various font-related properties o
 - `<system-font-family-name>`
   - : A single keyword representing a system font, including:
     - `caption`
-      - : The system font used for captioned controls (e.g., buttons, drop-downs, etc.).
+      - : The system font used for captioned controls (buttons, drop-downs, etc.).
     - `icon`
       - : The system font used to label icons.
     - `menu`
@@ -201,9 +201,9 @@ The order of some of the longhand values within the shorthand `font` declaration
 
 For backward compatibility, the valid values of the `font-variant` and `font-width` components do not include all the valid values or the longhand equivalents.
 
-The valid values for the `font-variant` component are limited `normal` or `small-caps`. While no other values are supported, the shorthand `font` declaration resets all the `font-variant-*` longhand properties to `normal`, including {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}}.
+The valid values for the `font-variant` component are limited to `normal` or `small-caps`. While no other values are supported, the shorthand `font` declaration resets all the `font-variant-*` longhand properties to `normal`, including {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}}.
 
-The valid values for the `font-width` component are limited to keyword values: `normal`, `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded`. The {{cssxref("font-width")}} longhand property also supports {{cssxref("percentage")}} values, which are not valid within the shorthand.
+The valid values for the `font-width` component are limited to keyword values: `normal`, `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded`. The {{cssxref("font-width")}} longhand property also supports {{cssxref("percentage")}} values, but they are not valid within the shorthand.
 
 ## Formal definition
 
@@ -271,7 +271,7 @@ p {
 
 #### HTML
 
-Our HTML includes a paragraph ({{htmlelement("p")}}) containing a link ({{htmlelement("a")}}) with a convoluted [`href`](/en-US/docs/Web/HTML/Reference/Elements/a#href) attribute value. When you hover over or focus on the rendered link, your browser's status bar should display the value of this `href` attribute.
+Our HTML includes a paragraph ({{htmlelement("p")}}) containing a link ({{htmlelement("a")}}) with a convoluted [`href`](/en-US/docs/Web/HTML/Reference/Elements/a#href) attribute value. When you hover or focus the rendered link, your browser's status bar should display the value of the `href` attribute.
 
 ```html
 <p>
@@ -289,8 +289,8 @@ family%20and%20size%20and%20the%20text%20in%20the%20example."
 As the URL in our HTML link is not good practice, we include a script that prevents the document from redirecting to a non-existent page when the link is clicked.
 
 ```js
-const a = document.querySelector("a");
-a.addEventListener("click", function (e) {
+const aElem = document.querySelector("a");
+aElem.addEventListener("click", function (e) {
   e.preventDefault();
   return false;
 });
@@ -300,7 +300,7 @@ a.addEventListener("click", function (e) {
 
 {{EmbedLiveSample('System font','100%', '100')}}
 
-Hover or focus the link, then look at your status bar. The font should be the same family and size and the text in your status bar at the bottom of your browser window..
+Hover or focus the link. The font should be the same family and size as the text in your status bar at the bottom of your browser window.
 
 ### Shorthand declaration creator
 

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -147,9 +147,9 @@ If `font` is specified as a `<system-font-family-name>` keyword, the full proper
 
 Browsers also support non-standard prefixed values:
 
- Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`.
- Webkit includes the Chromium values, and adds `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with several `-apple-system-*` prefixed system font names.
- Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
+- Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`.
+- Webkit includes the Chromium values, and adds `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with several `-apple-system-*` prefixed system font names.
+- Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
 
 The system font, or `<system-font-family-name>`, can only be set with the `font` property. Defining a single keyword value, such as `font: icon`, sets the font's family, size, weight, style, etc., to the values the browser defines for the named system font. These values can all be changed with longhand declarations placed _after_ the `font` declaration.
 

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -233,7 +233,7 @@ p {
 </p>
 ```
 
-{{ EmbedLiveSample('basic usage','100%', '100')}}
+{{EmbedLiveSample('basic usage','100%', '100')}}
 
 ### Multiple properties
 
@@ -252,7 +252,7 @@ p {
 </p>
 ```
 
-{{ EmbedLiveSample(' Multiple properties','100%', '100')}}
+{{EmbedLiveSample(' Multiple properties','100%', '100')}}
 
 ### System font
 
@@ -298,7 +298,7 @@ a.addEventListener("click", function (e) {
 
 #### Result
 
-{{ EmbedLiveSample('System font','100%', '100')}}
+{{EmbedLiveSample('System font','100%', '100')}}
 
 Hover or focus the link, then look at your status bar. The font should be the same family and size and the text in your status bar at the bottom of your browser window..
 
@@ -617,7 +617,7 @@ document.querySelectorAll("input[type='radio']").forEach((el) => {
 });
 ```
 
-{{ EmbedLiveSample('Shorthand declaration creator','100%', '500px')}}
+{{EmbedLiveSample('Shorthand declaration creator','100%', '500px')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -273,7 +273,7 @@ p {
 
 Our HTML includes a paragraph ({{htmlelement("p")}}) containing a link ({{htmlelement("a")}}) with a convoluted [`href`](/en-US/docs/Web/HTML/Reference/Elements/a#href) attribute value. When you hover over or focus on the rendered link, your browser's status bar should display the value of this `href` attribute.
 
-```html bad
+```html
 <p>
   <a
     href="/%20The%20font%20should%20be%20the%20same%20

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -78,7 +78,7 @@ This property is a shorthand for the following CSS properties:
 
 - {{cssxref("font-family")}}
 - {{cssxref("font-size")}}
-- {{cssxref("font-stretch")}}
+- {{cssxref("font-width")}}
 - {{cssxref("font-style")}}
 - {{cssxref("font-variant")}}
 - {{cssxref("font-weight")}}
@@ -96,7 +96,7 @@ font: 1.2em/2 "Fira Sans", sans-serif;
 /* font-style font-weight font-size font-family */
 font: italic bold 1.2em "Fira Sans", sans-serif;
 
-/* font-stretch font-variant font-size font-family */
+/* font-width font-variant font-size font-family */
 font: ultra-condensed small-caps 1.2em "Fira Sans", sans-serif;
 
 /* system font */
@@ -105,7 +105,7 @@ font: caption;
 
 ### Values
 
-The `font` shorthand property is either multiple data-types specifying the various font-related properties or a single `<system-font-family-name>` keyword:
+The value is either a shorthand specifying the various font-related properties or a single `<system-font-family-name>` keyword:
 
 - `<'font-style'>`
   - : See the {{cssxref("font-style")}} CSS property. Defaults to `normal`.
@@ -113,8 +113,8 @@ The `font` shorthand property is either multiple data-types specifying the vario
   - : Either the `normal` or `small-caps` value of the {{cssxref("font-variant")}} property. Defaults to `normal`.
 - `<'font-weight'>`
   - : See the {{cssxref("font-weight")}} CSS property. Defaults to `normal`.
-- `<'font-stretch'>`
-  - : See the {{cssxref("font-stretch")}} CSS property. Defaults to `normal`.
+- `<font-width>`
+  - : The keywords supported by the legacy `font-stretch` property. See the {{cssxref("font-width")}} CSS property. Defaults to `normal`.
 - `<'font-size'>`
   - : See the {{cssxref("font-size")}} CSS property. Required value.
 - `<'line-height'>`
@@ -137,19 +137,19 @@ The `font` shorthand property is either multiple data-types specifying the vario
     - `status-bar`
       - : The system font used in window status bars.
 
-    There are several non-standard values are implemented with prefixes. Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`. Webkit add `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with seveal `-apple-system-*` prefixed keywords. Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
+    There are several non-standard values are implemented with prefixes.
 
 ## Description
 
-Depending on its value, the `font` property value is either a single keyword reresenting a system-font-family-name or multiple longhand property value used to set all the different properties of an element's font.
+Depending on its value, the `font` property value is either a single keyword representing a system-font-family-name or multiple longhand property value used to set all the different properties of an element's font.
 
 ### System font declarations
 
-If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to either `caption`, `icon`, `menu`, `message-box`, `small-caption` or `status-bar`. These values are only treated as keywords when they occur as the full property value.
+If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to that single, case-insensitive keyword. Valid values include `caption`, `icon`, `menu`, `message-box`, `small-caption` or `status-bar`. Browsers also support non-standard prefixed values. Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`. Webkit includes these, and adds `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with several `-apple-system-*` prefixed system font names. Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
 
-System fonts can only be set with the `font` property. The single keyword value, such as `font: icon` sets the font family, size, weight, style, etc. to the values the browser defined for the named system font. The browser values can all be changed with longhand declarations coming after the `font` declaration. Setting any font components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration: `font: icon small` is invalid.
+The system font, or `<system-font-family-name>`, can only be set with the `font` property. Defining a single keyword value, such as `font: icon`, sets the font's family, size, weight, style, etc. to the values the browser defined for the named system font. These values can all be changed with longhand declarations coming _after_ the `font` declaration. Including any `font` longhand components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration. For example, `font: icon small` is invalid.
 
-If a `<system-font-family-name>` keyword appears anywhere in the value other than as the first component, the keyword is treated as an {{cssxref("ident")}} representing a `font-family` name. For example, the declaration `font: small icon` sets the `font-family` to a font named `icon`, a non-system font which may or may not exist, while also setting `font-size: small` and resetting all the other shorthand component properties to their initial value.
+If a `<system-font-family-name>` keyword appears anywhere in the value other than as the first component, the keyword is treated as an {{cssxref("ident")}} representing a standard `font-family` name. For example, the declaration `font: small icon` sets the `font-family` to a font named `icon`, a non-system font which may or may not exist. This declaration also sets the `font-size` to `small` and resets all the other shorthand component properties to their initial values.
 
 ### As a shorthand
 
@@ -163,7 +163,7 @@ If `font` is specified as a shorthand for several font-related properties, then:
   - {{cssxref("font-style")}}
   - {{cssxref("font-variant")}}, limited to `normal` or `small-caps`
   - {{cssxref("font-weight")}}
-  - {{cssxref("font-stretch")}}
+  - {{cssxref("font-width")}}
   - {{cssxref("line-height")}}
 
 As with any shorthand property, any of the longhand component properties not value that is not specified is set to its initial value, possibly overriding values previously set using non-shorthand properties. In addition, the shorthand resets the following properties to their initial values that can not be set by the shorthand:
@@ -174,7 +174,7 @@ As with any shorthand property, any of the longhand component properties not val
 - {{cssxref("font-optical-sizing")}}
 - {{cssxref("font-size-adjust")}}
 - {{cssxref("font-variant-alternates")}}
-- {{cssxref("font-variant-caps (css3 and above)")}}
+- {{cssxref("font-variant-caps")}}
 - {{cssxref("font-variant-east-asian")}}
 - {{cssxref("font-variant-emoji")}}
 - {{cssxref("font-variant-ligatures")}}
@@ -186,15 +186,19 @@ As with any shorthand property, any of the longhand component properties not val
 
 The order of some of the longhand values within the shorthand `font` declaration is partially important and must therefore follow a few rules:
 
-- The `font-style`, `font-variant` and `font-weight` compoents must precede the `font-size` value.
-- The valid values for the `font-variant` component are limited `normal` or `small-caps`.
-- The `font-stretch` may only be a single keyword value; {{cssxref("percentage")}} values are not valid within the shorthand.
+- Both the `font-size` and `font-family` components are required (unless setting a system font).
+- The `font-style`, `font-variant` and `font-weight` components must precede the `font-size` value.
 - A `line-height` can only be included if `font-size` is included. If present, the `line-height` must immediately follow the `font-size`, with the two values separated by a forward slash (`/`), for example: `16px / 3`.
 - The `font-family` must be the last value specified.
 
-### The `font-variant` component
+### Longhands with limited values
 
-The `<font-variant>` component of the shorthand is limited to the two values supported in CSS 2.1, including `normal` and `small-caps`. While no other values are supported, the shorthand `font` declaration resets the {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("ffont-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}} properties to `normal`.
+For backward compatibility, the valid values of the `<font-variant>` and `<font-variant>` components do not include all the valid values or the longhand equivalents.
+
+- The valid values for the `font-variant` component are limited `normal` or `small-caps`.
+  - : The `<font-variant>` component of the shorthand is limited to the two values supported in CSS 2.1, including `normal` and `small-caps`. While no other values are supported, the shorthand `font` declaration resets the {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}} properties to `normal`.
+- The `font-width` may only be a single keyword value
+ : The `<font-width>` component of the shorthand is limited to `normal`, `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded`. These keyword values were originally defined by the legacy `font-stretch` property, which is now an alias to `font-width`. The {{cssxref("font-width")}} longhand property also supports {{cssxref("percentage")}} values, which are not valid within the shorthand.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -37,13 +37,11 @@ font: caption;
 
 ```html interactive-example
 <section id="default-example">
-  <p id="example-element">
-    London. Michaelmas term lately over, and the Lord Chancellor sitting in
-    Lincoln's Inn Hall. Implacable November weather. As much mud in the streets
-    as if the waters had but newly retired from the face of the earth, and it
-    would not be wonderful to meet a Megalosaurus, forty feet long or so,
-    waddling like an elephantine lizard up Holborn Hill.
-  </p>
+  <q id="example-element">
+    Prejudices, it is well known, are most difficult to eradicate from the heart
+    whose soil has never been loosened or fertilised by education: they grow
+    there, firm as weeds among stones.
+  </q>
 </section>
 ```
 
@@ -88,16 +86,16 @@ This property is a shorthand for the following CSS properties:
 
 ```css-nolint
 /* font-size font-family */
-font: 1.2em "Fira Sans", sans-serif;
+font: 1.2em sans-serif;
 
 /* font-size/line-height font-family */
 font: 1.2em/2 "Fira Sans", sans-serif;
 
 /* font-style font-weight font-size font-family */
-font: italic bold 1.2em "Fira Sans", sans-serif;
+font: italic bold 1.2em monospace;
 
 /* font-width font-variant font-size font-family */
-font: ultra-condensed small-caps 1.2em "Fira Sans", sans-serif;
+font: ultra-condensed small-caps 1.2em Montserrat, Helvetica, sans-serif;
 
 /* system font */
 font: caption;
@@ -109,11 +107,11 @@ The value is either a shorthand specifying the various font-related properties o
 
 - `<'font-style'>`
   - : See the {{cssxref("font-style")}} CSS property. Defaults to `normal`.
-- `<font-variant>`
+- `<font-variant-css2>`
   - : Either the `normal` or `small-caps` value of the {{cssxref("font-variant")}} property. Defaults to `normal`.
 - `<'font-weight'>`
   - : See the {{cssxref("font-weight")}} CSS property. Defaults to `normal`.
-- `<font-width>`
+- `<font-width-css3>`
   - : The keywords supported by the legacy `font-stretch` property. See the {{cssxref("font-width")}} CSS property. Defaults to `normal`.
 - `<'font-size'>`
   - : See the {{cssxref("font-size")}} CSS property. Required value.
@@ -145,7 +143,9 @@ Depending on its value, the `font` property value is either a single keyword rep
 
 ### System font declarations
 
-If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to that single, case-insensitive keyword. Valid values include `caption`, `icon`, `menu`, `message-box`, `small-caption` or `status-bar`. Browsers also support non-standard prefixed values. Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`. Webkit includes these, and adds `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with several `-apple-system-*` prefixed system font names. Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
+If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to that single, case-insensitive keyword. Valid values include `caption`, `icon`, `menu`, `message-box`, `small-caption` or `status-bar`.
+
+Browsers also support non-standard prefixed values. Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`. Webkit includes these, and adds `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with several `-apple-system-*` prefixed system font names. Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
 
 The system font, or `<system-font-family-name>`, can only be set with the `font` property. Defining a single keyword value, such as `font: icon`, sets the font's family, size, weight, style, etc. to the values the browser defined for the named system font. These values can all be changed with longhand declarations coming _after_ the `font` declaration. Including any `font` longhand components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration. For example, `font: icon small` is invalid.
 
@@ -161,7 +161,7 @@ If `font` is specified as a shorthand for several font-related properties, then:
 
 - it may optionally include values for:
   - {{cssxref("font-style")}}
-  - {{cssxref("font-variant")}}, limited to `normal` or `small-caps`
+  - {{cssxref("font-variant")}}
   - {{cssxref("font-weight")}}
   - {{cssxref("font-width")}}
   - {{cssxref("line-height")}}
@@ -186,19 +186,20 @@ As with any shorthand property, any of the longhand component properties not val
 
 The order of some of the longhand values within the shorthand `font` declaration is partially important and must therefore follow a few rules:
 
-- Both the `font-size` and `font-family` components are required (unless setting a system font).
+- Both the `font-size` and `font-family` components are required (except for [system font declarations](#system_font_declarations)).
 - The `font-style`, `font-variant` and `font-weight` components must precede the `font-size` value.
 - A `line-height` can only be included if `font-size` is included. If present, the `line-height` must immediately follow the `font-size`, with the two values separated by a forward slash (`/`), for example: `16px / 3`.
 - The `font-family` must be the last value specified.
 
-### Longhands with limited values
+### Components with limited values
 
-For backward compatibility, the valid values of the `<font-variant>` and `<font-variant>` components do not include all the valid values or the longhand equivalents.
+For backward compatibility, the valid values of the `font-variant` and `font-width` components do not include all the valid values or the longhand equivalents.
 
 - The valid values for the `font-variant` component are limited `normal` or `small-caps`.
-  - : The `<font-variant>` component of the shorthand is limited to the two values supported in CSS 2.1, including `normal` and `small-caps`. While no other values are supported, the shorthand `font` declaration resets the {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}} properties to `normal`.
-- The `font-width` may only be a single keyword value
- : The `<font-width>` component of the shorthand is limited to `normal`, `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded`. These keyword values were originally defined by the legacy `font-stretch` property, which is now an alias to `font-width`. The {{cssxref("font-width")}} longhand property also supports {{cssxref("percentage")}} values, which are not valid within the shorthand.
+  - : The `<font-variant-css2>` component of the shorthand is limited to the two values supported in CSS 2.1, including `normal` and `small-caps`. While no other values are supported, the shorthand `font` declaration resets the {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}} properties to `normal`.
+
+- The valid values for the `font-width` component are limited to keyword values
+  - : The `<font-width-css3>` component of the shorthand is limited to `normal`, `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded`. These keyword values were originally defined by the legacy `font-stretch` property, which is now an alias to `font-width`. The {{cssxref("font-width")}} longhand property also supports {{cssxref("percentage")}} values, which are not valid within the shorthand.
 
 ## Formal definition
 
@@ -262,13 +263,29 @@ p {
 
 ```html hidden
 <p>
-  Take a look at your status bar. The font of this text should look the same.
+  <a
+    href="/%20The%20font%20should%20be%20the%20same%20family%20and%20size%20and%20the%20text%20in%20the%20example."
+    >Hover or focus this text. The font should be the same family and size and
+    the text in your status bar.</a
+  >
 </p>
+```
+
+```js hidden
+const a = document.querySelector("a");
+a.addEventListener("click", function (e) {
+  e.preventDefault();
+  return false;
+});
 ```
 
 {{ EmbedLiveSample('System font','100%', '100')}}
 
-### Live sample
+Hover or focus the link, then look at your status bar. The font should be the same family and size and the text in your status bar. We added a script to disable the link, which we hid for brevity.
+
+### Shorthand declaration creator
+
+In this live demonstration, you can select different radio buttons to generate different shorthand values, while visualizing the effects of the shorthand declarations you create.
 
 ```html hidden
 <p>
@@ -284,7 +301,7 @@ p {
         name="font_style"
         checked
         value="" />
-      <label for="font-style-none">none</label><br />
+      <label for="font-style-none">omit value</label><br />
       <input
         type="radio"
         id="font-style-normal"
@@ -313,7 +330,7 @@ p {
         name="font_variant"
         checked
         value=" " />
-      <label for="font-variant-none">none</label><br />
+      <label for="font-variant-none">omit value</label><br />
       <input
         type="radio"
         id="font-variant-normal"
@@ -331,7 +348,7 @@ p {
     <div class="setPropCont">
       font-weight<br />
       <input type="radio" id="font-weight-none" name="font_weight" value="" />
-      <label for="font-weight-none">none</label><br />
+      <label for="font-weight-none">omit value</label><br />
       <input
         type="radio"
         id="font-weight-normal"
@@ -370,7 +387,7 @@ p {
         name="line_height"
         checked
         value="" />
-      <label for="line-height-none">none</label><br />
+      <label for="line-height-none">omit value</label><br />
       <input
         type="radio"
         id="line-height-1-2"
@@ -472,8 +489,10 @@ p {
   </div>
 </form>
 
-<div class="fontShortHand">This is some sample text.</div>
-<br /><br /><br /><br /><br /><br />
+<div class="fontShortHand">
+  This is some sample text.<br />
+  This is some more sample text.
+</div>
 ```
 
 ```css hidden
@@ -579,7 +598,7 @@ document.querySelectorAll("input[type='radio']").forEach((el) => {
 });
 ```
 
-{{ EmbedLiveSample('Live_sample','100%', '440px')}}
+{{ EmbedLiveSample('Shorthand declaration creator','100%', '500px')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -105,20 +105,20 @@ font: caption;
 
 The value is either a shorthand specifying the various font-related properties or a single `<system-font-family-name>` keyword:
 
-- `<'font-style'>`
+- `<'font-style'>` {{optional_inline}}
   - : See the {{cssxref("font-style")}} CSS property. Defaults to `normal`.
-- `<font-variant-css2>`
+- `<font-variant-css2>` {{optional_inline}}
   - : Either the `normal` or `small-caps` value of the {{cssxref("font-variant")}} property. Defaults to `normal`.
-- `<'font-weight'>`
+- `<'font-weight'>` {{optional_inline}}
   - : See the {{cssxref("font-weight")}} CSS property. Defaults to `normal`.
-- `<font-width-css3>`
-  - : The keywords supported by the legacy `font-stretch` property. See the {{cssxref("font-width")}} CSS property. Defaults to `normal`.
+- `<font-width-css3>` {{optional_inline}}
+  - : The keywords supported by the {{cssxref("font-width")}} CSS property. Defaults to `normal`.
 - `<'font-size'>`
-  - : See the {{cssxref("font-size")}} CSS property. Required value.
-- `<'line-height'>`
+  - : See the {{cssxref("font-size")}} CSS property.
+- `<'line-height'>` {{optional_inline}}
   - : See the {{cssxref("line-height")}} CSS property. Defaults to `normal`.
 - `<'font-family'>`
-  - : See the {{cssxref("font-family")}} CSS property. Required value.
+  - : See the {{cssxref("font-family")}} CSS property. Must be the last value.
 
 - `<system-font-family-name>`
   - : A single keyword representing a system font, including:
@@ -135,23 +135,29 @@ The value is either a shorthand specifying the various font-related properties o
     - `status-bar`
       - : The system font used in window status bars.
 
-    There are several non-standard values are implemented with prefixes.
+    There are several non-standard values implemented with prefixes.
 
 ## Description
 
-Depending on its value, the `font` property value is either a single keyword representing a system-font-family-name or multiple longhand property value used to set all the different properties of an element's font.
+The `font` property value is either a single keyword representing a system-font-family-name or multiple longhand property values used to set all the different properties of an element's font.
 
 ### System font declarations
 
-If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to that single, case-insensitive keyword. Valid values include `caption`, `icon`, `menu`, `message-box`, `small-caption` or `status-bar`.
+If `font` is specified as a `<system-font-family-name>` keyword, the full property value must be set to that single, case-insensitive keyword. Valid values include `caption`, `icon`, `menu`, `message-box`, `small-caption`, or `status-bar`.
 
-Browsers also support non-standard prefixed values. Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`. Webkit includes these, and adds `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with several `-apple-system-*` prefixed system font names. Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
+Browsers also support non-standard prefixed values:
 
-The system font, or `<system-font-family-name>`, can only be set with the `font` property. Defining a single keyword value, such as `font: icon`, sets the font's family, size, weight, style, etc. to the values the browser defined for the named system font. These values can all be changed with longhand declarations coming _after_ the `font` declaration. Including any `font` longhand components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration. For example, `font: icon small` is invalid.
+ Chromium implements `-webkit-control`, `-webkit-small-control`, and `-webkit-mini-control`.
+ Webkit includes the Chromium values, and adds `-webkit-body`, `-webkit-pictograph`, and `-webkit-ruby-text`, along with several `-apple-system-*` prefixed system font names.
+ Gecko implements `-moz-window`, `-moz-document`, `-moz-desktop`, `-moz-info`, `-moz-dialog`, `-moz-button`, `-moz-pull-down-menu`, `-moz-list`, and `-moz-field`.
+
+The system font, or `<system-font-family-name>`, can only be set with the `font` property. Defining a single keyword value, such as `font: icon`, sets the font's family, size, weight, style, etc., to the values the browser defines for the named system font. These values can all be changed with longhand declarations placed _after_ the `font` declaration.
+
+Including any `font` longhand components after the `<system-font-family-name>` keyword within a `font` property value invalidates the declaration. For example, `font: icon small` is invalid.
 
 If a `<system-font-family-name>` keyword appears anywhere in the value other than as the first component, the keyword is treated as an {{cssxref("ident")}} representing a standard `font-family` name. For example, the declaration `font: small icon` sets the `font-family` to a font named `icon`, a non-system font which may or may not exist. This declaration also sets the `font-size` to `small` and resets all the other shorthand component properties to their initial values.
 
-### As a shorthand
+### Shorthand font declarations
 
 If `font` is specified as a shorthand for several font-related properties, then:
 
@@ -166,7 +172,7 @@ If `font` is specified as a shorthand for several font-related properties, then:
   - {{cssxref("font-width")}}
   - {{cssxref("line-height")}}
 
-As with any shorthand property, any of the longhand component properties not value that is not specified is set to its initial value, possibly overriding values previously set using non-shorthand properties. In addition, the shorthand resets the following properties to their initial values that can not be set by the shorthand:
+As with any shorthand property, any of the longhand component properties not specified are set to their initial values, possibly overriding values previously set using non-shorthand properties. In addition, the shorthand resets the following properties to their initial values. The shorthand cannot explicitly set them:
 
 - {{cssxref("font-feature-settings")}}
 - {{cssxref("font-kerning")}}
@@ -184,7 +190,7 @@ As with any shorthand property, any of the longhand component properties not val
 
 ### Shorthand property order
 
-The order of some of the longhand values within the shorthand `font` declaration is partially important and must therefore follow a few rules:
+The order of some of the longhand values within the shorthand `font` declaration must follow a few rules:
 
 - Both the `font-size` and `font-family` components are required (except for [system font declarations](#system_font_declarations)).
 - The `font-style`, `font-variant` and `font-weight` components must precede the `font-size` value.
@@ -195,11 +201,9 @@ The order of some of the longhand values within the shorthand `font` declaration
 
 For backward compatibility, the valid values of the `font-variant` and `font-width` components do not include all the valid values or the longhand equivalents.
 
-- The valid values for the `font-variant` component are limited `normal` or `small-caps`.
-  - : The `<font-variant-css2>` component of the shorthand is limited to the two values supported in CSS 2.1, including `normal` and `small-caps`. While no other values are supported, the shorthand `font` declaration resets the {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}} properties to `normal`.
+The valid values for the `font-variant` component are limited `normal` or `small-caps`. While no other values are supported, the shorthand `font` declaration resets all the `font-variant-*` longhand properties to `normal`, including {{cssxref("font-variation-settings")}}, {{cssxref("font-variant-position")}}, {{cssxref("font-variant-emoji")}}, {{cssxref("font-variant-caps")}}, {{cssxref("font-variant-ligatures")}}, {{cssxref("font-variant-numeric")}}, {{cssxref("font-variant-east-asian")}}, and {{cssxref("font-variant-alternates")}}.
 
-- The valid values for the `font-width` component are limited to keyword values
-  - : The `<font-width-css3>` component of the shorthand is limited to `normal`, `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded`. These keyword values were originally defined by the legacy `font-stretch` property, which is now an alias to `font-width`. The {{cssxref("font-width")}} longhand property also supports {{cssxref("percentage")}} values, which are not valid within the shorthand.
+The valid values for the `font-width` component are limited to keyword values: `normal`, `ultra-condensed`, `extra-condensed`, `condensed`, `semi-condensed`, `semi-expanded`, `expanded`, `extra-expanded`, `ultra-expanded`. The {{cssxref("font-width")}} longhand property also supports {{cssxref("percentage")}} values, which are not valid within the shorthand.
 
 ## Formal definition
 
@@ -213,7 +217,7 @@ For backward compatibility, the valid values of the `font-variant` and `font-wid
 
 ### Basic usage
 
-This example defines the `font` for all {{htmlelement("p")}} elements. We set the `font-size` to `12px` and the `line-height` to `14px`, separating them with a forward slash (`/`). We know which {{cssxref("length")}} refers to each component because of the rule: "If present, the `line-height` must immediately follow the `font-size`, with the two values separated by a forward slash (`/`)". The declaration also sets the `font-family` to `sans-serif`.
+This example defines the `font` for all {{htmlelement("p")}} elements. We set the `font-size` to `12px` and the `line-height` to `14px`, separating them with a forward slash (`/`). The declaration also sets the `font-family` to `sans-serif`.
 
 ```css
 p {
@@ -252,7 +256,11 @@ p {
 
 ### System font
 
-This example demonstrates using the `font` property to set a system font. We set the paragraph's font to have the same `font-family`, `line-height`, `font-size`, etc., as the status bar of the window, then we set the `line-height` to `1.6`.
+This example demonstrates using the `font` property to set a system font.
+
+#### CSS
+
+We set the paragraph's font to have the same `font-family`, `line-height`, `font-size`, etc., as the status bar of the window, then we set the `line-height` to `1.6`.
 
 ```css
 p {
@@ -261,17 +269,26 @@ p {
 }
 ```
 
-```html hidden
+#### HTML
+
+Our HTML includes a paragraph ({{htmlelement("p")}}) containing a link ({{htmlelement("a")}}) with a convoluted [`href`](/en-US/docs/Web/HTML/Reference/Elements/a#href) attribute value. When you hover over or focus on the rendered link, your browser's status bar should display the value of this `href` attribute.
+
+```html bad
 <p>
   <a
-    href="/%20The%20font%20should%20be%20the%20same%20family%20and%20size%20and%20the%20text%20in%20the%20example."
+    href="/%20The%20font%20should%20be%20the%20same%20
+family%20and%20size%20and%20the%20text%20in%20the%20example."
     >Hover or focus this text. The font should be the same family and size and
     the text in your status bar.</a
   >
 </p>
 ```
 
-```js hidden
+#### JavaScript
+
+As the URL in our HTML link is not good practice, we include a script that prevents the document from redirecting to a non-existent page when the link is clicked.
+
+```js
 const a = document.querySelector("a");
 a.addEventListener("click", function (e) {
   e.preventDefault();
@@ -279,9 +296,11 @@ a.addEventListener("click", function (e) {
 });
 ```
 
+#### Result
+
 {{ EmbedLiveSample('System font','100%', '100')}}
 
-Hover or focus the link, then look at your status bar. The font should be the same family and size and the text in your status bar. We added a script to disable the link, which we hid for brevity.
+Hover or focus the link, then look at your status bar. The font should be the same family and size and the text in your status bar at the bottom of your browser window..
 
 ### Shorthand declaration creator
 

--- a/files/en-us/web/css/reference/properties/font/index.md
+++ b/files/en-us/web/css/reference/properties/font/index.md
@@ -252,7 +252,7 @@ p {
 </p>
 ```
 
-{{EmbedLiveSample(' Multiple properties','100%', '100')}}
+{{EmbedLiveSample('Multiple properties','100%', '100')}}
 
 ### System font
 


### PR DESCRIPTION
Updated the 'font' property documentation to clarify usage, values, and examples.

elaborated on system fonts as a value

updated the examples to make them look a little more like exmples (didn't completely do this part). The system font one is a bit hokey, but it shows the effect.

updated the live sample to a jane eyre charlotte bronte quote.
