### PR TITLE
FF152 Relnote: AnimationEvent/TransitionEvent .animate supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -66,6 +66,9 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{domxref("PerformanceResourceTiming.firstInterimResponseStart","firstInterimResponseStart")}} and {{domxref("PerformanceResourceTiming.finalResponseHeadersStart","finalResponseHeadersStart")}} properties of the {{domxref("PerformanceResourceTiming")}} interface are supported.
   These can be used to measure how long it takes for the browser to receive interim HTTP responses and the final HTTP response after sending a request, respectively.
   ([Firefox bug 2006340](https://bugzil.la/2006340)).
+- The {{domxref("AnimationEvent.animation")}} and {{domxref("TransitionEvent.animation")}} properties are now supported.
+  These provide a more ergonomic way to access the associated animation than calling {{domxref("element.getAnimations()")}} and filtering on the event's `animationName` or `propertyName`.
+  ([Firefox bug 1929118](https://bugzil.la/1929118)).
 
 #### DOM
 


### PR DESCRIPTION
FF152 added support for `AnimationEvent.animation` and `TransitionEvent.animation` in https://bugzilla.mozilla.org/show_bug.cgi?id=1929118

This adds a release note

Related docs work can be tracked in #44164