### PR TITLE
API Event Template: Remove 'Event properties' section

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -116,15 +116,6 @@ _An {{domxref("XRSessionEvent")}}. Inherits from {{domxref("Event")}}._
 
 {{InheritanceDiagram("XRSessionEvent")}}
 
-## Event properties
-
-If the event is not just a generic {{domxref("Event")}}, list the additional properties the event has.
-
-_In addition to the properties listed below, properties from the parent interface, {{domxref("Event")}}, are available._
-
-- {{domxref("XRSessionEvent.session", "session")}} {{ReadOnlyInline}}
-  - : The {{domxref("XRSession")}} to which the event refers.
-
 ## Description
 
 If you want to provide additional text (too long for the summary), add a Description section.


### PR DESCRIPTION
Removes the properties section for the template for a particular event instance. 

In all other Web API docs we only include properties belong on interfaces. For some reason we arbitrarily add them on events. This does make things a tiny bit easier for readers, but it is quite a bit of unnecessary duplication.

There is "some" support for this from https://github.com/orgs/mdn/discussions/889#discussioncomment-16894834. I'm not sure if it is agreed, but it's a good idea, so doing this to hopefully progress it.