### PR TITLE
Fix static method name: getSupportFormat() → getSupportedFormats()

### DIFF
--- a/files/en-us/web/api/barcodedetector/getsupportedformats_static/index.md
+++ b/files/en-us/web/api/barcodedetector/getsupportedformats_static/index.md
@@ -35,7 +35,7 @@ No exceptions are thrown.
 
 ## Examples
 
-The following example calls the `getSupportFormat()` static method and logs
+The following example calls the `getSupportedFormats()` static method and logs
 the results to the console.
 
 ```js

--- a/files/en-us/web/api/barcodedetector/index.md
+++ b/files/en-us/web/api/barcodedetector/index.md
@@ -52,7 +52,7 @@ if (!("BarcodeDetector" in globalThis)) {
 
 ### Getting Supported Formats
 
-The following example calls the `getSupportFormat()` static method and logs the results to the console.
+The following example calls the `getSupportedFormats()` static method and logs the results to the console.
 
 ```js
 // check supported types


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Corrected a typo in index.md: replaced the incorrect `getSupportFormat()` with the proper static method name `getSupportedFormats()` to match the spec and MDN documentation.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
