### PR TITLE
BiDi docs: Update syntax blocks to include parameter examples

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/createusercontext/index.md
@@ -12,9 +12,25 @@ The `browser.createUserContext` [command](/en-US/docs/Web/WebDriver/Reference/Bi
 ## Syntax
 
 ```json-nolint
+/* Without optional parameters */
 {
   "method": "browser.createUserContext",
   "params": {}
+}
+
+/* With optional parameters */
+{
+  "method": "browser.createUserContext",
+  "params": {
+    "acceptInsecureCerts": true,
+    "proxy": {
+      "proxyType": "manual",
+      "httpProxy": "127.0.0.1:80"
+    },
+    "unhandledPromptBehavior": {
+      "default": "accept"
+    }
+  }
 }
 ```
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/removeusercontext/index.md
@@ -18,7 +18,7 @@ The `browser.removeUserContext` [command](/en-US/docs/Web/WebDriver/Reference/Bi
 {
   "method": "browser.removeUserContext",
   "params": {
-    "userContext": "<userContextId>"
+    "userContext": "4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -12,7 +12,7 @@ The `browser.setDownloadBehavior` [command](/en-US/docs/Web/WebDriver/Reference/
 ## Syntax
 
 ```json-nolint
-/* Allow */
+/* With required parameters */
 {
   "method": "browser.setDownloadBehavior",
   "params": {
@@ -23,25 +23,7 @@ The `browser.setDownloadBehavior` [command](/en-US/docs/Web/WebDriver/Reference/
   }
 }
 
-/* Deny */
-{
-  "method": "browser.setDownloadBehavior",
-  "params": {
-    "downloadBehavior": {
-      "type": "denied"
-    }
-  }
-}
-
-/* Reset to browser default */
-{
-  "method": "browser.setDownloadBehavior",
-  "params": {
-    "downloadBehavior": null
-  }
-}
-
-/* Per user context */
+/* With optional parameters */
 {
   "method": "browser.setDownloadBehavior",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -12,10 +12,44 @@ The `browser.setDownloadBehavior` [command](/en-US/docs/Web/WebDriver/Reference/
 ## Syntax
 
 ```json-nolint
+/* Allow */
 {
   "method": "browser.setDownloadBehavior",
   "params": {
-    "downloadBehavior": {}
+    "downloadBehavior": {
+      "type": "allowed",
+      "destinationFolder": "/tmp/downloads"
+    }
+  }
+}
+
+/* Deny */
+{
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": {
+      "type": "denied"
+    }
+  }
+}
+
+/* Reset to browser default */
+{
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": null
+  }
+}
+
+/* Per user context */
+{
+  "method": "browser.setDownloadBehavior",
+  "params": {
+    "downloadBehavior": {
+      "type": "allowed",
+      "destinationFolder": "/tmp/downloads"
+    },
+    "userContexts": ["4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"]
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browser/setdownloadbehavior/index.md
@@ -23,7 +23,7 @@ The `browser.setDownloadBehavior` [command](/en-US/docs/Web/WebDriver/Reference/
   }
 }
 
-/* With optional parameters */
+/* With required and optional parameters */
 {
   "method": "browser.setDownloadBehavior",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/activate/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/activate/index.md
@@ -15,7 +15,7 @@ The `browsingContext.activate` [command](/en-US/docs/Web/WebDriver/Reference/BiD
 {
   "method": "browsingContext.activate",
   "params": {
-    "context": "<contextId>"
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f"
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
@@ -20,7 +20,7 @@ The `browsingContext.close` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/M
   }
 }
 
-/* With optional parameters */
+/* With required and optional parameters */
 {
   "method": "browsingContext.close",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
@@ -12,10 +12,20 @@ The `browsingContext.close` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/M
 ## Syntax
 
 ```json-nolint
+/* Without optional parameters */
 {
   "method": "browsingContext.close",
   "params": {
-    "context": "<contextId>"
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f"
+  }
+}
+
+/* With optional parameters */
+{
+  "method": "browsingContext.close",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "promptUnload": true
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/close/index.md
@@ -12,7 +12,7 @@ The `browsingContext.close` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/M
 ## Syntax
 
 ```json-nolint
-/* Without optional parameters */
+/* With required parameters */
 {
   "method": "browsingContext.close",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -12,10 +12,47 @@ The `browsingContext.create` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/
 ## Syntax
 
 ```json-nolint
+/* Window */
+{
+  "method": "browsingContext.create",
+  "params": {
+    "type": "window"
+  }
+}
+
+/* Window with optional parameters */
+{
+  "method": "browsingContext.create",
+  "params": {
+    "type": "window",
+    "background": true
+  }
+}
+
+/* Tab */
 {
   "method": "browsingContext.create",
   "params": {
     "type": "tab"
+  }
+}
+
+/* Tab next to an existing tab */
+{
+  "method": "browsingContext.create",
+  "params": {
+    "type": "tab",
+    "background": true,
+    "referenceContext": "93ee5bd6-d256-4608-a002-9a8995cc0e5f"
+  }
+}
+
+/* Tab in a specific user context */
+{
+  "method": "browsingContext.create",
+  "params": {
+    "type": "tab",
+    "userContext": "4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -20,7 +20,7 @@ The `browsingContext.create` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/
   }
 }
 
-/* With optional parameters */
+/* With required and optional parameters */
 {
   "method": "browsingContext.create",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/create/index.md
@@ -12,7 +12,7 @@ The `browsingContext.create` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/
 ## Syntax
 
 ```json-nolint
-/* Window */
+/* With required parameters */
 {
   "method": "browsingContext.create",
   "params": {
@@ -20,38 +20,13 @@ The `browsingContext.create` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/
   }
 }
 
-/* Window with optional parameters */
-{
-  "method": "browsingContext.create",
-  "params": {
-    "type": "window",
-    "background": true
-  }
-}
-
-/* Tab */
-{
-  "method": "browsingContext.create",
-  "params": {
-    "type": "tab"
-  }
-}
-
-/* Tab next to an existing tab */
+/* With optional parameters */
 {
   "method": "browsingContext.create",
   "params": {
     "type": "tab",
     "background": true,
-    "referenceContext": "93ee5bd6-d256-4608-a002-9a8995cc0e5f"
-  }
-}
-
-/* Tab in a specific user context */
-{
-  "method": "browsingContext.create",
-  "params": {
-    "type": "tab",
+    "referenceContext": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
     "userContext": "4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"
   }
 }

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/gettree/index.md
@@ -82,7 +82,9 @@ The `result` object in the response contains the following fields:
 
 ### Getting all top-level contexts
 
-With a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), consider a scenario where two tabs are open in the browser: the first tab at `https://example.com/page1.html` has an `<iframe>` loading `https://example.com/frame.html`, and the second tab shows `https://example.com/page2.html`:
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new).
+
+Suppose two tabs are open in the browser: the first tab at `https://example.com/page1.html` has an `<iframe>` loading `https://example.com/frame.html`, and the second tab shows `https://example.com/page2.html`:
 
 ```plain
 Browser
@@ -103,7 +105,7 @@ Send the following message to get the full context tree:
 
 The `contexts` array lists the two top-level contexts. The `<iframe>` inside Tab 1 appears nested under its `children`. The browser responds as follows:
 
-```json
+```json-nolint
 {
   "id": 1,
   "type": "success",
@@ -239,7 +241,7 @@ Expanding on the same setup, consider that Tab 2 (`https://example.com/page2.htm
 
 The browser responds with the full context tree. The `originalOpener` field identifies the context that opened Tab 2:
 
-```json
+```json-nolint
 {
   "id": 4,
   "type": "success",

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -32,7 +32,7 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
   }
 }
 
-/* With optional parameters */
+/* With required and optional parameters */
 {
   "method": "input.performActions",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -12,7 +12,7 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 ## Syntax
 
 ```json-nolint
-/* Key action */
+/* With required parameters */
 {
   "method": "input.performActions",
   "params": {
@@ -25,10 +25,6 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
           {
             "type": "keyDown",
             "value": "a"
-          },
-          {
-            "type": "keyUp",
-            "value": "a"
           }
         ]
       }
@@ -36,7 +32,7 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
   }
 }
 
-/* Pointer action */
+/* With optional parameters */
 {
   "method": "input.performActions",
   "params": {
@@ -45,64 +41,16 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
       {
         "type": "pointer",
         "id": "mouse1",
+        "parameters": {
+          "pointerType": "mouse"
+        },
         "actions": [
           {
             "type": "pointerMove",
             "x": 100,
-            "y": 200
-          },
-          {
-            "type": "pointerDown",
-            "button": 0
-          },
-          {
-            "type": "pointerUp",
-            "button": 0
-          }
-        ]
-      }
-    ]
-  }
-}
-
-/* Wheel action */
-{
-  "method": "input.performActions",
-  "params": {
-    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
-    "actions": [
-      {
-        "type": "wheel",
-        "id": "wheel1",
-        "actions": [
-          {
-            "type": "scroll",
-            "x": 0,
-            "y": 0,
-            "deltaX": 0,
-            "deltaY": 300,
-            "duration": 0,
+            "y": 200,
+            "duration": 300,
             "origin": "viewport"
-          }
-        ]
-      }
-    ]
-  }
-}
-
-/* Pause */
-{
-  "method": "input.performActions",
-  "params": {
-    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
-    "actions": [
-      {
-        "type": "none",
-        "id": "none1",
-        "actions": [
-          {
-            "type": "pause",
-            "duration": 500
           }
         ]
       }

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/performactions/index.md
@@ -12,18 +12,97 @@ The `input.performActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 ## Syntax
 
 ```json-nolint
+/* Key action */
 {
   "method": "input.performActions",
   "params": {
-    "context": "<contextId>",
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
     "actions": [
       {
-        "type": "<outerType>",
-        "id": "<sourceId>",
+        "type": "key",
+        "id": "keyboard1",
         "actions": [
           {
-            "type": "<innerType>",
-            ...
+            "type": "keyDown",
+            "value": "a"
+          },
+          {
+            "type": "keyUp",
+            "value": "a"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+/* Pointer action */
+{
+  "method": "input.performActions",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "actions": [
+      {
+        "type": "pointer",
+        "id": "mouse1",
+        "actions": [
+          {
+            "type": "pointerMove",
+            "x": 100,
+            "y": 200
+          },
+          {
+            "type": "pointerDown",
+            "button": 0
+          },
+          {
+            "type": "pointerUp",
+            "button": 0
+          }
+        ]
+      }
+    ]
+  }
+}
+
+/* Wheel action */
+{
+  "method": "input.performActions",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "actions": [
+      {
+        "type": "wheel",
+        "id": "wheel1",
+        "actions": [
+          {
+            "type": "scroll",
+            "x": 0,
+            "y": 0,
+            "deltaX": 0,
+            "deltaY": 300,
+            "duration": 0,
+            "origin": "viewport"
+          }
+        ]
+      }
+    ]
+  }
+}
+
+/* Pause */
+{
+  "method": "input.performActions",
+  "params": {
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "actions": [
+      {
+        "type": "none",
+        "id": "none1",
+        "actions": [
+          {
+            "type": "pause",
+            "duration": 500
           }
         ]
       }

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/releaseactions/index.md
@@ -15,7 +15,7 @@ The `input.releaseActions` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mo
 {
   "method": "input.releaseActions",
   "params": {
-    "context": "<contextId>"
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf"
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/input/setfiles/index.md
@@ -15,9 +15,11 @@ The `input.setFiles` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#
 {
   "method": "input.setFiles",
   "params": {
-    "context": "<contextId>",
-    "element": "<elementId>",
-    "files": ["<filePath>", ...]
+    "context": "5f07e3ca-ecac-465e-b9ef-49000c196ecf",
+    "element": {
+      "sharedId": "3be28343-afd3-4dea-a2b6-a863fbbb80e1"
+    },
+    "files": ["/home/user/documents/report.pdf"]
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
@@ -25,7 +25,7 @@ Since this command is used to create a new session, it runs without an already a
   }
 }
 
-/* With optional parameters */
+/* With required and optional parameters */
 {
   "method": "session.new",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
@@ -17,7 +17,7 @@ Since this command is used to create a new session, it runs without an already a
 ## Syntax
 
 ```json-nolint
-/* Without optional capabilities */
+/* With required parameters */
 {
   "method": "session.new",
   "params": {
@@ -25,20 +25,31 @@ Since this command is used to create a new session, it runs without an already a
   }
 }
 
-/* With optional capabilities */
+/* With optional parameters */
 {
   "method": "session.new",
   "params": {
     "capabilities": {
       "alwaysMatch": {
         "acceptInsecureCerts": true,
-        "browserName": "firefox",
-        "browserVersion": "135.0",
-        "platformName": "mac",
+        "proxy": {
+          "proxyType": "manual",
+          "httpProxy": "127.0.0.1:80"
+        },
         "unhandledPromptBehavior": {
           "default": "accept"
         }
-      }
+      },
+      "firstMatch": [
+        {
+          "browserName": "firefox",
+          "platformName": "mac"
+        },
+        {
+          "browserName": "chrome",
+          "platformName": "windows"
+        }
+      ]
     }
   }
 }
@@ -50,17 +61,17 @@ The `params` field contains:
 
 - `capabilities`
   - : An object that specifies the requested features for the session. It can include the following fields:
-    - `alwaysMatch` {{optional_inline}}
+    - [`alwaysMatch`](/en-US/docs/Web/WebDriver/Reference/Capabilities#alwaysmatch) {{optional_inline}}
       - : An object that specifies the requested features that must all be satisfied by the browser for session creation.
         If the browser cannot satisfy all requested features in this object, the session is not created.
-    - `firstMatch` {{optional_inline}}
+    - [`firstMatch`](/en-US/docs/Web/WebDriver/Reference/Capabilities#firstmatch) {{optional_inline}}
       - : An array of objects, each specifying an alternative set of requested features for session creation.
         The browser tries each set in the order specified and creates a session using the first where all requested features can be satisfied.
         If the browser cannot satisfy all requested features in any of the sets, the session is not created.
 
 The `alwaysMatch` and `firstMatch` objects can include the following features:
 
-- `acceptInsecureCerts` {{optional_inline}}
+- [`acceptInsecureCerts`](/en-US/docs/Web/WebDriver/Reference/Capabilities/acceptInsecureCerts) {{optional_inline}}
   - : A boolean that controls whether untrusted TLS certificates (for example, self-signed or expired) are accepted for the duration of the session.
 - `browserName` {{optional_inline}}
   - : A string that specifies the name of the browser to use (for example, `"firefox"` or `"chrome"`).
@@ -210,3 +221,4 @@ In browsers that don't support multiple sessions (e.g., Firefox), sending `sessi
 
 - [`session.status`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/status) command
 - [`session.end`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/end) command
+- [Combining `alwaysMatch` and `firstMatch`](/en-US/docs/Web/WebDriver/Reference/Capabilities#combining_alwaysmatch_and_firstmatch)

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/new/index.md
@@ -17,10 +17,29 @@ Since this command is used to create a new session, it runs without an already a
 ## Syntax
 
 ```json-nolint
+/* Without optional capabilities */
 {
   "method": "session.new",
   "params": {
     "capabilities": {}
+  }
+}
+
+/* With optional capabilities */
+{
+  "method": "session.new",
+  "params": {
+    "capabilities": {
+      "alwaysMatch": {
+        "acceptInsecureCerts": true,
+        "browserName": "firefox",
+        "browserVersion": "135.0",
+        "platformName": "mac",
+        "unhandledPromptBehavior": {
+          "default": "accept"
+        }
+      }
+    }
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
@@ -12,10 +12,37 @@ The `session.subscribe` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
 ## Syntax
 
 ```json-nolint
+/* Subscription to all module events */
 {
   "method": "session.subscribe",
   "params": {
-    "events": ["<event name>"]
+    "events": ["log"]
+  }
+}
+
+/* Subscription to a specific event */
+{
+  "method": "session.subscribe",
+  "params": {
+    "events": ["log.entryAdded"]
+  }
+}
+
+/* Scoped to a context */
+{
+  "method": "session.subscribe",
+  "params": {
+    "events": ["log.entryAdded"],
+    "contexts": ["93ee5bd6-d256-4608-a002-9a8995cc0e5f"]
+  }
+}
+
+/* Scoped to a user context */
+{
+  "method": "session.subscribe",
+  "params": {
+    "events": ["log.entryAdded"],
+    "userContexts": ["4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"]
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
@@ -20,7 +20,7 @@ The `session.subscribe` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
   }
 }
 
-/* With optional parameters */
+/* With required and optional parameters */
 {
   "method": "session.subscribe",
   "params": {

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/subscribe/index.md
@@ -12,15 +12,7 @@ The `session.subscribe` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
 ## Syntax
 
 ```json-nolint
-/* Subscription to all module events */
-{
-  "method": "session.subscribe",
-  "params": {
-    "events": ["log"]
-  }
-}
-
-/* Subscription to a specific event */
+/* With required parameters */
 {
   "method": "session.subscribe",
   "params": {
@@ -28,21 +20,12 @@ The `session.subscribe` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
   }
 }
 
-/* Scoped to a context */
+/* With optional parameters */
 {
   "method": "session.subscribe",
   "params": {
     "events": ["log.entryAdded"],
     "contexts": ["93ee5bd6-d256-4608-a002-9a8995cc0e5f"]
-  }
-}
-
-/* Scoped to a user context */
-{
-  "method": "session.subscribe",
-  "params": {
-    "events": ["log.entryAdded"],
-    "userContexts": ["4e4b1f6d-3f1a-4b2e-9f8c-1a2b3c4d5e6f"]
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/session/unsubscribe/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/session/unsubscribe/index.md
@@ -11,24 +11,20 @@ The `session.unsubscribe` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Mod
 
 ## Syntax
 
-To unsubscribe using subscription ID:
-
 ```json-nolint
+/* Using event name */
 {
   "method": "session.unsubscribe",
   "params": {
-    "subscriptions": ["<subscription ID>"]
+    "events": ["log.entryAdded"]
   }
 }
-```
 
-To unsubscribe using event name:
-
-```json-nolint
+/* Using subscription ID */
 {
   "method": "session.unsubscribe",
   "params": {
-    "events": ["<event name>"]
+    "subscriptions": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"]
   }
 }
 ```


### PR DESCRIPTION
### Description

This is a follow-up to the feedback received in https://github.com/mdn/content/pull/44279#discussion_r3313674169.

Syntax blocks now show minimal (required set) and full (optional parameters) forms where applicable and also values for parameters instead of variables.

The approach here is based on the syntax pattern used in `browsingContext.getTree` in [PR 44279](https://pr44279.review.mdn.allizom.net/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#syntax).

Additionally,
- In `browsingContext.getTree`:
  - Fixed the example intro prose
  - Updated `json` -> `json-nolint` for code blocks that have inline comments

- In `session.unsubscribe`:
  - Swapped the order of parameters in the syntax block - event name before subscription ID (this will match up with the changes coming to this file via [PR 44378](https://github.com/mdn/content/pull/44378/changes#diff-1dd58adb4f8dab47c74de35d086b9813445a8b6e06ccf6d46747fe17da7c0e4d)) 

### Motivation

The "Syntax" block will now show meaningful usage information and allow readers to quickly grasp what's possible before they reach for the details in the "Parameters" section.


