### PR TITLE
Update Firefox 152 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -90,13 +90,21 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Improved the Marionette and WebDriver BiDi screenshot commands to enforce maximum allowed dimensions. ([Firefox bug 2020302](https://bugzil.la/2020302)).
 
-<!-- #### Marionette -->
+#### WebDriver BiDi
+
+- Extended the `webExtension.install` command to support installing WebExtensions in Firefox enabled in Private Browsing mode. ([Firefox bug 1947679](https://bugzil.la/1947679)).
+- Improved the `brower.setDownloadBehavior` command to allow overriding the download target folder before the temporary file is created. ([Firefox bug 2017252](https://bugzil.la/2017252)).
+- Fixed network events to only forward in-memory cached JavaScript responses when there is a matching network event collector, avoiding unnecessary data forwarding. ([Firefox bug 2018237](https://bugzil.la/2018237)).
+
+#### Marionette
+
+- Improved the `WebDriver:Navigate` and `WebDriver:Refresh` commands to properly report errors when triggering the navigation fails, instead of silently ignoring them. ([Firefox bug 2033769](https://bugzil.la/2033769)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -99,7 +99,7 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### WebDriver BiDi
 
 - Extended the `webExtension.install` command to support installing web extensions in Firefox enabled in Private Browsing mode. ([Firefox bug 1947679](https://bugzil.la/1947679)).
-- Improved the `brower.setDownloadBehavior` command to allow overriding the download target folder before the temporary file is created. ([Firefox bug 2017252](https://bugzil.la/2017252)).
+- Improved the `browser.setDownloadBehavior` command to allow overriding the download target folder before the temporary file is created. ([Firefox bug 2017252](https://bugzil.la/2017252)).
 - Fixed network events to only forward in-memory cached JavaScript responses when there is a matching network event collector, avoiding unnecessary data forwarding. ([Firefox bug 2018237](https://bugzil.la/2018237)).
 
 #### Marionette

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -98,7 +98,7 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### WebDriver BiDi
 
-- Extended the `webExtension.install` command to support installing WebExtensions in Firefox enabled in Private Browsing mode. ([Firefox bug 1947679](https://bugzil.la/1947679)).
+- Extended the `webExtension.install` command to support installing web extensions in Firefox enabled in Private Browsing mode. ([Firefox bug 1947679](https://bugzil.la/1947679)).
 - Improved the `brower.setDownloadBehavior` command to allow overriding the download target folder before the temporary file is created. ([Firefox bug 2017252](https://bugzil.la/2017252)).
 - Fixed network events to only forward in-memory cached JavaScript responses when there is a matching network event collector, avoiding unnecessary data forwarding. ([Firefox bug 2018237](https://bugzil.la/2018237)).
 


### PR DESCRIPTION
Changes for WebDriver conformance for the Firefox 152 release based on the [release note worthy bugs in this list](https://bugzilla.mozilla.org/buglist.cgi?include_fields=id,component,resolution,assigned_to,summary,bug_type,whiteboard,mentors&product=Remote%20Protocol&resolution=FIXED&f1=cf_status_firefox152&o1=equals&v1=fixed&f2=cf_status_firefox151&o2=notequals&v2=fixed&f3=status_whiteboard&o3=notsubstring&v3=%5Bwptsync%20downstream%5D&f4=status_whiteboard&o4=substring&v4=%5Bwebdriver%3Arelnote%5D&component=Agent&component=Marionette&component=WebDriver%20BiDi).

@juliandescottes and @lutien can you please review?