### PR TITLE
Fix typo in service worker register() description

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -72,7 +72,7 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("ServiceWorkerRegistratio
     This can happen if the URL can't be resolved to a valid URL or uses a scheme that is not `http:` or `https`.
     It may also happen if `scriptURL` is not a {{domxref("TrustedScriptURL")}}, and this is a requirement of the site's [Trusted Types Policy](/en-US/docs/Web/API/Trusted_Types_API).
 
-    The exception is also raised if the `scriptURL` or `scope URL` path contains the case-insensitive ASCII "%2f" (`*`) or "%5c" (`=`)
+    The exception is also raised if the `scriptURL` or `scope URL` path contains the case-insensitive ASCII "%2F" (`/`) or "%5C" (`=`)
 
 - `SecurityError` {{domxref("DOMException")}}
   - : The `scriptURL` is not a potentially trustworthy origin, such as `localhost` or an `https` URL.

--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -72,7 +72,7 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("ServiceWorkerRegistratio
     This can happen if the URL can't be resolved to a valid URL or uses a scheme that is not `http:` or `https`.
     It may also happen if `scriptURL` is not a {{domxref("TrustedScriptURL")}}, and this is a requirement of the site's [Trusted Types Policy](/en-US/docs/Web/API/Trusted_Types_API).
 
-    The exception is also raised if the `scriptURL` or `scope URL` path contains the case-insensitive ASCII "%2F" (`/`) or "%5C" (`=`)
+    The exception is also raised if the `scriptURL` or `scope URL` path contains the case-insensitive ASCII "%2F" (`/`) or "%5C" (`\`)
 
 - `SecurityError` {{domxref("DOMException")}}
   - : The `scriptURL` is not a potentially trustworthy origin, such as `localhost` or an `https` URL.


### PR DESCRIPTION
Also uppercase percent-encoded characters for style

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fix typo in `navigator.serviceWorker.register()` description; it stated that `%2F` and `%5C` are forbidden in service worker URLs (which seems to be true, oddly) but incorrectly depicted `*` and `=`, respectively, as being the ASCII characters which those percent-encodings decoded to.

### Motivation

the typo caused confusion as to which was correct. i also took the liberty to uppercase the percent encodings because i think that looks better (and is also the canonical(?) form produced by `encodeURIComponent()` et al)

### Additional details

relevant spec showing `%2F` and `%5C` are the correct ones https://www.w3.org/TR/service-workers/#start-register

also, this is a 2 year old typo. woof (i wonder how many AIs have gotten confused by it 😈)

### Related issues and pull requests

Didn't file an issue cuz I didn't feel like it. Let me know if I really need to.

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
