### PR TITLE
[codex] clarify setCustomValidity submit-button behavior

### DIFF
--- a/files/en-us/web/api/htmlbuttonelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/setcustomvalidity/index.md
@@ -10,6 +10,8 @@ browser-compat: api.HTMLButtonElement.setCustomValidity
 
 The **`setCustomValidity()`** method of the {{DOMxRef("HTMLButtonElement")}} interface sets the custom validity message for the {{htmlelement("button")}} element. Use the empty string to indicate that the element does _not_ have a custom validity error.
 
+> **Note:** This method only affects buttons whose `type` is `submit`; other button types are barred from constraint validation.
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
Adds a short note to clarify that `HTMLButtonElement.setCustomValidity()` only affects submit buttons.

~~Fixes~~ #42234.

Validation:
- `git diff --check`
