### PR TITLE
Enhance matrix3d documentation with homography examples

### DIFF
--- a/files/en-us/web/css/reference/values/transform-function/matrix3d/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/matrix3d/index.md
@@ -112,6 +112,73 @@ The `matrix3d()` function is specified with 16 values. They are described in the
 
 ## Examples
 
+## Using a 2D homography matrix
+
+Computer vision and image processing libraries often represent a planar projective transformation as a 3×3 homography matrix:
+
+[
+H =
+\begin{bmatrix}
+h_{11} & h_{12} & h_{13} \
+h_{21} & h_{22} & h_{23} \
+h_{31} & h_{32} & h_{33}
+\end{bmatrix}
+]
+
+where points are transformed in homogeneous coordinates:
+
+[
+\begin{bmatrix}
+x' \
+y' \
+w'
+\end{bmatrix}
+=============
+
+H
+\begin{bmatrix}
+x \
+y \
+1
+\end{bmatrix}
+]
+
+A homography can be embedded into a CSS `matrix3d()` transform as:
+
+```css
+transform: matrix3d(
+  h11, h21, 0, h31,
+  h12, h22, 0, h32,
+  0,   0,   1, 0,
+  h13, h23, 0, h33
+);
+```
+
+This mapping preserves the projective transformation, including perspective effects.
+
+The perspective coefficients `h31` and `h32` appear in the `m14` and `m24` positions because the parameters of `matrix3d()` are specified in column-major order.
+
+For example, the homography
+
+[
+\begin{bmatrix}
+1.2 & 0.1 & 100 \
+0.05 & 1.1 & 50 \
+0.0004 & 0.0002 & 1
+\end{bmatrix}
+]
+
+corresponds to:
+
+```css
+transform: matrix3d(
+  1.2,  0.05, 0, 0.0004,
+  0.1,  1.1,  0, 0.0002,
+  0,    0,    1, 0,
+  100,  50,   0, 1
+);
+```
+
 ### Cube squashing example
 
 The following example shows a 3D cube created from DOM elements and transforms, which can be hovered/focused to apply


### PR DESCRIPTION
The current matrix3d() documentation accurately describes the 4×4 matrix representation and column-major parameter ordering, but it does not explain how common 3×3 projective transforms (homographies) can be converted into CSS transforms.

This creates confusion for developers working with computer vision, AR, image registration, OpenCV, marker tracking, and homography estimation libraries, where the output is typically a 3×3 homography matrix.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Add a short subsection to the matrix3d() page describing how a 2D homography can be embedded into a CSS 4×4 transform matrix.

The subsection could include:

A brief explanation of homographies.
The mapping from a 3×3 homography to matrix3d().
A concrete example with numeric values.
A note explaining why the perspective coefficients appear in the m14 and m24 positions.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

This would improve interoperability between CSS transforms and common computer vision tooling such as:

OpenCV
AR marker tracking systems
Image registration libraries
Homography estimation libraries such as simple-homography

The additional documentation would be small but would address a the problem I had when moving between computer vision and CSS coordinate systems.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

I'm not sure if the latex is rendered correctly, so please double check that; including a sanity check for mistakes (I'm not an expert in this field).
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

["Last possibility: the Matrix is a projective one. No clue how to handle this." - quote from the answer](https://stackoverflow.com/questions/46038052/transform-a-3x3-transform-matrix-to-4x4-matrix-for-css-transform-matrix3d)

[Franklin Ta](https://franklinta.com/2014/09/08/computing-css-matrix3d-transforms/)

[Issue solved by just using Franklin Ta's tool](https://stackoverflow.com/questions/75115954/how-to-convert-the-opencv-getperpectivetransform-matrix-into-a-css-matrix)




<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
