### PR TITLE
Remove outdated example.com IP address example

### DIFF
--- a/files/en-us/web/api/requestinit/index.md
+++ b/files/en-us/web/api/requestinit/index.md
@@ -222,7 +222,7 @@ You can also construct a `Request` with a `RequestInit`, and pass the `Request` 
     - `loopback`
       - : The request is to a loopback address, which is only accessible on the local device; its target will differ on every device. For example, `127.0.0.1`, which is generally known as `localhost`.
     - `public`
-      - : The request is to an address available from anywhere on the internet; its target is the same for all devices globally. 
+      - : The request is to an address available from anywhere on the internet; its target is the same for all devices globally.
 
     See [Local Network Access](/en-US/docs/Web/Security/Defenses/Local_network_access) for more information.
 

--- a/files/en-us/web/api/requestinit/index.md
+++ b/files/en-us/web/api/requestinit/index.md
@@ -222,7 +222,7 @@ You can also construct a `Request` with a `RequestInit`, and pass the `Request` 
     - `loopback`
       - : The request is to a loopback address, which is only accessible on the local device; its target will differ on every device. For example, `127.0.0.1`, which is generally known as `localhost`.
     - `public`
-      - : The request is to an address available from anywhere on the internet; its target is the same for all devices globally. For example, `104.18.27.120` (the IP address of `example.com`)
+      - : The request is to an address available from anywhere on the internet; its target is the same for all devices globally. 
 
     See [Local Network Access](/en-US/docs/Web/Security/Defenses/Local_network_access) for more information.
 


### PR DESCRIPTION
### Description

Removed the example sentence that referenced a specific IP address for example.com in the RequestInit documentation.

### Motivation

The IP addresses associated with a domain can change over time. The previous example contained a hardcoded IP address for example.com, which is no longer accurate. Removing the sentence avoids outdated information and keeps the documentation correct.

### Additional details

This change follows the suggestion in the issue discussion to remove the entire "For example..." sentence rather than replace it with another IP address.

### Related issues and pull requests

Fixes #44411
