### PR TITLE
Improve clarity of `animation-composition`

### DIFF
--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -129,7 +129,10 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 
 ```css
 @keyframes slide {
-  to {
+  50% {
+    transform: translateY(30px);
+  }
+  100% {
     transform: translateX(150px);
   }
 }
@@ -153,9 +156,17 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
-- With `replace`, at the end of the animation, the keyframe's `transform` property will entirely replace that of the original. Therefore, the final effect value for the `transform` property at the end of the animation would simply be `translateX(150px)`. The target animates from `transform: translateX(30px) rotate(45deg)` to `transform: translateX(150px)`.
-- With `add`, the final effect value would be the current `transform` property with the keyframe's `transform` added to it, meaning the target animates to `transform: translateX(30px) rotate(45deg) translateX(150px)`.
-- With `accumulate`, the keyframe's `translateX(150px)` will accumulate with the current `translateX(30px)`, resulting in `translateX(180px)` and the rotation left untouched. The target therefore animates to a final effect value of `transform: translateX(180px) rotate(45deg)`.
+- With `replace`, the `transform` property in each keyframe will entirely replace that of the original one. The final effect value for the `transform` property at the 50% keyframe would simply be `translateY(30px)` on its own, and at the 100% keyframe would be `translateX(150px)` on its own.
+
+  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translateY(30px)`, then to `transform: translateX(150px)`.
+
+- With `add`, the final effect value at each keyframe would be the original `transform` property with the new one added after.
+
+  Therefore, the target effectively animates to `transform: translateX(30px) rotate(45deg) translateY(30px)` then to `transform: translateX(30px) rotate(45deg) translateX(150px)`.
+
+- With `accumulate`, the the final effect value would be the keyframe's `transform` combined with the original. At 50%, `translateY(30px)` combines with the original `translateX(30px)` into a single translation. At 100%, the `translateX(150px)` combines with the original `translateX(30px)`.
+
+  Therefore, the target effectively animates to `transform: translate(30px, 30px) rotate(45deg)` then to `transform: translateX(180px) rotate(45deg)`.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -129,24 +129,14 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 
 ```css
 @keyframes slide {
-  20%,
-  40% {
-    transform: translateX(100px);
-    background: yellow;
-  }
-  80%,
-  100% {
+  to {
     transform: translateX(150px);
-    background: orange;
   }
 }
 
 .target {
   transform: translateX(30px) rotate(45deg);
   animation: slide 5s linear infinite;
-}
-.target:hover {
-  animation-play-state: paused;
 }
 #replace {
   animation-composition: replace;
@@ -163,9 +153,9 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
-- With `replace`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(100px)` (completely replacing the underlying value `translateX(30px) rotate(45deg)`). In this case, the element rotates from 45deg to 0deg as it animates from the default value set on the element itself to the non-rotated value set at the 20% mark. This is the default behavior.
-- With `add`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(30px) rotate(45deg) translateX(100px)`. So the element is first moved 30px to the right, rotated 45deg in place, then moved by 100px along the rotated X axis.
-- With `accumulate`, the final effect value in the `20%, 40%` keyframe is `translateX(130px) rotate(45deg)`. This means that the two X-axis translation values of `30px` and `100px` are combined or "accumulated".
+- With `replace`, at the end of the animation, the keyframe's `transform` property will entirely replace that of the original. Therefore, the final effect value for the `transform` property at the end of the animation would simply be `translateX(150px)`. The target animates from `transform: translateX(30px) rotate(45deg)` to `transform: translateX(150px)`.
+- With `add`, the final effect value would be the current `transform` property with the keyframe's `transform` added to it, meaning the target animates to `transform: translateX(30px) rotate(45deg) translateX(150px)`.
+- With `accumulate`, the keyframe's `translateX(150px)` will accumulate with the current `translateX(30px)`, resulting in `translateX(180px)` and the rotation left untouched. The target therefore animates to a final effect value of `transform: translateX(180px) rotate(45deg)`.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -108,10 +108,17 @@ The example below shows the effect of different `animation-composition` values s
 #### CSS
 
 ```css hidden
+body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+}
+
 .container {
-  width: 230px;
+  flex: 1;
+  min-width: 200px;
   height: 200px;
-  background: cyan;
+  background: lightblue;
   display: inline-block;
   text-align: center;
 }

--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -107,8 +107,6 @@ The example below shows the effect of different `animation-composition` values s
 
 #### CSS
 
-Here the underlying value is `translateX(50px) rotate(45deg)`.
-
 ```css hidden
 .container {
   width: 230px;
@@ -155,6 +153,8 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 #### Result
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
+
+Here, the underlying value for all examples' `transform` property is `translateX(50px) rotate(45deg)`. The different `animation-composition` values' effects are as follows:
 
 - With `replace`, the `transform` property in each keyframe entirely replaces the underlying `transform` property set on the animated element. The final effect value for the `transform` property at the `50%` keyframe is `translateY(30px)` (no `rotate` or `translateX`); at the `100%` keyframe, it is `translateX(150px)` (no `rotate` or `translateY`).
 

--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -164,7 +164,7 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
 - With `replace`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(100px)` (completely replacing the underlying value `translateX(30px) rotate(45deg)`). In this case, the element rotates from 45deg to 0deg as it animates from the default value set on the element itself to the non-rotated value set at the 20% mark. This is the default behavior.
-- With `add`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(30px) rotate(45deg) translateX(100px)`. So the element is first moved 100px to the right, rotated 45deg around the origin, then moved to the right by 30px.
+- With `add`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(30px) rotate(45deg) translateX(100px)`. So the element is first moved 30px to the right, rotated 45deg in place, then moved by 100px along the rotated X axis.
 - With `accumulate`, the final effect value in the `20%, 40%` keyframe is `translateX(130px) rotate(45deg)`. This means that the two X-axis translation values of `30px` and `100px` are combined or "accumulated".
 
 ## Specifications

--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -154,19 +154,19 @@ The example below shows the effect of different `animation-composition` values s
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
-Here, the underlying value for all examples' `transform` property is `translateX(50px) rotate(45deg)`. The different `animation-composition` values' effects are as follows:
+The underlying value for the `transform` property in all cases is `translateX(50px) rotate(45deg)`. The different `animation-composition` values' effects are as follows:
 
 - With `replace`, the `transform` property in each keyframe entirely replaces the underlying `transform` property set on the animated element. The final effect value for the `transform` property at the `50%` keyframe is `translateY(30px)` (no `rotate` or `translateX`); at the `100%` keyframe, it is `translateX(150px)` (no `rotate` or `translateY`).
 
-  In essence, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translateY(30px)`, then to `transform: translateX(150px)`.
+  The target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translateY(30px)`, then to `transform: translateX(150px)`.
 
-- With `add`, the final effect value at each keyframe would be the original `transform` property with the new one added after.
+- With `add`, the final effect value at each keyframe is the underlying `transform` value with the effect value placed immediately after it.
 
-  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translateX(30px) rotate(45deg) translateY(30px)` (which is `30px` "downwards" on the rotated Y-axis), then to `transform: translateX(30px) rotate(45deg) translateX(150px)`. Since the additive operation is relative to the underlying `transform` and not the previous keyframe, there is no `translateY(30px)` at `100%`, leaving the element `150px` along the rotated X-axis from the original position.
+  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates first to `transform: translateX(30px) rotate(45deg) translateY(30px)` (which is `30px` "downwards" on the rotated Y-axis), and then to `transform: translateX(30px) rotate(45deg) translateX(150px)`. Since the additive operation is relative to the underlying `transform` and not the previous keyframe, there is no `translateY(30px)` at `100%`, placing the element `150px` along the rotated X-axis from the original position.
 
 - With `accumulate`, the final effect value is the keyframe's effect `transform` combined with the underlying original. At `50%`, `translateY(30px)` combines with the original `translateX(30px)` into a single translation (`translate(30px, 30px)`). At `100%`, the `translateX(150px)` combines with the original `translateX(30px)` to create `translateX(180px)`.
 
-  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translate(30px, 30px) rotate(45deg)` then to `transform: translateX(180px) rotate(45deg)`.
+  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates first to `transform: translate(30px, 30px) rotate(45deg)`, and then to `transform: translateX(180px) rotate(45deg)`.
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -156,17 +156,17 @@ Here the underlying value is `translateX(50px) rotate(45deg)`.
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
-- With `replace`, the `transform` property in each keyframe will entirely replace that of the original one. The final effect value for the `transform` property at the 50% keyframe would simply be `translateY(30px)` on its own, and at the 100% keyframe would be `translateX(150px)` on its own.
+- With `replace`, the `transform` property in each keyframe entirely replaces the underlying `transform` property set on the animated element. The final effect value for the `transform` property at the `50%` keyframe is `translateY(30px)` (no `rotate` or `translateX`); at the `100%` keyframe, it is `translateX(150px)` (no `rotate` or `translateY`).
 
-  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translateY(30px)`, then to `transform: translateX(150px)`.
+  In essence, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translateY(30px)`, then to `transform: translateX(150px)`.
 
 - With `add`, the final effect value at each keyframe would be the original `transform` property with the new one added after.
 
-  Therefore, the target effectively animates to `transform: translateX(30px) rotate(45deg) translateY(30px)` then to `transform: translateX(30px) rotate(45deg) translateX(150px)`.
+  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translateX(30px) rotate(45deg) translateY(30px)` (which is `30px` "downwards" on the rotated Y-axis), then to `transform: translateX(30px) rotate(45deg) translateX(150px)`. Since the additive operation is relative to the underlying `transform` and not the previous keyframe, there is no `translateY(30px)` at `100%`, leaving the element `150px` along the rotated X-axis from the original position.
 
-- With `accumulate`, the the final effect value would be the keyframe's `transform` combined with the original. At 50%, `translateY(30px)` combines with the original `translateX(30px)` into a single translation. At 100%, the `translateX(150px)` combines with the original `translateX(30px)`.
+- With `accumulate`, the final effect value is the keyframe's effect `transform` combined with the underlying original. At `50%`, `translateY(30px)` combines with the original `translateX(30px)` into a single translation (`translate(30px, 30px)`). At `100%`, the `translateX(150px)` combines with the original `translateX(30px)` to create `translateX(180px)`.
 
-  Therefore, the target effectively animates to `transform: translate(30px, 30px) rotate(45deg)` then to `transform: translateX(180px) rotate(45deg)`.
+  Therefore, the target starts at `transform: translateX(30px) rotate(45deg)` and effectively animates to `transform: translate(30px, 30px) rotate(45deg)` then to `transform: translateX(180px) rotate(45deg)`.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
- Fixes description of composite transform to use left-to-right order instead of right-to-left.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The composite transform example in `animation-composition` originally described the process from left-to-right, with each transform establishing a new coordinate space. This was changed to the right-to-left order in #38561 because at the time, the docs for `transform` were worded such that it seemed that right-to-left was "the order" in practice.

With #43496, the `transform` docs are much clearer on the different orders and respective behaviours with coordinate space, and uses the left-to-right order as the primary one for explanation. Therefore, we can return the `animation-composition` example to how it was before.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
Current [`transform` docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/transform#comparing_the_order_of_transform_functions)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
N/A
