### PR TITLE
Explain SVG presentation attributes

### DIFF
--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -6,9 +6,9 @@ page-type: landing-page
 sidebar: svgref
 ---
 
-SVG elements can be modified using attributes that specify details about exactly how the element should be handled or rendered.
+SVG elements can be modified using attributes that modify how the element is handled or rendered.
 
-Below is a list of all of the attributes available in SVG along with links to reference documentation to help you learn which elements support them and how they work.
+Below is a list of all of the attributes available in SVG, along with links to reference documentation to help you learn which elements support them and how they work.
 
 ## SVG attributes A to Z
 
@@ -309,7 +309,7 @@ The core attributes are global attributes.
 
 ### Conditional processing attributes
 
-The conditional processing attributes control whether or not the element on which it appears is processed.
+The conditional processing attributes control whether the elements they are set on are processed.
 
 - {{SVGAttr("requiredExtensions")}}
 - {{SVGAttr("requiredFeatures")}}
@@ -334,10 +334,7 @@ They set CSS property values on an element with a specificity of `0`, so other a
 Presentation attribute values are parsed as CSS values, not declarations, so they cannot contain `!important`.
 
 Most presentation attributes inherit when used as CSS properties (for example, {{cssxref("fill")}} and {{cssxref("stroke")}}).
-[Geometry properties](#geometry_properties) are the main exception: their CSS counterparts do not inherit, and setting them on a container such as {{SVGElement("g")}} has no effect on child elements.
-
-> [!NOTE]
-> Whether these attributes are presentation attributes depends on the element on which they are set. For example, `x` is a presentation attribute for {{svgelement("circle")}}, but not for {{svgelement("tspan")}}; it's the coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
+[Geometry properties](#geometry_properties) are the main exception: their CSS counterparts do not inherit.
 
 - {{SVGAttr("alignment-baseline")}}
 - {{SVGAttr("baseline-shift")}}
@@ -417,8 +414,8 @@ Most presentation attributes inherit when used as CSS properties (for example, {
 Geometry properties describe the position and dimensions of SVG shapes.
 In [SVG 2](https://www.w3.org/TR/SVG2/#GeometryProperties), they are a defined subset of presentation attributes whose CSS counterparts do not inherit.
 
-Each geometry property only applies as a presentation attribute on certain elements.
-For example, {{SVGAttr("r")}} defines a circle's radius on {{SVGElement("circle")}}, but has no effect on elements such as {{SVGElement("rect")}}.
+Each geometry property applies as a presentation attribute only on certain elements.
+For example, {{SVGAttr("r")}} defines the radius of a {{SVGElement("circle")}}, but has no effect on elements such as {{SVGElement("rect")}}.
 
 The SVG geometry properties are:
 

--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -329,10 +329,23 @@ The XLink attributes can reference resources.
 
 ### Presentation attributes
 
-All SVG presentation attributes can be used as CSS properties.
+SVG presentation attributes are SVG attributes that can also be used as CSS properties on SVG elements.
+They set CSS property values on an element and are applied as author-level style rules with specificity `0`, so other author styles in a stylesheet or {{SVGAttr("style")}} attribute can override them.
+Presentation attribute values are parsed as CSS values, not declarations, so they cannot contain `!important`.
 
 > [!NOTE]
 > Whether these attributes are presentation attributes depends on the element on which they are set. For example, `x` is a presentation attribute for {{svgelement("circle")}}, but not for {{svgelement("tspan")}}; it's the coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
+
+#### Geometry properties
+
+Geometry properties describe the position and dimensions of some SVG elements.
+They are a subset of presentation attributes, but their attribute form is only a presentation attribute on the elements for which the matching CSS property applies.
+For example, {{SVGAttr("x")}} is a geometry property for {{SVGElement("rect")}}, {{SVGElement("image")}}, and {{SVGElement("svg")}}, but not for {{SVGElement("text")}} or {{SVGElement("tspan")}}.
+
+Geometry properties are not inherited.
+Setting a geometry property on a container element, such as {{SVGElement("g")}}, has no effect on that element's children.
+
+SVG geometry properties include {{cssxref("cx")}}, {{cssxref("cy")}}, {{cssxref("r")}}, {{cssxref("rx")}}, {{cssxref("ry")}}, {{cssxref("x")}}, {{cssxref("y")}}, {{cssxref("width")}}, {{cssxref("height")}}, and {{cssxref("d")}}.
 
 - {{SVGAttr("alignment-baseline")}}
 - {{SVGAttr("baseline-shift")}}

--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -330,22 +330,14 @@ The XLink attributes can reference resources.
 ### Presentation attributes
 
 SVG presentation attributes are SVG attributes that can also be used as CSS properties on SVG elements.
-They set CSS property values on an element and are applied as author-level style rules with specificity `0`, so other author styles in a stylesheet or {{SVGAttr("style")}} attribute can override them.
+They set CSS property values on an element with a specificity of `0`, so other author styles in a stylesheet or {{SVGAttr("style")}} attribute can override them.
 Presentation attribute values are parsed as CSS values, not declarations, so they cannot contain `!important`.
+
+Most presentation attributes inherit when used as CSS properties (for example, {{cssxref("fill")}} and {{cssxref("stroke")}}).
+[Geometry properties](#geometry_properties) are the main exception: their CSS counterparts do not inherit, and setting them on a container such as {{SVGElement("g")}} has no effect on child elements.
 
 > [!NOTE]
 > Whether these attributes are presentation attributes depends on the element on which they are set. For example, `x` is a presentation attribute for {{svgelement("circle")}}, but not for {{svgelement("tspan")}}; it's the coordinate of the starting point of the text baseline, or the x coordinate of each individual glyph if a list of values is provided.
-
-#### Geometry properties
-
-Geometry properties describe the position and dimensions of some SVG elements.
-They are a subset of presentation attributes, but their attribute form is only a presentation attribute on the elements for which the matching CSS property applies.
-For example, {{SVGAttr("x")}} is a geometry property for {{SVGElement("rect")}}, {{SVGElement("image")}}, and {{SVGElement("svg")}}, but not for {{SVGElement("text")}} or {{SVGElement("tspan")}}.
-
-Geometry properties are not inherited.
-Setting a geometry property on a container element, such as {{SVGElement("g")}}, has no effect on that element's children.
-
-SVG geometry properties include {{cssxref("cx")}}, {{cssxref("cy")}}, {{cssxref("r")}}, {{cssxref("rx")}}, {{cssxref("ry")}}, {{cssxref("x")}}, {{cssxref("y")}}, {{cssxref("width")}}, {{cssxref("height")}}, and {{cssxref("d")}}.
 
 - {{SVGAttr("alignment-baseline")}}
 - {{SVGAttr("baseline-shift")}}
@@ -419,6 +411,29 @@ SVG geometry properties include {{cssxref("cx")}}, {{cssxref("cy")}}, {{cssxref(
 - {{SVGAttr("writing-mode")}}
 - {{SVGAttr("x")}}
 - {{SVGAttr("y")}}
+
+#### Geometry properties
+
+Geometry properties describe the position and dimensions of SVG shapes.
+In [SVG 2](https://www.w3.org/TR/SVG2/#GeometryProperties), they are a defined subset of presentation attributes whose CSS counterparts do not inherit.
+
+Each geometry property only applies as a presentation attribute on certain elements.
+For example, {{SVGAttr("r")}} defines a circle's radius on {{SVGElement("circle")}}, but has no effect on elements such as {{SVGElement("rect")}}.
+
+The SVG geometry properties are:
+
+- {{cssxref("cx")}}
+- {{cssxref("cy")}}
+- {{cssxref("d")}}
+- {{cssxref("r")}}
+- {{cssxref("rx")}}
+- {{cssxref("ry")}}
+- {{cssxref("x")}}
+- {{cssxref("y")}}
+- {{cssxref("width")}}
+- {{cssxref("height")}}
+
+For element-by-element applicability, see each property's attribute page and the list on the {{SVGElement("g")}} element page.
 
 ### Filters attributes
 

--- a/files/en-us/web/svg/reference/element/g/index.md
+++ b/files/en-us/web/svg/reference/element/g/index.md
@@ -19,7 +19,7 @@ Transformations applied to the `<g>` element are performed on its child elements
 This element only includes global attributes.
 
 Most of the [presentation attributes](/en-US/docs/Web/SVG/Reference/Attribute#presentation_attributes) applied to the element are inherited by its children.
-However, geometric attributes are only valid as presentation attributes on their designated elements — they have no effect on a `<g>` element and are not passed to its children.
+However, [geometry properties](/en-US/docs/Web/SVG/Reference/Attribute#geometry_properties) are only valid as presentation attributes on their designated elements — they have no effect on a `<g>` element and are not passed to its children.
 
 These non-inherited attributes include:
 


### PR DESCRIPTION
## Summary
- define SVG presentation attributes on the SVG attribute reference page
- explain how geometry properties are a subset of presentation attributes and why they do not inherit through container elements
- link the existing `<g>` page note to the new geometry-properties explanation

## Rationale
MDN links to the presentation attributes section from element pages, but the section did not explain how presentation attributes relate to CSS properties, cascade precedence, or element-specific geometry properties. This adds that context in one reference location instead of repeating it across individual element pages.

## Tests
- `corepack npm exec --yes --package=prettier@3.8.4 -- prettier --check files/en-us/web/svg/reference/attribute/index.md files/en-us/web/svg/reference/element/g/index.md`
- `corepack npm exec --yes --package=markdownlint-cli2@0.22.1 --package=markdownlint-rule-search-replace@1.2.0 -- markdownlint-cli2 files/en-us/web/svg/reference/attribute/index.md files/en-us/web/svg/reference/element/g/index.md`
- `git diff --check`

Fixes #44394