### PR TITLE
Fix grammatical errors across the privacy section

### DIFF
--- a/files/en-us/web/privacy/guides/state_partitioning/index.md
+++ b/files/en-us/web/privacy/guides/state_partitioning/index.md
@@ -18,8 +18,8 @@ From Firefox 103, State Partitioning is turned on by default.
 
 Browsers traditionally key client-side state by the origin (or sometimes registrable domain) of the location a resource was loaded from.
 For example, the cookies, localStorage objects, and caches available to an iframe loaded from `https://example.com/hello.html` will be keyed by `example.com`.
-This is true regardless of whether the browser is currently loading resources from that domain as a _first-party_
-resources or as an embedded _third party_ resources.
+This is true regardless of whether the browser is currently loading resources from that domain as _first-party_
+resources or as embedded _third-party_ resources.
 Trackers have taken advantage of this cross-site state to store user identifiers and access them across websites.
 The example below shows how `example.com` can use its cross-site state (in this instance, cookies) to track a user across its own site as well as `A.example` and `B.example`.
 
@@ -141,7 +141,7 @@ Let's say a site hosted at `a.example` navigates a user to `b.example` in the sa
 ## Storage Access API
 
 Third-party frames may use
-[document.requestStorageAccess](/en-US/docs/Web/API/Document/requestStorageAccess) to request unpartitioned access to cookie through the [Storage Access API](/en-US/docs/Web/API/Storage_Access_API).
+[document.requestStorageAccess](/en-US/docs/Web/API/Document/requestStorageAccess) to request unpartitioned access to cookies through the [Storage Access API](/en-US/docs/Web/API/Storage_Access_API).
 Once granted, the requesting party will gain access to its entire first-party cookies (i.e., the cookies it would have access to if visited as a first-party).
 
 > [!WARNING]

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookieblockedforeign/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: privacy
 ---
 
-A request to access cookies or storage was blocked because it came from a third-party (a different origin) and content blocking is enabled.
+A request to access cookies or storage was blocked because it came from a third party (a different origin) and content blocking is enabled.
 
 ## Message
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/errors/cookiepartitionedforeign/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/errors/cookiepartitionedforeign/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: privacy
 ---
 
-A request to access cookies or storage was _partitioned_ because it came from a third-party (a different origin) and [dynamic state partitioning](/en-US/docs/Web/Privacy/Guides/State_Partitioning#dynamic_partitioning) is enabled.
+A request to access cookies or storage was _partitioned_ because it came from a third party (a different origin) and [dynamic state partitioning](/en-US/docs/Web/Privacy/Guides/State_Partitioning#dynamic_partitioning) is enabled.
 
 ## Message
 

--- a/files/en-us/web/privacy/guides/storage_access_policy/index.md
+++ b/files/en-us/web/privacy/guides/storage_access_policy/index.md
@@ -154,7 +154,7 @@ No — this feature only restricts access to cookies and site data that can be u
 
 ### I use a third-party analytics service that is classified as a tracker. Will I still receive analytics data?
 
-This depends on how the third-party analytics service is implemented. Third-party analytics providers will no longer be able to user their third-party storage to collect data. This means that providers using cookies which are scoped to their third-party domain, or local storage and other site data stored under their origin, will no longer have access to those identifiers across other websites.
+This depends on how the third-party analytics service is implemented. Third-party analytics providers will no longer be able to use their third-party storage to collect data. This means that providers using cookies which are scoped to their third-party domain, or local storage and other site data stored under their origin, will no longer have access to those identifiers across other websites.
 
 If these services are embedded into the main context of the page, they can continue to use first-party cookies and site storage to track users across page visits on that specific first-party domain.
 


### PR DESCRIPTION
### Description

Fixed hyphenation issues and subject verb agreement on some pages. From reading other pages it seems the convention is third-party is an adjective, and third party is a noun, so that's what I've applied.

### Motivation

To make the pages more natural to read.

