### PR TITLE
Clarify limitations of Element.checkVisibility()

### DIFF
--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Element.checkVisibility
 
 {{APIRef("DOM")}}
 
-The **`checkVisibility()`** method of the {{domxref("Element")}} interface checks whether the element is visible.
+The **`checkVisibility()`** method of the {{domxref("Element")}} interface checks whether the element is potentially visible.
 
 The method returns `false` in either of the following situations:
 
@@ -17,6 +17,11 @@ The method returns `false` in either of the following situations:
 
 The optional parameter enables additional checks to test for other interpretations of what "visible" means.
 For example, you can further check whether an element has an opacity of `0`, if the value of the element {{cssxref("visibility")}} property makes it invisible, or if the element {{cssxref("content-visibility")}} property has a value of [`auto`](/en-US/docs/Web/CSS/Reference/Properties/content-visibility#auto) and its rendering is currently being skipped.
+
+> [!NOTE]
+> A return value of true does not guarantee the element is visible to the user.
+> It only indicates that the element is not considered hidden by this method.
+> Elements outside the viewport or occluded by other content may still return true.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -18,10 +18,8 @@ The method returns `false` in either of the following situations:
 The optional parameter enables additional checks to test for other interpretations of what "visible" means.
 For example, you can further check whether an element has an opacity of `0`, if the value of the element {{cssxref("visibility")}} property makes it invisible, or if the element {{cssxref("content-visibility")}} property has a value of [`auto`](/en-US/docs/Web/CSS/Reference/Properties/content-visibility#auto) and its rendering is currently being skipped.
 
-> [!NOTE]
-> A return value of true does not guarantee the element is visible to the user.
-> It only indicates that the element is not considered hidden by this method.
-> Elements outside the viewport or occluded by other content may still return true.
+Note that a a return value of `true` does not guarantee the element is visible to the user: just that it is may be.
+Elements outside the viewport or occluded by other content may still return `true`.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

I want to make the limitations of `checkVisibility` more obvious. For example when an element is occluded the `checkVisibility` method may still return `true`.

### Motivation

The current version claims this:
> checks whether the element is visible

while the spec uses more careful wording:
> whether an element is potentially "visible"

I think this is slightly misleading as there are many cases in which an element is not visible to the user but this method still returns true. Even with all the optional checks enabled.

### Additional details

[Specification](https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility:~:text=whether%20an%20element%20is%20potentially%20%22visible%22%2E)

### Related issues and pull requests

No related PRs or issues.

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
