### PR TITLE
Add note about Fetch Metadata headers on non-secure origins

### DIFF
--- a/files/en-us/glossary/fetch_metadata_request_header/index.md
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.md
@@ -20,7 +20,7 @@ The fetch metadata request headers are:
 
 > [!NOTE]
 > Fetch Metadata request headers are only sent in requests to [potentially trustworthy URLs](/en-US/docs/Web/Security/Defenses/Secure_Contexts#potentially_trustworthy_urls).
-> Servers on non-secure `http://` origins may not receive these headers.
+> Servers on non-secure (`http://`) origins may not receive these headers.
 
 The following request headers are not _strictly_ "fetch metadata request headers", as they are not in the same specification, but similarly provide information about the context of how a resource will be used.
 A server might use them to modify its caching behavior, or the information that is returned:

--- a/files/en-us/glossary/fetch_metadata_request_header/index.md
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.md
@@ -19,8 +19,8 @@ The fetch metadata request headers are:
 - {{HTTPHeader("Sec-Fetch-Dest")}}
 
 > [!NOTE]
-> Fetch Metadata request headers are only sent for potentially trustworthy URLs.
-> As a result, servers on non-secure `http://` origins may not receive these headers.
+> Fetch Metadata request headers are only sent in requests to [potentially trustworthy URLs](/en-US/docs/Web/Security/Defenses/Secure_Contexts#potentially_trustworthy_urls).
+> Servers on non-secure `http://` origins may not receive these headers.
 
 The following request headers are not _strictly_ "fetch metadata request headers", as they are not in the same specification, but similarly provide information about the context of how a resource will be used.
 A server might use them to modify its caching behavior, or the information that is returned:

--- a/files/en-us/glossary/fetch_metadata_request_header/index.md
+++ b/files/en-us/glossary/fetch_metadata_request_header/index.md
@@ -18,6 +18,10 @@ The fetch metadata request headers are:
 - {{HTTPHeader("Sec-Fetch-User")}}
 - {{HTTPHeader("Sec-Fetch-Dest")}}
 
+> [!NOTE]
+> Fetch Metadata request headers are only sent for potentially trustworthy URLs.
+> As a result, servers on non-secure `http://` origins may not receive these headers.
+
 The following request headers are not _strictly_ "fetch metadata request headers", as they are not in the same specification, but similarly provide information about the context of how a resource will be used.
 A server might use them to modify its caching behavior, or the information that is returned:
 

--- a/files/en-us/web/http/reference/headers/sec-fetch-dest/index.md
+++ b/files/en-us/web/http/reference/headers/sec-fetch-dest/index.md
@@ -12,6 +12,8 @@ That is the initiator of the original fetch request, which is where (and how) th
 
 This allows servers to determine whether to service a request based on whether it is appropriate for how it is _expected_ to be used. For example, a request with an `audio` destination should request audio data, not some other type of resource (for example, a document that includes sensitive user information).
 
+The header is only included in requests to [potentially trustworthy URLs](/en-US/docs/Web/Security/Defenses/Secure_Contexts#potentially_trustworthy_urls).
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/http/reference/headers/sec-fetch-mode/index.md
+++ b/files/en-us/web/http/reference/headers/sec-fetch-mode/index.md
@@ -12,6 +12,8 @@ The HTTP **`Sec-Fetch-Mode`** [fetch metadata request header](/en-US/docs/Web/HT
 Broadly speaking, this allows a server to distinguish between requests originating from a user navigating between HTML pages, and requests to load images and other resources.
 For example, this header would contain `navigate` for top level navigation requests, while `no-cors` is used for loading an image.
 
+The header is only included in requests to [potentially trustworthy URLs](/en-US/docs/Web/Security/Defenses/Secure_Contexts#potentially_trustworthy_urls).
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/http/reference/headers/sec-fetch-site/index.md
+++ b/files/en-us/web/http/reference/headers/sec-fetch-site/index.md
@@ -13,6 +13,8 @@ In other words, this header tells a server whether a request for a resource is c
 
 Same-origin requests would usually be allowed by default, but what happens for requests from other origins may further depend on what resource is being requested, or information in another fetch metadata request header. By default, requests that are not accepted should be rejected with a {{HTTPStatus("403")}} response code.
 
+The header is only included in requests to [potentially trustworthy URLs](/en-US/docs/Web/Security/Defenses/Secure_Contexts#potentially_trustworthy_urls).
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/http/reference/headers/sec-fetch-user/index.md
+++ b/files/en-us/web/http/reference/headers/sec-fetch-user/index.md
@@ -11,6 +11,8 @@ The HTTP **`Sec-Fetch-User`** [fetch metadata request header](/en-US/docs/Web/HT
 
 A server can use this header to identify whether a navigation request from a document, iframe, etc., was originated by the user.
 
+The header is only included in requests to [potentially trustworthy URLs](/en-US/docs/Web/Security/Defenses/Secure_Contexts#potentially_trustworthy_urls).
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/security/defenses/secure_contexts/index.md
+++ b/files/en-us/web/security/defenses/secure_contexts/index.md
@@ -31,7 +31,7 @@ Resources that are not local, to be considered secure, must meet the following c
 
 ## Potentially trustworthy origins
 
-A **potentially trustworthy origin** is one that the browser can generally trust to deliver data security, and will therefore (under some circumstances) grant it access to features that are otherwise restricted to secure contexts.
+A **potentially trustworthy origin** is one that the browser can generally trust to deliver data securely and will therefore (under some circumstances) grant it access to features otherwise restricted to secure contexts.
 
 Locally-delivered resources such as those with `http://127.0.0.1`, `http://localhost`, and `http://*.localhost` URLs (for example, `http://dev.whatever.localhost/`) are not delivered using HTTPS, but they can be considered to have been delivered securely because they are on the same device as the browser. They are therefore potentially trustworthy. This is convenient for developers testing applications locally.
 
@@ -48,12 +48,12 @@ Vendor-specific URL schemes like `app://` or `chrome-extension://` are not consi
 
 A **potentially trustworthy URL** is one that is from a [potentially trustworthy origin](#potentially_trustworthy_origins), or:
 
-- whose URL is `about:blank`, `about:srcdoc`, which inherit trustworthiness from their creator's origin
-- whose scheme is a `blob:` URL, which inherits trustworthiness from its creator's origin
-- who's scheme is `data:`, where content is inline rather than network-delivered
+- whose URL is `about:blank` or `about:srcdoc`, both of which inherit trustworthiness from their creator's origin.
+- whose scheme is a `blob:` URL, which inherits trustworthiness from its creator's origin.
+- whose scheme is `data:`, in which case the content is inline rather than network-delivered.
 
 While potentially trustworthy origins are used to make trust decisions about access to features generally allowed only to secure contexts, potentially trustworthy URLs are used to determine whether a request is allowed to include potentially private data.
-For example, [Fetch Metadata request headers](/en-US/docs/Glossary/Fetch_metadata_request_header) are only sent in requests to a potentially trustworthy URL.
+For example, [Fetch Metadata request headers](/en-US/docs/Glossary/Fetch_metadata_request_header) are only sent in requests to potentially trustworthy URLs.
 This means servers on non-secure `http://` URLs may not receive these headers.
 
 ## Feature detection

--- a/files/en-us/web/security/defenses/secure_contexts/index.md
+++ b/files/en-us/web/security/defenses/secure_contexts/index.md
@@ -31,7 +31,7 @@ Resources that are not local, to be considered secure, must meet the following c
 
 ## Potentially trustworthy origins
 
-A **potentially trustworthy origin** is one that the browser can generally trust to deliver data security, even though strictly speaking it does not meet the criteria of a secure context.
+A **potentially trustworthy origin** is one that the browser can generally trust to deliver data security, and will therefore (under some circumstances) grant it access to features that are otherwise restricted to secure contexts.
 
 Locally-delivered resources such as those with `http://127.0.0.1`, `http://localhost`, and `http://*.localhost` URLs (for example, `http://dev.whatever.localhost/`) are not delivered using HTTPS, but they can be considered to have been delivered securely because they are on the same device as the browser. They are therefore potentially trustworthy. This is convenient for developers testing applications locally.
 
@@ -43,6 +43,18 @@ Vendor-specific URL schemes like `app://` or `chrome-extension://` are not consi
 
 > [!NOTE]
 > Firefox 84 and later support `http://localhost` and `http://*.localhost` URLs as trustworthy origins (earlier versions did not, because `localhost` was not guaranteed to map to a local/loopback address).
+
+### Potentially trustworthy URLs
+
+A **potentially trustworthy URL** is one that is from a [potentially trustworthy origin](#potentially_trustworthy_origins), or:
+
+- whose URL is `about:blank`, `about:srcdoc`, which inherit trustworthiness from their creator's origin
+- whose scheme is a `blob:` URL, which inherits trustworthiness from its creator's origin
+- who's scheme is `data:`, where content is inline rather than network-delivered
+
+While potentially trustworthy origins are used to make trust decisions about access to features generally allowed only to secure contexts, potentially trustworthy URLs are used to determine whether a request is allowed to include potentially private data.
+For example, [Fetch Metadata request headers](/en-US/docs/Glossary/Fetch_metadata_request_header) are only sent in requests to a potentially trustworthy URL.
+This means servers on non-secure `http://` URLs may not receive these headers.
 
 ## Feature detection
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Adds a note to the Fetch Metadata Request Headers page clarifying that Fetch Metadata headers are only sent for potentially trustworthy URLs. This helps explain why headers such as `Sec-Fetch-Dest`, `Sec-Fetch-Mode`, and `Sec-Fetch-Site` may be absent on non-secure `http://` origins during development and testing.

### Motivation

We have a project where we use the `Sec-Fetch-Dest` header to test whether the content is in an iframe or not and return different content based on that. Worked locally but our non-production deployments did not use https. So this caught us by surprise and I thought a note like this might be helpful to other devs.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

https://www.w3.org/TR/secure-contexts/#potentially-trustworthy-url

### Related issues and pull requests

No related issues or PRs.
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
