### PR TITLE
IntersectionOberserver.observe() behavior when targetElement already observed

### DIFF
--- a/files/en-us/web/api/intersectionobserver/observe/index.md
+++ b/files/en-us/web/api/intersectionobserver/observe/index.md
@@ -13,8 +13,7 @@ One observer has one set of thresholds and one root, but can watch multiple targ
 
 To stop observing the element, call {{domxref("IntersectionObserver.unobserve()")}}.
 
-When the visibility of the specified element crosses over one of the observer's visibility thresholds (as listed in {{domxref("IntersectionObserver.thresholds")}}), the observer's callback is executed with an array of {{domxref("IntersectionObserverEntry")}} objects representing the intersection changes
-which occurred.
+When the visibility of the specified element crosses over one of the observer's visibility thresholds (as listed in {{domxref("IntersectionObserver.thresholds")}}), the observer's callback is executed with an array of {{domxref("IntersectionObserverEntry")}} objects representing the intersection changes which occurred.
 Note that this design allows multiple elements' intersection changes to be processed by a single call to the callback.
 
 > [!NOTE]

--- a/files/en-us/web/api/intersectionobserver/observe/index.md
+++ b/files/en-us/web/api/intersectionobserver/observe/index.md
@@ -33,6 +33,7 @@ observe(targetElement)
 - `targetElement`
   - : An {{domxref("element")}} whose visibility within the root is to be monitored.
     This element must be a descendant of the root element (or contained within the current document, if the root is the document's viewport).
+    If this element is already being observed, this method does nothing.
 
 ### Return value
 


### PR DESCRIPTION
IntersectionOberserver.observe() behavior when targetElement already observed.

Clarified description of observe method behavior when targetElement is already observed. Consistent with the spec and with the description of unobserve method behavior when target is not being observed.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
