### PR TITLE
Picture-in-Picture API - template/layout fixes

### DIFF
--- a/files/en-us/web/api/document/exitpictureinpicture/index.md
+++ b/files/en-us/web/api/document/exitpictureinpicture/index.md
@@ -24,7 +24,8 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}}, which is resolved once the {{Glossary("user agent")}} has finished exiting picture-in-picture mode. If an error occurs while attempting to exit fullscreen mode, the `catch()` handler for the promise is called.
+A {{jsxref("Promise")}}, which is resolved once the {{Glossary("user agent")}} has finished exiting picture-in-picture mode.
+If an error occurs while attempting to exit picture-in-picture mode, the `catch()` handler for the promise is called.
 
 ### Exceptions
 

--- a/files/en-us/web/api/document/exitpictureinpicture/index.md
+++ b/files/en-us/web/api/document/exitpictureinpicture/index.md
@@ -8,11 +8,9 @@ browser-compat: api.Document.exitPictureInPicture
 
 {{APIRef("Picture-in-Picture API")}}
 
-The **`exitPictureInPicture()`** method of the {{domxref("Document")}} interface
-requests that a video contained
-in this document, which is currently floating, be taken out of picture-in-picture
-mode, restoring the previous state of the screen. This usually reverses the
-effects of a previous call to {{domxref("HTMLVideoElement.requestPictureInPicture()")}}.
+The **`exitPictureInPicture()`** method of the {{domxref("Document")}} interface requests that a video contained in this document, which is currently floating, be taken out of picture-in-picture mode.
+
+This attempts to reverse the effects of a previous call to {{domxref("HTMLVideoElement.requestPictureInPicture()")}}, restoring the video back into the website flow.
 
 ## Syntax
 
@@ -26,9 +24,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}}, which is resolved once the {{Glossary("user agent")}} has
-finished exiting picture-in-picture mode. If an error occurs while attempting to exit
-fullscreen mode, the `catch()` handler for the promise is called.
+A {{jsxref("Promise")}}, which is resolved once the {{Glossary("user agent")}} has finished exiting picture-in-picture mode. If an error occurs while attempting to exit fullscreen mode, the `catch()` handler for the promise is called.
 
 ### Exceptions
 
@@ -37,8 +33,9 @@ fullscreen mode, the `catch()` handler for the promise is called.
 
 ## Examples
 
-This example causes the current document to exit picture-in-picture mode whenever the
-mouse button is clicked within it.
+### Basic usage
+
+This example causes the current document to exit picture-in-picture mode whenever the mouse button is clicked within it.
 
 ```js
 document.onclick = (event) => {
@@ -53,7 +50,8 @@ document.onclick = (event) => {
 };
 ```
 
-Note that if you want to track which video on your page is currently playing in picture-in-picture mode, you should listen to the `enterpictureinpicture` and `leavepictureinpicture` events on the {{DOMxRef("HTMLVideoElement")}} element(s) in question. Alternatively, you can check whether {{DOMxRef("Document.pictureInPictureElement")}} refers to the current {{DOMxRef("HTMLVideoElement")}} element.
+Note that if you want to track which video on your page is currently playing in picture-in-picture mode, you should listen to the `enterpictureinpicture` and `leavepictureinpicture` events on the {{DOMxRef("HTMLVideoElement")}} element(s) in question.
+Alternatively, you can check whether {{DOMxRef("Document.pictureInPictureElement")}} refers to the current {{DOMxRef("HTMLVideoElement")}} element.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/pictureinpictureelement/index.md
+++ b/files/en-us/web/api/document/pictureinpictureelement/index.md
@@ -8,13 +8,7 @@ browser-compat: api.Document.pictureInPictureElement
 
 {{APIRef("Picture-in-Picture API")}}
 
-The read-only **`pictureInPictureElement`** property of the {{domxref("Document")}}
-interface returns the {{ domxref("Element") }} that is currently being
-presented in picture-in-picture mode in this document, or `null` if
-picture-in-picture mode is not currently in use.
-
-Although this property is read-only, it will not throw if it is modified (even in
-strict mode); the setter is a no-operation and will be ignored.
+The **`pictureInPictureElement`** read-only property of the {{domxref("Document")}} interface returns the {{ domxref("Element") }} that is currently being presented in picture-in-picture mode in this document, or `null` if picture-in-picture mode is not currently in use.
 
 ## Value
 
@@ -22,13 +16,14 @@ A reference to the {{domxref("Element")}} object that's currently in picture-in-
 
 Returns `null` if the document has no associated element in picture-in-picture mode. For example, there's no picture-in-picture element, or the element is from an iframe.
 
+Although this property is read-only, it will not throw if it is modified (even in strict mode); the setter is a no-operation and will be ignored.
+
 ## Examples
 
-This example presents a function, `exitPictureInPicture()`,
-which tests the value returned by `pictureInPictureElement`. If the document
-is in picture-in-picture mode (`pictureInPictureElement` isn't
-`null`), [`Document.exitPictureInPicture()`](/en-US/docs/Web/API/Document/exitPictureInPicture) is run to exit
-picture-in-picture mode.
+### Basic usage
+
+This example presents a function, `exitPictureInPicture()`, which tests the value returned by `pictureInPictureElement`.
+If the document is in picture-in-picture mode (`pictureInPictureElement` isn't `null`), [`Document.exitPictureInPicture()`](/en-US/docs/Web/API/Document/exitPictureInPicture) is run to exit picture-in-picture mode.
 
 ```js
 function exitPictureInPicture() {

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.md
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.md
@@ -8,29 +8,21 @@ browser-compat: api.Document.pictureInPictureEnabled
 
 {{APIRef("Picture-in-Picture API")}}
 
-The read-only
-**`pictureInPictureEnabled`** property of the
-{{domxref("Document")}} interface indicates whether or not picture-in-picture mode is
-available.
+The **`pictureInPictureEnabled`** read-only property of the {{domxref("Document")}} interface indicates whether or not picture-in-picture mode is available.
 
-Picture-in-Picture mode is available by default unless specified
-otherwise by a [Permissions-Policy](/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/picture-in-picture).
-
-Although this property is read-only, it will not throw if it is modified (even in
-strict mode); the setter is a no-operation and will be ignored.
+Picture-in-Picture mode is available by default unless denied by the page [Permissions-Policy](/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy/picture-in-picture).
 
 ## Value
 
-A boolean value, which is `true` if a video can enter
-picture-in-picture and be displayed in a floating window by calling
-{{domxref("HTMLVideoElement.requestPictureInPicture()")}}. If picture-in-picture mode isn't
-available, this value is `false`.
+A boolean value, which is `true` if a video can enter picture-in-picture and be displayed in a floating window by calling {{domxref("HTMLVideoElement.requestPictureInPicture()")}}. If picture-in-picture mode isn't available, this value is `false`.
+
+Although this property is read-only, it will not throw if it is modified (even in strict mode); the setter is a no-operation and will be ignored.
 
 ## Examples
 
-In this example, before attempting to enter picture-in-picture mode for a
-{{htmlElement("video")}} element the value of `pictureInPictureEnabled` is
-checked, to avoid making the call if the feature is not available.
+### Basic usage
+
+In this example, before attempting to enter picture-in-picture mode for a {{htmlElement("video")}} element the value of `pictureInPictureEnabled` is checked, to avoid making the call if the feature is not available.
 
 ```js
 function requestPictureInPicture() {

--- a/files/en-us/web/api/document_picture-in-picture_api/index.md
+++ b/files/en-us/web/api/document_picture-in-picture_api/index.md
@@ -74,3 +74,7 @@ See [Document Picture-in-Picture API Example](https://mdn.github.io/dom-examples
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Picture-in-Picture API](/en-US/docs/Web/API/Picture-in-Picture_API)

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -8,13 +8,16 @@ browser-compat: api.HTMLVideoElement.disablePictureInPicture
 
 {{APIRef("Picture-in-Picture API")}}
 
-The {{domxref("HTMLVideoElement")}} **`disablePictureInPicture`** property reflects the HTML attribute indicating whether the picture-in-picture feature is disabled for the current element.
+The **`disablePictureInPicture`** property of the {{domxref("HTMLVideoElement")}} interface reflects the HTML attribute indicating whether the picture-in-picture feature is disabled for the current element.
 
-This value only represents a request from the website to the user agent. User configuration may change the eventual behavior—for example, Firefox users can change the `media.videocontrols.picture-in-picture.respect-disablePictureInPicture` setting to ignore the request to disable PiP.
+This value only represents a request from the website to the user agent.
+User configuration may change the eventual behavior—for example, Firefox users can change the `media.videocontrols.picture-in-picture.respect-disablePictureInPicture` setting to ignore the request to disable PiP.
 
 ## Value
 
-A boolean value that is `true` if the picture-in-picture feature is disabled for this element. This means that the user agent should not suggest that feature to users, or request it automatically.
+A boolean value that is `true` if the picture-in-picture feature is disabled for this element.
+
+When true, the user agent will not suggest picture-in-picture to users, or request it automatically.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -17,7 +17,7 @@ User configuration may change the eventual behavior—for example, Firefox users
 
 A boolean value that is `true` if the picture-in-picture feature is disabled for this element.
 
-When true, the user agent will not suggest picture-in-picture to users, or request it automatically.
+When `true`, the user agent will not suggest picture-in-picture to users, or request it automatically.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLVideoElement.disablePictureInPicture
 
 {{APIRef("Picture-in-Picture API")}}
 
-The **`disablePictureInPicture`** property of the {{domxref("HTMLVideoElement")}} interface reflects the HTML attribute indicating whether the picture-in-picture feature is disabled for the current element.
+The **`disablePictureInPicture`** property of the {{domxref("HTMLVideoElement")}} interface reflects the [`disablepictureinpicture`](/en-US/docs/Web/HTML/Reference/Elements/video#disablepictureinpicture) HTML attribute indicating whether the picture-in-picture feature is disabled for the current element.
 
 This value only represents a request from the website to the user agent.
 User configuration may change the eventual behavior—for example, Firefox users can change the `media.videocontrols.picture-in-picture.respect-disablePictureInPicture` setting to ignore the request to disable PiP.

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -8,13 +8,10 @@ browser-compat: api.HTMLVideoElement.requestPictureInPicture
 
 {{APIRef("Picture-in-Picture API")}}
 
-The **{{domxref("HTMLVideoElement")}}** method
-**`requestPictureInPicture()`** issues an asynchronous request
-to display the video in picture-in-picture mode.
+The **`requestPictureInPicture()`** method of the **{{domxref("HTMLVideoElement")}}** interface issues an asynchronous request to display the video in picture-in-picture mode.
 
-It's not guaranteed that the video will be put into picture-in-picture. If permission
-to enter that mode is granted, the returned {{jsxref("Promise")}} will resolve and the
-video will receive an {{domxref("HTMLVideoElement.enterpictureinpicture_event", "enterpictureinpicture")}} event to let it know that it's now in picture-in-picture.
+It's not guaranteed that the video will be put into picture-in-picture.
+If permission to enter that mode is granted, the returned {{jsxref("Promise")}} will resolve and the video will receive an {{domxref("HTMLVideoElement.enterpictureinpicture_event", "enterpictureinpicture")}} event to let it know that it's now in picture-in-picture.
 
 ## Syntax
 
@@ -28,8 +25,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that will resolve to a {{domxref("PictureInPictureWindow")}}
-object that can be used to listen when a user will resize that floating window.
+A {{jsxref("Promise")}} that will resolve to a {{domxref("PictureInPictureWindow")}} object that can be used to listen when a user will resize that floating window.
 
 ### Exceptions
 
@@ -48,8 +44,7 @@ object that can be used to listen when a user will resize that floating window.
 
 ## Examples
 
-This example requests that the video enters Picture-in-Picture mode, and sets an event
-listener to handle the floating window resizing.
+This example requests that the video enters Picture-in-Picture mode, and sets an event listener to handle the floating window resizing.
 
 ```js
 function enterPictureInPicture() {

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLVideoElement.requestPictureInPicture
 
 {{APIRef("Picture-in-Picture API")}}
 
-The **`requestPictureInPicture()`** method of the **{{domxref("HTMLVideoElement")}}** interface issues an asynchronous request to display the video in picture-in-picture mode.
+The **`requestPictureInPicture()`** method of the {{domxref("HTMLVideoElement")}} interface issues an asynchronous request to display the video in picture-in-picture mode.
 
 It's not guaranteed that the video will be put into picture-in-picture.
 If permission to enter that mode is granted, the returned {{jsxref("Promise")}} will resolve and the video will receive an {{domxref("HTMLVideoElement.enterpictureinpicture_event", "enterpictureinpicture")}} event to let it know that it's now in picture-in-picture.

--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -18,7 +18,7 @@ This allows users to continue consuming media while they interact with other sit
 > [!NOTE]
 > The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) extends the Picture-in-Picture API to allow the always-on-top window to be populated with _any_ arbitrary HTML content, not just a video.
 
-## Concepts
+## Concepts and usage
 
 It is often helpful to play video in a separate window to the rest of your website, allowing you to continue to watch while keeping associated app content in view, or even to view some other website.
 You could achieve this by just opening a regular new browser window, but this has two major issues:
@@ -28,7 +28,7 @@ You could achieve this by just opening a regular new browser window, but this ha
 
 One way to solve these problems is to use [Picture-in-Picture API for `<video>`](/en-US/docs/Web/API/Picture-in-Picture_API), which manages most of the complexity of placing a single {{htmlelement("video")}} element into a separate window.
 
-### Adding Controls
+### Adding controls
 
 If media action handlers have been set via the [Media Session API](/en-US/docs/Web/API/Media_Session_API), then appropriate controls for those actions will be added by the browser to the picture-in-picture overlay. For example, if a `"nexttrack"` action has been set, then a skip button might be displayed in the picture-in-picture view. There is no support for adding custom HTML buttons or controls.
 

--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -7,15 +7,38 @@ browser-compat: api.PictureInPictureWindow
 
 {{DefaultAPISidebar("Picture-in-Picture API")}}
 
-The **Picture-in-Picture API** allow websites to create a floating, always-on-top video window. This allows users to continue consuming media while they interact with other sites or applications on their device.
-
-> [!NOTE]
-> The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) extends the Picture-in-Picture API to allow the always-on-top window to be populated with _any_ arbitrary HTML content, not just a video.
+The **Picture-in-Picture API** enables websites to create a floating, always-on-top video window.
+This allows users to continue consuming media while they interact with other sites or applications on their device.
 
 > [!NOTE]
 > You can run code when the always-on-top window is programmatically opened, using the {{domxref("HTMLVideoElement.enterpictureinpicture_event", "enterpictureinpicture")}} event. However, this event isn't fired when the browser itself (rather than your code) triggers moving content into the always-on-top window. This can occur, for example, due to the content being occluded, by the displayed tab being switched, or by the user selecting a "picture-in-picture" option from a video's context menu or the browser chrome.
 >
 > To run code in response to such actions, set up a media session action handler using {{domxref("MediaSession.setActionHandler()")}} with a `type` of `enterpictureinpicture`.
+
+> [!NOTE]
+> The [Document Picture-in-Picture API](/en-US/docs/Web/API/Document_Picture-in-Picture_API) extends the Picture-in-Picture API to allow the always-on-top window to be populated with _any_ arbitrary HTML content, not just a video.
+
+## Concepts
+
+It is often helpful to play video in a separate window to the rest of your website, allowing you to continue to watch while keeping associated app content in view, or even to view some other website.
+You could achieve this by just opening a regular new browser window, but this has two major issues:
+
+1. You have to handle sharing of state information between the two windows.
+2. The additional app window doesn't always stay on top, and can therefore get hidden by other windows.
+
+One way to solve these problems is to use [Picture-in-Picture API for `<video>`](/en-US/docs/Web/API/Picture-in-Picture_API), which manages most of the complexity of placing a single {{htmlelement("video")}} element into a separate window.
+
+### Adding Controls
+
+If media action handlers have been set via the [Media Session API](/en-US/docs/Web/API/Media_Session_API), then appropriate controls for those actions will be added by the browser to the picture-in-picture overlay. For example, if a `"nexttrack"` action has been set, then a skip button might be displayed in the picture-in-picture view. There is no support for adding custom HTML buttons or controls.
+
+### Controlling styling
+
+The {{cssxref(":picture-in-picture")}} [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) matches the video element currently in picture-in-picture mode, allowing you to configure your stylesheets to automatically adjust the size, style, or layout of content when a video switches back and forth between picture-in-picture and traditional presentation modes.
+
+### Security considerations
+
+The availability of picture-in-picture mode can be controlled using [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy). The picture-in-picture mode feature is identified by the string `"picture-in-picture"`, with a default allowlist value of `*`, meaning that picture-in-picture mode is permitted in top-level document contexts, as well as to nested browsing contexts loaded from the same origin as the top-most document.
 
 ## Interfaces
 
@@ -67,18 +90,6 @@ _The Picture-in-Picture API defines three events, which can be used to detect wh
   - : Sent to a {{DOMxRef("HTMLVideoElement")}} when it leaves picture-in-picture mode.
 - {{domxref("PictureInPictureWindow.resize_event", "resize")}}
   - : Sent to a {{DOMxRef("PictureInPictureWindow")}} when it changes size.
-
-## Adding Controls
-
-If media action handlers have been set via the [Media Session API](/en-US/docs/Web/API/Media_Session_API), then appropriate controls for those actions will be added by the browser to the picture-in-picture overlay. For example, if a `"nexttrack"` action has been set, then a skip button might be displayed in the picture-in-picture view. There is no support for adding custom HTML buttons or controls.
-
-## Controlling styling
-
-The {{cssxref(":picture-in-picture")}} [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) matches the video element currently in picture-in-picture mode, allowing you to configure your stylesheets to automatically adjust the size, style, or layout of content when a video switches back and forth between picture-in-picture and traditional presentation modes.
-
-## Controlling access
-
-The availability of picture-in-picture mode can be controlled using [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy). The picture-in-picture mode feature is identified by the string `"picture-in-picture"`, with a default allowlist value of `*`, meaning that picture-in-picture mode is permitted in top-level document contexts, as well as to nested browsing contexts loaded from the same origin as the top-most document.
 
 ## Examples
 

--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -26,7 +26,7 @@ You could achieve this by just opening a regular new browser window, but this ha
 1. You have to handle sharing of state information between the two windows.
 2. The additional app window doesn't always stay on top, and can therefore get hidden by other windows.
 
-One way to solve these problems is to use [Picture-in-Picture API for `<video>`](/en-US/docs/Web/API/Picture-in-Picture_API), which manages most of the complexity of placing a single {{htmlelement("video")}} element into a separate window.
+The Picture-in-Picture API for `<video>` solves these problems, managing most of the complexity of placing a single {{htmlelement("video")}} element into a separate always-on-top window.
 
 ### Adding controls
 

--- a/files/en-us/web/api/pictureinpicturewindow/height/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/height/index.md
@@ -8,7 +8,7 @@ browser-compat: api.PictureInPictureWindow.height
 
 {{APIRef("Picture-in-Picture API")}}
 
-The read-only **`height`** property of the {{domxref("PictureInPictureWindow")}} interface returns the height of the floating video window in pixels.
+The **`height`** read-only property of the {{domxref("PictureInPictureWindow")}} interface returns the height of the floating video window in pixels.
 
 ## Value
 

--- a/files/en-us/web/api/pictureinpicturewindow/width/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/width/index.md
@@ -8,7 +8,7 @@ browser-compat: api.PictureInPictureWindow.width
 
 {{APIRef("Picture-in-Picture API")}}
 
-The read-only **`width`** property of the {{domxref("PictureInPictureWindow")}} interface returns the width of the floating video window in pixels.
+The **`width`** read-only property of the {{domxref("PictureInPictureWindow")}} interface returns the width of the floating video window in pixels.
 
 ## Value
 


### PR DESCRIPTION
This makes a number of changes to the Picture in Picture API - primarily to fix up minor consistency issues with the web templates, and also to fix spurious line breaks.

Related docs work can be tracked in #44464