### PR TITLE
FF153 Relnote/Expr: Javascript text modules

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -459,21 +459,38 @@ This algorithm is similar to strict equality `===` (where `-0` and `+0` are cons
 - `javascript.options.experimental.iterator_includes`
   - : Set to `true` to enable.
 
+<<<<<<< HEAD
 ### Text module import
 
 The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) allows importing a module's source as a string value.
 The media type of the response is ignored, and the content is parsed as text even if the source contains scripts or other executable code.
 ([Firefox bug 2024854](https://bugzil.la/2024854)).
+=======
+### TC39 Intl.Locale info proposal
+
+The [TC39 Intl.Locale info proposal](https://github.com/tc39/proposal-intl-locale-info) is now supported.
+This includes all the instance methods on `Intl.Locale` that are prefixed with "get" — {{jsxref("Intl/Locale/getCalendars", "Intl.Locale.prototype.getCalendars()")}}, {{jsxref("Intl/Locale/getCollations", "Intl.Locale.prototype.getCollations()")}}, {{jsxref("Intl/Locale/getHourCycles", "Intl.Locale.prototype.getHourCycles()")}}, {{jsxref("Intl/Locale/getNumberingSystems", "Intl.Locale.prototype.getNumberingSystems()")}}, {{jsxref("Intl/Locale/getTextInfo", "Intl.Locale.prototype.getTextInfo()")}}, {{jsxref("Intl/Locale/getTimeZones", "Intl.Locale.prototype.getTimeZones()")}}, {{jsxref("Intl/Locale/getWeekInfo", "Intl.Locale.prototype.getWeekInfo()")}}.
+([Firefox bug 1693576](https://bugzil.la/1693576)).
+>>>>>>> 5dd593e85c (FF153 Relnote: Text modules)
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
 | Nightly           | 152           | No                  |
+<<<<<<< HEAD
 | Developer Edition | 152           | No                  |
 | Beta              | 152           | No                  |
 | Release           | 152           | No                  |
 
 - `javascript.options.experimental.import_text`
   - : Set to `true` to enable.
+=======
+| Developer Edition | —             | —                   |
+| Beta              | —             | —                   |
+| Release           | —             | —                   |
+
+- `javascript.options.experimental.intl_locale_info`
+  - : Set to `true` to enable on Nightly.
+>>>>>>> 5dd593e85c (FF153 Relnote: Text modules)
 
 ### Multiple import maps
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -459,38 +459,21 @@ This algorithm is similar to strict equality `===` (where `-0` and `+0` are cons
 - `javascript.options.experimental.iterator_includes`
   - : Set to `true` to enable.
 
-<<<<<<< HEAD
-### Text module import
-
-The `with` clause [`{ type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text) allows importing a module's source as a string value.
-The media type of the response is ignored, and the content is parsed as text even if the source contains scripts or other executable code.
-([Firefox bug 2024854](https://bugzil.la/2024854)).
-=======
 ### TC39 Intl.Locale info proposal
 
 The [TC39 Intl.Locale info proposal](https://github.com/tc39/proposal-intl-locale-info) is now supported.
 This includes all the instance methods on `Intl.Locale` that are prefixed with "get" — {{jsxref("Intl/Locale/getCalendars", "Intl.Locale.prototype.getCalendars()")}}, {{jsxref("Intl/Locale/getCollations", "Intl.Locale.prototype.getCollations()")}}, {{jsxref("Intl/Locale/getHourCycles", "Intl.Locale.prototype.getHourCycles()")}}, {{jsxref("Intl/Locale/getNumberingSystems", "Intl.Locale.prototype.getNumberingSystems()")}}, {{jsxref("Intl/Locale/getTextInfo", "Intl.Locale.prototype.getTextInfo()")}}, {{jsxref("Intl/Locale/getTimeZones", "Intl.Locale.prototype.getTimeZones()")}}, {{jsxref("Intl/Locale/getWeekInfo", "Intl.Locale.prototype.getWeekInfo()")}}.
 ([Firefox bug 1693576](https://bugzil.la/1693576)).
->>>>>>> 5dd593e85c (FF153 Relnote: Text modules)
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
 | Nightly           | 152           | No                  |
-<<<<<<< HEAD
-| Developer Edition | 152           | No                  |
-| Beta              | 152           | No                  |
-| Release           | 152           | No                  |
-
-- `javascript.options.experimental.import_text`
-  - : Set to `true` to enable.
-=======
 | Developer Edition | —             | —                   |
 | Beta              | —             | —                   |
 | Release           | —             | —                   |
 
 - `javascript.options.experimental.intl_locale_info`
   - : Set to `true` to enable on Nightly.
->>>>>>> 5dd593e85c (FF153 Relnote: Text modules)
 
 ### Multiple import maps
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -44,6 +44,9 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The {{jsxref("Error.stackTraceLimit")}} static data property is supported for setting or getting the maximum number of stack frames captured in an error stack trace.
   Setting the value smaller than the default can improve performance.
   ([Firefox bug 2037856](https://bugzil.la/2037856)).
+- Text modules can now be imported into a string using [`with { type: "text" }`](/en-US/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text).
+  Unlike for JavaScript or CSS modules, the media type of the response is ignored, and the content is parsed as text even if the file contains scripts or other executable code.
+  ([Firefox bug 2039881](https://bugzil.la/2039881)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
FF153 enables support for JavaScript text modules in https://bugzilla.mozilla.org/show_bug.cgi?id=2039881.
This adds the release note and removes the Experimental features entry.

Related docs work can be tracked in #44457