### PR TITLE
Clarify dispatchEvent synchronous handler wording

### DIFF
--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -19,10 +19,9 @@ should have already been created and initialized using an {{domxref("Event/Event
 > [!NOTE]
 > When calling this method, the {{domxref("Event.target")}} property is initialized to the current `EventTarget`.
 
-Unlike "native" events, which are fired by the browser and invoke event handlers
-asynchronously via the [event loop](/en-US/docs/Web/JavaScript/Reference/Execution_model),
-`dispatchEvent()` invokes event handlers _synchronously_. All applicable event
-handlers are called and return before `dispatchEvent()` returns.
+Unlike browser-fired events, `dispatchEvent()` invokes event handlers
+_synchronously_. All applicable event handlers are called and return before
+`dispatchEvent()` returns.
 
 ## Syntax
 


### PR DESCRIPTION
## Summary

- clarify that `dispatchEvent()` invokes handlers synchronously
- remove wording that could imply browser-fired handlers themselves run asynchronously

## Why

Issue #43519 points out that the existing sentence can be interpreted as if native event handler execution itself is asynchronous. This update narrows the wording to the important behavior on this page: `dispatchEvent()` calls applicable handlers synchronously and returns only after they complete.

## Testing

- not run, docs wording change only
