### PR TITLE
Finalize release notes for Firefox 152

### DIFF
--- a/files/en-us/mozilla/firefox/releases/151/index.md
+++ b/files/en-us/mozilla/firefox/releases/151/index.md
@@ -1,8 +1,8 @@
 ---
-title: Firefox 151 release notes for developers (Stable)
-short-title: Firefox 151 (Stable)
+title: Firefox 151 release notes for developers
+short-title: Firefox 151
 slug: Mozilla/Firefox/Releases/151
-page-type: firefox-release-notes-active
+page-type: firefox-release-notes
 sidebar: firefox
 ---
 

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -1,18 +1,13 @@
 ---
-title: Firefox 152 release notes for developers (Beta)
-short-title: Firefox 152 (Beta)
+title: Firefox 152 release notes for developers (Stable)
+short-title: Firefox 152 (Stable)
 slug: Mozilla/Firefox/Releases/152
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
 This article provides information about the changes in Firefox 152 that affect developers.
-Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [June 16, 2026](https://whattrainisitnow.com/release/?version=152).
-
-> [!NOTE]
-> The release notes for this Firefox version are still a work in progress.
-
-<!-- Authors: Please uncomment any headings you are writing notes for -->
+Firefox 152 was released on [June 16, 2026](https://whattrainisitnow.com/release/?version=152).
 
 ## Changes for web developers
 
@@ -22,15 +17,9 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
   This option can be found in the [Settings panel](https://firefox-source-docs.mozilla.org/devtools-user/settings/index.html#settings-inspector).
   ([Firefox bug 1455294](https://bugzil.la/1455294)).
 
-<!-- ### HTML -->
+### HTML
 
-<!-- No notable changes. -->
-
-<!-- #### Removals -->
-
-<!-- ### MathML -->
-
-<!-- #### Removals -->
+No notable changes.
 
 ### SVG
 
@@ -38,28 +27,14 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
   This reflects the corresponding [`side`](/en-US/docs/Web/SVG/Reference/Attribute/side) attribute on the [`<textPath>`](/en-US/docs/Web/SVG/Reference/Element/textPath) element.
   ([Firefox bug 2034371](https://bugzil.la/2034371)).
 
-<!-- #### Removals -->
-
 ### CSS
 
 - The {{cssxref("field-sizing")}} CSS property lets you control the sizing behavior of form control elements. This property has two values: `content` allows elements to adjust in size to fit their content, and `fixed` sets a fixed size on elements.
   ([Firefox bug 2036620](https://bugzil.la/2036620)).
 
-<!-- #### Removals -->
+### JavaScript
 
-<!-- ### JavaScript -->
-
-<!-- No notable changes. -->
-
-<!-- #### Removals -->
-
-<!-- ### HTTP -->
-
-<!-- #### Removals -->
-
-<!-- ### Security -->
-
-<!-- #### Removals -->
+No notable changes.
 
 ### APIs
 
@@ -87,12 +62,6 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The `receiveTime` property is now included in the metadata returned from [`RTCEncodedVideoFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/getMetadata#receivetime) and [`RTCEncodedAudioFrame.getMetadata()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/getMetadata#receivetime), and can be passed to the [`RTCEncodedVideoFrame()`](/en-US/docs/Web/API/RTCEncodedVideoFrame/RTCEncodedVideoFrame) and [`RTCEncodedAudioFrame()`](/en-US/docs/Web/API/RTCEncodedAudioFrame/RTCEncodedAudioFrame) constructors as a property in the `options` parameter.
   ([Firefox bug 2033420](https://bugzil.la/2033420)).
 
-<!-- #### Removals -->
-
-<!-- ### WebAssembly -->
-
-<!-- #### Removals -->
-
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### General
@@ -114,10 +83,6 @@ Firefox 152 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The ability of extensions to dynamically execute code in their `moz-extension:` documents with {{WebExtAPIRef("tabs.executeScript")}}, {{WebExtAPIRef("tabs.insertCSS")}}, {{WebExtAPIRef("tabs.removeCSS")}}, {{WebExtAPIRef("scripting.executeScript")}}, {{WebExtAPIRef("scripting.insertCSS")}}, and {{WebExtAPIRef("scripting.removeCSS")}} has been removed. This feature was deprecated in Firefox 149. ([Firefox bug 2015559](https://bugzil.la/2015559))
 
   As an alternative, an extension can run code in its documents dynamically by registering a {{WebExtAPIRef("runtime.onMessage")}} listener in the document's script, then sending a message to trigger execution of the required code.
-
-<!-- ### Removals -->
-
-<!-- ### Other -->
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -1,13 +1,13 @@
 ---
-title: Firefox 153 release notes for developers (Nightly)
-short-title: Firefox 153 (Nightly)
+title: Firefox 153 release notes for developers (Beta)
+short-title: Firefox 153 (Beta)
 slug: Mozilla/Firefox/Releases/153
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
 This article provides information about the changes in Firefox 153 that affect developers.
-Firefox 153 is the current [Nightly version of Firefox](https://www.firefox.com/en-US/channel/desktop/#nightly) and ships on [July 21, 2026](https://whattrainisitnow.com/release/?version=153).
+Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [July 21, 2026](https://whattrainisitnow.com/release/?version=153).
 
 > [!NOTE]
 > The release notes for this Firefox version are still a work in progress.

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -1,0 +1,83 @@
+---
+title: Firefox 154 release notes for developers (Nightly)
+short-title: Firefox 154 (Nightly)
+slug: Mozilla/Firefox/Releases/154
+page-type: firefox-release-notes-active
+sidebar: firefox
+---
+
+This article provides information about the changes in Firefox 154 that affect developers.
+Firefox 154 is the current [Nightly version of Firefox](https://www.firefox.com/en-US/channel/desktop/#nightly) and ships on [August 18, 2026](https://whattrainisitnow.com/release/?version=154).
+
+> [!NOTE]
+> The release notes for this Firefox version are still a work in progress.
+
+<!-- Authors: Please uncomment any headings you are writing notes for -->
+
+## Changes for web developers
+
+<!-- ### Developer Tools -->
+
+<!-- ### HTML -->
+
+<!-- No notable changes. -->
+
+<!-- #### Removals -->
+
+<!-- ### MathML -->
+
+<!-- #### Removals -->
+
+<!-- ### SVG -->
+
+<!-- #### Removals -->
+
+<!-- ### CSS -->
+
+<!-- #### Removals -->
+
+<!-- ### JavaScript -->
+
+<!-- No notable changes. -->
+
+<!-- #### Removals -->
+
+<!-- ### HTTP -->
+
+<!-- #### Removals -->
+
+<!-- ### Security -->
+
+<!-- #### Removals -->
+
+<!-- ### APIs -->
+
+<!-- #### DOM -->
+
+<!-- #### Media, WebRTC, and Web Audio -->
+
+<!-- #### Removals -->
+
+<!-- ### WebAssembly -->
+
+<!-- #### Removals -->
+
+<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+
+<!-- #### General -->
+
+<!-- #### WebDriver BiDi -->
+
+<!-- #### Marionette -->
+
+## Changes for add-on developers
+
+<!-- ### Removals -->
+
+<!-- ### Other -->
+
+## Experimental web features
+
+These features are shipping in Firefox 154 but are disabled by default.
+To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
+You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
### Description

Updates pages for Firefox 152 release (June 16, 2026).

- Removed active status from Firefox 151
- Updated Firefox 152 to (Stable)
- Updated Firefox 153 to (Beta)
- Created a new Nightly page for Firefox 154