### PR TITLE
Update live sample embed for `translate` transform attribute function

### DIFF
--- a/files/en-us/web/svg/reference/attribute/transform/index.md
+++ b/files/en-us/web/svg/reference/attribute/transform/index.md
@@ -237,7 +237,7 @@ svg {
 </svg>
 ```
 
-{{EmbedLiveSample('Example_3', '100%', 200)}}
+{{EmbedLiveSample('Translate', '100%', 200)}}
 
 ### Scale
 


### PR DESCRIPTION
### Description

The live sample embed for `translate` transform attribute function referenced a non existing id (i.e. `Example_3`); in consequence the live example from `Scale` was actually used instead.

### Motivation

Fix an error, provide readers correct example.