### PR TITLE
Fix grammar in checkVisibility() note

### DIFF
--- a/files/en-us/web/api/element/checkvisibility/index.md
+++ b/files/en-us/web/api/element/checkvisibility/index.md
@@ -18,7 +18,7 @@ The method returns `false` in either of the following situations:
 The optional parameter enables additional checks to test for other interpretations of what "visible" means.
 For example, you can further check whether an element has an opacity of `0`, if the value of the element {{cssxref("visibility")}} property makes it invisible, or if the element {{cssxref("content-visibility")}} property has a value of [`auto`](/en-US/docs/Web/CSS/Reference/Properties/content-visibility#auto) and its rendering is currently being skipped.
 
-Note that a a return value of `true` does not guarantee the element is visible to the user: just that it is may be.
+Note that a return value of `true` does not guarantee the element is visible to the user, just that it may be visible.
 Elements outside the viewport or occluded by other content may still return `true`.
 
 ## Syntax


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes a couple of grammatical issues in the Element.checkVisibility() note.

### Motivation

The current wording contains an editing mistake ("a a" and "it is may be"), which makes the note difficult to read. This change improves clarity and readability without altering the information being conveyed to readers.

### Related issues and pull requests

It got introduced in this PR: https://github.com/mdn/content/pull/44443/
