### PR TITLE
Editorial review: Update LNA affected list to include service workers

### DIFF
--- a/files/en-us/web/security/defenses/local_network_access/index.md
+++ b/files/en-us/web/security/defenses/local_network_access/index.md
@@ -36,13 +36,14 @@ Local network access defines three different **address spaces**, which all netwo
 
 Depending on which address space a request URL is categorised in, the browser will handle its permissions differently.
 
-## What request types are effected?
+## What request types are affected?
 
 Local network access restrictions apply to:
 
 - Subresource requests
 - {{domxref("Window.fetch", "fetch()")}} requests
 - Navigating subframes
+- [Service Workers](/en-US/docs/Web/API/Service_Worker_API), including requests made via {{domxref("WindowClient.navigate()")}} when the navigated {{domxref("WindowClient")}} is a subframe
 - [WebSockets](/en-US/docs/Web/API/WebSockets_API)
 - [WebTransport](/en-US/docs/Web/API/WebTransport_API)
 - [WebRTC](/en-US/docs/Web/API/WebRTC_API)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

From Chrome 147, local network requests made by Service Worker `WindowClient.navigate()`, `WebSocket`, and `WebTransport` are subject to control/restriction by the [Local Network Access](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Local_network_access) feature.

See:

- https://chromestatus.com/feature/5172375182245888
- https://chromestatus.com/feature/5197681148428288
- https://chromestatus.com/feature/5126430912544768

This PR updates the list of affected request types to include service workers. `WebSocket` and `WebTransport` were already in the list.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
