### PR TITLE
Document VTTRegion instance properties

### DIFF
--- a/files/en-us/web/api/vttregion/id/index.md
+++ b/files/en-us/web/api/vttregion/id/index.md
@@ -12,11 +12,11 @@ The **`id`** property of the {{domxref("VTTRegion")}} interface is a string that
 
 ## Value
 
-A string that identifies the region, or an empty string if none is set.
+A string that identifies the region. Initialized to an empty string when the `VTTRegion` object is first constructed.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `id` is set to `"region1"`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `id` is set to `"region1"`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();

--- a/files/en-us/web/api/vttregion/id/index.md
+++ b/files/en-us/web/api/vttregion/id/index.md
@@ -1,0 +1,33 @@
+---
+title: "VTTRegion: id property"
+short-title: id
+slug: Web/API/VTTRegion/id
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.id
+---
+
+{{APIRef("WebVTT")}}
+
+The **`id`** property of the {{domxref("VTTRegion")}} interface is a string that identifies the region.
+
+## Value
+
+A string that identifies the region, or an empty string if none is set.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `id` is set to `"region1"`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.id = "region1";
+console.log(region.id);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/index.md
+++ b/files/en-us/web/api/vttregion/index.md
@@ -12,34 +12,34 @@ The `VTTRegion` interface of the [WebVTT API](/en-US/docs/Web/API/WebVTT_API) de
 ## Constructor
 
 - {{domxref("VTTRegion.VTTRegion", "VTTRegion()")}}
-  - : Returns a newly created `VTTRegion` object.
+  - : Creates a new `VTTRegion` object instance.
 
 ## Instance properties
 
 - {{domxref("VTTRegion.id")}}
   - : A string that identifies the region.
 - {{domxref("VTTRegion.width")}}
-  - : Represents the width of the region, as a percentage of the video.
+  - : Represents the width of the region, as a percentage of the video's width.
 - {{domxref("VTTRegion.lines")}}
   - : Represents the height of the region, in number of lines.
 - {{domxref("VTTRegion.regionAnchorX")}}
-  - : Represents the region anchor X offset, as a percentage of the region.
+  - : Represents the region anchor X offset, as a percentage of the region's width.
 - {{domxref("VTTRegion.regionAnchorY")}}
-  - : Represents the region anchor Y offset, as a percentage of the region.
+  - : Represents the region anchor Y offset, as a percentage of the region's height.
 - {{domxref("VTTRegion.viewportAnchorX")}}
-  - : Represents the viewport anchor X offset, as a percentage of the video.
+  - : Represents the viewport anchor X offset, as a percentage of the video's width.
 - {{domxref("VTTRegion.viewportAnchorY")}}
-  - : Represents the viewport anchor Y offset, as a percentage of the video.
+  - : Represents the viewport anchor Y offset, as a percentage of the video's height.
 - {{domxref("VTTRegion.scroll")}}
-  - : An enum representing how adding a new cue will move existing cues.
+  - : An enumerated value indicating how existing cues in the region move when a new cue is added.
 
 ## Examples
 
 ```js
 const region = new VTTRegion();
-region.width = 50; // Use 50% of the video width
-region.lines = 4; // Use 4 lines of height.
-region.viewportAnchorX = 25; // Have the region start at 25% from the left.
+region.width = 50; // Set the region to 50% of the video's width
+region.lines = 4; // Render cues in 4 lines
+region.viewportAnchorX = 25; // Place the region 25% from the left edge of the video
 const cue = new VTTCue(2, 3, "Cool text to be displayed");
 cue.region = region; // This cue will be drawn only within this region.
 ```

--- a/files/en-us/web/api/vttregion/lines/index.md
+++ b/files/en-us/web/api/vttregion/lines/index.md
@@ -1,0 +1,33 @@
+---
+title: "VTTRegion: lines property"
+short-title: lines
+slug: Web/API/VTTRegion/lines
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.lines
+---
+
+{{APIRef("WebVTT")}}
+
+The **`lines`** property of the {{domxref("VTTRegion")}} interface represents the height of the region, in number of lines.
+
+## Value
+
+A number giving the number of lines of the region within which the text of the contained cues is rendered. The default is `3`.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `lines` is set to `4`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.lines = 4; // Use 4 lines of height.
+console.log(region.lines);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/lines/index.md
+++ b/files/en-us/web/api/vttregion/lines/index.md
@@ -12,15 +12,15 @@ The **`lines`** property of the {{domxref("VTTRegion")}} interface represents th
 
 ## Value
 
-A number giving the number of lines of the region within which the text of the contained cues is rendered. The default is `3`.
+A number representing the number of lines inside the region that cue text is rendered in. The default is `3`.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `lines` is set to `4`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `lines` is set to `4`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();
-region.lines = 4; // Use 4 lines of height.
+region.lines = 4; // Render cues in 4 lines
 console.log(region.lines);
 ```
 

--- a/files/en-us/web/api/vttregion/regionanchorx/index.md
+++ b/files/en-us/web/api/vttregion/regionanchorx/index.md
@@ -1,0 +1,33 @@
+---
+title: "VTTRegion: regionAnchorX property"
+short-title: regionAnchorX
+slug: Web/API/VTTRegion/regionAnchorX
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.regionAnchorX
+---
+
+{{APIRef("WebVTT")}}
+
+The **`regionAnchorX`** property of the {{domxref("VTTRegion")}} interface represents the x-coordinate of the region anchor, as a percentage of the region.
+
+## Value
+
+A number, in the range `0` to `100`, giving the x-coordinate of the region anchor as a percentage of the region. The default is `0`.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorX` is set to `30`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.regionAnchorX = 30;
+console.log(region.regionAnchorX);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/regionanchorx/index.md
+++ b/files/en-us/web/api/vttregion/regionanchorx/index.md
@@ -8,15 +8,15 @@ browser-compat: api.VTTRegion.regionAnchorX
 
 {{APIRef("WebVTT")}}
 
-The **`regionAnchorX`** property of the {{domxref("VTTRegion")}} interface represents the x-coordinate of the region anchor, as a percentage of the region.
+The **`regionAnchorX`** property of the {{domxref("VTTRegion")}} interface represents the x-coordinate of the region anchor, as a percentage of the region's width.
 
 ## Value
 
-A number, in the range `0` to `100`, giving the x-coordinate of the region anchor as a percentage of the region. The default is `0`.
+A number, in the range `0` to `100` inclusive, representing the x-coordinate of the region anchor as a percentage of the region's width. The default is `0`.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorX` is set to `30`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorX` is set to `30`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();

--- a/files/en-us/web/api/vttregion/regionanchorx/index.md
+++ b/files/en-us/web/api/vttregion/regionanchorx/index.md
@@ -14,6 +14,11 @@ The **`regionAnchorX`** property of the {{domxref("VTTRegion")}} interface repre
 
 A number, in the range `0` to `100` inclusive, representing the x-coordinate of the region anchor as a percentage of the region's width. The default is `0`.
 
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown when set to a value that is negative or greater than `100`.
+
 ## Examples
 
 In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorX` is set to `30`. The value is then printed to the console.

--- a/files/en-us/web/api/vttregion/regionanchory/index.md
+++ b/files/en-us/web/api/vttregion/regionanchory/index.md
@@ -8,15 +8,15 @@ browser-compat: api.VTTRegion.regionAnchorY
 
 {{APIRef("WebVTT")}}
 
-The **`regionAnchorY`** property of the {{domxref("VTTRegion")}} interface represents the y-coordinate of the region anchor, as a percentage of the region.
+The **`regionAnchorY`** property of the {{domxref("VTTRegion")}} interface represents the y-coordinate of the region anchor, as a percentage of the region's height.
 
 ## Value
 
-A number, in the range `0` to `100`, giving the y-coordinate of the region anchor as a percentage of the region. The default is `100`.
+A number, in the range `0` to `100` inclusive, representing the y-coordinate of the region anchor as a percentage of the region's height. The default is `100`.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorY` is set to `70`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorY` is set to `70`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();

--- a/files/en-us/web/api/vttregion/regionanchory/index.md
+++ b/files/en-us/web/api/vttregion/regionanchory/index.md
@@ -14,6 +14,11 @@ The **`regionAnchorY`** property of the {{domxref("VTTRegion")}} interface repre
 
 A number, in the range `0` to `100` inclusive, representing the y-coordinate of the region anchor as a percentage of the region's height. The default is `100`.
 
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown when set to a value that is negative or greater than `100`.
+
 ## Examples
 
 In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorY` is set to `70`. The value is then printed to the console.

--- a/files/en-us/web/api/vttregion/regionanchory/index.md
+++ b/files/en-us/web/api/vttregion/regionanchory/index.md
@@ -1,0 +1,33 @@
+---
+title: "VTTRegion: regionAnchorY property"
+short-title: regionAnchorY
+slug: Web/API/VTTRegion/regionAnchorY
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.regionAnchorY
+---
+
+{{APIRef("WebVTT")}}
+
+The **`regionAnchorY`** property of the {{domxref("VTTRegion")}} interface represents the y-coordinate of the region anchor, as a percentage of the region.
+
+## Value
+
+A number, in the range `0` to `100`, giving the y-coordinate of the region anchor as a percentage of the region. The default is `100`.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `regionAnchorY` is set to `70`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.regionAnchorY = 70;
+console.log(region.regionAnchorY);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/scroll/index.md
+++ b/files/en-us/web/api/vttregion/scroll/index.md
@@ -1,0 +1,38 @@
+---
+title: "VTTRegion: scroll property"
+short-title: scroll
+slug: Web/API/VTTRegion/scroll
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.scroll
+---
+
+{{APIRef("WebVTT")}}
+
+The **`scroll`** property of the {{domxref("VTTRegion")}} interface is an enumerated value representing how adding a new cue will move existing cues in the region.
+
+## Value
+
+A string. Possible values are:
+
+- `""` (the empty string)
+  - : The cues in the region are not to scroll, and are instead displayed simultaneously. This is the default.
+- `"up"`
+  - : The cues in the region are added at the bottom of the region and scroll any already-displayed cues upwards.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `scroll` is set to `"up"`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.scroll = "up";
+console.log(region.scroll);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/scroll/index.md
+++ b/files/en-us/web/api/vttregion/scroll/index.md
@@ -8,20 +8,20 @@ browser-compat: api.VTTRegion.scroll
 
 {{APIRef("WebVTT")}}
 
-The **`scroll`** property of the {{domxref("VTTRegion")}} interface is an enumerated value representing how adding a new cue will move existing cues in the region.
+The **`scroll`** property of the {{domxref("VTTRegion")}} interface is an enumerated value indicating how existing cues in the region move when a new cue is added.
 
 ## Value
 
 A string. Possible values are:
 
 - `""` (the empty string)
-  - : The cues in the region are not to scroll, and are instead displayed simultaneously. This is the default.
+  - : Existing cues in the region don't scroll; instead, they are displayed at the same time as new cues. This is the default.
 - `"up"`
-  - : The cues in the region are added at the bottom of the region and scroll any already-displayed cues upwards.
+  - : New cues are added at the bottom of the region, and existing cues scroll upwards to make space for them.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `scroll` is set to `"up"`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `scroll` is set to `"up"`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();

--- a/files/en-us/web/api/vttregion/viewportanchorx/index.md
+++ b/files/en-us/web/api/vttregion/viewportanchorx/index.md
@@ -8,19 +8,19 @@ browser-compat: api.VTTRegion.viewportAnchorX
 
 {{APIRef("WebVTT")}}
 
-The **`viewportAnchorX`** property of the {{domxref("VTTRegion")}} interface represents the x-coordinate of the viewport anchor, as a percentage of the video.
+The **`viewportAnchorX`** property of the {{domxref("VTTRegion")}} interface represents the x-coordinate of the viewport anchor, as a percentage of the video's width.
 
 ## Value
 
-A number, in the range `0` to `100`, giving the x-coordinate of the viewport anchor as a percentage of the video. The default is `0`.
+A number, in the range `0` to `100` inclusive, representing the x-coordinate of the viewport anchor as a percentage of the video's width. The default is `0`.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorX` is set to `25`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorX` is set to `25`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();
-region.viewportAnchorX = 25; // Have the region start at 25% from the left.
+region.viewportAnchorX = 25; // Place the region 25% from the left edge of the video
 console.log(region.viewportAnchorX);
 ```
 

--- a/files/en-us/web/api/vttregion/viewportanchorx/index.md
+++ b/files/en-us/web/api/vttregion/viewportanchorx/index.md
@@ -14,6 +14,11 @@ The **`viewportAnchorX`** property of the {{domxref("VTTRegion")}} interface rep
 
 A number, in the range `0` to `100` inclusive, representing the x-coordinate of the viewport anchor as a percentage of the video's width. The default is `0`.
 
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown when set to a value that is negative or greater than `100`.
+
 ## Examples
 
 In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorX` is set to `25`. The value is then printed to the console.

--- a/files/en-us/web/api/vttregion/viewportanchorx/index.md
+++ b/files/en-us/web/api/vttregion/viewportanchorx/index.md
@@ -1,0 +1,33 @@
+---
+title: "VTTRegion: viewportAnchorX property"
+short-title: viewportAnchorX
+slug: Web/API/VTTRegion/viewportAnchorX
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.viewportAnchorX
+---
+
+{{APIRef("WebVTT")}}
+
+The **`viewportAnchorX`** property of the {{domxref("VTTRegion")}} interface represents the x-coordinate of the viewport anchor, as a percentage of the video.
+
+## Value
+
+A number, in the range `0` to `100`, giving the x-coordinate of the viewport anchor as a percentage of the video. The default is `0`.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorX` is set to `25`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.viewportAnchorX = 25; // Have the region start at 25% from the left.
+console.log(region.viewportAnchorX);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/viewportanchory/index.md
+++ b/files/en-us/web/api/vttregion/viewportanchory/index.md
@@ -8,19 +8,19 @@ browser-compat: api.VTTRegion.viewportAnchorY
 
 {{APIRef("WebVTT")}}
 
-The **`viewportAnchorY`** property of the {{domxref("VTTRegion")}} interface represents the y-coordinate of the viewport anchor, as a percentage of the video.
+The **`viewportAnchorY`** property of the {{domxref("VTTRegion")}} interface represents the y-coordinate of the viewport anchor, as a percentage of the video's height.
 
 ## Value
 
-A number, in the range `0` to `100`, giving the y-coordinate of the viewport anchor as a percentage of the video. The default is `100`.
+A number, in the range `0` to `100` inclusive, representing the y-coordinate of the viewport anchor as a percentage of the video's height. The default is `100`.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorY` is set to `75`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorY` is set to `75`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();
-region.viewportAnchorY = 75;
+region.viewportAnchorY = 75; // Place the region 75% from the top edge of the video
 console.log(region.viewportAnchorY);
 ```
 

--- a/files/en-us/web/api/vttregion/viewportanchory/index.md
+++ b/files/en-us/web/api/vttregion/viewportanchory/index.md
@@ -14,6 +14,11 @@ The **`viewportAnchorY`** property of the {{domxref("VTTRegion")}} interface rep
 
 A number, in the range `0` to `100` inclusive, representing the y-coordinate of the viewport anchor as a percentage of the video's height. The default is `100`.
 
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown when set to a value that is negative or greater than `100`.
+
 ## Examples
 
 In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorY` is set to `75`. The value is then printed to the console.

--- a/files/en-us/web/api/vttregion/viewportanchory/index.md
+++ b/files/en-us/web/api/vttregion/viewportanchory/index.md
@@ -1,0 +1,33 @@
+---
+title: "VTTRegion: viewportAnchorY property"
+short-title: viewportAnchorY
+slug: Web/API/VTTRegion/viewportAnchorY
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.viewportAnchorY
+---
+
+{{APIRef("WebVTT")}}
+
+The **`viewportAnchorY`** property of the {{domxref("VTTRegion")}} interface represents the y-coordinate of the viewport anchor, as a percentage of the video.
+
+## Value
+
+A number, in the range `0` to `100`, giving the y-coordinate of the viewport anchor as a percentage of the video. The default is `100`.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `viewportAnchorY` is set to `75`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.viewportAnchorY = 75;
+console.log(region.viewportAnchorY);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/vttregion/index.md
+++ b/files/en-us/web/api/vttregion/vttregion/index.md
@@ -1,0 +1,41 @@
+---
+title: "VTTRegion: VTTRegion() constructor"
+short-title: VTTRegion()
+slug: Web/API/VTTRegion/VTTRegion
+page-type: web-api-constructor
+browser-compat: api.VTTRegion.VTTRegion
+---
+
+{{APIRef("WebVTT")}}
+
+The **`VTTRegion()`** constructor creates and returns a new {{domxref("VTTRegion")}} object.
+
+## Syntax
+
+```js-nolint
+new VTTRegion()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A new {{domxref("VTTRegion")}} object.
+
+## Examples
+
+```js
+const region = new VTTRegion();
+region.width = 50; // Use 50% of the video width
+region.lines = 4; // Use 4 lines of height.
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/vttregion/index.md
+++ b/files/en-us/web/api/vttregion/vttregion/index.md
@@ -8,7 +8,7 @@ browser-compat: api.VTTRegion.VTTRegion
 
 {{APIRef("WebVTT")}}
 
-The **`VTTRegion()`** constructor creates and returns a new {{domxref("VTTRegion")}} object.
+The **`VTTRegion()`** constructor creates a new {{domxref("VTTRegion")}} object instance.
 
 ## Syntax
 

--- a/files/en-us/web/api/vttregion/vttregion/index.md
+++ b/files/en-us/web/api/vttregion/vttregion/index.md
@@ -24,6 +24,17 @@ None.
 
 A new {{domxref("VTTRegion")}} object.
 
+The properties of the returned object are initialized to the following values:
+
+- {{domxref("VTTRegion.id", "id")}}: `""` (the empty string)
+- {{domxref("VTTRegion.width", "width")}}: `100`
+- {{domxref("VTTRegion.lines", "lines")}}: `3`
+- {{domxref("VTTRegion.regionAnchorX", "regionAnchorX")}}: `0`
+- {{domxref("VTTRegion.regionAnchorY", "regionAnchorY")}}: `100`
+- {{domxref("VTTRegion.viewportAnchorX", "viewportAnchorX")}}: `0`
+- {{domxref("VTTRegion.viewportAnchorY", "viewportAnchorY")}}: `100`
+- {{domxref("VTTRegion.scroll", "scroll")}}: `""` (the empty string)
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/vttregion/width/index.md
+++ b/files/en-us/web/api/vttregion/width/index.md
@@ -8,19 +8,19 @@ browser-compat: api.VTTRegion.width
 
 {{APIRef("WebVTT")}}
 
-The **`width`** property of the {{domxref("VTTRegion")}} interface represents the width of the region, as a percentage of the video.
+The **`width`** property of the {{domxref("VTTRegion")}} interface represents the width of the region, as a percentage of the video's width.
 
 ## Value
 
-A number, in the range `0` to `100`, giving the width of the region as a percentage of the video. The default is `100`.
+A number in the range `0` to `100` inclusive, representing the width of the region as a percentage of the video's width. The default is `100`.
 
 ## Examples
 
-In the following example a new {{domxref("VTTRegion")}} is created, then the value of `width` is set to `50`. The value is then printed to the console.
+In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `width` is set to `50`. The value is then printed to the console.
 
 ```js
 const region = new VTTRegion();
-region.width = 50; // Use 50% of the video width
+region.width = 50; // Set the region to 50% of the video's width
 console.log(region.width);
 ```
 

--- a/files/en-us/web/api/vttregion/width/index.md
+++ b/files/en-us/web/api/vttregion/width/index.md
@@ -1,0 +1,33 @@
+---
+title: "VTTRegion: width property"
+short-title: width
+slug: Web/API/VTTRegion/width
+page-type: web-api-instance-property
+browser-compat: api.VTTRegion.width
+---
+
+{{APIRef("WebVTT")}}
+
+The **`width`** property of the {{domxref("VTTRegion")}} interface represents the width of the region, as a percentage of the video.
+
+## Value
+
+A number, in the range `0` to `100`, giving the width of the region as a percentage of the video. The default is `100`.
+
+## Examples
+
+In the following example a new {{domxref("VTTRegion")}} is created, then the value of `width` is set to `50`. The value is then printed to the console.
+
+```js
+const region = new VTTRegion();
+region.width = 50; // Use 50% of the video width
+console.log(region.width);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/vttregion/width/index.md
+++ b/files/en-us/web/api/vttregion/width/index.md
@@ -14,6 +14,11 @@ The **`width`** property of the {{domxref("VTTRegion")}} interface represents th
 
 A number in the range `0` to `100` inclusive, representing the width of the region as a percentage of the video's width. The default is `100`.
 
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown when set to a value that is negative or greater than `100`.
+
 ## Examples
 
 In the following example, a new {{domxref("VTTRegion")}} is created, then the value of `width` is set to `50`. The value is then printed to the console.


### PR DESCRIPTION
## Description

**New pages**

-   `API/VTTRegion/VTTRegion`
-   `API/VTTRegion/id`
-   `API/VTTRegion/lines`
-   `API/VTTRegion/regionAnchorX`
-   `API/VTTRegion/regionAnchorY`
-   `API/VTTRegion/scroll`
-   `API/VTTRegion/viewportAnchorX`
-   `API/VTTRegion/viewportAnchorY`
-   `API/VTTRegion/width`

## Motivation

Document the `VTTRegion` constructor and properties, supported since Safari 7 and Firefox 59.

## Additional details

- [BCD: VTTRegion](https://github.com/mdn/browser-compat-data/blob/main/api/VTTRegion.json#L3)