### PR TITLE
Fix exhausted iterator example on Array.prototype.values()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/values/index.md
@@ -98,7 +98,7 @@ for (const letter of values) {
 for (const letter of values) {
   console.log(letter);
 }
-// undefined
+// No output
 ```
 
 If you use a [`break`](/en-US/docs/Web/JavaScript/Reference/Statements/break) statement to end the iteration early, the iterator can resume from the current position when continuing to iterate it.


### PR DESCRIPTION

### Description

Fixes the example output in the "Reusing the iterable" section of `Array.prototype.values()`.

The explanatory text already says that iterating an exhausted iterator has no effect, but the example implied that a second `for...of` loop logs `undefined`. In practice, the second loop produces no output.

### Motivation

This keeps the example consistent with the text above it and avoids suggesting that an exhausted iterator yields a final `undefined` value in a `for...of` loop.

### Additional details

This change only updates the example output comment. The code sample itself is unchanged.

### Related issues and pull requests

None

