### PR TITLE
FF152 Relnote/Expr: Crash reports

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -495,6 +495,22 @@ These give developers more flexibility when structuring and loading JavaScript m
 
 ## APIs
 
+### Crash Reporting
+
+Crash reports can now be sent through the [Reporting API](/en-US/docs/Web/API/Reporting_API) to the `default` endpoint.
+Note that Firefox does not support providing {{domxref("CrashReportContext")}} in the report body.
+([Firefox bug 2036160](https://bugzil.la/2036160)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 152           | Yes                 |
+| Developer Edition | 152           | No                  |
+| Beta              | 152           | No                  |
+| Release           | 152           | No                  |
+
+- `dom.reporting.crash.enabled`
+  - : Set to `true` to enable (enabled by default in Nightly).
+
 ### Scoped custom element registries
 
 Support for [scoped custom element registries](/en-US/docs/Web/API/Web_components/Using_custom_elements#scoped_custom_element_registries) is being implemented.

--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -121,3 +121,8 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **`<timeline-range-name>` values in `@keyframes` selectors**: `layout.css.scroll-driven-animations.enabled`
 
   The {{cssxref("@keyframes")}} at-rule now supports [`<timeline-range-name>`](/en-US/docs/Web/CSS/Reference/Values/timeline-range-name) values. These [values](/en-US/docs/Web/CSS/Guides/Scroll-driven_animations/Timeline_range_names#timeline_range_names) let you specify the segment within which a scroll-driven animation takes place. ([Firefox bug 1824875](https://bugzil.la/1824875)).
+
+- **Crash Reporting** (Nightly): `dom.reporting.crash.enabled`
+
+  Crash report can now be sent through the [Reporting API](/en-US/docs/Web/API/Reporting_API).
+  ([Firefox bug 2036160](https://bugzil.la/2036160)).


### PR DESCRIPTION
FF152 enables basic crash reports (but not the full Crash Reporting API which is still under discussion) in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=2036160.

This adds information to the experimental features page and release note.

Related docs work can be tracked in #44297