### PR TITLE
FF153 IDBIndex/IDBObjectStore.getAllRecords()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -53,7 +53,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 ### APIs
 
 - The {{domxref("IDBObjectStore.getAllRecords()")}} and {{domxref("IDBIndex.getAllRecords()")}} methods are now supported.
-  These retrieve all records (or some some specified subset of records) from an IDB object store and index, respectively.
+  These retrieve all records (or a specified subset of records) from an object store and index, respectively.
   ([Firefox bug 1927945](https://bugzil.la/1927945)).
 
 <!-- #### DOM -->

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -52,6 +52,10 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
+- The {{domxref("IDBObjectStore.getAllRecords()")}} and {{domxref("IDBIndex.getAllRecords()")}} methods are now supported.
+  These retrieve all records (or some some specified subset of records) from an IDB object store and index, respectively.
+  ([Firefox bug 1927945](https://bugzil.la/1927945)).
+
 <!-- #### DOM -->
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF153 supports [`IDBIndex.getAllRecords()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/getAllRecords) and [`IDBIndex.getAllRecords()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex/getAllRecords) in https://bugzilla.mozilla.org/show_bug.cgi?id=1927945

This adds a release note.
Note, the methods return an `IDBRequest`. On success an event is fired at that instance, and its `results` field is populated with an array of `IDBRecord` instances reflecting the retrieved records. I have NOT included info about support for `IDBRecord` here - though I did add a page for the interface. The reason being that this is effectively a dictionary, and at this level you just want to know you can get all records, not exactly the form that they have.

Related docs work can be tracked in #44449