### PR TITLE
Make MediaSource example self-contained

### DIFF
--- a/files/en-us/web/api/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/index.md
@@ -52,7 +52,7 @@ _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 ## Static methods
 
 - {{domxref("MediaSource.isTypeSupported_static", "MediaSource.isTypeSupported()")}}
-  - : Returns a boolean value indicating if the given MIME type is supported by the current user agent — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.
+  - : Returns a boolean value indicating whether the current user agent supports the given MIME type — this is, if it can successfully create {{domxref("SourceBuffer")}} objects for that MIME type.
 
 ## Events
 
@@ -61,13 +61,13 @@ _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 - {{domxref("MediaSource.sourceended_event", "sourceended")}}
   - : Fired when the `MediaSource` instance is still attached to a media element, but {{domxref("MediaSource.endOfStream", "endOfStream()")}} has been called.
 - {{domxref("MediaSource.sourceopen_event", "sourceopen")}}
-  - : Fired when the `MediaSource` instance has been opened by a media element and is ready for data to be appended to the {{domxref("SourceBuffer")}} objects in {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}}.
+  - : Fired when a media element has opened the `MediaSource` instance and it is ready for data to be appended to the {{domxref("SourceBuffer")}} objects in {{domxref("MediaSource.sourceBuffers", "sourceBuffers")}}.
 
 ## Examples
 
 ### Complete basic example
 
-The following simple example loads a video with {{domxref("XMLHttpRequest")}}, playing it as soon as it can. This example was written by Nick Desaulniers and can be [viewed live here](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html) (you can also [download the source](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html) for further investigation).
+The following basic example loads a video using {{domxref("XMLHttpRequest")}} and plays it as soon as it can. This example can be [viewed live here](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html) (you can also [download the source](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html) for further investigation).
 
 ```js
 const video = document.querySelector("video");
@@ -114,7 +114,7 @@ function fetchAB(url, cb) {
 
 ### Constructing a `MediaSource` in a dedicated worker and passing it to the main thread
 
-The {{domxref("MediaSource.handle", "handle")}} property can be accessed inside a dedicated worker and the resulting {{domxref("MediaSourceHandle")}} object is then transferred over to the thread that created the worker (in this case the main thread) via a {{domxref("DedicatedWorkerGlobalScope.postMessage()", "postMessage()")}} call:
+The {{domxref("MediaSource.handle", "handle")}} property can be accessed inside a dedicated worker, and the resulting {{domxref("MediaSourceHandle")}} object is then transferred over to the thread that created the worker (in this case, the main thread) via a {{domxref("DedicatedWorkerGlobalScope.postMessage()", "postMessage()")}} call:
 
 ```js
 // Inside dedicated worker

--- a/files/en-us/web/api/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/index.md
@@ -67,7 +67,7 @@ _Inherits methods from its parent interface, {{domxref("EventTarget")}}._
 
 ### Complete basic example
 
-The following simple example loads a video with {{domxref("XMLHttpRequest")}}, playing it as soon as it can. This example was written by Nick Desaulniers and can be [viewed live here](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html) (you can also [download the source](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html) for further investigation). The function `getMediaSource()`, which is not defined here, returns a `MediaSource`.
+The following simple example loads a video with {{domxref("XMLHttpRequest")}}, playing it as soon as it can. This example was written by Nick Desaulniers and can be [viewed live here](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html) (you can also [download the source](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html) for further investigation).
 
 ```js
 const video = document.querySelector("video");
@@ -79,7 +79,7 @@ const mimeCodec = 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"';
 let mediaSource;
 
 if ("MediaSource" in window && MediaSource.isTypeSupported(mimeCodec)) {
-  mediaSource = getMediaSource();
+  mediaSource = new MediaSource();
   console.log(mediaSource.readyState); // closed
   video.src = URL.createObjectURL(mediaSource);
   mediaSource.addEventListener("sourceopen", sourceOpen);


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR modifies the MediaSource example to use the MediaSource constructor directly, instead of relying on a `getMediaSource` function that is not defined anywhere on the page.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The existing example code might be confusing by not directly showing how a MediaSource can be created. It mentions that the used function is _not defined here_ and that it _returns a MediaSource_.

However, the original example by Nick Desaulniers in it's current revision does not use such a function either and creates a `new MediaSource` directly too.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
- [Original Example Code](https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html#L17)

<!-- ### Related issues and pull requests -->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
