### PR TITLE
Fix typo in Array.prototype.map() example comment

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -145,7 +145,7 @@ const filteredNumbers = numbers.map((num, index) => {
   }
 });
 
-// index goes from 0, so the filterNumbers are 1,2,3 and undefined.
+// index goes from 0, so the filteredNumbers are 1,2,3 and undefined.
 // filteredNumbers is [1, 2, 3, undefined]
 // numbers is still [1, 2, 3, 4]
 ```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Fixes a typo in a code comment in the `Array.prototype.map()` reference page.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation
The example under "Mapped array contains undefined" declares a variable named `filteredNumbers`, but the explanatory comment above it referred to it as `filterNumbers`. This fixes the inconsistency so the comment matches the actual variable name.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details
N/A
<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
