### PR TITLE
Mention anti-fingerprinting effects on getImageData()

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -61,6 +61,12 @@ canvas specified. The coordinates of the rectangle's top-left corner are
 `(sx, sy)`, while the coordinates of the bottom corner are
 `(sx + sw - 1, sy + sh - 1)`.
 
+> [!NOTE]
+> Browsers may alter the data returned by `getImageData()` to protect users from
+> fingerprinting. For example, Firefox can add subtle noise to canvas data when
+> fingerprinting protection is enabled, so code that compares exact pixel values
+> may observe differences from the rendered canvas.
+
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -62,7 +62,7 @@ canvas specified. The coordinates of the rectangle's top-left corner are
 `(sx + sw - 1, sy + sh - 1)`.
 
 > [!NOTE]
-> Browsers may alter the data returned by `getImageData()` to protect users from fingerprinting. For example, Firefox can add subtle noise to canvas data when fingerprinting protection is enabled, so code that compares exact pixel values may observe differences from the rendered canvas.
+> With certain privacy settings (such as fingerprinting protection), random subtle noise is introduced to the `getImageData()` result to prevent the website from inferring the user's rendering device. Therefore, `putImageData()` and `getImageData()` may not round-trip.
 
 ### Exceptions
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -62,10 +62,7 @@ canvas specified. The coordinates of the rectangle's top-left corner are
 `(sx + sw - 1, sy + sh - 1)`.
 
 > [!NOTE]
-> Browsers may alter the data returned by `getImageData()` to protect users from
-> fingerprinting. For example, Firefox can add subtle noise to canvas data when
-> fingerprinting protection is enabled, so code that compares exact pixel values
-> may observe differences from the rendered canvas.
+> Browsers may alter the data returned by `getImageData()` to protect users from fingerprinting. For example, Firefox can add subtle noise to canvas data when fingerprinting protection is enabled, so code that compares exact pixel values may observe differences from the rendered canvas.
 
 ### Exceptions
 


### PR DESCRIPTION
﻿## Summary

Adds a note to the `CanvasRenderingContext2D.getImageData()` return value section explaining that browser anti-fingerprinting protections can alter canvas pixel data returned to script.

This addresses the exact-pixel-comparison impact described in #39084 without presenting the behavior as a Canvas API specification guarantee.

## Validation

- `git diff --check`

Fixes #39084
