### PR TITLE
Document.evaluate(): document resultType default and mark optional parameters

### DIFF
--- a/files/en-us/web/api/document/evaluate/index.md
+++ b/files/en-us/web/api/document/evaluate/index.md
@@ -34,7 +34,7 @@ evaluate(xpathExpression, contextNode, namespaceResolver, resultType, result)
     The value `null` is common for HTML documents or when no namespace prefixes are used.
     If omitted, it defaults to `null`.
 - `resultType` {{optional_inline}}
-  - : An integer that corresponds to the type of result `XPathResult` to return.
+  - : An integer that corresponds to the type of `XPathResult` to return.
     If omitted, it defaults to `ANY_TYPE` (`0`).
     The following values are possible:
     - `ANY_TYPE` (`0`)

--- a/files/en-us/web/api/document/evaluate/index.md
+++ b/files/en-us/web/api/document/evaluate/index.md
@@ -26,14 +26,16 @@ evaluate(xpathExpression, contextNode, namespaceResolver, resultType, result)
 - `contextNode`
   - : The _context node_ for the query.
     It's common to pass `document` as the context node.
-- `namespaceResolver`
+- `namespaceResolver` {{optional_inline}}
   - : A function that will be passed any namespace prefixes
     and should return a string representing the namespace URI associated with that prefix.
     It will be used to resolve prefixes within the _xpath_ itself,
     so that they can be matched with the document.
     The value `null` is common for HTML documents or when no namespace prefixes are used.
-- `resultType`
+    If omitted, it defaults to `null`.
+- `resultType` {{optional_inline}}
   - : An integer that corresponds to the type of result `XPathResult` to return.
+    If omitted, it defaults to `ANY_TYPE` (`0`).
     The following values are possible:
     - `ANY_TYPE` (`0`)
       - : Whatever type naturally results from the given expression.
@@ -88,8 +90,8 @@ evaluate(xpathExpression, contextNode, namespaceResolver, resultType, result)
       - : A result set containing the first node in the document that matches the
         expression.
 
-- `result`
-  - : An existing `XPathResult` to use for the results. If set to `null` the method will create and return a new `XPathResult`.
+- `result` {{optional_inline}}
+  - : An existing `XPathResult` to use for the results. If set to `null` or omitted, the method will create and return a new `XPathResult`.
 
 ### Return value
 


### PR DESCRIPTION
Fixes #44495.

The `resultType` parameter of `Document.evaluate()` is optional, but the page neither marked it optional nor documented its default value, so readers calling `evaluate()` with three arguments had no way to know what result type they'd get.

Per the [WHATWG DOM Standard](https://dom.spec.whatwg.org/#dom-xpathevaluatorbase-evaluate), the WebIDL is:

```webidl
XPathResult evaluate(DOMString expression, Node contextNode,
    optional XPathNSResolver? resolver = null,
    optional unsigned short type = 0,
    optional XPathResult? result = null);
```

So the three trailing parameters are all optional, and `type` (documented here as `resultType`) defaults to `0`, which is [`XPathResult.ANY_TYPE`](/en-US/docs/Web/API/XPathResult#any_type).

Changes:

- `resultType` — added `{{optional_inline}}` and documented the default: "If omitted, it defaults to `ANY_TYPE` (`0`)." (the issue's specific request).
- `namespaceResolver` — added `{{optional_inline}}` and noted it defaults to `null`.
- `result` — added `{{optional_inline}}` and clarified that omitting it (not only passing `null`) creates a new `XPathResult`.

All three are optional in the spec, and a parameter can only be optional if every following one is too, so marking only `resultType` would have been inconsistent.
