### PR TITLE
Add example showing that uninitialized var doesn't override a same-name function

### DIFF
--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -150,6 +150,19 @@ function a() {}
 console.log(a); // 1
 ```
 
+A `var` declaration without an initializer does not overwrite the function's value.
+
+```js
+function foo() {
+  console.log(typeof a); // "function"
+  var a;
+  function a() {}
+  console.log(typeof a); // "function"
+}
+
+foo();
+```
+
 `var` declarations cannot be in the same scope as a {{jsxref("Statements/let", "let")}}, {{jsxref("Statements/const", "const")}}, {{jsxref("Statements/class", "class")}}, or {{jsxref("Statements/import", "import")}} declaration.
 
 ```js-nolint example-bad

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -146,8 +146,8 @@ console.log(a); // 2; not undefined
 
 ```js
 console.log(typeof a); // "function"
-var a;
 function a() {}
+var a;
 console.log(typeof a); // "function"
 ```
 

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -142,25 +142,19 @@ var a;
 console.log(a); // 2; not undefined
 ```
 
-`var` declarations can also be in the same scope as a `function` declaration. In this case, the `var` declaration's initializer always overrides the function's value, regardless of their relative position. This is because function declarations are hoisted before any initializer gets evaluated, so the initializer comes later and overrides the value.
+`var` declarations can also be in the same scope as a `function` declaration. Both the function declaration and the `var` declaration are hoisted to the top, so the function value is only accessible from the start of its scope until the variable's initializer or first assignment, regardless of the two declarations' relative positions in the source code.
+
+```js
+console.log(typeof a); // "function"
+var a;
+function a() {}
+console.log(typeof a); // "function"
+```
 
 ```js
 var a = 1;
 function a() {}
 console.log(a); // 1
-```
-
-A `var` declaration without an initializer does not overwrite the function's value.
-
-```js
-function foo() {
-  console.log(typeof a); // "function"
-  var a;
-  function a() {}
-  console.log(typeof a); // "function"
-}
-
-foo();
 ```
 
 `var` declarations cannot be in the same scope as a {{jsxref("Statements/let", "let")}}, {{jsxref("Statements/const", "const")}}, {{jsxref("Statements/class", "class")}}, or {{jsxref("Statements/import", "import")}} declaration.


### PR DESCRIPTION

### Description

Adds a clarifying example to the `var` redeclarations section showing that a `var` declaration without an initializer does not overwrite the value of a same-name function declaration.

### Motivation

The page already explains that duplicate `var` declarations without initializers do not overwrite an existing value, and that a `var` initializer overrides a same-name function declaration. This example directly shows the related case of a `var` declaration without an initializer alongside a same-name function declaration, making that behavior clearer for readers.

### Additional details

None

### Related issues and pull requests

None
