### PR TITLE
Fix typo in webassembly/reference/value_types/i64

### DIFF
--- a/files/en-us/webassembly/reference/value_types/i64/index.md
+++ b/files/en-us/webassembly/reference/value_types/i64/index.md
@@ -32,7 +32,7 @@ The **`i64`** value type holds a 64-bit integer.
 
 `i64` is _transparent_: its bit pattern is observable, and `i64` values may be stored in [linear memory](/en-US/docs/WebAssembly/Reference/Memory).
 
-### `i64` intergration with JavaScript BigInt
+### `i64` integration with JavaScript BigInt
 
 JavaScript's `Number` type cannot losslessly represent the full `i64` range, therefore `i64` values are converted to [`BigInt`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) values (and vice versa) when they cross the JavaScript boundary; for example, when exporting or importing functions involving `i64` parameters or return values.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The correct word is `integration`. Earlier it was `intergration`.