### PR TITLE
FF153 Relnote: Error.stackTraceLimit

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -38,7 +38,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### JavaScript
 
-- The {{jsxref("Error.stackTraceLimit")}} static data property is now supported for setting or getting the maximum size of the captured error stack.
+- The {{jsxref("Error.stackTraceLimit")}} static data property is supported for setting or getting the maximum number of stack frames captured in an error stack trace.
   Setting the value smaller than the default can improve performance.
   ([Firefox bug 2037856](https://bugzil.la/2037856)).
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -39,10 +39,9 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 ### JavaScript
 
 - The {{jsxref("Error.stackTraceLimit")}} static data property is now supported for setting or getting the maximum size of the captured error stack.
-  Setting the value smaller than the default (128) can improve performance.
-  ([Firefox 2037856](https://bugzil.la/2037856)).
+  Setting the value smaller than the default can improve performance.
+  ([Firefox bug 2037856](https://bugzil.la/2037856)).
 
-<!-- No notable changes. -->
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -36,7 +36,11 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### JavaScript -->
+### JavaScript
+
+- The {{jsxref("Error.stackTraceLimit")}} static data property is now supported for setting or getting the maximum size of the captured error stack.
+  Setting the value smaller than the default (128) can improve performance.
+  ([Firefox 2037856](https://bugzil.la/2037856)).
 
 <!-- No notable changes. -->
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -42,7 +42,6 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
   Setting the value smaller than the default can improve performance.
   ([Firefox bug 2037856](https://bugzil.la/2037856)).
 
-
 <!-- #### Removals -->
 
 <!-- ### HTTP -->


### PR DESCRIPTION
FF152 supports [`Error.stackTraceLimit`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stackTraceLimit) in https://bugzilla.mozilla.org/show_bug.cgi?id=2037856

This just adds a release note.

Related docs work can be tracked in #44458