### PR TITLE
chore(sidebar): update and renew french titles on sidebars

### DIFF
--- a/files/sidebars/accessibilitysidebar.yaml
+++ b/files/sidebars/accessibilitysidebar.yaml
@@ -50,6 +50,11 @@ l10n:
   en-US:
     ARIA: ARIA
     ARIA_guides: ARIA guides
+  fr:
+    ARIA: ARIA
+    ARIA_guides: Guides ARIA
+    ARIA reference: Références ARIA
+    Understanding WCAG: Comprendre les WCAG
   ja:
     ARIA: ARIA
     ARIA_guides: ARIA ガイド

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -450,29 +450,60 @@ l10n:
     Transitions: Transitions
     Tools: Tools
   fr:
+    Accessibility_Understanding_colors_and_luminance: "Accessibilité : Couleurs et luminance"
+    At-rules: Règles @
     Guides: Guides
+    Anchor_positioning: Positionnement par ancre
     Animations: Animations
     Backgrounds_and_Borders: Arrière-plans et bordures
     Box_model: Modèle de boîte
+    Cascade: Cascade
+    Colors: Couleurs
+    Color_contrast: "Accessibilité : Contraste de la couleur"
     Columns: Colonnes
+    Combinators: Combinateurs
     Conditional_rules: Règles conditionnelles
+    Containment: Compartimentation
+    Coordinate_systems: Systèmes de coordonnées (API)
+    Contribute a recipe: Contribuer à une recette
     Counters: Compteurs
     CSSOM_view: Vue CSSOM
+    Custom_functions_and_mixins: Fonctions et composantes personnalisées
+    Display: Mise en page
+    Environment_variables: Variables d'environnement
+    Filter_effects: Effets de filtre
     Flexbox: Boîtes flexibles
-    Display: Mis en page
     Fonts: Polices
+    Functions: Fonctions
     Grid: Grille
     Images: Images
+    Layout cookbook: Recettes de mise en page
     Lists: Listes
     Logical_properties: Propriétés logiques
+    Masking: Masquage
     Media_queries: Requêtes média
+    Nesting: Imbrication
+    Overflow: Débordement
     Positioning: Positionnement
-    Scroll_snap: Ancrage du défilement
+    Properties: Propriétés
+    Properties and Values API: API des propriétés et des valeurs
+    Pseudo-classes: Pseudo-classes
+    Pseudo-elements: Pseudo-éléments
+    Selectors: Sélecteurs
+    Scroll_anchoring: Ancrage de défilement
+    Scroll-driven_animations: Animations pilotées par le défilement
+    Scroll_snap: Accrochage du défilement
     Shapes: Formes
+    Syntax: Syntaxe
     Text: Texte
+    Text decoration: Décoration de texte
     Transforms: Transformations
     Transitions: Transitions
     Tools: Outils
+    Types: Types
+    Values: Valeurs
+    Values and units: Valeurs et unités
+    Writing modes: Modes d'écriture
   ja:
     Accessibility_Understanding_colors_and_luminance: "アクセシビリティ: 色と輝度"
     At-rules: アットルール

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -468,7 +468,7 @@ l10n:
     Contribute a recipe: Contribuer à une recette
     Counters: Compteurs
     CSSOM_view: Vue CSSOM
-    Custom_functions_and_mixins: Fonctions et composantes personnalisées
+    Custom_functions_and_mixins: Fonctions et mixins personnalisées
     Display: Mise en page
     Environment_variables: Variables d'environnement
     Filter_effects: Effets de filtre

--- a/files/sidebars/firefox.yaml
+++ b/files/sidebars/firefox.yaml
@@ -41,9 +41,10 @@ l10n:
     Firefox_documentation: Documentación de Firefox
   fr:
     Add-ons: Modules complémentaires
-    Browser_extensions: WebExtensions
+    Browser_extensions: Extensions de navigateur
     Themes: Thèmes
     Firefox_documentation: Documentation de Firefox
+    Release notes archive: Archive des notes de version
   ja:
     Add-ons: アドオン
     Browser_extensions: ブラウザー拡張機能

--- a/files/sidebars/glossarysidebar.yaml
+++ b/files/sidebars/glossarysidebar.yaml
@@ -8,3 +8,6 @@ sidebar:
     path: /Glossary
     depth: 2
     nested: true
+l10n:
+  fr:
+    Glossary: Glossaire

--- a/files/sidebars/htmlsidebar.yaml
+++ b/files/sidebars/htmlsidebar.yaml
@@ -92,7 +92,11 @@ l10n:
     HTML_Elements: Éléments
     Global_attributes: Attributs universels
     Attributes: Attributs
+    Attributes_element: Attributs par élément
+    Attribute_values: Valeurs des attributs
     Input_types: Types <code>&lt;input&gt;</code>
+    Script_types: Types <code>&lt;script&gt;</code>
+    Rel_keywords: Mots-clés <code>&lt;link rel&gt;</code>
     Guides: Guides
   ja:
     Reference: リファレンス

--- a/files/sidebars/http.yaml
+++ b/files/sidebars/http.yaml
@@ -111,7 +111,7 @@ l10n:
     PermissionsPolicyDirectives: Permissions-Policy directives
   fr:
     Guides: Guides
-    Security: Sécurité HTTP
+    Security: Sécurité et confidentialité
     Reference: Références
     Headers: En-têtes HTTP
     Methods: Méthodes de requête HTTP

--- a/files/sidebars/jssidebar.yaml
+++ b/files/sidebars/jssidebar.yaml
@@ -280,7 +280,7 @@ l10n:
     Deprecated_features: Устаревшие возможности
   fr:
     Technology_overview: Aperçu des technologies JavaScript
-    Tutorials: Tutoriels
+    Tutorials: Tutoriels et guides
     Guide: Guide JavaScript
     Guide_Introduction: Introduction
     Guide_Grammar: Types et grammaire
@@ -288,22 +288,22 @@ l10n:
     Guide_Loops: Boucles et itération
     Guide_Functions: Fonctions
     Guide_Expressions: Expressions et opérateurs
-    Guide_Numbers: Numbers and strings
-    Guide_Dates: Representing dates & times
+    Guide_Numbers: Nombres et chaînes de caractères
+    Guide_Dates: Représentation des dates et heures
     Guide_RegExp: Expressions rationnelles
     Guide_Indexed_collections: Collections indexées
     Guide_keyed_collections: Collections avec clés
     Guide_Objects: Manipuler les objets
-    Guide_Classes: Using classes
+    Guide_Classes: Utiliser les classes
     Guide_Promises: Utiliser les promesses
     Guide_Typed_arrays: Tableaux typés en JavaScript
     Guide_Iterators_generators: Itérateurs et générateurs
-    Guide_Resource_management: Resource management
-    Guide_Internationalization: Internationalization
+    Guide_Resource_management: Gestion des ressources
+    Guide_Internationalization: Internationalisation
     Guide_Meta: Métaprogrammation
     Guide_Modules: Modules JavaScript
     Intermediate: Intermédiaire
-    Language_overview: Language overview
+    Language_overview: Aperçu du langage
     Data_structures: Structures de données en JavaScript
     Equality: Différents tests d'égalité
     Closures: Fermetures (closures)
@@ -319,9 +319,9 @@ l10n:
     Classes: Classes
     Errors: Erreurs
     More: Divers
-    Execution_model: Execution model
+    Execution_model: Modèle d'exécution
     Lexical_grammar: Grammaire lexicale
-    Enumerability: Rattachement des propriétés
+    Enumerability: Énumérabilité et rattachement des propriétés
     Iteration_protocols: Protocoles d'itération
     Template_strings: Gabarits de chaînes de caractères
     Trailing_commas: Virgules finales

--- a/files/sidebars/learnsidebar.yaml
+++ b/files/sidebars/learnsidebar.yaml
@@ -488,12 +488,37 @@ l10n:
     Django_web_framework_(Python): Django 網站框架 (Python)
     Further_resources: 更多資源
   fr:
+    Advanced JavaScript objects: Objets JavaScript avancés
+    Getting_started_modules: Modules pour bien démarrer
+    Environment_setup: Configuration de l'environnement
+    Your_first_website: Votre premier site web
+    Web_standards: Normes Web
+    Soft_skills: Compétences générales
+    Core_modules: Modules fondamentaux
+    Structuring_content_with_HTML: Structurer le contenu avec HTML
+    CSS_styling_basics: Bases de la mise en forme CSS
+    CSS_text_styling: Mise en forme du texte en CSS
     CSS_layout: Disposition en CSS
-    Asynchronous_JavaScript: JavaScript asynchrone
+    Dynamic_scripting_with_JavaScript: Script dynamique avec JavaScript
+    JavaScript_frameworks_and_libraries: Cadriciels et bibliothèques JavaScript
+    Accessibility: Accessibilité
+    Design_for_developers: Conception pour les développeur·euse·s
+    Version_control: Contrôle de version
+    Extension_modules: Modules étendus
     Client-side_web_APIs: Les API web côté client
-    Web_forms: Formulaires web — Travailler avec les données des utilisateur·rice·s
+    Asynchronous_JavaScript: JavaScript asynchrone
+    Web_forms: Formulaires web
+    Understanding_client-side_tools: Comprendre les outils côté client
     Django_web_framework_(Python): Django (Python)
+    Express_web_framework_(Node.js): Express (Node.js)
+    Web_performance: Performance Web
+    Testing: Tests
     Further_resources: Ressources complémentaires
+    How_to_solve_common_problems: Comment résoudre les problèmes courants
+    About: À propos
+    Resources_for_educators: Ressources pour les éducateur·ice·s
+    Changelog: Journal des modifications
+    Additional_tutorials: Tutoriels supplémentaires
   ja:
     Getting_started_modules: 入門モジュール
     Environment_setup: 環境設定

--- a/files/sidebars/mathmlref.yaml
+++ b/files/sidebars/mathmlref.yaml
@@ -59,7 +59,10 @@ l10n:
   fr:
     Reference: Références
     Elements: Éléments
+    Global attributes: Attributs universels
     Guides: Guides
+    Examples: Exemples
+    Beginners: Pour débutants
   ja:
     Reference: リファレンス
     Elements: 要素

--- a/files/sidebars/mdnsidebar.yaml
+++ b/files/sidebars/mdnsidebar.yaml
@@ -65,9 +65,9 @@ l10n:
     how_to_guides: How-to guides
     page_structures: Page structures
   fr:
-    community_resources: Ressources de la communauté
-    writing_guide: Règles de rédaction
-    learning_guidelines: Règles pour les contenus d'apprentissage
+    community_resources: Ressources communautaires
+    writing_guide: Directives de rédaction
+    learning_guidelines: Directives pour les contenus d'apprentissage
     how_to_guides: Guides pratiques
     page_structures: Structures de page
   ja:

--- a/files/sidebars/mdnsidebar.yaml
+++ b/files/sidebars/mdnsidebar.yaml
@@ -65,11 +65,11 @@ l10n:
     how_to_guides: How-to guides
     page_structures: Page structures
   fr:
-    community_resources: Règles de la communauté
-    writing_guide: Writing guidelines
-    learning_guidelines: Learning content guidelines
-    how_to_guides: How-to guides
-    page_structures: Page structures
+    community_resources: Ressources de la communauté
+    writing_guide: Règles de rédaction
+    learning_guidelines: Règles pour les contenus d'apprentissage
+    how_to_guides: Guides pratiques
+    page_structures: Structures de page
   ja:
     community_resources: コミュニティリソース
     writing_guide: 執筆ガイドライン

--- a/files/sidebars/mediasidebar.yaml
+++ b/files/sidebars/mediasidebar.yaml
@@ -27,3 +27,8 @@ sidebar:
     link: /Web/Media/Guides/Formats
     title: Media formats
     details: closed
+l10n:
+  fr:
+    Audio and video delivery: Diffusion audio et vidéo
+    Media: Médias
+    Media formats: Formats de médias

--- a/files/sidebars/performancesidebar.yaml
+++ b/files/sidebars/performancesidebar.yaml
@@ -44,6 +44,12 @@ l10n:
     Reference: Reference
     PerformanceAPIs: Performance APIs
     RelatedAPIs: Related_APIs
+  fr:
+    Tutorials: Tutoriels
+    Learn_web_performance: Apprendre les performances web
+    Reference: Références
+    PerformanceAPIs: API de performance
+    RelatedAPIs: API associées
   ja:
     Tutorials: チュートリアル
     Learn_web_performance: ウェブパフォーマンスの学習

--- a/files/sidebars/privacy.yaml
+++ b/files/sidebars/privacy.yaml
@@ -21,3 +21,6 @@ sidebar:
     link: /Web/Privacy/Guides/Storage_Access_Policy
     details: closed
   - link: /Web/Privacy/Guides/Third-party_cookies
+l10n:
+  fr:
+    Privacy: Confidentialité

--- a/files/sidebars/security.yaml
+++ b/files/sidebars/security.yaml
@@ -27,3 +27,8 @@ sidebar:
     link: /Web/Security/Threat_modeling
     title: Threat modeling
     details: closed
+l10n:
+  fr:
+    Guides: Guides
+    Practical implementation guides: Guides pratiques de mise en œuvre
+    Threat modeling: Modélisation des menaces

--- a/files/sidebars/svgref.yaml
+++ b/files/sidebars/svgref.yaml
@@ -68,6 +68,7 @@ l10n:
     Elements: Éléments
     Attributes: Attributs
     Guides: Guides
+    Introducing SVG from scratch: Introduction à SVG de zéro
   ja:
     Tutorials: チュートリアル
     Reference: リファレンス

--- a/files/sidebars/urlsidebar.yaml
+++ b/files/sidebars/urlsidebar.yaml
@@ -22,3 +22,7 @@ sidebar:
     path: /Web/URI/Reference/Fragment
     link: /Web/URI/Reference/Fragment
     details: open
+l10n:
+  fr:
+    URIs: URIs
+    Reference: Références

--- a/files/sidebars/web.yaml
+++ b/files/sidebars/web.yaml
@@ -5,3 +5,6 @@ sidebar:
     title: Web documentation
   - type: listSubPages
     path: /Web
+l10n:
+  fr:
+    Web documentation: Documentation Web

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -263,7 +263,7 @@ l10n:
     Memory: Mémoire
     Numeric: Numérique
     Arithmetic: Arithmétique
-    Bitwise: Opérations binaires
+    Bitwise: Binaire
     Extract: Extraction
     Load and store: Chargement et stockage
     Table: Tableau

--- a/files/sidebars/webassemblysidebar.yaml
+++ b/files/sidebars/webassemblysidebar.yaml
@@ -252,15 +252,32 @@ l10n:
     JavaScript_interface: JavaScript interface
   fr:
     WebAssembly_concepts: Concepts WebAssembly
+    Compiling_WebAssembly: Compiler WebAssembly
+    Language_guide: Le langage WebAssembly
+    API_guide: Guide de l'API JavaScript
+    Reference: Références
+    Value_types: Types de valeurs
+    Definitions: Définitions
+    Control flow: Contrôle de flux
+    Exception handling: Gérer les exceptions
+    Memory: Mémoire
+    Numeric: Numérique
+    Arithmetic: Arithmétique
+    Bitwise: Opérations binaires
+    Extract: Extraction
+    Load and store: Chargement et stockage
+    Table: Tableau
     Compiling_to_Wasm: Compiler du C/C++ en WebAssembly
-    Existing_C_to_Wasm: Compiling an existing C module to WebAssembly
+    Existing_C_to_Wasm: Compiler un module C existant en WebAssembly
     Compiling_Rust_to_Wasm: Compiler du Rust en WebAssembly
     JavaScript_API: Utiliser l'API JavaScript WebAssembly
     Text_format: Comprendre le format texte WebAssembly
-    Text_format_to_Wasm: Converting WebAssembly text format
+    Text_format_to_Wasm: Convertir le format texte WebAssembly en binaire
     Loading_and_running: Chargement et exécution de code WebAssembly
     Exported_functions: Fonctions WebAssembly exportées
-    JavaScript_interface: JavaScript interface
+    JavaScript_builtins: JavaScript intégrés
+    Imported_string_constants: Constantes de chaînes de caractères globales importées
+    JavaScript_interface: Interface JavaScript
   ko:
     WebAssembly_concepts: 웹어셈블리의 개념
     Compiling_to_Wasm: C/C++ 모듈을 웹어셈블리로 컴파일하기

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -139,3 +139,8 @@ sidebar:
     link: /Web/WebDriver/Reference/Errors
     details: closed
     code: true
+l10n:
+  fr:
+    Commands: Commandes
+    Events: Évènements
+    Shared: Partagé

--- a/files/sidebars/xmlsidebar.yaml
+++ b/files/sidebars/xmlsidebar.yaml
@@ -80,3 +80,11 @@ sidebar:
         link: /Web/XML/EXSLT/Reference/str
         details: closed
         code: true
+l10n:
+  fr:
+    EXSLT: EXSLT
+    Reference: Références
+    XML: XML
+    XML Guides: Guides XML
+    XPath: XPath
+    XSLT: XSLT


### PR DESCRIPTION
### Description

Update the French lines that are no longer aligned with the current English lines. Revise the existing translations. Translate any missing lines or categories that have not yet been translated.

20 files affected.

### Motivation

Make final adjustments to the French interfaces to reflect the various translations already completed and the progress made on major French-language projects: HTML, CSS, JavaScript, HTTP, URI, MDN, Accessibility, and Learn. And ongoing and upcoming projects: SVG, Privacy, Security, Media, and APIs.

### Additional details

All lines were tested in a local Fred environment containing both the English repository and the translated-only repository.

### Related issues and pull requests

In continuation of: https://github.com/mdn/content/pull/41367 https://github.com/mdn/fred/pull/767 https://github.com/mdn/fred/pull/1373