### PR TITLE
Update HTML Sanitizer spec links

### DIFF
--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -89,7 +89,7 @@ const serializedHTML = div.innerHTML; // Serialized as a plain string
 other_div.setHTML(serializedHTML); // Safe — re-sanitized by setHTML()
 ```
 
-There is a class of attacks that take advantage of this flaw, referred to as [mutated XSS](https://wicg.github.io/sanitizer-api/#mutated-xss).
+There is a class of attacks that take advantage of this flaw, referred to as [mutated XSS](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#html-sanitization).
 The simple rule to avoid this problem is to only ever inject HTML strings using safe methods such as `setHTML()`.
 
 ## Examples

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -89,7 +89,7 @@ const serializedHTML = div.innerHTML; // Serialized as a plain string
 other_div.setHTML(serializedHTML); // Safe — re-sanitized by setHTML()
 ```
 
-There is a class of attacks that take advantage of this flaw, referred to as [mutated XSS](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#html-sanitization).
+There is a class of attacks that take advantage of this flaw, referred to as [mutation XSS](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#sanitizer-security-mxss).
 The simple rule to avoid this problem is to only ever inject HTML strings using safe methods such as `setHTML()`.
 
 ## Examples

--- a/files/en-us/web/api/sanitizerconfig/index.md
+++ b/files/en-us/web/api/sanitizerconfig/index.md
@@ -127,7 +127,7 @@ The empty object `{}` is a valid configuration.
 
 > [!NOTE]
 > The conditions above are from the perspective of a web developer.
-> The [validity check defined in the specification](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#safe-and-unsafe) is slightly different because it is executed after canonicalization of the configuration, such as adding `removeElements` when both are missing, and adding default namespaces.
+> The [validity check defined in the specification](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-sanitizerconfig-valid) is slightly different because it is executed after canonicalization of the configuration, such as adding `removeElements` when both are missing, and adding default namespaces.
 
 ### Allow and remove configurations
 

--- a/files/en-us/web/api/sanitizerconfig/index.md
+++ b/files/en-us/web/api/sanitizerconfig/index.md
@@ -127,7 +127,7 @@ The empty object `{}` is a valid configuration.
 
 > [!NOTE]
 > The conditions above are from the perspective of a web developer.
-> The [validity check defined in the specification](https://wicg.github.io/sanitizer-api/#sanitizerconfig-valid) is slightly different because it is executed after canonicalization of the configuration, such as adding `removeElements` when both are missing, and adding default namespaces.
+> The [validity check defined in the specification](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#safe-and-unsafe) is slightly different because it is executed after canonicalization of the configuration, such as adding `removeElements` when both are missing, and adding default namespaces.
 
 ### Allow and remove configurations
 

--- a/files/jsondata/SpecData.json
+++ b/files/jsondata/SpecData.json
@@ -1006,8 +1006,8 @@
   },
   "HTML Sanitizer API": {
     "name": "HTML Sanitizer API",
-    "url": "https://wicg.github.io/sanitizer-api/",
-    "status": "WD"
+    "url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#html-sanitization",
+    "status": "Living"
   },
   "HTML WHATWG": {
     "name": "HTML Living Standard",


### PR DESCRIPTION
### Summary
- Point HTML Sanitizer API spec data at the WHATWG HTML sanitization section
- Update remaining WICG Sanitizer links in affected MDN pages to WHATWG HTML anchors
- Mark the spec entry as Living

### Notes
- Fixes #44426
- There is an existing open PR (#44441), but it currently has changes requested for the WHATWG anchor and missed reference coverage.

### Testing
- npx markdownlint-cli2 files/en-us/web/api/element/sethtml/index.md files/en-us/web/api/sanitizerconfig/index.md
- npx prettier -c files/en-us/web/api/element/sethtml/index.md files/en-us/web/api/sanitizerconfig/index.md files/jsondata/SpecData.json
- npm run build -- --no-basic --content --deny-warnings files/en-us/web/api/element/sethtml/index.md files/en-us/web/api/sanitizerconfig/index.md