### PR TITLE
fix(regex): Correct \q{} disjunction-order example in Character_class

### DIFF
--- a/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
@@ -155,22 +155,19 @@ nonASCIINumbers("𐆊0零1𝟜𑜹a"); // [ '𝟜', '𑜹' ]
 
 ### Matching strings
 
-The following function matches all line terminator sequences, including the [line terminator characters](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#line_terminators) and the sequence `\r\n` (CRLF).
+The following function matches all line terminator sequences, including the [line terminator characters](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#line_terminators) and the sequence `\r\n` (CRLF), treating `\r\n` as a single match.
 
 ```js
-function getLineTerminators(str) {
+function getLineTerminatorSequences(str) {
   return str.match(/[\r\n\u2028\u2029\q{\r\n}]/gv);
 }
 
-getLineTerminators(`
-A poem\r
-Is split\r\n
-Into many
-Stanzas
-`); // [ '\r', '\r\n', '\n' ]
+getLineTerminatorSequences("CR \r LF \n CRLF \r\n"); // [ '\r', '\n', '\r\n' ]
 ```
 
-This example is exactly equivalent to `/(?:\r|\n|\u2028|\u2029|\r\n)/gu` or `/(?:[\r\n\u2028\u2029]|\r\n)/gu`, except shorter.
+This expression is equivalent to `/(?:\r\n|\r|\n|\u2028|\u2029)/gu` or `/(?:\r\n|[\r\n\u2028\u2029])/gu`, with `\r\n` listed as the first alternative. The order matters here: disjunction (`|`) is not commutative, since a regex engine tries alternatives from left to right and stops at the first one that matches. Putting `\r\n` after `\r` (e.g., `\r|\r\n`) would mean the lone `\r` always matches first, so the two-character sequence would never be produced.
+
+Despite this, `\q{\r\n}` can appear at the _end_ of the character class above, after `\r` and `\n`, and still correctly match the two-character sequence as a whole. This is because, within a character class, string operands (and the class as a whole) are matched greedily: the engine tries to match the longest possible alternative at each position, regardless of where that alternative appears in the class. Since `\r\n` is longer than `\r` alone, it's preferred whenever both could match.
 
 The most useful case of `\q{}` is when doing subtraction and intersection. Previously, this was possible with [multiple lookaheads](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion#pattern_subtraction_and_intersection). The following function matches flags that are not one of the American, Chinese, Russian, British, and French flags.
 

--- a/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
+++ b/files/en-us/web/javascript/reference/regular_expressions/character_class/index.md
@@ -86,12 +86,14 @@ With the `v` flag, intersection is expressed with `&&`, and subtraction with `--
 
 In `v` mode, the [Unicode character class escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape) `\p` can match finite-length strings, such as emojis. For symmetry, regular character classes can also match more than one character. To write a "string literal" in a character class, you wrap the string in `\q{...}`. The only regex syntax supported here is [disjunction](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction) — apart from this, `\q` must completely enclose literals (including escaped characters). This ensures that character classes can only match finite-length strings with finitely many possibilities.
 
+Unlike regular disjunction, the order of alternatives within `\q` does not matter, neither does the order of the `\q` escape with the rest of the operands being unioned. During matching, all alternatives specified in a character class are always attempted in descending order of length, so the match is greedy. For example, `[\q{a|ab}]`, `[\q{ab|a}]`, `[\q{ab}a]`, and `[a\q{ab}]` applied to `"ab"` will all match `"ab"`.
+
+Complement character classes `[^...]` cannot possibly be able to match strings longer than one character. For example, `[\q{ab|c}]` is valid and matches the string `"ab"`, but `[^\q{ab|c}]` is invalid because it's unclear how many characters should be consumed. The check is done by checking if all `\q` contain single characters and all `\p` specify character properties — for unions, all operands must be purely characters; for intersections, at least one operand must be purely characters; for subtraction, the leftmost operand must be purely characters. The check is syntactic without looking at the actual character set being specified, which means although `/[^\q{ab|c}--\q{ab}]/v` is equivalent to `/[^c]/v`, it's still rejected.
+
 Because the character class syntax is now more sophisticated, more characters are reserved and forbidden from appearing literally.
 
 - In addition to `]` and `\`, the following characters must be escaped in character classes if they represent literal characters: `(`, `)`, `[`, `{`, `}`, `/`, `-`, `|`. This list is somewhat similar to the list of [syntax characters](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character), except that `^`, `$`, `*`, `+`, and `?` are not reserved inside character classes, while `/` and `-` are not reserved outside character classes (although `/` may delimit a regex literal and therefore still needs to be escaped). All these characters may also be optionally escaped in `u`-mode character classes.
 - The following "double punctuator" sequences must be escaped as well (but they don't make much sense without the `v` flag anyway): `&&`, `!!`, `##`, `$$`, `%%`, `**`, `++`, `,,`, `..`, `::`, `;;`, `<<`, `==`, `>>`, `??`, `@@`, `^^`, ` `` `, `~~`. In `u` mode, some of these characters can only appear literally within character classes and cause a syntax error when escaped. In `v` mode, they must be escaped when appearing in pairs, but can be optionally escaped when appearing alone. For example, `/[\!]/u` is invalid because it's an [identity escape](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape), but both `/[\!]/v` and `/[!]/v` are valid, while `/[!!]/v` is invalid. The [literal character](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character) reference has a detailed table of which characters can appear escaped or unescaped.
-
-Complement character classes `[^...]` cannot possibly be able to match strings longer than one character. For example, `[\q{ab|c}]` is valid and matches the string `"ab"`, but `[^\q{ab|c}]` is invalid because it's unclear how many characters should be consumed. The check is done by checking if all `\q` contain single characters and all `\p` specify character properties — for unions, all operands must be purely characters; for intersections, at least one operand must be purely characters; for subtraction, the leftmost operand must be purely characters. The check is syntactic without looking at the actual character set being specified, which means although `/[^\q{ab|c}--\q{ab}]/v` is equivalent to `/[^c]/v`, it's still rejected.
 
 ### Complement classes and case-insensitive matching
 
@@ -155,19 +157,21 @@ nonASCIINumbers("𐆊0零1𝟜𑜹a"); // [ '𝟜', '𑜹' ]
 
 ### Matching strings
 
-The following function matches all line terminator sequences, including the [line terminator characters](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#line_terminators) and the sequence `\r\n` (CRLF), treating `\r\n` as a single match.
+The following function matches all line terminator sequences, including the [line terminator characters](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#line_terminators) and the sequence `\r\n` (CRLF). The order in which the alternatives are specified does not matter, because the longest alternative, `\r\n`, is always preferred.
 
 ```js
 function getLineTerminatorSequences(str) {
   return str.match(/[\r\n\u2028\u2029\q{\r\n}]/gv);
 }
 
-getLineTerminatorSequences("CR \r LF \n CRLF \r\n"); // [ '\r', '\n', '\r\n' ]
+getLineTerminatorSequences(`
+A poem\r
+Is split\rInto many
+Stanzas
+`); // ['\n', '\r\n', '\r', '\n', '\n']
 ```
 
-This expression is equivalent to `/(?:\r\n|\r|\n|\u2028|\u2029)/gu` or `/(?:\r\n|[\r\n\u2028\u2029])/gu`, with `\r\n` listed as the first alternative. The order matters here: disjunction (`|`) is not commutative, since a regex engine tries alternatives from left to right and stops at the first one that matches. Putting `\r\n` after `\r` (e.g., `\r|\r\n`) would mean the lone `\r` always matches first, so the two-character sequence would never be produced.
-
-Despite this, `\q{\r\n}` can appear at the _end_ of the character class above, after `\r` and `\n`, and still correctly match the two-character sequence as a whole. This is because, within a character class, string operands (and the class as a whole) are matched greedily: the engine tries to match the longest possible alternative at each position, regardless of where that alternative appears in the class. Since `\r\n` is longer than `\r` alone, it's preferred whenever both could match.
+This regular expression is exactly equivalent to `/(?:\r\n|\r|\n|\u2028|\u2029)/gu` or `/(?:\r\n|[\r\n\u2028\u2029])/gu`. However, in regular disjunction, the order of alternatives matters, so `\r\n` must be specified first in order for it to be preferred. Using a character class not only is shorter but also avoids this pitfall.
 
 The most useful case of `\q{}` is when doing subtraction and intersection. Previously, this was possible with [multiple lookaheads](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion#pattern_subtraction_and_intersection). The following function matches flags that are not one of the American, Chinese, Russian, British, and French flags.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes the `\q{}` example in the "Matching strings" section of the Character class reference page. Replaces the confusing template-literal test string with a plain string literal and a correct sample output, fixes the incorrect equivalence claim about disjunction order, and adds an explanation of why `\q{\r\n}` can appear at the end of the character class.

### Motivation

The original example used a template literal mixing real line breaks with `\r`/`\n` escapes, so the commented return value didn't match what the regex actually produces. The explanation that followed was also wrong: it claimed the regex was equivalent to forms like `\r|\r\n`, but disjunction in a regex is not commutative an engine tries alternatives left to right and stops at the first match, so `\r\n` must be listed before `\r` to ever match as a pair. The article also never explained that `v`-mode character classes try to match the longest operand first, which is the actual reason `\q{\r\n}` can sit after `\r` and `\n` in the class and still match correctly.

### Additional details

See the `Atom :: CharacterClass` case of the `CompileAtom` syntax-directed operation in the regex spec for how a character class tries to match longer strings first.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #44526 <!-- replace with the issue number -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
