### PR TITLE
Update the description for an `image-rendering` example

### DIFF
--- a/files/en-us/web/css/reference/properties/image-rendering/index.md
+++ b/files/en-us/web/css/reference/properties/image-rendering/index.md
@@ -91,7 +91,7 @@ image-rendering: unset;
 
 ### Setting image scaling algorithms
 
-In this example, an image is repeated three times, with each having a different `image-rendering` value applied.
+In this example, an image is repeated four times, with each having a different `image-rendering` value applied.
 
 ```html hidden
 <div>


### PR DESCRIPTION
### Description

While tinkering with canvas rendering, I noticed the description at https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/image-rendering#setting_image_scaling_algorithms said "three" instead of "four". It seems that a new example was introduced in https://github.com/mdn/content/pull/34765, but the description didn't get updated alongside it. This PR fixes that!

### Motivation

Correctness.

### Additional details

Not applicable.

### Related issues and pull requests

- https://github.com/mdn/content/pull/34765
