### PR TITLE
Fix: mistake in the `image-rendering` example text

### DIFF
--- a/files/en-us/web/css/reference/properties/image-rendering/index.md
+++ b/files/en-us/web/css/reference/properties/image-rendering/index.md
@@ -91,7 +91,7 @@ image-rendering: unset;
 
 ### Setting image scaling algorithms
 
-In this example, an image is repeated three times, with each having a different `image-rendering` value applied.
+In this example, an image is repeated four times, with each having a different `image-rendering` value applied.
 
 ```html hidden
 <div>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
The example repeats the image four times with four different CSS classes, but it says "three times" instead of the correct "four times".

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Being correct and not confusing users with wrong descriptions.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
[Link to the MDN Docs site](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/image-rendering#setting_image_scaling_algorithms)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->
N/A

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
