### PR TITLE
Clarify Number precision as significant digits

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/number/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/index.md
@@ -51,7 +51,7 @@ The mantissa (also called _significand_) is the part of the number representing 
 </math>
 <!-- prettier-ignore-end -->
 
-The mantissa is stored with 52 bits, interpreted as digits after `1.…` in a binary fractional number. Therefore, the mantissa's precision is 2<sup>-52</sup> (obtainable via {{jsxref("Number.EPSILON")}}), or about 15 to 17 decimal places; arithmetic above that level of precision is subject to [rounding](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Representable_numbers,_conversion_and_rounding).
+The mantissa is stored with 52 bits, interpreted as digits after `1.…` in a binary fractional number. Therefore, the mantissa's precision is 2<sup>-52</sup> (obtainable via {{jsxref("Number.EPSILON")}}), or about 15 to 17 significant decimal digits; arithmetic above that level of precision is subject to [rounding](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Representable_numbers,_conversion_and_rounding).
 
 The largest value a number can hold is 2<sup>1023</sup> × (2 - 2<sup>-52</sup>) (with the exponent being 1023 and the mantissa being 0.1111… in base 2), which is obtainable via {{jsxref("Number.MAX_VALUE")}}. Values higher than that are replaced with the special number constant {{jsxref("Infinity")}}.
 


### PR DESCRIPTION
### Description
Clarify the precision description for JavaScript `Number`.

This changes "about 15 to 17 decimal places" to wording that describes the precision as approximately 15–17 significant decimal digits.

### Motivation
The current wording says "decimal places", but the surrounding explanation is about the precision of the mantissa/significand.

This precision is not a fixed number of digits after the decimal point. It is better described as significant decimal digits. For example, larger integer values can lose unit precision even without any fractional digits.

This change helps avoid the impression that `Number` always preserves 15–17 digits after the decimal point regardless of the magnitude of the value.

### Additional details
A corresponding Japanese translation update is planned for `mdn/translated-content`.

### Related issues and pull requests
Relates to mdn/translated-content#36668