### PR TITLE
Add HTTP QUERY method and Accept-Query header references

### DIFF
--- a/files/en-us/web/http/reference/headers/accept-query/index.md
+++ b/files/en-us/web/http/reference/headers/accept-query/index.md
@@ -9,7 +9,7 @@ sidebar: http
 
 The HTTP **`Accept-Query`** {{Glossary("response header")}} indicates that a resource supports the {{HTTPMethod("QUERY")}} method and identifies the query format [media types](/en-US/docs/Web/HTTP/Guides/MIME_types) that it accepts.
 
-`Accept-Query` is a [structured field](https://www.rfc-editor.org/rfc/rfc9651.html) whose value is a list of media ranges.
+`Accept-Query` is a structured field whose value is a list of media ranges.
 The order of media ranges in the list is not significant.
 Its value applies to every URI on the server with the same path, regardless of the URI's query component.
 
@@ -40,12 +40,12 @@ Accept-Query: <media-range>, <media-range>
 
 ### Advertising supported query formats
 
-The following response indicates that the resource supports `QUERY` requests with JSONPath or SQL content:
+The following response indicates that the resource supports `QUERY` requests with URL-encoded form data or SQL content:
 
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/json
-Accept-Query: "application/jsonpath", application/sql;charset="UTF-8"
+Accept-Query: application/x-www-form-urlencoded, application/sql
 ```
 
 ## Specifications
@@ -57,4 +57,7 @@ Accept-Query: "application/jsonpath", application/sql;charset="UTF-8"
 - {{HTTPMethod("QUERY")}}
 - {{HTTPHeader("Accept")}}
 - {{HTTPHeader("Content-Type")}}
+- {{HTTPHeader("Content-Location")}}
+- {{HTTPHeader("Location")}}
 - {{HTTPStatus("415", "415 Unsupported Media Type")}}
+- [RFC 9651: Structured Field Values for HTTP](https://www.rfc-editor.org/rfc/rfc9651.html)

--- a/files/en-us/web/http/reference/headers/accept-query/index.md
+++ b/files/en-us/web/http/reference/headers/accept-query/index.md
@@ -3,13 +3,13 @@ title: Accept-Query header
 short-title: Accept-Query
 slug: Web/HTTP/Reference/Headers/Accept-Query
 page-type: http-header
-spec-urls: https://www.rfc-editor.org/rfc/rfc10008.html#section-3
+spec-urls: https://www.rfc-editor.org/info/rfc10008/#name-the-accept-query-header-fie
 sidebar: http
 ---
 
 The HTTP **`Accept-Query`** {{Glossary("response header")}} indicates that a resource supports the {{HTTPMethod("QUERY")}} method and identifies the query format [media types](/en-US/docs/Web/HTTP/Guides/MIME_types) that it accepts.
 
-`Accept-Query` is a structured field whose value is a list of media ranges.
+`Accept-Query` is a structured field whose value is a list of media ranges, each represented as a structured field string or token and optionally including structured field parameters.
 The order of media ranges in the list is not significant.
 Its value applies to every URI on the server with the same path, regardless of the URI's query component.
 
@@ -25,16 +25,23 @@ Its value applies to every URI on the server with the same path, regardless of t
 ## Syntax
 
 ```http
-Accept-Query: <media-range>
-Accept-Query: <media-range>, <media-range>
+Accept-Query: <media-type>/<subtype>
+Accept-Query: <media-type>/*
+Accept-Query: */*
+
+// Comma-separated list of media types
+Accept-Query: <media-type>/<subtype>, <media-type>/<subtype-2>, <media-type-2>/*
 ```
 
 ## Directives
 
-- `<media-range>`
-  - : A media type that the resource accepts as the content of a `QUERY` request.
-    Media ranges are represented as structured field strings or tokens and can include structured field parameters.
-    The `*/*` value matches every media type, and `<type>/*` matches every subtype of the indicated type.
+- `<media-type>/<subtype>`
+  - : A [media type](/en-US/docs/Web/HTTP/Guides/MIME_types) with a subtype that the resource accepts as `QUERY` request content, such as `application/json`.
+- `<media-type>/*`
+  - : A media type that accepts any subtype.
+    For example, `image/*` corresponds to `image/png`, `image/svg`, `image/gif`, and other image types.
+- `*/*`
+  - : Any media type.
 
 ## Examples
 
@@ -52,12 +59,16 @@ Accept-Query: application/x-www-form-urlencoded, application/sql
 
 {{Specifications}}
 
+## Browser compatibility
+
+Browser compatibility is not relevant for this header.
+Browsers have no built-in handling of `Accept-Query`; it's up to the client sending `QUERY` requests to read the header and use it to select a supported media type for the request content.
+
 ## See also
 
-- {{HTTPMethod("QUERY")}}
+- {{HTTPMethod("QUERY")}} request method
 - {{HTTPHeader("Accept")}}
 - {{HTTPHeader("Content-Type")}}
 - {{HTTPHeader("Content-Location")}}
 - {{HTTPHeader("Location")}}
 - {{HTTPStatus("415", "415 Unsupported Media Type")}}
-- [RFC 9651: Structured Field Values for HTTP](https://www.rfc-editor.org/rfc/rfc9651.html)

--- a/files/en-us/web/http/reference/headers/accept-query/index.md
+++ b/files/en-us/web/http/reference/headers/accept-query/index.md
@@ -9,8 +9,8 @@ sidebar: http
 
 The HTTP **`Accept-Query`** {{Glossary("response header")}} indicates that a resource supports the {{HTTPMethod("QUERY")}} method and identifies the query format [media types](/en-US/docs/Web/HTTP/Guides/MIME_types) that it accepts.
 
-`Accept-Query` is a structured field whose value is a list of media ranges, each represented as a structured field string or token and optionally including structured field parameters.
-The order of media ranges in the list is not significant.
+`Accept-Query` is a structured field whose value is a list of media ranges (a media type that might include wildcards), each represented as a structured field string or token and optionally including structured field parameters.
+The order of media types in the list is not significant.
 Its value applies to every URI on the server with the same path, regardless of the URI's query component.
 
 <table class="properties">
@@ -29,7 +29,7 @@ Accept-Query: <media-type>/<subtype>
 Accept-Query: <media-type>/*
 Accept-Query: */*
 
-// Comma-separated list of media types
+// Comma-separated list of media ranges in any order
 Accept-Query: <media-type>/<subtype>, <media-type>/<subtype-2>, <media-type-2>/*
 ```
 

--- a/files/en-us/web/http/reference/headers/accept-query/index.md
+++ b/files/en-us/web/http/reference/headers/accept-query/index.md
@@ -1,0 +1,60 @@
+---
+title: Accept-Query header
+short-title: Accept-Query
+slug: Web/HTTP/Reference/Headers/Accept-Query
+page-type: http-header
+spec-urls: https://www.rfc-editor.org/rfc/rfc10008.html#section-3
+sidebar: http
+---
+
+The HTTP **`Accept-Query`** {{Glossary("response header")}} indicates that a resource supports the {{HTTPMethod("QUERY")}} method and identifies the query format [media types](/en-US/docs/Web/HTTP/Guides/MIME_types) that it accepts.
+
+`Accept-Query` is a [structured field](https://www.rfc-editor.org/rfc/rfc9651.html) whose value is a list of media ranges.
+The order of media ranges in the list is not significant.
+Its value applies to every URI on the server with the same path, regardless of the URI's query component.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Header type</th>
+      <td>{{Glossary("Response header")}}</td>
+    </tr>
+  </tbody>
+</table>
+
+## Syntax
+
+```http
+Accept-Query: <media-range>
+Accept-Query: <media-range>, <media-range>
+```
+
+## Directives
+
+- `<media-range>`
+  - : A media type that the resource accepts as the content of a `QUERY` request.
+    Media ranges are represented as structured field strings or tokens and can include structured field parameters.
+    The `*/*` value matches every media type, and `<type>/*` matches every subtype of the indicated type.
+
+## Examples
+
+### Advertising supported query formats
+
+The following response indicates that the resource supports `QUERY` requests with JSONPath or SQL content:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Accept-Query: "application/jsonpath", application/sql;charset="UTF-8"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## See also
+
+- {{HTTPMethod("QUERY")}}
+- {{HTTPHeader("Accept")}}
+- {{HTTPHeader("Content-Type")}}
+- {{HTTPStatus("415", "415 Unsupported Media Type")}}

--- a/files/en-us/web/http/reference/headers/accept-query/index.md
+++ b/files/en-us/web/http/reference/headers/accept-query/index.md
@@ -40,7 +40,7 @@ Accept-Query: <media-range>, <media-range>
 
 ### Advertising supported query formats
 
-The following response indicates that the resource supports `QUERY` requests with URL-encoded form data or SQL content:
+The following response indicates that the resource supports `QUERY` requests with `application/x-www-form-urlencoded` or `application/sql` content:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/http/reference/methods/index.md
+++ b/files/en-us/web/http/reference/methods/index.md
@@ -15,8 +15,8 @@ Each request method has its own semantics, but some characteristics are shared a
   - : The `GET` method requests a representation of the specified resource.
     Requests using `GET` should only retrieve data and should not contain a request {{Glossary("HTTP Content", "content")}}.
 - {{HTTPMethod("QUERY")}}
-  - : The `QUERY` method requests that the target resource process the request {{Glossary("HTTP Content", "content")}} in a safe and idempotent manner and respond with the result.
-    It is similar to `GET`, but allows request content to be sent, for example when query parameters are too large or complex to fit comfortably in the URI.
+  - : The `QUERY` method requests that the target resource process the request content in a safe and idempotent manner, returning the result in the response.
+   It is similar to GET, but allows request body content with defined semantics.
 - {{HTTPMethod("HEAD")}}
   - : The `HEAD` method asks for a response identical to a `GET` request, but without a response body.
 - {{HTTPMethod("POST")}}

--- a/files/en-us/web/http/reference/methods/index.md
+++ b/files/en-us/web/http/reference/methods/index.md
@@ -14,6 +14,9 @@ Each request method has its own semantics, but some characteristics are shared a
 - {{HTTPMethod("GET")}}
   - : The `GET` method requests a representation of the specified resource.
     Requests using `GET` should only retrieve data and should not contain a request {{Glossary("HTTP Content", "content")}}.
+- {{HTTPMethod("QUERY")}}
+  - : The `QUERY` method requests that the target resource process the request {{Glossary("HTTP Content", "content")}} in a safe and idempotent manner and respond with the result.
+    It is similar to `GET`, but allows request content to be sent, for example when query parameters are too large or complex to fit comfortably in the URI.
 - {{HTTPMethod("HEAD")}}
   - : The `HEAD` method asks for a response identical to a `GET` request, but without a response body.
 - {{HTTPMethod("POST")}}
@@ -38,6 +41,7 @@ The following table lists HTTP request methods and their categorization in terms
 | Method                    | Safe | Idempotent | Cacheable     |
 | ------------------------- | ---- | ---------- | ------------- |
 | {{HTTPMethod("GET")}}     | Yes  | Yes        | Yes           |
+| {{HTTPMethod("QUERY")}}   | Yes  | Yes        | Yes           |
 | {{HTTPMethod("HEAD")}}    | Yes  | Yes        | Yes           |
 | {{HTTPMethod("OPTIONS")}} | Yes  | Yes        | No            |
 | {{HTTPMethod("TRACE")}}   | Yes  | Yes        | No            |

--- a/files/en-us/web/http/reference/methods/index.md
+++ b/files/en-us/web/http/reference/methods/index.md
@@ -16,7 +16,7 @@ Each request method has its own semantics, but some characteristics are shared a
     Requests using `GET` should only retrieve data and should not contain a request {{Glossary("HTTP Content", "content")}}.
 - {{HTTPMethod("QUERY")}}
   - : The `QUERY` method requests that the target resource process the request content in a safe and idempotent manner, returning the result in the response.
-   It is similar to GET, but allows request body content with defined semantics.
+    It is similar to `GET`, but allows request body content with defined semantics.
 - {{HTTPMethod("HEAD")}}
   - : The `HEAD` method asks for a response identical to a `GET` request, but without a response body.
 - {{HTTPMethod("POST")}}

--- a/files/en-us/web/http/reference/methods/index.md
+++ b/files/en-us/web/http/reference/methods/index.md
@@ -16,7 +16,7 @@ Each request method has its own semantics, but some characteristics are shared a
     Requests using `GET` should only retrieve data and should not contain a request {{Glossary("HTTP Content", "content")}}.
 - {{HTTPMethod("QUERY")}}
   - : The `QUERY` method requests that the target resource process the request content in a safe and idempotent manner, returning the result in the response.
-    It is similar to `GET`, but allows request body content with defined semantics.
+    It is similar to `GET`, but allows request content with defined semantics.
 - {{HTTPMethod("HEAD")}}
   - : The `HEAD` method asks for a response identical to a `GET` request, but without a response body.
 - {{HTTPMethod("POST")}}

--- a/files/en-us/web/http/reference/methods/query/index.md
+++ b/files/en-us/web/http/reference/methods/query/index.md
@@ -3,7 +3,7 @@ title: QUERY request method
 short-title: QUERY
 slug: Web/HTTP/Reference/Methods/QUERY
 page-type: http-method
-spec-urls: https://www.rfc-editor.org/info/rfc10008/#section-2
+spec-urls: https://www.rfc-editor.org/rfc/rfc10008.html#section-2
 sidebar: http
 ---
 
@@ -98,16 +98,11 @@ Content-Type: application/json
 
 {{Specifications}}
 
-## Browser compatibility
-
-Browsers don't use the `QUERY` method for user-initiated actions, so "browser compatibility" doesn't apply.
-Developers can set this request method using [`fetch()`](/en-US/docs/Web/API/Window/fetch).
-A cross-origin `QUERY` request requires a [CORS preflight request](/en-US/docs/Glossary/Preflight_request).
-
 ## See also
 
 - [HTTP request methods](/en-US/docs/Web/HTTP/Reference/Methods)
 - {{HTTPMethod("GET")}} and {{HTTPMethod("POST")}}
+- {{HTTPHeader("Accept-Query")}}
 - {{HTTPHeader("Content-Type")}}
 - {{HTTPHeader("Content-Location")}} and {{HTTPHeader("Location")}}
 - {{HTTPHeader("Allow")}}

--- a/files/en-us/web/http/reference/methods/query/index.md
+++ b/files/en-us/web/http/reference/methods/query/index.md
@@ -1,0 +1,113 @@
+---
+title: QUERY request method
+short-title: QUERY
+slug: Web/HTTP/Reference/Methods/QUERY
+page-type: http-method
+spec-urls: https://www.rfc-editor.org/info/rfc10008/#section-2
+sidebar: http
+---
+
+The **`QUERY`** HTTP method asks the target resource to process the request content in a safe and idempotent manner and return the result.
+It is similar to {{HTTPMethod("POST")}} because the query is carried in the request content, but unlike `POST`, `QUERY` is explicitly {{Glossary("Safe/HTTP", "safe")}} and {{Glossary("Idempotent", "idempotent")}}.
+This allows a `QUERY` request to be retried automatically without concern that it will cause additional changes to the target resource.
+
+`QUERY` is useful when the query input is too large or complex for the target URI's query component.
+The request's {{HTTPHeader("Content-Type")}} header is required and determines how the request content is interpreted by the target resource.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Request has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Successful response has body</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Idempotent")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">{{Glossary("Cacheable")}}</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">
+        Allowed in <a href="/en-US/docs/Learn_web_development/Extensions/Forms">HTML forms</a>
+      </th>
+      <td>No</td>
+    </tr>
+  </tbody>
+</table>
+
+## Syntax
+
+```http
+QUERY <request-target>["?"<query>] HTTP/1.1
+```
+
+- `<request-target>`
+  - : Identifies the target resource that will process the query when combined with the information provided in the {{HTTPHeader("Host")}} header.
+    This is an absolute path (e.g., `/path/to/resource`) in requests to an origin server, and an absolute URL in requests to proxies (e.g., `https://example.com/path/to/resource`).
+- `<query>` {{optional_inline}}
+  - : An optional URI query component preceded by a question mark (`?`).
+    It helps identify the resource being queried; the query operation itself is defined by the request content and its media type.
+
+## Examples
+
+### Querying a collection
+
+The following request queries a contacts collection.
+The request content selects three fields, limits the response to ten results, and filters contacts by email address:
+
+```http
+QUERY /contacts HTTP/1.1
+Host: example.org
+Content-Type: application/x-www-form-urlencoded
+Accept: application/json
+
+select=surname,givenname,email&limit=10&match=%22email=*@example.*%22
+```
+
+A successful response includes the query result in the response content:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "surname": "Smith",
+    "givenname": "John",
+    "email": "smith@example.org"
+  },
+  {
+    "surname": "Jones",
+    "givenname": "Sally",
+    "email": "sally.jones@example.com"
+  }
+]
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+Browsers don't use the `QUERY` method for user-initiated actions, so "browser compatibility" doesn't apply.
+Developers can set this request method using [`fetch()`](/en-US/docs/Web/API/Window/fetch).
+A cross-origin `QUERY` request requires a [CORS preflight request](/en-US/docs/Glossary/Preflight_request).
+
+## See also
+
+- [HTTP request methods](/en-US/docs/Web/HTTP/Reference/Methods)
+- {{HTTPMethod("GET")}} and {{HTTPMethod("POST")}}
+- {{HTTPHeader("Content-Type")}}
+- {{HTTPHeader("Content-Location")}} and {{HTTPHeader("Location")}}
+- {{HTTPHeader("Allow")}}

--- a/files/en-us/web/http/reference/methods/query/index.md
+++ b/files/en-us/web/http/reference/methods/query/index.md
@@ -3,7 +3,7 @@ title: QUERY request method
 short-title: QUERY
 slug: Web/HTTP/Reference/Methods/QUERY
 page-type: http-method
-spec-urls: https://www.rfc-editor.org/rfc/rfc10008.html#section-2
+spec-urls: https://www.rfc-editor.org/info/rfc10008/#name-query-method
 sidebar: http
 ---
 
@@ -71,7 +71,7 @@ Host: example.org
 Content-Type: application/x-www-form-urlencoded
 Accept: application/json
 
-select=surname,givenname,email&limit=10&match=%22email=*@example.*%22
+select=surname,givenname,email&limit=10&email=%2A%40example.%2A
 ```
 
 A successful response includes the query result in the response content:
@@ -98,11 +98,19 @@ Content-Type: application/json
 
 {{Specifications}}
 
+## Browser compatibility
+
+Browser compatibility is not relevant for this method.
+Browsers have no specific integration support for `QUERY`: it isn't sent for user-initiated actions like HTML form submissions, and browsers don't send it automatically in response to other headers or mechanisms.
+
+Developers can issue a `QUERY` request using [`fetch()`](/en-US/docs/Web/API/Window/fetch).
+NOte that because `QUERY` isn't one of the CORS-safelisted methods, cross-origin requests trigger a [CORS](/en-US/docs/Web/HTTP/Guides/CORS) preflight {{HTTPMethod("OPTIONS")}} request, the same as for other non-simple methods.
+
 ## See also
 
 - [HTTP request methods](/en-US/docs/Web/HTTP/Reference/Methods)
-- {{HTTPMethod("GET")}} and {{HTTPMethod("POST")}}
 - {{HTTPHeader("Accept-Query")}}
+- {{HTTPMethod("GET")}} and {{HTTPMethod("POST")}}
 - {{HTTPHeader("Content-Type")}}
 - {{HTTPHeader("Content-Location")}} and {{HTTPHeader("Location")}}
 - {{HTTPHeader("Allow")}}


### PR DESCRIPTION
## Description

Adds documentation for the HTTP `QUERY` method defined by RFC 10008.

This PR adds:
- A dedicated `QUERY` method reference page
- An `Accept-Query` header reference page
- Updates to the HTTP request methods landing page, including the method list and safe/idempotent/cacheable table

## Motivation

RFC 10008 defines `QUERY` as a safe and idempotent HTTP method that carries request content and returns the result of processing that content. It fills the use case where a request is read-only like `GET`, but the query input is too large or complex to fit comfortably in the URI.

## Additional details

This PR does not add BCD data because there is no explicit browser integration for `QUERY` yet. The new reference pages use `spec-urls` metadata instead.

The RFC defines the response header as `Accept-Query`; this PR uses that name for the header reference page.

Fixes https://github.com/mdn/content/issues/44665