### PR TITLE
[Editorial review] BiDi - Add pages for navigation and page load events of browsingContext module

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
@@ -11,7 +11,7 @@ The `browsingContext.contextCreated` [event](/en-US/docs/Web/WebDriver/Reference
 
 ## Event data
 
-The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following properties:
+The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following fields:
 
 - `children`
   - : An array of [context objects](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) that represents child contexts.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
@@ -11,7 +11,7 @@ The `browsingContext.contextDestroyed` [event](/en-US/docs/Web/WebDriver/Referen
 
 ## Event data
 
-The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following properties, describing the discarded context and its subtree:
+The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following fields, describing the discarded context and its subtree:
 
 - `children`
   - : An array of [context objects](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) that represents child contexts.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -1,0 +1,72 @@
+---
+title: "`browsingContext.domContentLoaded` event"
+short-title: domContentLoaded
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.domContentLoaded_event
+sidebar: webdriver
+---
+
+The `browsingContext.domContentLoaded` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the HTML document has been parsed during a cross-document navigation in a context.
+
+## Description
+
+In the lifecycle of a successful navigation, this event fires after [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) and before [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) events.
+
+At this point, the HTML has been parsed, equivalent to the {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event firing in the context, but subresources such as stylesheets and images may still be loading.
+
+## Event data
+
+The `params` field in the event notification is a navigation object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the HTML document is being parsed.
+- `navigation`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
+    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+- `timestamp`
+  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL being loaded.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the HTML document is being parsed.
+
+## Examples
+
+### Receiving an event when a document is parsed
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.domContentLoaded`.
+
+Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+
+The browser first fires [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) events (those notifications are not received since the subscription in this example is only to `browsingContext.domContentLoaded`).
+
+Once the HTML has been parsed, the browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.domContentLoaded",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+    "timestamp": 1712345678901,
+    "url": "https://example.com"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
+- [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) event
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -27,7 +27,7 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
     This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
-  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -13,13 +13,13 @@ The `browsingContext.domContentLoaded` [event](/en-US/docs/Web/WebDriver/Referen
 
 In the lifecycle of a successful navigation, this event fires after [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) and before [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) events.
 
-At this point, the HTML has been parsed, equivalent to the {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event firing in the context, but subresources such as stylesheets and images may still be loading.
+At this point, the HTML has been parsed, but subresources such as stylesheets and images may still be loading. This event is equivalent to the {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event firing in the context.
 
 If you set `wait` to `"interactive"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.domContentLoaded` fires.
 
 ## Event data
 
-The `params` field in the event notification is a navigation object with the following fields:
+The `params` field in the event notification is an object with the following fields:
 
 - `context`
   - : A string that contains the ID of the context in which the HTML document is being parsed.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -15,6 +15,8 @@ In the lifecycle of a successful navigation, this event fires after [`browsingCo
 
 At this point, the HTML has been parsed, equivalent to the {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event firing in the context, but subresources such as stylesheets and images may still be loading.
 
+If you set `wait` to `"interactive"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.domContentLoaded` fires.
+
 ## Event data
 
 The `params` field in the event notification is a navigation object with the following fields:
@@ -50,7 +52,7 @@ Once the HTML has been parsed, the browser sends the following notification, whe
   "params": {
     "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
     "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-    "timestamp": 1712345678901,
+    "timestamp": 1782342489906,
     "url": "https://example.com"
   }
 }

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -25,7 +25,8 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the ID of the context in which the HTML document is being parsed.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -30,8 +30,6 @@ The `params` field in the event notification is a navigation object with the fol
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the HTML document is being parsed.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -9,14 +9,6 @@ sidebar: webdriver
 
 The `browsingContext.domContentLoaded` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the HTML document has been parsed during a cross-document navigation in a context.
 
-## Description
-
-In the lifecycle of a successful navigation, this event fires after [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) and before [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) events.
-
-At this point, the HTML has been parsed, but subresources such as stylesheets and images may still be loading. This event is equivalent to the {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event firing in the context.
-
-If you set `wait` to `"interactive"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.domContentLoaded` fires.
-
 ## Event data
 
 The `params` field in the event notification is an object with the following fields:
@@ -31,6 +23,14 @@ The `params` field in the event notification is an object with the following fie
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
+
+## Description
+
+In the lifecycle of a successful navigation, this event fires after [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) and before [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) events.
+
+At this point, the HTML has been parsed, but subresources such as stylesheets and images may still be loading. This event is equivalent to the {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}} event firing in the context.
+
+If you set `wait` to `"interactive"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.domContentLoaded` fires.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.domContentLoaded_event
 sidebar: webdriver
 ---
 
-The `browsingContext.domContentLoaded` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the HTML document has been parsed during a cross-document navigation in a context.
+The `browsingContext.domContentLoaded` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the HTML document has been parsed during a cross-document navigation in a [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts).
 
 ## Event data
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/domcontentloaded/index.md
@@ -40,7 +40,7 @@ Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/C
 
 Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
-The browser first fires [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) events (those notifications are not received since the subscription in this example is only to `browsingContext.domContentLoaded`).
+The browser first fires [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) events (you don't receive those notifications because the subscription in this example is only to `browsingContext.domContentLoaded`).
 
 Once the HTML has been parsed, the browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
@@ -22,8 +22,6 @@ The `params` field in the event notification is a navigation object with the fol
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the updated URL, including the fragment.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the fragment navigation is occurring.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
@@ -1,0 +1,60 @@
+---
+title: "`browsingContext.fragmentNavigated` event"
+short-title: fragmentNavigated
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.fragmentNavigated_event
+sidebar: webdriver
+---
+
+The `browsingContext.fragmentNavigated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a same-document navigation to a [URL fragment](/en-US/docs/Web/URI/Reference/Fragment) occurs in a context.
+
+## Event data
+
+The `params` field in the event notification is a navigation object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the fragment navigation is occurring.
+- `navigation`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
+    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+- `timestamp`
+  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the updated URL, including the fragment.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the fragment navigation is occurring.
+
+## Examples
+
+### Receiving a fragment navigation event
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.fragmentNavigated`.
+
+Suppose a navigation to a section on `https://example.com/page` occurs. The browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.fragmentNavigated",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+    "timestamp": 1712345678901,
+    "url": "https://example.com/page#section-2"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
+- [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
@@ -19,7 +19,7 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
     This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
-  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the updated URL, including the fragment.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
@@ -17,7 +17,8 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the ID of the context in which the fragment navigation is occurring.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
@@ -11,7 +11,7 @@ The `browsingContext.fragmentNavigated` [event](/en-US/docs/Web/WebDriver/Refere
 
 ## Event data
 
-The `params` field in the event notification is a navigation object with the following fields:
+The `params` field in the event notification is an object with the following fields:
 
 - `context`
   - : A string that contains the ID of the context in which the fragment navigation is occurring.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/fragmentnavigated/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.fragmentNavigated_event
 sidebar: webdriver
 ---
 
-The `browsingContext.fragmentNavigated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a same-document navigation to a [URL fragment](/en-US/docs/Web/URI/Reference/Fragment) occurs in a context.
+The `browsingContext.fragmentNavigated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a same-document navigation to a [URL fragment](/en-US/docs/Web/URI/Reference/Fragment) occurs in a [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts).
 
 ## Event data
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
@@ -26,8 +26,6 @@ The `params` field in the event notification is a history update object with the
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the updated URL.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the history update is occurring.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
@@ -18,7 +18,7 @@ These calls change the active URL in the context.
 
 ## Event data
 
-The `params` field in the event notification is a history update object with the following fields:
+The `params` field in the event notification is an object with the following fields:
 
 - `context`
   - : A string that contains the ID of the context in which the history update is occurring.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
@@ -1,0 +1,63 @@
+---
+title: "`browsingContext.historyUpdated` event"
+short-title: historyUpdated
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.historyUpdated_event
+sidebar: webdriver
+---
+
+The `browsingContext.historyUpdated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the active URL in a context is updated programmatically without a full navigation.
+
+## Description
+
+This event fires when {{domxref("History.pushState", "history.pushState()")}} or {{domxref("History.replaceState", "history.replaceState()")}} is called to update the URL, or when {{domxref("Document.open", "document.open()")}} is called to replace the document.
+These calls change the active URL in the context.
+
+`browsingContext.historyUpdated` fires specifically when the URL is changed programmatically, unlike [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated), which fires for same-document navigations to a URL fragment.
+
+## Event data
+
+The `params` field in the event notification is a history update object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the history update is occurring.
+- `timestamp`
+  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the updated URL.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the history update is occurring.
+
+## Examples
+
+### Receiving an event when `history.pushState()` is called
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.historyUpdated`.
+
+Suppose {{domxref("History.pushState", "history.pushState()")}} is called to update the URL to `https://example.com/new-path`. The browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.historyUpdated",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "timestamp": 1781888825943,
+    "url": "https://example.com/new-path"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
+- [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
@@ -23,7 +23,7 @@ The `params` field in the event notification is a history update object with the
 - `context`
   - : A string that contains the ID of the context in which the history update is occurring.
 - `timestamp`
-  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the updated URL.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
@@ -9,13 +9,6 @@ sidebar: webdriver
 
 The `browsingContext.historyUpdated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the active URL in a context is updated programmatically without a full navigation.
 
-## Description
-
-This event fires when {{domxref("History.pushState", "history.pushState()")}} or {{domxref("History.replaceState", "history.replaceState()")}} is called to update the URL, or when {{domxref("Document.open", "document.open()")}} is called to replace the document.
-These calls change the active URL in the context.
-
-`browsingContext.historyUpdated` fires specifically when the URL is changed programmatically, unlike [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated), which fires for same-document navigations to a URL fragment.
-
 ## Event data
 
 The `params` field in the event notification is an object with the following fields:
@@ -26,6 +19,13 @@ The `params` field in the event notification is an object with the following fie
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the updated URL.
+
+## Description
+
+This event fires when {{domxref("History.pushState", "history.pushState()")}} or {{domxref("History.replaceState", "history.replaceState()")}} is called to update the URL, or when {{domxref("Document.open", "document.open()")}} is called to replace the document.
+These calls change the active URL in the context.
+
+`browsingContext.historyUpdated` fires specifically when the URL is changed programmatically, unlike [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated), which fires for same-document navigations to a URL fragment.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/historyupdated/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.historyUpdated_event
 sidebar: webdriver
 ---
 
-The `browsingContext.historyUpdated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the active URL in a context is updated programmatically without a full navigation.
+The `browsingContext.historyUpdated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the active URL in a [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) is updated programmatically without a full navigation.
 
 ## Event data
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -39,6 +39,13 @@ Calling [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Mod
 
 - [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated)
 - [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed)
+- [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded)
+- [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated)
+- [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated)
+- [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load)
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted)
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed)
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted)
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -19,7 +19,7 @@ If you set `wait` to `"complete"` for the [`browsingContext.navigate`](/en-US/do
 
 ## Event data
 
-The `params` field in the event notification is a navigation object with the following fields:
+The `params` field in the event notification is an object with the following fields:
 
 - `context`
   - : A string that contains the ID of the context in which the document has fully loaded.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -25,7 +25,8 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the ID of the context in which the document has fully loaded.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -27,7 +27,7 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
     This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
-  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL of the document that has fully loaded.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -1,0 +1,72 @@
+---
+title: "`browsingContext.load` event"
+short-title: load
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/load
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.load_event
+sidebar: webdriver
+---
+
+The `browsingContext.load` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation has fully completed in a context.
+
+## Description
+
+In the lifecycle of a successful navigation, this event fires after [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) and is the final event in the sequence.
+
+At this point, the document and all its subresources have finished loading, equivalent to the {{domxref("Window/load_event", "load")}} event firing.
+
+## Event data
+
+The `params` field in the event notification is a navigation object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the document has fully loaded.
+- `navigation`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
+    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+- `timestamp`
+  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL of the document that has fully loaded.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the document has fully loaded.
+
+## Examples
+
+### Receiving an event when a document has fully loaded
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.load`.
+
+Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+
+The browser first fires [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted), [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted), and [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) events (those notifications are not received since the subscription in this example is only to `browsingContext.load`).
+
+Once the document and all its subresources have finished loading, the browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.load",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+    "timestamp": 1712345678901,
+    "url": "https://example.com"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
+- [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) event
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -30,8 +30,6 @@ The `params` field in the event notification is a navigation object with the fol
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL of the document that has fully loaded.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the document has fully loaded.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -15,6 +15,8 @@ In the lifecycle of a successful navigation, this event fires after [`browsingCo
 
 At this point, the document and all its subresources have finished loading, equivalent to the {{domxref("Window/load_event", "load")}} event firing.
 
+If you set `wait` to `"complete"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.load` fires.
+
 ## Event data
 
 The `params` field in the event notification is a navigation object with the following fields:
@@ -50,7 +52,7 @@ Once the document and all its subresources have finished loading, the browser se
   "params": {
     "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
     "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-    "timestamp": 1712345678901,
+    "timestamp": 1782343062410,
     "url": "https://example.com"
   }
 }

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -9,14 +9,6 @@ sidebar: webdriver
 
 The `browsingContext.load` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation has fully completed in a context.
 
-## Description
-
-In the lifecycle of a successful navigation, this event fires after [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) and is the final event in the sequence.
-
-At this point, the document and all its subresources have finished loading, equivalent to the {{domxref("Window/load_event", "load")}} event firing.
-
-If you set `wait` to `"complete"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.load` fires.
-
 ## Event data
 
 The `params` field in the event notification is an object with the following fields:
@@ -31,6 +23,14 @@ The `params` field in the event notification is an object with the following fie
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL of the document that has fully loaded.
+
+## Description
+
+In the lifecycle of a successful navigation, this event fires after [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) and is the final event in the sequence.
+
+At this point, the document and all its subresources have finished loading, equivalent to the {{domxref("Window/load_event", "load")}} event firing.
+
+If you set `wait` to `"complete"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.load` fires.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -40,7 +40,7 @@ Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/C
 
 Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
-The browser first fires [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted), [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted), and [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) events (those notifications are not received since the subscription in this example is only to `browsingContext.load`).
+The browser first fires [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted), [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted), and [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) events (you don't receive those notifications because the subscription in this example is only to `browsingContext.load`).
 
 Once the document and all its subresources have finished loading, the browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/load/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.load_event
 sidebar: webdriver
 ---
 
-The `browsingContext.load` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation has fully completed in a context.
+The `browsingContext.load` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation has fully completed in a [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts).
 
 ## Event data
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -1,0 +1,73 @@
+---
+title: "`browsingContext.navigationCommitted` event"
+short-title: navigationCommitted
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.navigationCommitted_event
+sidebar: webdriver
+---
+
+The `browsingContext.navigationCommitted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the browser commits a navigation and begins loading the new document.
+
+## Description
+
+A navigation is committed when the browser has accepted the URL from the server response and begun loading the new page, but before any content has been parsed or rendered. Page content is not yet available at this point.
+
+In the lifecycle of a successful navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and before [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) and [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) events.
+
+If you set `wait` to `"none"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.navigationCommitted` fires.
+
+This event does not fire for same-document navigations.
+For navigations to a URL fragment, see [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated).
+For URL changes made through the History API without a full navigation, see [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated).
+
+## Event data
+
+The `params` field in the event notification is a navigation object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the navigation is committed.
+- `navigation`
+  - : A string that contains the ID of the navigation that is committed, or the value `null` if the navigation does not have an associated navigation ID.
+- `timestamp`
+  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL being loaded, including any basic auth credentials.
+
+## Examples
+
+### Receiving an event when a cross-document navigation commits
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationCommitted`.
+
+Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (since this example only subscribes to `browsingContext.navigationCommitted`, that notification is not received).
+Once the browser accepts the server response and commits to loading the page, it sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.navigationCommitted",
+  "params": {
+    "context": "9f271a75-04b2-4b35-80cc-e22427d446fc",
+    "navigation": "dc716296-7076-4ec0-b446-51c6fb5fefe8",
+    "timestamp": 1781715436774,
+    "url": "https://example.com"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
+- [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated) event
+- [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -34,8 +34,6 @@ The `params` field in the event notification is a navigation object with the fol
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded, including any basic auth credentials.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation is committed.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -31,7 +31,7 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
     This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
-  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded, including any basic auth credentials.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.navigationCommitted_event
 sidebar: webdriver
 ---
 
-The `browsingContext.navigationCommitted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the browser commits a navigation and begins loading the new document.
+The `browsingContext.navigationCommitted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the browser commits a cross-document navigation and begins loading the new page.
 
 ## Description
 
@@ -28,11 +28,14 @@ The `params` field in the event notification is a navigation object with the fol
 - `context`
   - : A string that contains the ID of the context in which the navigation is committed.
 - `navigation`
-  - : A string that contains the ID of the navigation that is committed, or the value `null` if the navigation does not have an associated navigation ID.
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
+    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded, including any basic auth credentials.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation is committed.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -23,7 +23,7 @@ For URL changes made through the History API without a full navigation, see [`br
 
 ## Event data
 
-The `params` field in the event notification is a navigation object with the following fields:
+The `params` field in the event notification is an object with the following fields:
 
 - `context`
   - : A string that contains the ID of the context in which the navigation is committed.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -44,7 +44,9 @@ The `params` field in the event notification is a navigation object with the fol
 Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationCommitted`.
 
 Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
-The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (since this example only subscribes to `browsingContext.navigationCommitted`, that notification is not received).
+
+The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (that notification is not received since the subscription in this example is only to `browsingContext.navigationCommitted`).
+
 Once the browser accepts the server response and commits to loading the page, it sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
 
 ```json

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -29,7 +29,8 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the ID of the context in which the navigation is committed.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -9,18 +9,6 @@ sidebar: webdriver
 
 The `browsingContext.navigationCommitted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the browser commits a cross-document navigation and begins loading the new page.
 
-## Description
-
-A navigation is committed when the browser has accepted the URL from the server response and begun loading the new page, but before any content has been parsed or rendered. Page content is not yet available at this point.
-
-In the lifecycle of a successful navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and before [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) and [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) events.
-
-If you set `wait` to `"none"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.navigationCommitted` fires.
-
-This event does not fire for same-document navigations.
-For navigations to a URL fragment, see [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated).
-For URL changes made through the History API without a full navigation, see [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated).
-
 ## Event data
 
 The `params` field in the event notification is an object with the following fields:
@@ -35,6 +23,18 @@ The `params` field in the event notification is an object with the following fie
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded, including any basic auth credentials.
+
+## Description
+
+A navigation is committed when the browser has accepted the URL from the server response and begun loading the new page, but before any content has been parsed or rendered. Page content is not yet available at this point.
+
+In the lifecycle of a successful navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and before [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) and [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) events.
+
+If you set `wait` to `"none"` for the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands, they return as soon as `browsingContext.navigationCommitted` fires.
+
+This event does not fire for same-document navigations.
+For navigations to a URL fragment, see [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated).
+For URL changes made through the History API without a full navigation, see [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated).
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationcommitted/index.md
@@ -44,7 +44,7 @@ Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/C
 
 Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
 
-The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (that notification is not received since the subscription in this example is only to `browsingContext.navigationCommitted`).
+The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (you don't receive that notification because the subscription in this example is only to `browsingContext.navigationCommitted`).
 
 Once the browser accepts the server response and commits to loading the page, it sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -1,0 +1,61 @@
+---
+title: "`browsingContext.navigationFailed` event"
+short-title: navigationFailed
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.navigationFailed_event
+sidebar: webdriver
+---
+
+The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the browser cannot successfully load a URL.
+
+## Description
+
+In the lifecycle of a failed navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) when the navigation cannot be completed.
+
+## Event data
+
+The `params` field in the event notification is a navigation object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the navigation failed.
+- `navigation`
+  - : A string that contains the ID of the failed navigation, or the value `null` if the navigation does not have an associated navigation ID.
+- `timestamp`
+  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL being loaded.
+
+## Examples
+
+### Receiving an event when a cross-document navigation fails
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationFailed`.
+
+Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load a URL, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree). The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (since this example only subscribes to `browsingContext.navigationFailed`, that notification is not received). The browser sends the following notification if the navigation cannot be completed, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.navigationFailed",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+    "timestamp": 1712345678901,
+    "url": "https://not-a-valid-domain.example"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.navigationFailed_event
 sidebar: webdriver
 ---
 
-The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the browser cannot successfully load a URL.
+The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation cannot be completed.
 
 ## Description
 
@@ -20,11 +20,14 @@ The `params` field in the event notification is a navigation object with the fol
 - `context`
   - : A string that contains the ID of the context in which the navigation failed.
 - `navigation`
-  - : A string that contains the ID of the failed navigation, or the value `null` if the navigation does not have an associated navigation ID.
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
+    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation failed.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -26,8 +26,6 @@ The `params` field in the event notification is a navigation object with the fol
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation failed.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -35,7 +35,11 @@ The `params` field in the event notification is a navigation object with the fol
 
 Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationFailed`.
 
-Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load a URL, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree). The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (since this example only subscribes to `browsingContext.navigationFailed`, that notification is not received). The browser sends the following notification if the navigation cannot be completed, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load a URL, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+
+The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (that notification is not received since the subscription in this example is only to `browsingContext.navigationFailed`).
+
+The browser sends the following notification if the navigation cannot be completed, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -11,7 +11,7 @@ The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Referen
 
 ## Description
 
-In the lifecycle of a navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) when the navigation is blocked, for example because of a security or CSP restriction or because the client cancels the unload prompt.
+In the lifecycle of a navigation, this event fires when the navigation is blocked, for example because of a security or CSP restriction or because the client cancels the unload prompt.
 
 ## Event data
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -11,7 +11,7 @@ The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Referen
 
 ## Description
 
-In the lifecycle of a navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) when the navigation is blocked, for example because of a security or CSP restriction or because a user cancels the unload prompt.
+In the lifecycle of a navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) when the navigation is blocked, for example because of a security or CSP restriction or because the client cancels the unload prompt.
 
 ## Event data
 
@@ -21,8 +21,7 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the ID of the context in which the navigation failed.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
-    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
+    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
@@ -30,15 +29,16 @@ The `params` field in the event notification is a navigation object with the fol
 
 ## Examples
 
-### Receiving an event when a cross-document navigation fails
+### Receiving an event when a cross-document navigation is blocked
 
-Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationFailed`.
+Consider the following scenario: you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationFailed`.
+The session's `unhandledPromptBehavior` capability is configured to dismiss [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) prompts.
+The current page also has a `beforeunload` handler that calls [`event.preventDefault()`](/en-US/docs/Web/API/Event/preventDefault) to warn before leaving.
 
-Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load a URL, passing the context ID you obtain from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+Suppose there are unsaved changes on this page and you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load a different URL.
 
-The browser first fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event (that notification is not received since the subscription in this example is only to `browsingContext.navigationFailed`).
-
-The browser sends the following notification if the navigation cannot be completed, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+The browser opens the `beforeunload` prompt, fires a [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) event, and blocks the navigation.
+The browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`, and the `navigation` value is the ID of the blocked navigation:
 
 ```json
 {
@@ -47,8 +47,7 @@ The browser sends the following notification if the navigation cannot be complet
   "params": {
     "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
     "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-    "timestamp": 1712345678901,
-    "url": "https://not-a-valid-domain.example"
+    "timestamp": 1712345678901
   }
 }
 ```

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -7,11 +7,11 @@ browser-compat: webdriver.bidi.browsingContext.navigationFailed_event
 sidebar: webdriver
 ---
 
-The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation cannot be completed.
+The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation is blocked.
 
 ## Description
 
-In the lifecycle of a failed navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) when the navigation cannot be completed.
+In the lifecycle of a navigation, this event fires after [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) when the navigation is blocked, for example because of a security or CSP restriction or because a user cancels the unload prompt.
 
 ## Event data
 
@@ -21,7 +21,8 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the ID of the context in which the navigation failed.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -15,7 +15,7 @@ In the lifecycle of a navigation, this event fires when the navigation is blocke
 
 ## Event data
 
-The `params` field in the event notification is a navigation object with the following fields:
+The `params` field in the event notification is an object with the following fields:
 
 - `context`
   - : A string that contains the ID of the context in which the navigation failed.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -23,7 +23,7 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
     This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
-  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -9,10 +9,6 @@ sidebar: webdriver
 
 The `browsingContext.navigationFailed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation is blocked.
 
-## Description
-
-In the lifecycle of a navigation, this event fires when the navigation is blocked, for example because of a security or CSP restriction or because the client cancels the unload prompt.
-
 ## Event data
 
 The `params` field in the event notification is an object with the following fields:
@@ -26,6 +22,10 @@ The `params` field in the event notification is an object with the following fie
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
+
+## Description
+
+In the lifecycle of a navigation, this event fires when the navigation is blocked, for example because of a security or CSP restriction or because the client cancels the unload prompt.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationfailed/index.md
@@ -17,7 +17,8 @@ The `params` field in the event notification is an object with the following fie
   - : A string that contains the ID of the context in which the navigation failed.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
@@ -31,7 +32,7 @@ In the lifecycle of a navigation, this event fires when the navigation is blocke
 
 ### Receiving an event when a cross-document navigation is blocked
 
-Consider the following scenario: you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationFailed`.
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationFailed`.
 The session's `unhandledPromptBehavior` capability is configured to dismiss [`beforeunload`](/en-US/docs/Web/API/Window/beforeunload_event) prompts.
 The current page also has a `beforeunload` handler that calls [`event.preventDefault()`](/en-US/docs/Web/API/Event/preventDefault) to warn before leaving.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -35,7 +35,7 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
     This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
-  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -1,0 +1,70 @@
+---
+title: "`browsingContext.navigationStarted` event"
+short-title: navigationStarted
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.navigationStarted_event
+sidebar: webdriver
+---
+
+The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a navigation to a new document begins in a context.
+
+## Description
+
+The navigation to a different page can be triggered by the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, by user interaction with elements on the page, or by JavaScript running in the page's context.
+
+> [!NOTE]
+> This event is not emitted when the initial `about:blank` page is loaded for a new top-level browsing context.
+
+This event does not fire for same-document navigations.
+For navigations to a URL fragment, see [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated).
+For URL changes made through the History API without a full navigation, see [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated).
+
+## Event data
+
+The `params` field in the event notification is a navigation object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the navigation is occurring.
+- `navigation`
+  - : A string that contains the ID of the navigation, or the value `null` if the navigation does not have an associated navigation ID.
+- `timestamp`
+  - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL being loaded.
+
+## Examples
+
+### Receiving an event when a cross-document navigation starts
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationStarted`.
+
+Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtained from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree). The browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.navigationStarted",
+  "params": {
+    "context": "5e5e96e8-5247-4f22-9b35-a4a2d841cbaa",
+    "navigation": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+    "timestamp": 1781646423959,
+    "url": "https://example.com"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated) event
+- [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated) event
+- [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
+- [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -38,8 +38,6 @@ The `params` field in the event notification is a navigation object with the fol
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
-- `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation is starting.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -13,6 +13,10 @@ The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Refere
 
 The navigation to a different page can be triggered by the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, by user interaction with elements on the page, or by JavaScript running in the page's context.
 
+For cross-document navigations, this event is the first in the sequence of navigation events and fires when the browser begins fetching the URL.
+If the navigation succeeds, [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) fires next, when the browser has accepted the response and begun loading the new page.
+If the navigation fails, [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) fires instead.
+
 > [!NOTE]
 > This event is not emitted when the initial `about:blank` page is loaded for a new top-level browsing context.
 
@@ -64,7 +68,7 @@ Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference
 
 ## See also
 
-- [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated) event
-- [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated) event
 - [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) event
 - [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) event
+- [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated) event
+- [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -27,7 +27,7 @@ For URL changes made through the History API without a full navigation, see [`br
 
 ## Event data
 
-The `params` field in the event notification is a navigation object with the following fields:
+The `params` field in the event notification is an object with the following fields:
 
 - `context`
   - : A string that contains the ID of the context in which the navigation is starting.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -13,8 +13,9 @@ The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Refere
 
 The navigation to a different page can be triggered by the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, by user interaction with elements on the page, or by JavaScript running in the page's context.
 
-For cross-document navigations, this event is the first in the sequence of navigation events and fires when the browser begins fetching the URL.
+For cross-document navigations, this is the first in the sequence of navigation events and fires when the browser begins fetching the URL.
 If the navigation succeeds, [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted) fires next, when the browser has accepted the response and begun loading the new page.
+After that, [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded) fires when the HTML has been parsed, and [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load) fires last when the document and all its subresources have finished loading.
 If the navigation fails, [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed) fires instead.
 
 > [!NOTE]
@@ -29,7 +30,7 @@ For URL changes made through the History API without a full navigation, see [`br
 The `params` field in the event notification is a navigation object with the following fields:
 
 - `context`
-  - : A string that contains the ID of the context in which the navigation is occurring.
+  - : A string that contains the ID of the context in which the navigation is starting.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
     This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
@@ -38,7 +39,7 @@ The `params` field in the event notification is a navigation object with the fol
 - `url`
   - : A string that contains the URL being loaded.
 - `userContext` {{optional_inline}}
-  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation is occurring.
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation is starting.
 
 ## Examples
 
@@ -46,7 +47,9 @@ The `params` field in the event notification is a navigation object with the fol
 
 Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.navigationStarted`.
 
-Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtained from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree). The browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
+Suppose you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to load `https://example.com`, passing the context ID you obtained from [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+
+The browser sends the following notification, where the `context` value matches the context ID you passed to `browsingContext.navigate`:
 
 ```json
 {

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.navigationStarted_event
 sidebar: webdriver
 ---
 
-The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a navigation to a new document begins in a context.
+The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation begins in a context.
 
 ## Description
 
@@ -31,11 +31,14 @@ The `params` field in the event notification is a navigation object with the fol
 - `context`
   - : A string that contains the ID of the context in which the navigation is occurring.
 - `navigation`
-  - : A string that contains the ID of the navigation, or the value `null` if the navigation does not have an associated navigation ID.
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
+    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
 - `timestamp`
   - : A non-negative integer that represents the time in UTC when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`
   - : A string that contains the URL being loaded.
+- `userContext` {{optional_inline}}
+  - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the navigation is occurring.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -33,7 +33,8 @@ The `params` field in the event notification is a navigation object with the fol
   - : A string that contains the ID of the context in which the navigation is starting.
 - `navigation`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    This ID matches the `navigation` value in the response of the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) and [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) commands.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
 - `timestamp`
   - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
 - `url`

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.browsingContext.navigationStarted_event
 sidebar: webdriver
 ---
 
-The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation begins in a context.
+The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation begins in a [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts).
 
 ## Event data
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/navigationstarted/index.md
@@ -9,6 +9,21 @@ sidebar: webdriver
 
 The `browsingContext.navigationStarted` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a cross-document navigation begins in a context.
 
+## Event data
+
+The `params` field in the event notification is an object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the navigation is starting.
+- `navigation`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
+- `timestamp`
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL being loaded.
+
 ## Description
 
 The navigation to a different page can be triggered by the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, by user interaction with elements on the page, or by JavaScript running in the page's context.
@@ -24,21 +39,6 @@ If the navigation fails, [`browsingContext.navigationFailed`](/en-US/docs/Web/We
 This event does not fire for same-document navigations.
 For navigations to a URL fragment, see [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated).
 For URL changes made through the History API without a full navigation, see [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated).
-
-## Event data
-
-The `params` field in the event notification is an object with the following fields:
-
-- `context`
-  - : A string that contains the ID of the context in which the navigation is starting.
-- `navigation`
-  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this navigation.
-    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
-    The same ID is shared by all events related to this navigation, including other navigation events in the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#events) module and events in the [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module.
-- `timestamp`
-  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
-- `url`
-  - : A string that contains the URL being loaded.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
@@ -37,7 +37,7 @@ All log entry objects include the following fields:
   - : A string that contains the log message or `null` if not available. For console entries, it is the concatenation of all stringified arguments joined by spaces, and for JavaScript errors, it is generally the error message.
     The exact format is browser-dependent, so don't rely on this value for assertions in tests.
 - `timestamp`
-  - : A non-negative integer that represents the time when the log entry was created, in UTC, as milliseconds elapsed since the epoch ({{jsxref("Date.now()")}}).
+  - : A non-negative integer that represents the time when the log entry was created, as milliseconds elapsed since the epoch ({{jsxref("Date.now()")}}).
 - `type`
   - : A string that identifies the source of the log entry. It has one of the following values:
     - `"console"`: Indicates that the log entry was generated from a call to a console API method (for example, {{domxref("console/log_static", "console.log()")}}, {{domxref("console/warn_static", "console.warn()")}}). Log entry objects of this type include [additional fields](#console_log_entry_fields).

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -62,6 +62,16 @@ sidebar:
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed
             code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted
+            code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/input

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -66,6 +66,10 @@ sidebar:
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated
             code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/load
+            code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -62,11 +62,11 @@ sidebar:
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed
             code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded
+            code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated
-            code: true
-          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/load
             code: true


### PR DESCRIPTION
### Description

This PR adds pages for the following navigation and page load events:
  - `browsingContext.navigationStarted`
  - `browsingContext.navigationCommitted`
  - `browsingContext.domContentLoaded`
  - `browsingContext.load`
  - `browsingContext.navigationFailed`
  - `browsingContext.fragmentNavigated`
  - `browsingContext.historyUpdated`


> [!NOTE]
> `browsingContext.navigationAborted` is not documented yet. The BCD key is also missing for this event. I'll cover it when there is an implementation.


### Spec links

- https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationStarted
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationCommitted
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-domContentLoaded
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-load
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-navigationFailed
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-fragmentNavigated
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-historyUpdated

### Related issue

Doc issue: mdn/mdn#851