### PR TITLE
Update hoisting explanation for const declarations

### DIFF
--- a/files/en-us/glossary/hoisting/index.md
+++ b/files/en-us/glossary/hoisting/index.md
@@ -26,7 +26,7 @@ const x = 1;
 }
 ```
 
-If the `const x = 2` declaration is not hoisted at all (as in, it only comes into effect when it's executed), then the `console.log(x)` statement should be able to read the `x` value from the upper scope. However, because the `const` declaration still "taints" the entire scope it's defined in, the `console.log(x)` statement reads the `x` from the `const x = 2` declaration instead, which is not yet initialized, and throws a {{jsxref("ReferenceError")}}. Still, it may be more useful to characterize lexical declarations as non-hoisting, because from a utilitarian perspective, the hoisting of these declarations doesn't bring any meaningful features.
+If the `const x = 2` declaration is not hoisted at all (as in, it only comes into effect when it's executed), then the `console.log(x)` statement should be able to read the `x` value from the outer scope. However, because the `const` declaration still "taints" the entire scope it's defined in, the `console.log(x)` statement reads the `x` from the `const x = 2` declaration instead, which is not yet initialized, and throws a {{jsxref("ReferenceError")}}. Still, it may be more useful to characterize lexical declarations as non-hoisting, because from a utilitarian perspective, the hoisting of these declarations doesn't bring any meaningful features.
 
 Note that the following is not a form of hoisting:
 


### PR DESCRIPTION
outer is more specific word here from the upper scope

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Replace "upper scope" with "outer scope" in the hoisting article.

### Motivation

"Outer scope" is the more commonly used and precise term in JavaScript discussions of lexical scoping and scope chains. The phrase "upper scope" may be interpreted as a positional description, whereas "outer scope" clearly refers to the enclosing lexical scope from which variable resolution proceeds.

### Additional details

No technical behavior is changed. This is a wording clarification intended to improve consistency with common JavaScript terminology.

### Related issues and pull requests

N/A

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
