### PR TITLE
Fix typo in web/api/response/status

### DIFF
--- a/files/en-us/web/api/response/status/index.md
+++ b/files/en-us/web/api/response/status/index.md
@@ -8,7 +8,9 @@ browser-compat: api.Response.status
 
 {{APIRef("Fetch API")}}{{AvailableInWorkers}}
 
-The **`status`** read-only property of the {{domxref("Response")}} interface contains the [HTTP status code](/en-US/docs/Web/HTTP/Reference/Status) of the response, e.g., `200` for success or `404` if the resource could not be found.
+The **`status`** read-only property of the {{domxref("Response")}} interface contains the [HTTP status code](/en-US/docs/Web/HTTP/Reference/Status) of the response.
+
+For example, `200` for success or `404` if the resource could not be found.
 
 ## Value
 

--- a/files/en-us/web/api/response/status/index.md
+++ b/files/en-us/web/api/response/status/index.md
@@ -8,16 +8,14 @@ browser-compat: api.Response.status
 
 {{APIRef("Fetch API")}}{{AvailableInWorkers}}
 
-The **`status`** read-only property of the {{domxref("Response")}} interface contains the [HTTP status codes](/en-US/docs/Web/HTTP/Reference/Status) of the response.
-
-For example, `200` for success, `404` if the resource could not be found.
+The **`status`** read-only property of the {{domxref("Response")}} interface contains the [HTTP status code](/en-US/docs/Web/HTTP/Reference/Status) of the response, e.g., `200` for success or `404` if the resource could not be found.
 
 ## Value
 
 An unsigned short number.
 This is one of the [HTTP response status codes](/en-US/docs/Web/HTTP/Reference/Status).
 
-A value is `0` is returned for a response whose {{domxref("Response.type", "type")}} is `opaque`, `opaqueredirect`, or `error`.
+A value of `0` is returned for a response whose {{domxref("Response.type", "type")}} is `opaque`, `opaqueredirect`, or `error`.
 
 ## Examples
 


### PR DESCRIPTION
I first noticed the sentence starting with _"A value is `0` is returned"_ which I assume originally meant to say _"value of"_, but then looking for other thing to improve in the article I have also made minor changes in the introduction.