### PR TITLE
FF153 Range requests pass through SW in same-origin no-cors requests

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -46,7 +46,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### HTTP
 
-- A same-origin fetch request for a media element (for example, using a {{htmlelement("video")}} element) will now pass through a service worker without stripping the {{httpheader("Range")}} header.
+- A same-origin fetch request for a media element (for example, from a {{htmlelement("video")}} element) will now pass through a service worker without stripping the {{httpheader("Range")}} header.
   Previously the `Range` header was only preserved in same-origin CORS requests, made by adding the `crossorigin` attribute (`<video crossorigin>`).
   Note that `Range` headers are still stripped from cross-origin no-cors requests passing through a service worker.
   ([Firefox bug 1465074](https://bugzil.la/1465074)).

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -44,7 +44,12 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### HTTP -->
+### HTTP
+
+- A same-origin fetch request for a media element (for example, using a {{htmlelement("video")}} element) will now pass through a service worker without stripping the {{httpheader("Range")}} header.
+  Previously the `Range` header was only preserved in same-origin CORS requests, made by adding the `crossorigin` attribute (`<video crossorigin>`).
+  Note that `Range` headers are still stripped from cross-origin no-cors requests passing through a service worker.
+  ([Firefox bug 1465074](https://bugzil.la/1465074)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -48,7 +48,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 - A same-origin fetch request for a media element (for example, from a {{htmlelement("video")}} element) will now pass through a service worker without stripping the {{httpheader("Range")}} header.
   Previously the `Range` header was only preserved in same-origin CORS requests, made by adding the `crossorigin` attribute (`<video crossorigin>`).
-  Note that `Range` headers are still stripped from cross-origin no-cors requests passing through a service worker.
+  Note that fetch requests for genuinely cross-origin media don't yet go through service workers.
   ([Firefox bug 1465074](https://bugzil.la/1465074)).
 
 <!-- #### Removals -->


### PR DESCRIPTION
FF153 allows `Range` headers to be preseved in a same-origin no-cors requests passed through a service worker.
This is not hugely interesting, but has been added to the release note for historical record.

Related docs work can be tracked in #44467