### PR TITLE
Update codec preference handling for video

### DIFF
--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -371,6 +371,7 @@ function changeVideoCodec(mimeType) {
     }
   });
 
+  // Manually trigger a new negotiation (setCodecPreferences() does not automatically do so).
   peerConnection.onnegotiationneeded();
 }
 ```
@@ -391,10 +392,9 @@ The `preferCodec()` function called by the code above looks like this to move a 
 function preferCodec(codecs, mimeType) {
   let otherCodecs = [];
   let sortedCodecs = [];
-  let count = codecs.length;
 
   codecs.forEach((codec) => {
-    if (codec.mimeType === mimeType) {
+    if (codec.mimeType.toLowerCase() === mimeType.toLowerCase()) {
       sortedCodecs.push(codec);
     } else {
       otherCodecs.push(codec);

--- a/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/webrtc_codecs/index.md
@@ -365,8 +365,8 @@ function changeVideoCodec(mimeType) {
     let recvCodecs = RTCRtpReceiver.getCapabilities(kind).codecs;
 
     if (kind === "video") {
-      sendCodecs = preferCodec(mimeType);
-      recvCodecs = preferCodec(mimeType);
+      sendCodecs = preferCodec(sendCodecs, mimeType);
+      recvCodecs = preferCodec(recvCodecs, mimeType);
       transceiver.setCodecPreferences([...sendCodecs, ...recvCodecs]);
     }
   });


### PR DESCRIPTION
Code calling preferCodec in changeVideoCodec has missing parameters

There is a sample code in the documentation that calls preferCodec method with one parameter but the real method expects two parameters.

### Description

I added the required parameter

### Motivation

I was executing the code in my head but it did not feel right. I checked the rest of the documentation and noticed the mistake.

### Additional details

None

### Related issues and pull requests

None
