### PR TITLE
Fix redirect lines with spaces as field delimiter

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -15726,12 +15726,12 @@
 /en-US/docs/Web/Performance/dns-prefetch	/en-US/docs/Web/Performance/Guides/dns-prefetch
 /en-US/docs/Web/Performance/learn	/en-US/docs/Web/Performance/Guides/How_browsers_work
 /en-US/docs/Web/Privacy/Firefox_tracking_protection	/en-US/docs/Web/Privacy/Guides/Firefox_tracking_protection
-/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies     /en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies
-/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Enrollment      /en-US/docs/Web/Privacy/Guides/Privacy_sandbox#enrollment
-/en-US/docs/Web/Privacy/Partitioned_cookies    /en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies
+/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Enrollment	/en-US/docs/Web/Privacy/Guides/Privacy_sandbox#enrollment
+/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies	/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies
+/en-US/docs/Web/Privacy/Partitioned_cookies	/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies
 /en-US/docs/Web/Privacy/Privacy_sandbox	/en-US/docs/Web/Privacy/Guides/Privacy_sandbox
-/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment     /en-US/docs/Web/Privacy/Guides/Privacy_sandbox#enrollment
-/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies    /en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies
+/en-US/docs/Web/Privacy/Privacy_sandbox/Enrollment	/en-US/docs/Web/Privacy/Guides/Privacy_sandbox#enrollment
+/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies	/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies
 /en-US/docs/Web/Privacy/Redirect_tracking_protection	/en-US/docs/Web/Privacy/Guides/Redirect_tracking_protection
 /en-US/docs/Web/Privacy/State_Partitioning	/en-US/docs/Web/Privacy/Guides/State_Partitioning
 /en-US/docs/Web/Privacy/Storage_Access_Policy	/en-US/docs/Web/Privacy/Guides/Storage_Access_Policy


### PR DESCRIPTION
### Description

Fixes redirect lines that used spaces as a field separator instead of a single tab.

### Motivation

Avoid breaking consumers that expect a tab field separator.

### Additional details

Note: `fix-redirects` also sorted them alphabetically.

### Related issues and pull requests

Regressor:

- https://github.com/mdn/content/pull/44425.
