### PR TITLE
Remove unavailable Exploring JS link

### DIFF
--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -358,4 +358,3 @@ import { myFunction, myVariable, MyClass } from "parentModule.js";
 - [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules) guide
 - [ES6 in Depth: Modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/) on hacks.mozilla.org (2015)
 - [ES modules: A cartoon deep-dive](https://hacks.mozilla.org/2018/03/es-modules-a-cartoon-deep-dive/) on hacks.mozilla.org (2018)
-- [Exploring JS, Ch.16: Modules](https://exploringjs.com/es6/ch_modules.html) by Dr. Axel Rauschmayer


### PR DESCRIPTION
### Description

Removes the external “Exploring JS, Ch.16: Modules” link from the See also section of the JavaScript export reference page.

### Motivation

The linked page is currently unavailable, so removing it avoids sending MDN readers to a dead external resource.

### Additional details

The remaining See also links still provide related module documentation and learning resources.

### Related issues and pull requests

None.
