### PR TITLE
Update fit-content() function documentation

### DIFF
--- a/files/en-us/web/css/reference/values/fit-content_function/index.md
+++ b/files/en-us/web/css/reference/values/fit-content_function/index.md
@@ -11,6 +11,8 @@ sidebar: cssref
 
 The **`fit-content()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) clamps a given size to an available size according to the formula `min(maximum size, max(minimum size, argument))`.
 
+This function is different from the {{cssxref("fit-content")}} sizing keyword.
+
 {{InteractiveExample("CSS Demo: fit-content()")}}
 
 ```css interactive-example-choice


### PR DESCRIPTION
Clarified the distinction between fit-content() and the fit-content sizing keyword.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

fit-content and fit-content() are not the same thing

### Motivation

The same keyword is confusing

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
