### PR TITLE
fix(ci): pin npx fred-ssr and rari to their @mdn packages

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -134,12 +134,12 @@ jobs:
             ARGS+=("-f" "$PWD/$file")
           done
 
-          npx rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
+          npx @mdn/rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
 
           # Workaround, as fred-ssr doesn't copy assets.
           cp -vR node_modules/@mdn/fred/out/. "$BUILD_OUT_ROOT"
 
-          npx fred-ssr
+          npx --package=@mdn/fred fred-ssr
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT


### PR DESCRIPTION
## Description

- `.github/workflows/pr-test.yml`: `npx fred-ssr` → `npx --package=@mdn/fred fred-ssr`
- `.github/workflows/pr-test.yml`: `npx rari …` → `npx @mdn/rari …`

## Motivation

Prevent dependency-confusion fallbacks in `npx fred-ssr` and `npx rari`.

## Additional details

`npx <bin>` resolves to the local bin only when present; otherwise npm silently downloads and runs a registry package literally named `<bin>`. In CI, `npx` assumes `--yes`, so this happens with no prompt. `fred-ssr` is a bin of `@mdn/fred` and its bare name is unpublished (squattable); the unscoped `rari` name is owned by an unrelated third party, not MDN. Pinning `--package=@mdn/fred` / `@mdn/rari` guarantees the intended bins.

## Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.
