### PR TITLE
Update fit-content() documentation for clarity

### DIFF
--- a/files/en-us/web/css/reference/values/fit-content_function/index.md
+++ b/files/en-us/web/css/reference/values/fit-content_function/index.md
@@ -11,6 +11,9 @@ sidebar: cssref
 
 The **`fit-content()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) clamps a given size to an available size according to the formula `min(maximum size, max(minimum size, argument))`.
 
+> [!NOTE]
+> This keyword is different from the {{cssxref("fit-content")}} sizing keyword. The sizing keyword represents an element size that adapts to its content while staying within the limits of its container and is not related to {{cssxref("grid-template-columns")}}.
+
 {{InteractiveExample("CSS Demo: fit-content()")}}
 
 ```css interactive-example-choice

--- a/files/en-us/web/css/reference/values/fit-content_function/index.md
+++ b/files/en-us/web/css/reference/values/fit-content_function/index.md
@@ -11,8 +11,8 @@ sidebar: cssref
 
 The **`fit-content()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) clamps a given size to an available size according to the formula `min(maximum size, max(minimum size, argument))`.
 
-> [!NOTE]
-> This keyword is different from the {{cssxref("fit-content")}} sizing keyword. The sizing keyword represents an element size that adapts to its content while staying within the limits of its container and is not related to {{cssxref("grid-template-columns")}}.
+It is distinct from the {{cssxref("fit-content")}} keyword, which takes no argument and sizes a box based on its content within the available space.
+Only `fit-content()` is valid in grid track sizing properties such as {{cssxref("grid-template-columns")}}.
 
 {{InteractiveExample("CSS Demo: fit-content()")}}
 
@@ -150,5 +150,6 @@ fit-content(40%)
 - {{cssxref("grid-auto-columns")}}
 - {{cssxref("grid-auto-rows")}}
 - {{cssxref("grid-auto-flow")}}
+- {{cssxref("fit-content")}} keyterm
 - [Line-based placement with CSS grid](/en-US/docs/Web/CSS/Guides/Grid_layout/Line-based_placement)
 - [Grid template areas: grid definition shorthands](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_template_areas#grid_definition_shorthands)


### PR DESCRIPTION
Clarified the distinction between the fit-content() function and the fit-content sizing keyword in the documentation.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Clarify the existens of the sizing keyword with the same name.

### Motivation

The two equal keywords could lead to confusion

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
