### PR TITLE
docs(css): clarify pointer-events none description

### DIFF
--- a/files/en-us/web/css/reference/properties/pointer-events/index.md
+++ b/files/en-us/web/css/reference/properties/pointer-events/index.md
@@ -99,7 +99,7 @@ The `pointer-events` property is specified as a single keyword chosen from the l
 - `auto`
   - : The element behaves as it would if the `pointer-events` property were not specified. In SVG content, this value and the value `visiblePainted` have the same effect.
 - `none`
-  - : The element on its own is never the [target](/en-US/docs/Web/API/Event/target) of pointer events. However its subtree could be kept targetable by setting `pointer-events` to some other value. In these circumstances, pointer events will trigger event listeners on this parent element as appropriate on their way to or from the descendant during the event capture and [bubble](/en-US/docs/Web/API/Event/bubbles) phases.
+  - : The element on its own is generally not the [target](/en-US/docs/Web/API/Event/target) of pointer events. However its subtree could be kept targetable by setting `pointer-events` to some other value. In these circumstances, pointer events will trigger event listeners on this parent element as appropriate on their way to or from the descendant during the event capture and [bubble](/en-US/docs/Web/API/Event/bubbles) phases.
 
     > [!NOTE]
     > The `pointerenter` and `pointerleave` events are fired when a pointing device is moved into an element or one of its descendants. So, even if `pointer-events: none` is set on the parent and not set on children, the events are triggered on the parent after the pointer is moved in or out of a descendant.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->
<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
this all is given in description tell me what to paste in description

Description
Clarifies the documentation for the pointer-events: none CSS value.
Changed wording from “never the target of pointer events” to “generally not the target of pointer events”.

Motivation
The previous wording was too absolute and could mislead readers. This update makes the description more accurate, reflecting exceptions such as pointerenter and pointerleave.

Additional details
This change improves developer understanding of how pointer-events: none behaves in practice.

Related issues and pull requests
Fixes #44565

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
