### PR TITLE
added release notes for tree counting css functions

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -406,6 +406,20 @@ The {{cssxref("@keyframes")}} at-rule now supports [`<timeline-range-name>`](/en
 - `layout.css.scroll-driven-animations.enabled`
   - : Set to `true` to enable.
 
+### Tree counting CSS functions
+
+The {{cssxref("sibling-count")}} and {{cssxref("sibling-index")}} function are now supported. The `sibling-count()` function returns the number sibling elements as well as the element itself. The `sibling-index()` function returns the index number of the element in relation to its siblings, this starts from `1` and not `0`. ([Firefox bug 2042063](https://bugzil.la/2042063)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 154           | Yes                 |
+| Developer Edition | 153           | No                  |
+| Beta              | 153           | No                  |
+| Release           | 153           | No                  |
+
+- `layout.css.tree-counting-functions.enabled`
+  - : Set to `true` to enable.
+
 ## SVG
 
 **No experimental features in this release cycle.**

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -104,3 +104,8 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 These features are shipping in Firefox 153 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+
+- **Tree counting CSS functions**: `layout.css.tree-counting-functions.enabled`
+
+  The {{cssxref("sibling-count")}} and {{cssxref("sibling-index")}} function are now supported. The `sibling-count()` function returns the number sibling elements as well as the element itself. The `sibling-index()` function returns the index number of the element in relation to its siblings, this starts from `1` and not `0`.
+  ([Firefox bug 2042063](https://bugzil.la/2042063)).


### PR DESCRIPTION
### Description

- Added release for CSS tree counting functions, `sibling-count()` & `sibling-index()`, to:
  - Experimental features
  - Firefox 153 (experimental section)

### Motivation

- Working on [MDN issue #44465](https://github.com/mdn/content/issues/44465)
- Working on [MDN issue #44469](https://github.com/mdn/content/issues/44469)

### Related pull requests

- [BCD PR](https://github.com/mdn/browser-compat-data/pull/29909)