### PR TITLE
New pages: *-rule-visibility-items

### DIFF
--- a/files/en-us/web/css/guides/gaps/index.md
+++ b/files/en-us/web/css/guides/gaps/index.md
@@ -429,6 +429,7 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{CSSxRef("grid")}}
 - {{CSSxRef("grid-column")}}
 - {{CSSxRef("grid-row")}}
+- {{cssxref("repeat()")}}
 
 [CSS multi-column layout](/en-US/docs/Web/CSS/Guides/Multicol_layout) module
 

--- a/files/en-us/web/css/guides/gaps/index.md
+++ b/files/en-us/web/css/guides/gaps/index.md
@@ -352,9 +352,12 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{cssxref("column-rule")}}
 - {{cssxref("column-rule-color")}}
 - {{cssxref("column-rule-style")}}
+- {{cssxref("column-rule-visibility-items")}}
 - {{cssxref("column-rule-width")}}
 - {{cssxref("gap")}}
 - {{cssxref("row-gap")}}
+- {{cssxref("row-rule-visibility-items")}}
+- {{cssxref("rule-visibility-items")}}
 <!-- Will be uncommented when issue https://github.com/mdn/content/issues/44435 is resolved.
 - {{cssxref("column-rule-break")}}
 - {{cssxref("column-rule-inset")}}
@@ -366,7 +369,6 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{cssxref("column-rule-inset-junction-end")}}
 - {{cssxref("column-rule-inset-junction-start")}}
 - {{cssxref("column-rule-inset-start")}}
-- {{cssxref("column-rule-visibility-items")}}
 - {{cssxref("row-rule")}}
 - {{cssxref("row-rule-break")}}
 - {{cssxref("row-rule-color")}}
@@ -380,7 +382,6 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{cssxref("row-rule-inset-junction-start")}}
 - {{cssxref("row-rule-inset-start")}}
 - {{cssxref("row-rule-style")}}
-- {{cssxref("row-rule-visibility-items")}}
 - {{cssxref("row-rule-width")}}
 - {{cssxref("rule")}}
 - {{cssxref("rule-break")}}
@@ -392,7 +393,6 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{cssxref("rule-inset-start")}}
 - {{cssxref("rule-overlap")}}
 - {{cssxref("rule-style")}}
-- {{cssxref("rule-visibility-items")}}
 - {{cssxref("rule-width")}} -->
 
 ### Terms and glossary definitions

--- a/files/en-us/web/css/guides/gaps/index.md
+++ b/files/en-us/web/css/guides/gaps/index.md
@@ -350,16 +350,8 @@ When the column rule is larger than the column gap, the decorative line appears 
 
 - {{cssxref("column-gap")}}
 - {{cssxref("column-rule")}}
-- {{cssxref("column-rule-color")}}
-- {{cssxref("column-rule-style")}}
-- {{cssxref("column-rule-visibility-items")}}
-- {{cssxref("column-rule-width")}}
-- {{cssxref("gap")}}
-- {{cssxref("row-gap")}}
-- {{cssxref("row-rule-visibility-items")}}
-- {{cssxref("rule-visibility-items")}}
-<!-- Will be uncommented when issue https://github.com/mdn/content/issues/44435 is resolved.
 - {{cssxref("column-rule-break")}}
+- {{cssxref("column-rule-color")}}
 - {{cssxref("column-rule-inset")}}
 - {{cssxref("column-rule-inset-cap")}}
 - {{cssxref("column-rule-inset-cap-end")}}
@@ -369,6 +361,11 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{cssxref("column-rule-inset-junction-end")}}
 - {{cssxref("column-rule-inset-junction-start")}}
 - {{cssxref("column-rule-inset-start")}}
+- {{cssxref("column-rule-style")}}
+- {{cssxref("column-rule-visibility-items")}}
+- {{cssxref("column-rule-width")}}
+- {{cssxref("gap")}}
+- {{cssxref("row-gap")}}
 - {{cssxref("row-rule")}}
 - {{cssxref("row-rule-break")}}
 - {{cssxref("row-rule-color")}}
@@ -382,6 +379,7 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{cssxref("row-rule-inset-junction-start")}}
 - {{cssxref("row-rule-inset-start")}}
 - {{cssxref("row-rule-style")}}
+- {{cssxref("row-rule-visibility-items")}}
 - {{cssxref("row-rule-width")}}
 - {{cssxref("rule")}}
 - {{cssxref("rule-break")}}
@@ -393,7 +391,8 @@ When the column rule is larger than the column gap, the decorative line appears 
 - {{cssxref("rule-inset-start")}}
 - {{cssxref("rule-overlap")}}
 - {{cssxref("rule-style")}}
-- {{cssxref("rule-width")}} -->
+- {{cssxref("rule-visibility-items")}}
+- {{cssxref("rule-width")}}
 
 ### Terms and glossary definitions
 

--- a/files/en-us/web/css/reference/properties/column-rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/column-rule-visibility-items/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.column-rule-visibility-items
 sidebar: cssref
 ---
 
-The **`column-rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) property defines whether a column-rule segment is painted in portions of gaps adjacent to empty areas.
+The **`column-rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) property defines whether a column-rule segment is painted in gaps adjacent to empty areas.
 
 {{InteractiveExample("CSS Demo: column-rule-visibility-items")}}
 
@@ -56,7 +56,7 @@ cite {
 ## Syntax
 
 ```css
-/* keywords */
+/* Keywords */
 column-rule-visibility-items: all;
 column-rule-visibility-items: around;
 column-rule-visibility-items: between;
@@ -86,9 +86,9 @@ column-rule-visibility-items: unset;
 
 ## Description
 
-The `column-rule-visibility-items` property defines whether a column-rule segment is painted in portions of gaps adjacent to empty areas in the gaps between columns in [multi-row](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one column.
+The `column-rule-visibility-items` property defines whether a column-rule segment is painted in column gaps adjacent to empty areas in [multi-row](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one column.
 
-The `column-rule-visibility-items`, along with the {{cssxref("column-rule-visibility-items")}}, can be set using the {{cssxref("rule-visibility-items")}} shorthand.
+The `column-rule-visibility-items` and {{cssxref("row-rule-visibility-items")}} properties can both be set using the {{cssxref("rule-visibility-items")}} shorthand.
 
 ## Formal definition
 
@@ -121,9 +121,9 @@ We include a list of dynamic sports duos:
 
 #### CSS
 
-We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 columns and 4 rows by setting both the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} to `repeat(4, 1fr)`, and move the last item to the 16th grid area using {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. We include a {{cssxref("gap")}} of `20px` to provide enough room between the columns to fit our `5px` dashed rule.
+We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 columns and 4 rows by setting both the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} properties to `repeat(4, 1fr)`, and move the last item to the bottom-right grid area using {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. We include a {{cssxref("gap")}} of `20px` to provide enough room between the columns to fit our `5px` dashed rule.
 
-Finally, we set `column-rule-visibility-items` to `between`, so only if both grid area adjacent to a column rule segment contains a grid item with the column rule be painted.
+Finally, we set `column-rule-visibility-items` to `between`, so that a column rule is painted in a column gap only if both adjacent grid areas contain a grid item.
 
 ```css
 ol {
@@ -142,6 +142,9 @@ li:last-child {
 ```
 
 ```css hidden
+li {
+  margin-left: 1em;
+}
 @layer no-support {
   @supports not (column-rule-visibility-items: around) {
     body::before {

--- a/files/en-us/web/css/reference/properties/column-rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/column-rule-visibility-items/index.md
@@ -1,0 +1,176 @@
+---
+title: "`column-rule-visibility-items` CSS property"
+short-title: column-rule-visibility-items
+slug: Web/CSS/Reference/Properties/column-rule-visibility-items
+page-type: css-property
+browser-compat: css.properties.column-rule-visibility-items
+sidebar: cssref
+---
+
+The **`column-rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) property defines whether a column-rule segment is painted in portions of gaps adjacent to empty areas.
+
+{{InteractiveExample("CSS Demo: column-rule-visibility-items")}}
+
+```css interactive-example-choice
+column-rule-visibility-items: all;
+```
+
+```css interactive-example-choice
+column-rule-visibility-items: around;
+```
+
+```css interactive-example-choice
+column-rule-visibility-items: between;
+```
+
+```css interactive-example-choice
+column-rule-visibility-items: normal;
+```
+
+```html interactive-example
+<section id="default-example">
+  <section id="example-element">
+    <p>One fish</p>
+    <p>Two fish</p>
+    <p>Red fish</p>
+    <p>Blue fish</p>
+    <cite>-- Dr. Seuss<cite>
+  </section>
+</section>
+```
+
+```css interactive-example
+#example-element {
+  display: grid;
+  column-rule: solid 5px red;
+  gap: 10px;
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr);
+}
+cite {
+  grid-row: 3;
+  grid-column: 3;
+}
+```
+
+## Syntax
+
+```css
+/* keywords */
+column-rule-visibility-items: all;
+column-rule-visibility-items: around;
+column-rule-visibility-items: between;
+column-rule-visibility-items: normal;
+
+/* Global values */
+column-rule-visibility-items: inherit;
+column-rule-visibility-items: initial;
+column-rule-visibility-items: revert;
+column-rule-visibility-items: revert-layer;
+column-rule-visibility-items: unset;
+```
+
+### Values
+
+- `all`
+  - : The column rule should be painted in all gap segments, regardless of whether adjacent areas contain an item.
+
+- `around`
+  - : The column rule should be painted in a gap segment if at least one of the two adjacent areas is occupied by a item.
+
+- `between`
+  - : The column rule should be painted in a gap segment if both adjacent areas are occupied by items.
+
+- `normal`
+  - : With grid containers, behaves the same as `all`. In multicol layout, behaves the same as `between`. This is the default.
+
+## Description
+
+The `column-rule-visibility-items` property defines whether a column-rule segment is painted in portions of gaps adjacent to empty areas in the gaps between columns in [multi-row](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one column.
+
+The `column-rule-visibility-items`, along with the {{cssxref("column-rule-visibility-items")}}, can be set using the {{cssxref("rule-visibility-items")}} shorthand.
+
+## Formal definition
+
+{{cssinfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+### Basic example
+
+In this example, we define a column rule to be drawn between two grid areas if at least one adjacent grid area contains a grid item.
+
+#### HTML
+
+We include a list of dynamic sports duos:
+
+```html
+<ol>
+  <li>Simone Biles + Jonathan Owens</li>
+  <li>Serena Williams + Venus Williams</li>
+  <li>Aaron Judge + Giancarlo Stanton</li>
+  <li>LeBron James + Dwyane Wade</li>
+  <li>Xavi Hernandez + Andres Iniesta</li>
+  <li>Kerri Walsh + Misty May Treanor</li>
+</ol>
+```
+
+#### CSS
+
+We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 columns and 4 rows by setting both the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} to `repeat(4, 1fr)`, and move the last item to the 16th grid area using {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. We include a {{cssxref("gap")}} of `20px` to provide enough room between the columns to fit our `5px` dashed rule.
+
+Finally, we set `column-rule-visibility-items` to `between`, so only if both grid area adjacent to a column rule segment contains a grid item with the column rule be painted.
+
+```css
+ol {
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+
+  column-rule: dashed 5px blue;
+  column-rule-visibility-items: between;
+}
+li:last-child {
+  grid-row: 4;
+  grid-column: 4;
+}
+```
+
+```css hidden
+@layer no-support {
+  @supports not (column-rule-visibility-items: around) {
+    body::before {
+      content: "Your browser doesn't support the column-rule-visibility-items property";
+      background-color: wheat;
+      display: block;
+      text-align: center;
+      padding: 1rem 0;
+    }
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Basic", "", "230")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{cssxref("rule-visibility-items")}} shorthand
+- {{cssxref("row-rule-visibility-items")}}
+- {{cssxref("column-rule")}} shorthand
+- {{cssxref("rule")}} shorthand
+- [CSS gaps](/en-US/docs/Web/CSS/Guides/Gaps) module

--- a/files/en-us/web/css/reference/properties/row-rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/row-rule-visibility-items/index.md
@@ -1,0 +1,176 @@
+---
+title: "`row-rule-visibility-items` CSS property"
+short-title: row-rule-visibility-items
+slug: Web/CSS/Reference/Properties/row-rule-visibility-items
+page-type: css-property
+browser-compat: css.properties.row-rule-visibility-items
+sidebar: cssref
+---
+
+The **`row-rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) property defines whether a row-rule segment is painted in portions of gaps adjacent to empty areas.
+
+{{InteractiveExample("CSS Demo: row-rule-visibility-items")}}
+
+```css interactive-example-choice
+row-rule-visibility-items: all;
+```
+
+```css interactive-example-choice
+row-rule-visibility-items: around;
+```
+
+```css interactive-example-choice
+row-rule-visibility-items: between;
+```
+
+```css interactive-example-choice
+row-rule-visibility-items: normal;
+```
+
+```html interactive-example
+<section id="default-example">
+  <section id="example-element">
+    <p>One fish</p>
+    <p>Two fish</p>
+    <p>Red fish</p>
+    <p>Blue fish</p>
+    <cite>-- Dr. Seuss<cite>
+  </section>
+</section>
+```
+
+```css interactive-example
+#example-element {
+  display: grid;
+  row-rule: solid 5px red;
+  gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+}
+cite {
+  grid-column: 3;
+  grid-row: 3;
+}
+```
+
+## Syntax
+
+```css
+/* keywords */
+row-rule-visibility-items: all;
+row-rule-visibility-items: around;
+row-rule-visibility-items: between;
+row-rule-visibility-items: normal;
+
+/* Global values */
+row-rule-visibility-items: inherit;
+row-rule-visibility-items: initial;
+row-rule-visibility-items: revert;
+row-rule-visibility-items: revert-layer;
+row-rule-visibility-items: unset;
+```
+
+### Values
+
+- `all`
+  - : The row rule should be painted in all gap segments, regardless of whether adjacent areas contain an item.
+
+- `around`
+  - : The row rule should be painted in a gap segment if at least one of the two adjacent areas is occupied by an item.
+
+- `between`
+  - : The row rule should be painted in a gap segment if both adjacent areas are occupied by items.
+
+- `normal`
+  - : Behaves the same as `all`. This is the default.
+
+## Description
+
+The `row-rule-visibility-items` property defines whether, in [multi-column](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one row a row-rule, row rule segments area painted in the gaps between two adjacent areas if one or both of the areas area empty.
+
+The `row-rule-visibility-items`, along with the {{cssxref("row-rule-visibility-items")}}, can be set using the {{cssxref("rule-visibility-items")}} shorthand.
+
+## Formal definition
+
+{{cssinfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+### Basic example
+
+In this example, we define a row rules to be drawn between two grid areas if at least one adjacent grid area contains grid items.
+
+#### HTML
+
+We include a list of dynamic sports duos:
+
+```html
+<ol>
+  <li>Simone Biles + Jonathan Owens</li>
+  <li>Serena Williams + Venus Williams</li>
+  <li>Aaron Judge + Giancarlo Stanton</li>
+  <li>LeBron James + Dwyane Wade</li>
+  <li>Xavi Hernandez + Andres Iniesta</li>
+  <li>Kerri Walsh + Misty May Treanor</li>
+</ol>
+```
+
+#### CSS
+
+We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 rows and 4 columns by setting both the {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} to `repeat(4, 1fr)`, and move the last item to the 16th grid area using {{cssxref("grid-row")}} and {{cssxref("grid-column")}}. We include a {{cssxref("gap")}} of `20px` to provide enough room between the rows to fit our `5px` dashed rule.
+
+Finally, we set `row-rule-visibility-items` to `around`, so only if a grid area above or below a segment contains a grid item, the row rule will be painted.
+
+```css
+ol {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(4, 1fr);
+  gap: 10px;
+
+  row-rule: dashed 5px blue;
+  row-rule-visibility-items: around;
+}
+li:last-child {
+  grid-column: 4;
+  grid-row: 4;
+}
+```
+
+```css hidden
+@layer no-support {
+  @supports not (row-rule-visibility-items: around) {
+    body::before {
+      content: "Your browser doesn't support the row-rule-visibility-items property";
+      background-color: wheat;
+      display: block;
+      text-align: center;
+      padding: 1rem 0;
+    }
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Basic", "", "230")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{cssxref("rule-visibility-items")}} shorthand
+- {{cssxref("column-rule-visibility-items")}}
+- {{cssxref("row-rule")}} shorthand
+- {{cssxref("rule")}} shorthand
+- [CSS gaps](/en-US/docs/Web/CSS/Guides/Gaps) module

--- a/files/en-us/web/css/reference/properties/row-rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/row-rule-visibility-items/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.row-rule-visibility-items
 sidebar: cssref
 ---
 
-The **`row-rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) property defines whether a row-rule segment is painted in portions of gaps adjacent to empty areas.
+The **`row-rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) property defines whether a row-rule segment is painted in gaps adjacent to empty areas.
 
 {{InteractiveExample("CSS Demo: row-rule-visibility-items")}}
 
@@ -56,7 +56,7 @@ cite {
 ## Syntax
 
 ```css
-/* keywords */
+/* Keywords */
 row-rule-visibility-items: all;
 row-rule-visibility-items: around;
 row-rule-visibility-items: between;
@@ -86,9 +86,9 @@ row-rule-visibility-items: unset;
 
 ## Description
 
-The `row-rule-visibility-items` property defines whether, in [multi-column](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one row a row-rule, row rule segments area painted in the gaps between two adjacent areas if one or both of the areas area empty.
+The `row-rule-visibility-items` property defines whether, in [multi-column](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one row, row rule segments are painted in the gaps between two adjacent areas if one or both of the areas are empty.
 
-The `row-rule-visibility-items`, along with the {{cssxref("row-rule-visibility-items")}}, can be set using the {{cssxref("rule-visibility-items")}} shorthand.
+The `row-rule-visibility-items` and {{cssxref("row-rule-visibility-items")}} properties can both be set to the same values using the {{cssxref("rule-visibility-items")}} shorthand.
 
 ## Formal definition
 
@@ -121,9 +121,9 @@ We include a list of dynamic sports duos:
 
 #### CSS
 
-We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 rows and 4 columns by setting both the {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} to `repeat(4, 1fr)`, and move the last item to the 16th grid area using {{cssxref("grid-row")}} and {{cssxref("grid-column")}}. We include a {{cssxref("gap")}} of `20px` to provide enough room between the rows to fit our `5px` dashed rule.
+We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 rows and 4 columns by setting both the {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} properties to `repeat(4, 1fr)`, and move the last item to the bottom-right grid area using {{cssxref("grid-row")}} and {{cssxref("grid-column")}}. We include a {{cssxref("gap")}} of `20px` to provide enough room between the rows to fit our `5px` dashed rule.
 
-Finally, we set `row-rule-visibility-items` to `around`, so only if a grid area above or below a segment contains a grid item, the row rule will be painted.
+Finally, we set `row-rule-visibility-items` to `around`, so that a row rule segment is only painted in a row gap if one or both adjacent grid areas contain a grid item.
 
 ```css
 ol {
@@ -142,6 +142,9 @@ li:last-child {
 ```
 
 ```css hidden
+li {
+  margin-left: 1em;
+}
 @layer no-support {
   @supports not (row-rule-visibility-items: around) {
     body::before {

--- a/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.rule-visibility-items
 sidebar: cssref
 ---
 
-The **`rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) shorthand property defines whether a rule segment is painted in portions of gaps adjacent to empty areas, setting both the {{cssxref("column-rule-visibility-items")}} and {{cssxref("row-rule-visibility-items")}} to the same value.
+The **`rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) shorthand property defines whether rule segments are painted in both row and column gaps adjacent to empty areas.
 
 ## Constituent properties
 
@@ -63,7 +63,7 @@ cite {
 ## Syntax
 
 ```css
-/* keywords */
+/* Keywords */
 rule-visibility-items: all;
 rule-visibility-items: around;
 rule-visibility-items: between;
@@ -93,7 +93,7 @@ rule-visibility-items: unset;
 
 ## Description
 
-The `rule-visibility-items` property defines whether rule segments are painted in portions of gaps adjacent to empty areas in the gaps between rows and columns in [multi-row](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one row or column.
+The `rule-visibility-items` property defines whether rule segments are painted in gaps adjacent to empty areas in the gaps between rows and columns in [multi-row](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one row or column.
 
 The value is a single keyword that sets the same value to both the {{cssxref("column-rule-visibility-items")}} and {{cssxref("row-rule-visibility-items")}} properties.
 
@@ -128,9 +128,9 @@ We include a list of dynamic sports duos:
 
 #### CSS
 
-We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 columns and 4 rows by setting both the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} to `repeat(4, 1fr)`, and move the last item to the 16th grid area using {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. We include a {{cssxref("gap")}} of `20px` to provide enough room between the columns to fit our `5px` dashed rule. We set the column rules to `dashed` and the row rules to `solid`.
+We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 columns and 4 rows by setting both the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} properties to `repeat(4, 1fr)`, and move the last item to the bottom-right grid area using the {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. We include a {{cssxref("gap")}} of `20px` to provide enough room between the columns to fit our `5px` rules. We set the column rules to `dashed` and the row rules to `solid`.
 
-Finally, we set `rule-visibility-items` to `around`, so every gap area that is adjacent to a grid item will contain a painted gap rule segment.
+Finally, we set `rule-visibility-items` to `between`, so that row- and column-rules are painted only if both grid areas adjacent to them contain a grid item.
 
 ```css
 ol {
@@ -151,6 +151,9 @@ li:last-child {
 ```
 
 ```css hidden
+li {
+  margin-left: 1em;
+}
 @layer no-support {
   @supports not (rule-visibility-items: around) {
     body::before {

--- a/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
@@ -130,7 +130,7 @@ We include a list of dynamic sports duos:
 
 We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 columns and 4 rows by setting both the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} to `repeat(4, 1fr)`, and move the last item to the 16th grid area using {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. We include a {{cssxref("gap")}} of `20px` to provide enough room between the columns to fit our `5px` dashed rule. We set the column rules to `dashed` and the row rules to `solid`.
 
-Finally, we set `rule-visibility-items` to `between`, so only if both grid area adjacent to a column rule segment contains a grid item with the column rule be painted.
+Finally, we set `rule-visibility-items` to `around`, so every gap area that is adjacent to a grid item will contain a painted gap rule segment.
 
 ```css
 ol {
@@ -142,7 +142,7 @@ ol {
   column-rule: dashed 5px blue;
   row-rule: solid 5px red;
 
-  rule-visibility-items: between;
+  rule-visibility-items: around;
 }
 li:last-child {
   grid-row: 4;

--- a/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
@@ -95,7 +95,7 @@ rule-visibility-items: unset;
 
 The `rule-visibility-items` property defines whether rule segments are painted in gaps adjacent to empty areas in the gaps between rows and columns in [multi-row](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one row or column.
 
-The value is a single keyword that sets the same value to both the {{cssxref("column-rule-visibility-items")}} and {{cssxref("row-rule-visibility-items")}} properties.
+The value is a single keyword that sets the same value for both the {{cssxref("column-rule-visibility-items")}} and {{cssxref("row-rule-visibility-items")}} properties.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
+++ b/files/en-us/web/css/reference/properties/rule-visibility-items/index.md
@@ -1,0 +1,184 @@
+---
+title: "`rule-visibility-items` CSS property"
+short-title: rule-visibility-items
+slug: Web/CSS/Reference/Properties/rule-visibility-items
+page-type: css-property
+browser-compat: css.properties.rule-visibility-items
+sidebar: cssref
+---
+
+The **`rule-visibility-items`** [CSS](/en-US/docs/Web/CSS) shorthand property defines whether a rule segment is painted in portions of gaps adjacent to empty areas, setting both the {{cssxref("column-rule-visibility-items")}} and {{cssxref("row-rule-visibility-items")}} to the same value.
+
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{cssxref("column-rule-visibility-items")}}
+- {{cssxref("row-rule-visibility-items")}}
+
+{{InteractiveExample("CSS Demo: rule-visibility-items")}}
+
+```css interactive-example-choice
+rule-visibility-items: all;
+```
+
+```css interactive-example-choice
+rule-visibility-items: around;
+```
+
+```css interactive-example-choice
+rule-visibility-items: between;
+```
+
+```css interactive-example-choice
+rule-visibility-items: normal;
+```
+
+```html interactive-example
+<section id="default-example">
+  <section id="example-element">
+    <p>One fish</p>
+    <p>Two fish</p>
+    <p>Red fish</p>
+    <p>Blue fish</p>
+    <cite>-- Dr. Seuss<cite>
+  </section>
+</section>
+```
+
+```css interactive-example
+#example-element {
+  display: grid;
+  rule: solid 5px red;
+  gap: 10px;
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr);
+}
+cite {
+  grid-row: 3;
+  grid-column: 3;
+}
+```
+
+## Syntax
+
+```css
+/* keywords */
+rule-visibility-items: all;
+rule-visibility-items: around;
+rule-visibility-items: between;
+rule-visibility-items: normal;
+
+/* Global values */
+rule-visibility-items: inherit;
+rule-visibility-items: initial;
+rule-visibility-items: revert;
+rule-visibility-items: revert-layer;
+rule-visibility-items: unset;
+```
+
+### Values
+
+- `all`
+  - : Rules should be painted in all gap segments, regardless of whether adjacent areas contain an item.
+
+- `around`
+  - : A rule should be painted in a gap segment if at least one of the two adjacent areas is occupied by a item.
+
+- `between`
+  - : A rule should be painted in a gap segment only if both adjacent areas are occupied by items.
+
+- `normal`
+  - : With grid containers, behaves the same as `all`. In multicol layout, behaves the same as `between`. This is the default.
+
+## Description
+
+The `rule-visibility-items` property defines whether rule segments are painted in portions of gaps adjacent to empty areas in the gaps between rows and columns in [multi-row](/en-US/docs/Web/CSS/Guides/Multicol_layout) and [grid](/en-US/docs/Web/CSS/Guides/Grid_layout) containers with more than one row or column.
+
+The value is a single keyword that sets the same value to both the {{cssxref("column-rule-visibility-items")}} and {{cssxref("row-rule-visibility-items")}} properties.
+
+## Formal definition
+
+{{cssinfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+### Basic example
+
+In this example, we define a rule to be drawn between two grid areas if at least one adjacent grid area contains a grid item.
+
+#### HTML
+
+We include a list of dynamic sports duos:
+
+```html
+<ol>
+  <li>Simone Biles + Jonathan Owens</li>
+  <li>Serena Williams + Venus Williams</li>
+  <li>Aaron Judge + Giancarlo Stanton</li>
+  <li>LeBron James + Dwyane Wade</li>
+  <li>Xavi Hernandez + Andres Iniesta</li>
+  <li>Kerri Walsh + Misty May Treanor</li>
+</ol>
+```
+
+#### CSS
+
+We define the ordered list ({{htmlelement("ol")}}) to be a grid container, creating 4 columns and 4 rows by setting both the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} to `repeat(4, 1fr)`, and move the last item to the 16th grid area using {{cssxref("grid-column")}} and {{cssxref("grid-row")}} properties. We include a {{cssxref("gap")}} of `20px` to provide enough room between the columns to fit our `5px` dashed rule. We set the column rules to `dashed` and the row rules to `solid`.
+
+Finally, we set `rule-visibility-items` to `between`, so only if both grid area adjacent to a column rule segment contains a grid item with the column rule be painted.
+
+```css
+ol {
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+
+  column-rule: dashed 5px blue;
+  row-rule: solid 5px red;
+
+  rule-visibility-items: between;
+}
+li:last-child {
+  grid-row: 4;
+  grid-column: 4;
+}
+```
+
+```css hidden
+@layer no-support {
+  @supports not (rule-visibility-items: around) {
+    body::before {
+      content: "Your browser doesn't support the rule-visibility-items shorthand";
+      background-color: wheat;
+      display: block;
+      text-align: center;
+      padding: 1rem 0;
+    }
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Basic", "", "230")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{cssxref("column-rule-visibility-items")}} shorthand
+- {{cssxref("row-rule-visibility-items")}}
+- {{cssxref("rule")}} shorthand
+- [CSS gaps](/en-US/docs/Web/CSS/Guides/Gaps) module


### PR DESCRIPTION
Three new pages:

- `column-rule-visibility-items`
- `row-rule-visibility-items`
- `rule-visibility-items`

spec: https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-visibility-items

Part of https://github.com/openwebdocs/project/issues/238

**EDIT**: This PR also uncomments all the hidden props on the module page as they are supported in a released browser. They aren't yet written, but they can't be in a "not supported" paragraph, and our docs should be complete. Working on writing those docs now, so it should be de-redded soon.