### PR TITLE
docs(glossary): improve SDP definition

### DIFF
--- a/files/en-us/glossary/sdp/index.md
+++ b/files/en-us/glossary/sdp/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**SDP** (Session Description {{glossary("Protocol")}}) is the standard describing a {{Glossary("P2P","peer-to-peer")}} connection. SDP contains the {{Glossary("codec")}}, source address, and timing information of audio and video.
+**SDP** (Session Description {{glossary("Protocol")}}) is a standard for describing multimedia sessions. It contains information such as media types, transport addresses, timing, and {{Glossary("codec")}}s.
 
 Here is a typical SDP message:
 
@@ -23,9 +23,10 @@ m=video 53000 RTP/AVP 32
 a=rtpmap:32 MPV/90000
 ```
 
-SDP is never used alone, but by protocols like {{Glossary("RTP")}} and {{Glossary("RTSP")}}. SDP is also a component of {{Glossary("WebRTC")}}, which uses SDP as a way of describing a session.
+SDP is used together with protocols such as {{Glossary("RTP")}} and {{Glossary("RTSP")}}. It is also used by {{Glossary("WebRTC")}} to describe multimedia sessions.
 
 ## See also
 
+- {{RFC(8866, "Session Description Protocol")}}
 - [WebRTC protocols](/en-US/docs/Web/API/WebRTC_API/Protocols)
 - [Session Description Protocol](https://en.wikipedia.org/wiki/Session_Description_Protocol) on Wikipedia

--- a/files/en-us/glossary/sdp/index.md
+++ b/files/en-us/glossary/sdp/index.md
@@ -5,7 +5,7 @@ page-type: glossary-definition
 sidebar: glossarysidebar
 ---
 
-**SDP** (Session Description {{glossary("Protocol")}}) is a standard for describing multimedia sessions. It contains information such as media types, transport addresses, timing, and {{Glossary("codec")}}s.
+**SDP** (Session Description {{glossary("Protocol")}}) is a standard for describing multimedia sessions. It contains information such as media types, transport addresses, timing, and {{Glossary("codec","codecs")}}.
 
 Here is a typical SDP message:
 
@@ -27,6 +27,7 @@ SDP is used together with protocols such as {{Glossary("RTP")}} and {{Glossary("
 
 ## See also
 
+- {{domxref("RTCSessionDescription")}}
 - {{RFC(8866, "Session Description Protocol")}}
 - [WebRTC protocols](/en-US/docs/Web/API/WebRTC_API/Protocols)
 - [Session Description Protocol](https://en.wikipedia.org/wiki/Session_Description_Protocol) on Wikipedia


### PR DESCRIPTION
### Description (What)

- Improved the glossary definition of SDP.
- Clarified how SDP is used with WebRTC.
- Added a reference to RFC 8866 in the **See also** section.

### Motivation (Why)

The existing glossary entry did not clearly explain what SDP is, how it relates to WebRTC, and did not include a reference to RFC 8866, as discussed in the related issue.

### Additional details (How)

- Updated the SDP definition to better reflect the description in RFC 8866.
- Clarified how SDP is used with WebRTC.
- Added an RFC 8866 reference to the **See also** section.
- Verified that the project's pre-commit checks completed successfully.

### Related issues and pull requests

Relates to #36500.