### PR TITLE
docs(document.hidden): clarify hidden tab versus hidden styling

### DIFF
--- a/files/en-us/web/api/document/hidden/index.md
+++ b/files/en-us/web/api/document/hidden/index.md
@@ -9,7 +9,9 @@ browser-compat: api.Document.hidden
 {{ ApiRef("DOM") }}
 
 The **`Document.hidden`** read-only property returns a Boolean
-value indicating if the page is considered hidden or not.
+value indicating if the page is considered hidden or not (not the same as
+visually hiding with styling). For example, the page is considered hidden if
+the user is in a different browser tab.
 
 The {{domxref("Document.visibilityState")}} property provides an alternative way to determine whether the page is hidden.
 
@@ -24,6 +26,12 @@ document.addEventListener("visibilitychange", () => {
   console.log(document.hidden);
   // Modify behavior…
 });
+```
+
+```js
+setInterval(() => {
+  console.log(document.hidden);
+}, 1000);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/document/hidden/index.md
+++ b/files/en-us/web/api/document/hidden/index.md
@@ -8,10 +8,8 @@ browser-compat: api.Document.hidden
 
 {{ ApiRef("DOM") }}
 
-The **`Document.hidden`** read-only property returns a Boolean
-value indicating if the page is considered hidden or not (not the same as
-visually hiding with styling). For example, the page is considered hidden if
-the user is in a different browser tab.
+The **`Document.hidden`** read-only property returns a Boolean value indicating if the page is considered hidden or not.
+This can be used to check whether the document is in the background or in a minimized window, or is otherwise not visible to the user.
 
 The {{domxref("Document.visibilityState")}} property provides an alternative way to determine whether the page is hidden.
 
@@ -26,12 +24,6 @@ document.addEventListener("visibilitychange", () => {
   console.log(document.hidden);
   // Modify behavior…
 });
-```
-
-```js
-setInterval(() => {
-  console.log(document.hidden);
-}, 1000);
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description/Motivation

- added clarification to disambiguate between "hidden" in the sense of styling the page you're looking at, versus "hidden" in the sense of the entire tab being not currnetly being viewed by the user
- added example using polling so beginners can trust/understand it more readily - more likely to know polling and not be familiar with the lesser-known event listener `visibilitychange` (speaking for myself i guess haha, although i can understand if polling is a reason for not wanting to include the polling example to begin with)

### Additional details

- https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState has the clarification "It can be used to check whether the document is in the background or in a minimized window, or is otherwise not visible to the user." and the `visibilityState` page is linked in https://developer.mozilla.org/en-US/docs/Web/API/Document/hidden, but that requires the reader to think to go there first and back to the `document.hidden` page to read it in  the correct sense