### PR TITLE
Fix "Handling the return value" example

### DIFF
--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -287,7 +287,7 @@ When the dialog is closed, the return value is displayed under the "Show the dia
       <label>
         Favorite animal:
         <select>
-          <option value="">Choose…</option>
+          <option value="nothing">Choose…</option>
           <option>Brine shrimp</option>
           <option>Red panda</option>
           <option>Spider monkey</option>
@@ -296,6 +296,7 @@ When the dialog is closed, the return value is displayed under the "Show the dia
     </p>
     <div>
       <button value="cancel" formmethod="dialog">Cancel</button>
+      <button id="requestCloseBtn">Cancel with requestClose</button>
       <button id="confirmBtn">Confirm</button>
     </div>
   </form>
@@ -320,6 +321,7 @@ const showButton = document.getElementById("showDialog");
 const favDialog = document.getElementById("favDialog");
 const outputBox = document.querySelector("output");
 const selectEl = favDialog.querySelector("select");
+const requestCloseBtn = favDialog.querySelector("#requestCloseBtn");
 const confirmBtn = favDialog.querySelector("#confirmBtn");
 
 // "Show the dialog" button opens the <dialog> modally
@@ -327,14 +329,20 @@ showButton.addEventListener("click", () => {
   favDialog.showModal();
 });
 
-// "Cancel" button closes the dialog without submitting because of [formmethod="dialog"]
-// or `favDialog.close()` was called, triggering a close event.
-// Or "Esc" was pressed, followed by a cancel event, which is also followed by a close event.
+// e.g.: Escape pressed
+favDialog.addEventListener("cancel", (e) => {
+  favDialog.returnValue = "cancelEvent"; // pressing Escape leaves returnValue untouched
+  // requestClose also triggers this but for the following close event it sets returnValue to its argument
+});
+
+// e.g.: "Cancel" button closes the dialog without submitting because of [formmethod="dialog"], triggering a close event.
 favDialog.addEventListener("close", (e) => {
-  outputBox.value =
-    favDialog.returnValue === ""
-      ? "No return value." // returnValue had its default "" starting value, or the select box's "Choose…" option's "" value
-      : `ReturnValue: ${favDialog.returnValue}.`;
+  outputBox.value = `ReturnValue: ${favDialog.returnValue}.`;
+});
+
+requestCloseBtn.addEventListener("click", (event) => {
+  event.preventDefault();
+  favDialog.requestClose("requestClose");
 });
 
 // Prevent the "confirm" button from the default behavior of submitting the form, and close the dialog with the `close()` method, which triggers the "close" event.

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -273,9 +273,9 @@ When the modal dialog is displayed, it appears above any other dialogs that migh
 
 This example demonstrates the [`returnValue`](/en-US/docs/Web/API/HTMLDialogElement/returnValue) of the `<dialog>` element and how to close a modal dialog by using a form. By default, the `returnValue` is the empty string or the value of the button that submits the form within the `<dialog>` element, if there is one.
 
-This example opens a modal dialog when the "Show the dialog" button is activated. The dialog contains a form with a {{HTMLElement("select")}} and two {{HTMLElement("button")}} elements, which default to `type="submit"`. An event listener updates the value of the "Confirm" button when the select option changes. If the "Confirm" button is activated to close the dialog, the current value of the button is the return value. If the dialog is closed by pressing the "Cancel" button, the `returnValue` is `cancel`.
+This example opens a modal dialog when the "Show the dialog" button is activated. The dialog contains a form with a {{HTMLElement("select")}} and two {{HTMLElement("button")}} elements, which default to `type="submit"`. If the "Confirm" button is activated to close the dialog, an event listener sets `returnValue` to the current value of the select box instead of the button's value. If the dialog is closed by pressing the "Cancel" button, the `returnValue` is `cancel`.
 
-When the dialog is closed, the return value is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the `returnValue` is not updated, and the `close` event doesn't occur, so the text in the {{HTMLElement("output")}} is not updated.
+When the dialog is closed, the return value is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the `returnValue` is not updated, but the `close` event still occurs, so the text in the {{HTMLElement("output")}} is "updated" with the (unchanged) `returnValue`.
 
 #### HTML
 
@@ -287,7 +287,7 @@ When the dialog is closed, the return value is displayed under the "Show the dia
       <label>
         Favorite animal:
         <select>
-          <option value="default">Choose…</option>
+          <option value="">Choose…</option>
           <option>Brine shrimp</option>
           <option>Red panda</option>
           <option>Spider monkey</option>
@@ -296,7 +296,7 @@ When the dialog is closed, the return value is displayed under the "Show the dia
     </p>
     <div>
       <button value="cancel" formmethod="dialog">Cancel</button>
-      <button id="confirmBtn" value="default">Confirm</button>
+      <button id="confirmBtn">Confirm</button>
     </div>
   </form>
 </dialog>
@@ -327,12 +327,13 @@ showButton.addEventListener("click", () => {
   favDialog.showModal();
 });
 
-// "Cancel" button closes the dialog without submitting because of [formmethod="dialog"], triggering a close event.
+// "Cancel" button closes the dialog without submitting because of [formmethod="dialog"],
+// "Esc" was pressed, or `favDialog.close()` was called, triggering a close event.
 favDialog.addEventListener("close", (e) => {
   outputBox.value =
-    favDialog.returnValue === "default"
-      ? "No return value."
-      : `ReturnValue: ${favDialog.returnValue}.`; // Have to check for "default" rather than empty string
+    favDialog.returnValue === ""
+      ? "No return value." // returnValue had its default "" starting value, or the select box's "Choose…" option's "" value
+      : `ReturnValue: ${favDialog.returnValue}.`;
 });
 
 // Prevent the "confirm" button from the default behavior of submitting the form, and close the dialog with the `close()` method, which triggers the "close" event.

--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -275,7 +275,7 @@ This example demonstrates the [`returnValue`](/en-US/docs/Web/API/HTMLDialogElem
 
 This example opens a modal dialog when the "Show the dialog" button is activated. The dialog contains a form with a {{HTMLElement("select")}} and two {{HTMLElement("button")}} elements, which default to `type="submit"`. If the "Confirm" button is activated to close the dialog, an event listener sets `returnValue` to the current value of the select box instead of the button's value. If the dialog is closed by pressing the "Cancel" button, the `returnValue` is `cancel`.
 
-When the dialog is closed, the return value is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the `returnValue` is not updated, but the `close` event still occurs, so the text in the {{HTMLElement("output")}} is "updated" with the (unchanged) `returnValue`.
+When the dialog is closed, the return value is displayed under the "Show the dialog" button. If the dialog is closed by pressing the <kbd>Esc</kbd> key, the `returnValue` is not updated, a `cancel` event gets triggered, and finally a `close` event occurs, so the text in the {{HTMLElement("output")}} is "updated" with the (unchanged) `returnValue`.
 
 #### HTML
 
@@ -327,8 +327,9 @@ showButton.addEventListener("click", () => {
   favDialog.showModal();
 });
 
-// "Cancel" button closes the dialog without submitting because of [formmethod="dialog"],
-// "Esc" was pressed, or `favDialog.close()` was called, triggering a close event.
+// "Cancel" button closes the dialog without submitting because of [formmethod="dialog"]
+// or `favDialog.close()` was called, triggering a close event.
+// Or "Esc" was pressed, followed by a cancel event, which is also followed by a close event.
 favDialog.addEventListener("close", (e) => {
   outputBox.value =
     favDialog.returnValue === ""


### PR DESCRIPTION
- Code description was inaccurate
- Falsely stated that "Esc" doesn't trigger close event
- "Confirm" button having a value that is never used is confusing
- Code didn't check for the initial "" returnValue, which seems like an oversight to me

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixes inaccuracies and oversights in the example description and code.
Maybe the code could say `<option value>Choose…</option>` instead of `<option value="">Choose…</option>`?
And maybe instead of `favDialog.returnValue === ""` the truthiness could be checked instead.
But probably fine as it is?

Of course it could also check for `(favDialog.returnValue === "default" || favDialog.returnValue === "")` instead and leave the `<option value="default">Choose…</option>` untouched, but in any way it probably should check for the initial "" value in some way IMO.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Descriptions that don't match the code are confusing.
Code with additional bits that have no influence on the behavior even though they look like they might is confusing.
Code that doesn't handle edge cases makes it easy to forget that they exist, leading to potential bugs along the road.
Clearing those things up will hopefully be beneficial to the average reader.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
