### PR TITLE
docs: clarify aside complementary role mapping

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/roles/complementary_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/complementary_role/index.md
@@ -25,7 +25,7 @@ This is a sidebar containing links to project sponsors.
 The `complementary` role is [a landmark](/en-US/docs/Web/Accessibility/ARIA/Guides/Techniques#landmark_roles) role. Landmarks can be used by assistive technology to quickly identify and navigate to large sections of the document. Content listed within a container with the `complementary` landmark role should make sense if separated from the main content of the document.
 
 > [!NOTE]
-> Using the {{HTMLElement('aside')}} element will automatically communicate a section has a role of `complementary`. Developers should always prefer using the correct semantic HTML element over using ARIA.
+> Using the {{HTMLElement('aside')}} element will usually communicate a section has a role of `complementary`. When an `<aside>` is nested in sectioning content, it maps to `complementary` only if it has an accessible name. Developers should always prefer using the correct semantic HTML element over using ARIA.
 
 ## Examples
 
@@ -54,7 +54,7 @@ The `complementary` role is [a landmark](/en-US/docs/Web/Accessibility/ARIA/Guid
 
 ### Prefer HTML
 
-Using the {{HTMLElement('aside')}} element will automatically communicate that the element has a role of `complementary`. If possible, prefer using the semantic `<aside>` element instead of the `complementary` role.
+Using the {{HTMLElement('aside')}} element will usually communicate that the element has a role of `complementary`. If an `<aside>` is nested in sectioning content, it maps to `complementary` only if it has an accessible name. If possible, prefer using the semantic `<aside>` element instead of the `complementary` role.
 
 ### Labeling landmarks
 

--- a/files/en-us/web/accessibility/aria/reference/roles/complementary_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/complementary_role/index.md
@@ -25,7 +25,7 @@ This is a sidebar containing links to project sponsors.
 The `complementary` role is [a landmark](/en-US/docs/Web/Accessibility/ARIA/Guides/Techniques#landmark_roles) role. Landmarks can be used by assistive technology to quickly identify and navigate to large sections of the document. Content listed within a container with the `complementary` landmark role should make sense if separated from the main content of the document.
 
 > [!NOTE]
-> Using the {{HTMLElement('aside')}} element will usually communicate a section has a role of `complementary`. When an `<aside>` is nested in sectioning content, it maps to `complementary` only if it has an accessible name. Developers should always prefer using the correct semantic HTML element over using ARIA.
+> The {{HTMLElement('aside')}} element has an implicit role of `complementary`, unless it has no {{glossary("accessible name")}} and is nested in [sectioning content](/en-US/docs/Web/HTML/Guides/Content_categories#sectioning_content). Developers should always prefer using the correct semantic HTML element over using ARIA.
 
 ## Examples
 
@@ -54,7 +54,7 @@ The `complementary` role is [a landmark](/en-US/docs/Web/Accessibility/ARIA/Guid
 
 ### Prefer HTML
 
-Using the {{HTMLElement('aside')}} element will usually communicate that the element has a role of `complementary`. If an `<aside>` is nested in sectioning content, it maps to `complementary` only if it has an accessible name. If possible, prefer using the semantic `<aside>` element instead of the `complementary` role.
+The {{HTMLElement('aside')}} element has an implicit role of `complementary`, unless it has no {{glossary("accessible name")}} and is nested in [sectioning content](/en-US/docs/Web/HTML/Guides/Content_categories#sectioning_content). If possible, prefer using the semantic `<aside>` element instead of the `complementary` role.
 
 ### Labeling landmarks
 

--- a/files/en-us/web/html/reference/elements/aside/index.md
+++ b/files/en-us/web/html/reference/elements/aside/index.md
@@ -52,6 +52,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 ## Usage notes
 
 - Do not use the `<aside>` element to tag parenthesized text, as this kind of text is considered part of the main flow.
+- The implicit ARIA role of `<aside>` is `complementary` when it is scoped to the {{HTMLElement("body")}} or {{HTMLElement("main")}} element. If it is nested in sectioning content, such as an {{HTMLElement("article")}}, {{HTMLElement("section")}}, or another `<aside>`, it maps to the `complementary` role only if it has an accessible name. Otherwise, it maps to the `generic` role.
 
 ## Examples
 
@@ -128,7 +129,7 @@ This example uses `<aside>` to mark up a paragraph in an article. The paragraph 
           ><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/complementary_role"
             >complementary</a
           ></code
-        >
+        >, or <code>generic</code> when nested in sectioning content without an accessible name
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/reference/elements/aside/index.md
+++ b/files/en-us/web/html/reference/elements/aside/index.md
@@ -52,7 +52,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 ## Usage notes
 
 - Do not use the `<aside>` element to tag parenthesized text, as this kind of text is considered part of the main flow.
-- The implicit ARIA role of `<aside>` is `complementary` when it is scoped to the {{HTMLElement("body")}} or {{HTMLElement("main")}} element. If it is nested in sectioning content, such as an {{HTMLElement("article")}}, {{HTMLElement("section")}}, or another `<aside>`, it maps to the `complementary` role only if it has an accessible name. Otherwise, it maps to the `generic` role.
+- The implicit ARIA role of `<aside>` is `complementary` when it is scoped to the {{HTMLElement("body")}} or {{HTMLElement("main")}} element. If it is nested in sectioning content, such as an {{HTMLElement("article")}}, {{HTMLElement("section")}}, or another `<aside>`, it maps to the `complementary` role only if it has an accessible name. Otherwise, it maps to the [`generic`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role) role.
 
 ## Examples
 
@@ -129,7 +129,7 @@ This example uses `<aside>` to mark up a paragraph in an article. The paragraph 
           ><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/complementary_role"
             >complementary</a
           ></code
-        >, or <code>generic</code> when nested in sectioning content without an accessible name
+        >, or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role">generic</a></code> when nested in sectioning content without an accessible name
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/reference/elements/aside/index.md
+++ b/files/en-us/web/html/reference/elements/aside/index.md
@@ -52,7 +52,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 ## Usage notes
 
 - Do not use the `<aside>` element to tag parenthesized text, as this kind of text is considered part of the main flow.
-- The implicit ARIA role of `<aside>` is `complementary` when it is scoped to the {{HTMLElement("body")}} or {{HTMLElement("main")}} element. If it is nested in sectioning content, such as an {{HTMLElement("article")}}, {{HTMLElement("section")}}, or another `<aside>`, it maps to the `complementary` role only if it has an accessible name. Otherwise, it maps to the [`generic`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role) role.
+- The `<aside>` element has an implicit role of [`complementary`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/complementary_role), unless it has no {{glossary("accessible name")}} and is nested in [sectioning content](/en-US/docs/Web/HTML/Guides/Content_categories#sectioning_content), in which case it has the [`generic`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role) role.
 
 ## Examples
 
@@ -129,7 +129,7 @@ This example uses `<aside>` to mark up a paragraph in an article. The paragraph 
           ><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/complementary_role"
             >complementary</a
           ></code
-        >, or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role">generic</a></code> when nested in sectioning content without an accessible name
+        >, or <code><a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role">generic</a></code> when it has no {{glossary("accessible name")}} and is nested in <a href="/en-US/docs/Web/HTML/Guides/Content_categories#sectioning_content">sectioning content</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
### Description

Clarifies that `<aside>` maps to `complementary` only conditionally when nested in sectioning content.

### Motivation

This matches the HTML-AAM mapping for `<aside>` and addresses reader confusion in the `<aside>` and `complementary` role pages.

### Additional details

- HTML-AAM maps `<aside>` scoped to `body` or `main` to `complementary`.
- HTML-AAM maps `<aside>` scoped to sectioning content to `complementary` only when it has an accessible name; otherwise it maps to `generic`.

Validation:

- `git diff --check`
- source guard for the new conditional role wording

### Related issues and pull requests

Fixes #40664
