### PR TITLE
fix Element.scrollIntoView() rendering issue

### DIFF
--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -22,17 +22,11 @@ scrollIntoView(options)
 
 - `alignToTop` {{optional_inline}}
   - : A boolean value:
-    - If `true`, the top of the element will be aligned to the top of the
-      visible area of the scrollable ancestor. Corresponds to
-      `scrollIntoViewOptions: {block: "start", inline: "nearest"}`. This is
-      the default value.
-    - If `false`, the bottom of the element will be aligned to the bottom
-      of the visible area of the scrollable ancestor. Corresponds to
-- If `true`, the top of the element will be aligned to the top of the visible area of the scrollable ancestor.
-  Corresponds to `scrollIntoViewOptions: {block: "start", inline: "nearest"}`.
-  This is the default value.
-- If `false`, the bottom of the element will be aligned to the bottom of the visible area of the scrollable ancestor.
-  Corresponds to `scrollIntoViewOptions: {block: "end", inline: "nearest"}`.
+    - If `true`, the top of the element will be aligned to the top of the visible area of the scrollable ancestor.
+      Corresponds to `scrollIntoViewOptions: {block: "start", inline: "nearest"}`.
+      This is the default value.
+    - If `false`, the bottom of the element will be aligned to the bottom of the visible area of the scrollable ancestor.
+      Corresponds to `scrollIntoViewOptions: {block: "end", inline: "nearest"}`.
 
 - `options` {{optional_inline}}
   - : An object with the following properties:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

As per [this comment](https://github.com/mdn/content/pull/44515#issuecomment-4869013405), the [Element.scrollIntoView()](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) parameters list rendering has been broken by some duplicated content being added.

This PR fixes the problem.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
