### PR TITLE
Remove unused code

### DIFF
--- a/files/en-us/web/api/popover_api/using/index.md
+++ b/files/en-us/web/api/popover_api/using/index.md
@@ -156,8 +156,6 @@ Putting these three together, you can programmatically set up a popover and its 
 const popover = document.getElementById("mypopover");
 const toggleBtn = document.getElementById("toggleBtn");
 
-const keyboardHelpPara = document.getElementById("keyboard-help-para");
-
 const popoverSupported = supportsPopover();
 
 if (popoverSupported) {


### PR DESCRIPTION
The removed line isn't used anywhere in this code example or even anywhere in the rest of the page.

It looks like it's copied from https://mdn.github.io/dom-examples/popover-api/toggle-help-ui/ where it was used to hide the help text if no popover support is detected.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Removes unused code from a code example.
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

Reading a code example with irrelevant unused lines is confusing.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
