### PR TITLE
Fix top right "Next" link

### DIFF
--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
@@ -6,7 +6,7 @@ page-type: tutorial-chapter
 sidebar: pwasidebar
 ---
 
-{{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/CycleTracker/Secure_connection", "Web/Progressive_web_apps/Tutorials/CycleTracker", "Web/Progressive_web_apps/Tutorials/CycleTracker/Manifest_file")}}
+{{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/CycleTracker/Secure_connection", "Web/Progressive_web_apps/Tutorials/CycleTracker/Manifest_file", "Web/Progressive_web_apps/Tutorials/CycleTracker")}}
 
 In the previous section, we wrote the HTML and CSS for CycleTracker, creating a static version of our web app. In this section, we will write the JavaScript required to convert static HTML into a fully functional web application.
 

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
@@ -6,7 +6,7 @@ page-type: tutorial-chapter
 sidebar: pwasidebar
 ---
 
-{{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/CycleTracker/Secure_connection", "Web/Progressive_web_apps/Tutorials/CycleTracker", "Web/Progressive_web_apps/Tutorials/CycleTracker")}}
+{{PreviousMenuNext("Web/Progressive_web_apps/Tutorials/CycleTracker/Secure_connection", "Web/Progressive_web_apps/Tutorials/CycleTracker", "Web/Progressive_web_apps/Tutorials/CycleTracker/Manifest_file")}}
 
 In the previous section, we wrote the HTML and CSS for CycleTracker, creating a static version of our web app. In this section, we will write the JavaScript required to convert static HTML into a fully functional web application.
 


### PR DESCRIPTION
The first "Next ->" link that should bring you to the "Manifest file" page, instead brings you back to the beginning of the tutorial.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Changed the link so it brings the reader to Web/Progressive_web_apps/Tutorials/CycleTracker/Manifest_file instead of Web/Progressive_web_apps/Tutorials/CycleTracker

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The link now sends you to the next step in the tutorial instead of the beginning.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
