### PR TITLE
ci(pr-check): expand path filters across pr-check workflows

### DIFF
--- a/.github/workflows/pr-check_cspell_lists.yml
+++ b/.github/workflows/pr-check_cspell_lists.yml
@@ -3,7 +3,10 @@ name: Check cSpell lists
 on:
   pull_request:
     paths:
+      - .github/workflows/pr-check_cspell_lists.yml
+      - .nvmrc
       - .vscode/dictionaries/*
+      - scripts/sort_and_unique_file_lines.js
 
 # No GITHUB_TOKEN permissions, as we don't use it.
 permissions: {}

--- a/.github/workflows/pr-check_javascript.yml
+++ b/.github/workflows/pr-check_javascript.yml
@@ -3,10 +3,14 @@ name: JavaScript lint
 on:
   pull_request:
     paths:
+      - .github/workflows/pr-check_javascript.yml
       - .nvmrc
+      - package.json
+      - package-lock.json
+      - "*.js"
+      - "*.mjs"
       - "**/*.js"
       - "**/*.mjs"
-      - .github/workflows/pr-check_javascript.yml
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}

--- a/.github/workflows/pr-check_json.yml
+++ b/.github/workflows/pr-check_json.yml
@@ -3,10 +3,12 @@ name: JSON lint
 on:
   pull_request:
     paths:
+      - .github/workflows/pr-check_json.yml
       - .nvmrc
+      - "*.json"
+      - "*.jsonc"
       - "**/*.json"
       - "**/*.jsonc"
-      - .github/workflows/pr-check_json.yml
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}

--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -3,10 +3,10 @@ name: Check scripts
 on:
   pull_request:
     paths:
+      - .github/workflows/pr-check_scripts.yml
       - .nvmrc
       - package.json
       - package-lock.json
-      - .github/workflows/pr-check_scripts.yml
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}

--- a/.github/workflows/pr-check_url-issues.yml
+++ b/.github/workflows/pr-check_url-issues.yml
@@ -3,6 +3,8 @@ name: Check URL issues
 on:
   pull_request:
     paths:
+      - .github/workflows/pr-check_url-issues.yml
+      - .nvmrc
       - "files/**/*.md"
 
 # No GITHUB_TOKEN permissions, as we don't use it.

--- a/.github/workflows/pr-check_url-issues.yml
+++ b/.github/workflows/pr-check_url-issues.yml
@@ -5,7 +5,10 @@ on:
     paths:
       - .github/workflows/pr-check_url-issues.yml
       - .nvmrc
+      - package.json
+      - package-lock.json
       - "files/**/*.md"
+      - scripts/log-url-issues.js
 
 # No GITHUB_TOKEN permissions, as we don't use it.
 permissions: {}

--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -7,6 +7,7 @@ on:
       - .nvmrc
       - package.json
       - package-lock.json
+      - "*.yml"
       - "**/*.yml"
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.

--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -3,10 +3,11 @@ name: Lint YAML
 on:
   pull_request:
     paths:
+      - .github/workflows/pr-check_yml.yml
       - .nvmrc
+      - package.json
       - package-lock.json
       - "**/*.yml"
-      - .github/workflows/pr-check_yml.yml
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}

--- a/scripts/sort_and_unique_file_lines.js
+++ b/scripts/sort_and_unique_file_lines.js
@@ -37,7 +37,7 @@ for (const filePath of filePaths) {
     return a < b ? -1 : a > b ? 1 : 0;
   });
 
-  for (let i = 0; i < lines.length; ) {
+  for (let i = 0; i < lines.length;) {
     const line = lines[i];
     if (line.trim() !== "") {
       uniq.push(line);


### PR DESCRIPTION
### Description

Expand and normalize the `paths:` triggers across the `pr-check_*` workflows:

- Trigger each workflow when its own workflow file changes.
- Add `.nvmrc` where missing (cSpell lists, URL issues).
- Add relevant dependency files (`package.json`/`package-lock.json` for JavaScript and YAML lint; `scripts/sort_and_unique_file_lines.js` for cSpell lists).
- Add root-level globs (`*.js`, `*.mjs`, `*.json`, `*.jsonc`) alongside the existing `**/*` patterns.

### Motivation

Ensure the relevant checks run when a change affects their behavior — whether through the workflow definition itself, the Node version, project dependencies, or files at the repository root.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->