### PR TITLE
fix: correct RTCIceCandidate definition on WebRTC index page

### DIFF
--- a/files/en-us/web/api/webrtc_api/index.md
+++ b/files/en-us/web/api/webrtc_api/index.md
@@ -49,7 +49,7 @@ These interfaces, dictionaries, and types are used to set up, open, and manage W
 - {{DOMxRef("RTCStatsReport")}}
   - : Provides information detailing statistics for a connection or for an individual track on the connection; the report can be obtained by calling {{DOMxRef("RTCPeerConnection.getStats()")}}.
 - {{DOMxRef("RTCIceCandidate")}}
-  - : Represents a candidate Interactive Connectivity Establishment ({{Glossary("ICE")}}) server for establishing an {{DOMxRef("RTCPeerConnection")}}.
+  - : Represents a candidate Interactive Connectivity Establishment ({{Glossary("ICE")}}) configuration for establishing an {{DOMxRef("RTCPeerConnection")}}.
 - {{DOMxRef("RTCIceTransport")}}
   - : Represents information about an {{Glossary("ICE")}} transport.
 - {{DOMxRef("RTCPeerConnectionIceEvent")}}


### PR DESCRIPTION
### Description

Corrected the definition of the `RTCIceCandidate` interface on the WebRTC API landing page.

### Motivation

The page incorrectly referred to it as a "server configuration" (a typo likely copied from `RTCIceServer`), which was causing confusion for beginners learning WebRTC. It now correctly defines it as a configuration/address and uses the proper MDN macros.

### Additional details

None.

### Related issues and pull requests

Fixes #44656
