### PR TITLE
Removes reference to masonry values

### DIFF
--- a/files/en-us/web/css/reference/properties/grid-auto-flow/index.md
+++ b/files/en-us/web/css/reference/properties/grid-auto-flow/index.md
@@ -61,10 +61,6 @@ grid-auto-flow: row dense;
 }
 ```
 
-> [!NOTE]
-> The `masonry-auto-flow` property was dropped from CSS [Masonry layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout) in favor of `grid-auto-flow`.
-> See [csswg-drafts #10231](https://github.com/w3c/csswg-drafts/issues/10231) for details.
-
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/reference/properties/grid-template-columns/index.md
+++ b/files/en-us/web/css/reference/properties/grid-template-columns/index.md
@@ -70,7 +70,6 @@ grid-template-columns: minmax(100px, 1fr);
 grid-template-columns: fit-content(40%);
 grid-template-columns: repeat(3, 200px);
 grid-template-columns: subgrid;
-grid-template-columns: masonry;
 
 /* <auto-track-list> values */
 grid-template-columns: 200px repeat(auto-fill, 100px) 300px;
@@ -129,8 +128,6 @@ grid-template-columns: unset;
   - : Represents the formula `max(minimum, min(limit, max-content))`, where _minimum_ represents an `auto` minimum (which is often, but not always, equal to a {{cssxref("min-content")}} minimum), and _limit_ is the track sizing function passed as an argument to fit-content(). This is essentially calculated as the smaller of `minmax(auto, max-content)` and `minmax(auto, limit)`.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of columns that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout)
-  - : The masonry value indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : The `subgrid` value indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.
 

--- a/files/en-us/web/css/reference/properties/grid-template-rows/index.md
+++ b/files/en-us/web/css/reference/properties/grid-template-rows/index.md
@@ -70,7 +70,6 @@ grid-template-rows: minmax(100px, 1fr);
 grid-template-rows: fit-content(40%);
 grid-template-rows: repeat(3, 200px);
 grid-template-rows: subgrid;
-grid-template-rows: masonry;
 
 /* <auto-track-list> values */
 grid-template-rows: 200px repeat(auto-fill, 100px) 300px;
@@ -131,8 +130,6 @@ This property may be specified as:
   - : Represents the formula `min(max-content, max(auto, argument))`, which is calculated similar to `auto` (i.e., `minmax(auto, max-content)`), except that the track size is clamped at _argument_ if it is greater than the `auto` minimum.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of rows that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout)
-  - : Indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : Indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.
 


### PR DESCRIPTION
### Description

⚠️ Not a proper `display: grid-lanes` docs PR yet, just a cleanup for old masonry spec leftovers.

- Removes outdated `grid-template-*: masonry` values
- Removes irrelevant `masonry-auto-flow` note

### Motivation

To remove confusion from the Masonry guide and reference pages.

### Additional details

The only old masonry implementation remains in Firefox behind the flag and has never been publicly available. It probably shouldn’t have been documented on MDN in the first place.

The new `display: grid-lanes` implementation has been shipped in Safari and is being worked on in Chrome.

### See also

- https://github.com/mdn/content/pull/44436