### PR TITLE
Fix whitespace rendering inside <q> element example

### DIFF
--- a/files/en-us/web/html/reference/elements/q/index.md
+++ b/files/en-us/web/html/reference/elements/q/index.md
@@ -39,9 +39,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 ```html
 <p>
   According to Mozilla's website,
-  <q cite="https://www.mozilla.org/en-US/about/history/details/">
-    Firefox 1.0 was released in 2004 and became a big success.
-  </q>
+  <q cite="https://www.mozilla.org/en-US/about/history/details/"
+    >Firefox 1.0 was released in 2004 and became a big success.</q
+  >
 </p>
 ```
 


### PR DESCRIPTION
Fixes #44644

### Problem
The example in the Examples section of `Web/HTML/Reference/Elements/q` places the quoted text on its own indented lines inside the `<q>` element. Because `<q>` renders quotation marks around its content inline, the leading and trailing whitespace renders as a visible space between each quotation mark and the text.

### Fix
The text now sits directly against the tag boundaries, so the rendered quotation marks hug the quoted text. The file is formatted with Prettier.

### Verification
Ran `npm start` and confirmed at `/en-US/docs/Web/HTML/Reference/Elements/q#examples` that no space renders inside the quotation marks.

### Note
The interactive example at the top of the page has the same pattern. I kept this PR scoped to what the issue reports, but I am happy to fix that too if preferred.