### PR TITLE
Make explicit that scrollIntoView 'nearest' is only done if needed

### DIFF
--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -49,7 +49,7 @@ scrollIntoView(options)
         - `start`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
         - `center`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
         - `end`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
-        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom edge, it will align to the bottom. This minimizes the scrolling distance.
+        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom edge, it will align to the bottom. This minimizes the scrolling distance. If the element is already visible, no scrolling is done.
 
         The default is `start`.
 
@@ -65,7 +65,7 @@ scrollIntoView(options)
         - `start`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
         - `center`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
         - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
-        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance.
+        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance. If the element is already visible, no scrolling is done.
 
         The default is `nearest`.
 

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -49,7 +49,7 @@ scrollIntoView(options)
         - `start`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
         - `center`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
         - `end`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
-        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom edge, it will align to the bottom. This minimizes the scrolling distance. If the element is already visible, no scrolling is done.
+        - `nearest`: Scrolls as little as possible to bring the element into view. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom edge, it will align to the bottom. If the element is already visible, no scrolling is done.
 
         The default is `start`.
 
@@ -65,7 +65,7 @@ scrollIntoView(options)
         - `start`: Aligns the element's left edge with the left of the scrollable container, making the element appear at the start of the visible area horizontally.
         - `center`: Aligns the element horizontally at the center of the scrollable container, positioning it in the middle of the visible area.
         - `end`: Aligns the element's right edge with the right of the scrollable container, placing the element at the end of the visible area horizontally.
-        - `nearest`: Scrolls the element to the nearest edge in the horizontal direction. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. This minimizes the scrolling distance. If the element is already visible, no scrolling is done.
+        - `nearest`: Scrolls as little as possible to bring the element into view. If the element is closer to the left edge of the scrollable container, it will align to the left; if it's closer to the right edge, it will align to the right. If the element is already visible, no scrolling is done.
 
         The default is `nearest`.
 


### PR DESCRIPTION
In comparing native DOM capabilities with NPM packages like [scroll-into-view-if-needed](https://www.npmjs.com/package/scroll-into-view-if-needed), it was not clear to me that `scrollIntoView` with `'nearest'` only scrolls if needed.

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Make `scrollIntoView` `nearest` behavior more explicit.

### Motivation

In comparing native DOM capabilities with NPM packages like [scroll-into-view-if-needed](https://www.npmjs.com/package/scroll-into-view-if-needed), it was not clear to me that `scrollIntoView` with `'nearest'` only scrolls if needed.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
