### PR TITLE
Update description of how to set `offsetNanoseconds`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/offsetnanoseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/offsetnanoseconds/index.md
@@ -9,7 +9,7 @@ sidebar: jsref
 
 The **`offsetNanoseconds`** accessor property of {{jsxref("Temporal.ZonedDateTime")}} instances returns an integer representing the [offset](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime#time_zones_and_offsets) used to interpret the internal instant, as a number of nanoseconds (positive or negative). The value is a safe integer because it's less than a day, which is 8.64e15 nanoseconds.
 
-The set accessor of `offsetNanoseconds` is `undefined`. You cannot change this property directly. Change {{jsxref("Temporal/ZonedDateTime/offset", "offset")}} to change this property too.
+The set accessor of `offsetNanoseconds` is `undefined`. You cannot change this property directly. Use the {{jsxref("Temporal/ZonedDateTime/with", "with()")}} method to create a new `Temporal.ZonedDateTime` object with the desired new {{jsxref("Temporal/ZonedDateTime/offset", "offset")}} value (which will change this property too), or use the {{jsxref("Temporal/ZonedDateTime/withTimeZone", "withTimeZone()")}} method to create a new `Temporal.ZonedDateTime` object in another time zone.
 
 ## Examples
 


### PR DESCRIPTION
### Description

This PR updates the description of the `offsetNanoseconds` property to clarify how to change the `offset` property.

### Motivation

The current docs imply that you can set the `offset` property directly. However, the set accessor of `offset` is also `undefined`. This PR copies language from [the `offset` page](https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/offset/index.md) to explain how to change the `offset` of a `ZonedDateTime`.

### Additional details

None

### Related issues and pull requests

None
