### PR TITLE
PerformanceNavigationTiming.notRestoredReasons: untangle/expand reasons for null

### DIFF
--- a/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
@@ -19,7 +19,9 @@ When the associated `PerformanceNavigationTiming` object represents a history na
 When the `PerformanceNavigationTiming` object does not represent a history navigation, `notRestoredReasons` will return `null`. This is useful for determining whether bfcache is not relevant to a particular navigation (as opposed to `notRestoredReasons` not being supported, in which case it would return `undefined`).
 
 > [!NOTE]
-> `notRestoredReasons` may return `null` despite the navigation type being reported as a back/forward navigation. These circumstances include duplicating a back/forward navigation in a new tab and restoring a back/forward navigation tab after a browser restart. In such cases, some browsers copy the navigation type from the original tab, but as these are not actually back/forward navigations, `notRestoredReasons` returns `null`.
+> `notRestoredReasons` may return `null` despite the navigation type being reported as a back/forward navigation. These circumstances include
+> - Duplicating a back/forward navigation in a new tab. In such cases, some browsers copy the navigation type from the original tab, but as these are not actually back/forward navigations, `notRestoredReasons` returns `null`.
+> - Restoring a back/forward navigation tab after a browser restart. Since the bfcache stores fully-loaded pages including DOM and JavaScript heap, there's nothing developers can do to make bfcache survive a full restart, so `notRestoredReasons` returns `null` because there was no bfcache entry to block restoration of in the first place.
 
 ## Examples
 

--- a/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
@@ -19,7 +19,8 @@ When the associated `PerformanceNavigationTiming` object represents a history na
 When the `PerformanceNavigationTiming` object does not represent a history navigation, `notRestoredReasons` will return `null`. This is useful for determining whether bfcache is not relevant to a particular navigation (as opposed to `notRestoredReasons` not being supported, in which case it would return `undefined`).
 
 > [!NOTE]
-> `notRestoredReasons` may return `null` despite the navigation type being reported as a back/forward navigation. These circumstances include
+> `notRestoredReasons` may return `null` despite the navigation type being reported as a back/forward navigation. These circumstances include:
+>
 > - Duplicating a back/forward navigation in a new tab. In such cases, some browsers copy the navigation type from the original tab, but as these are not actually back/forward navigations, `notRestoredReasons` returns `null`.
 > - Restoring a back/forward navigation tab after a browser restart. Since the bfcache stores fully-loaded pages including DOM and JavaScript heap, there's nothing developers can do to make bfcache survive a full restart, so `notRestoredReasons` returns `null` because there was no bfcache entry to block restoration of in the first place.
 

--- a/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
@@ -18,11 +18,10 @@ When the associated `PerformanceNavigationTiming` object represents a history na
 
 When the `PerformanceNavigationTiming` object does not represent a history navigation, `notRestoredReasons` will return `null`. This is useful for determining whether bfcache is not relevant to a particular navigation (as opposed to `notRestoredReasons` not being supported, in which case it would return `undefined`).
 
-> [!NOTE]
-> `notRestoredReasons` may return `null` despite the navigation type being reported as a back/forward navigation. These circumstances include:
->
-> - Duplicating a back/forward navigation in a new tab. In such cases, some browsers copy the navigation type from the original tab, but as these are not actually back/forward navigations, `notRestoredReasons` returns `null`.
-> - Restoring a back/forward navigation tab after a browser restart. Since the bfcache stores fully-loaded pages including DOM and JavaScript heap, there's nothing developers can do to make bfcache survive a full restart, so `notRestoredReasons` returns `null` because there was no bfcache entry to block restoration of in the first place.
+`notRestoredReasons` may return `null` even when the navigation type is reported as back/forward. These circumstances include:
+
+- Duplicating a back/forward navigation in a new tab. In such cases, some browsers copy the navigation type from the original tab, but as these are not actually back/forward navigations, `notRestoredReasons` returns `null`.
+- Restoring a back/forward navigation tab after a browser restart. Since the bfcache stores fully-loaded pages including DOM and JavaScript heap, there's nothing developers can do to make bfcache survive a full restart, so `notRestoredReasons` returns `null` because there was no bfcache entry to block restoration of in the first place.
 
 ## Examples
 

--- a/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
@@ -16,12 +16,12 @@ The **`notRestoredReasons`** read-only property of the {{domxref("PerformanceNav
 
 When the associated `PerformanceNavigationTiming` object represents a history navigation, `notRestoredReasons` returns a {{domxref("NotRestoredReasons")}} object.
 
-When the `PerformanceNavigationTiming` object does not represent a history navigation, `notRestoredReasons` will return `null`. This is useful for determining whether bfcache is not relevant to a particular navigation (as opposed to `notRestoredReasons` not being supported, in which case it would return `undefined`).
+When the `PerformanceNavigationTiming` object does not represent a history navigation, `notRestoredReasons` will return `null`. This is useful to determine whether bfcache is not relevant to a particular navigation (as opposed to `notRestoredReasons` not being supported, in which case it would return `undefined`).
 
-`notRestoredReasons` may return `null` even when the navigation type is reported as back/forward. These circumstances include:
+The `notRestoredReasons` property may return `null` even when the navigation type is reported as back/forward. The circumstances under which this happens include:
 
 - Duplicating a back/forward navigation in a new tab. In such cases, some browsers copy the navigation type from the original tab, but as these are not actually back/forward navigations, `notRestoredReasons` returns `null`.
-- Restoring a back/forward navigation tab after a browser restart. Since the bfcache stores fully-loaded pages including DOM and JavaScript heap, there's nothing developers can do to make bfcache survive a full restart, so `notRestoredReasons` returns `null` because there was no bfcache entry to block restoration of in the first place.
+- Restoring a back/forward navigation tab after a browser restart. Since the bfcache stores fully loaded pages including DOM and JavaScript heap, developers cannot make bfcache survive a full restart. The property therefore returns `null` because there was no bfcache entry to block restoration in the first place.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Explain less-obvious reasons for this property to be `null` one at a time.

### Motivation

The existing text seemed a bit confused, since back/forward navigations after restart are real enough. Given this, I assumed the explanation already present was actually written for the first circumstance only.