### PR TITLE
WebEx fix optional macro format in `permissions.Permissions`

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -16,7 +16,7 @@ An {{jsxref("Object")}} with these properties:
   - : An array of [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns), representing [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions).
 - `permissions` {{optional_inline}}
   - : An array of named permissions, including [API permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions) and [clipboard permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#clipboard_access).
-- `data_collection` {optional_inline}}
+- `data_collection` {{optional_inline}}
   - : An array of [data collection permissions types](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#data_collection_permissions).
 
 {{WebExtExamples}}


### PR DESCRIPTION
### Description

Fixes an in correctly formatting macro

