### PR TITLE
Remove 'border' from list of properties that can be given a 'url()'

### DIFF
--- a/files/en-us/web/css/reference/values/url_function/index.md
+++ b/files/en-us/web/css/reference/values/url_function/index.md
@@ -17,7 +17,7 @@ The **`url()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Refere
 Relative URLs, if used, are relative to the URL of the stylesheet (not to the URL of the web page).
 
 The **`url()`** function can be included as a value for
-{{cssxref('background')}}, {{cssxref('background-image')}}, {{cssxref('border')}}, {{cssxref('border-image')}}, {{cssxref('border-image-source')}}, {{cssxref('content')}}, {{cssxref('cursor')}}, {{cssxref('filter')}}, {{cssxref('list-style')}}, {{cssxref('list-style-image')}}, {{cssxref('mask')}}, {{cssxref('mask-image')}}, {{cssxref('offset-path')}}, {{cssxref('clip-path')}},
+{{cssxref('background')}}, {{cssxref('background-image')}}, {{cssxref('border-image')}}, {{cssxref('border-image-source')}}, {{cssxref('content')}}, {{cssxref('cursor')}}, {{cssxref('filter')}}, {{cssxref('list-style')}}, {{cssxref('list-style-image')}}, {{cssxref('mask')}}, {{cssxref('mask-image')}}, {{cssxref('offset-path')}}, {{cssxref('clip-path')}},
 [src](/en-US/docs/Web/CSS/Reference/At-rules/@font-face/src) as part of a {{cssxref("@font-face")}} block, and [@counter-style/`symbol`](/en-US/docs/Web/CSS/Reference/At-rules/@counter-style/symbols)
 
 ## Syntax


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Page: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/url_function

In the CSS `url()` documentation, remove `border` from a list of properties that can be given a `url()` as their value (or part thereof).

### Motivation

The Backgrounds & Borders Module Level 3 spec explicitly **prohibits** `border` from accepting a `url()` argument. It is a shorthand for `border-width`, `border-color`, and `border-style` only, and is required to implicitly _reset_ the corresponding `border-image` properties back to their initial value whenever it is used.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

Relevant section of the spec: [CSS Backgrounds and Borders Module Level 3, § Border Shorthand Properties](https://www.w3.org/TR/css-backgrounds-3/#border-shorthands)


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
