### PR TITLE
Editorial review: Add notes about web app scope system accent color

### DIFF
--- a/files/en-us/web/css/reference/properties/accent-color/index.md
+++ b/files/en-us/web/css/reference/properties/accent-color/index.md
@@ -95,7 +95,7 @@ every state of the control. The `accent-color` is only applied to user-interface
 controls that use an accent color in the states where it is applicable.
 
 > [!NOTE]
-> To reduce the risk of {{glossary("fingerprinting")}}, `accent-color: auto` is only set in installed web apps, on a user's initial profile.
+> To reduce the risk of {{glossary("fingerprinting")}}, some browsers return a fixed value for `accent-color: auto` unless it is used in certain restricted circumstances. See [browser compatibility](#browser_compatibility) for details.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/accent-color/index.md
+++ b/files/en-us/web/css/reference/properties/accent-color/index.md
@@ -94,6 +94,9 @@ contrast. That accent color is not used by every user-interface control nor in
 every state of the control. The `accent-color` is only applied to user-interface
 controls that use an accent color in the states where it is applicable.
 
+> [!NOTE]
+> To reduce the risk of {{glossary("fingerprinting")}}, `accent-color: auto` is only set in installed web apps, on a user's initial profile.
+
 ## Formal definition
 
 {{cssinfo}}

--- a/files/en-us/web/css/reference/values/system-color/index.md
+++ b/files/en-us/web/css/reference/values/system-color/index.md
@@ -130,6 +130,9 @@ Depending on your settings, the sample colors displayed in the table may change.
   </tbody>
 </table>
 
+> [!NOTE]
+> To reduce the risk of {{glossary("fingerprinting")}}, the `AccentColor` and `AccentColorText` colors are only set in installed web apps, on a user's initial profile.
+
 ### Deprecated system color keywords
 
 The following keywords were defined in earlier versions of the CSS Color Module. They are now deprecated for use on public web pages.

--- a/files/en-us/web/css/reference/values/system-color/index.md
+++ b/files/en-us/web/css/reference/values/system-color/index.md
@@ -131,7 +131,7 @@ Depending on your settings, the sample colors displayed in the table may change.
 </table>
 
 > [!NOTE]
-> To reduce the risk of {{glossary("fingerprinting")}}, the `AccentColor` and `AccentColorText` colors are only set in installed web apps, on a user's initial profile.
+> To reduce the risk of {{glossary("fingerprinting")}}, some browsers return a fixed value for `AccentColor` and `AccentColorText` unless they are used in certain restricted circumstances. See [browser compatibility](#browser_compatibility) for details.
 
 ### Deprecated system color keywords
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Chrome 150 adds the restriction whereby app system accent colors (`AccentColor` and `AccentColorText` CSS keywords, and `accent-color: auto` ) are limited to installed web apps, and only in the user's initial profile context.

See https://chromestatus.com/feature/5106043975761920. 

Note that this is not specified behavior; this is an optional restriction that browsers may choose to interpret how they want (see the [spec wording](https://www.w3.org/TR/css-color-4/#css-system-colors:~:text=User%20agents%20may,user)). I have therefore chosen to cover this change in general notes, and point to the BCD for specific browser behaviors.

See the related BCD update: https://github.com/mdn/browser-compat-data/pull/30025.


<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
