### PR TITLE
Clarify that Element.slot reflects the attribute

### DIFF
--- a/files/en-us/web/api/element/classname/index.md
+++ b/files/en-us/web/api/element/classname/index.md
@@ -8,13 +8,11 @@ browser-compat: api.Element.className
 
 {{APIRef("DOM")}}
 
-The **`className`** property of the
-{{domxref("Element")}} interface gets and sets the value of the [`class` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/class)
-of the specified element.
+The **`className`** property of the {{domxref("Element")}} interface reflects the element's [`class`](/en-US/docs/Web/HTML/Reference/Global_attributes/class) content attribute.
 
 ## Value
 
-A string variable representing the class or space-separated classes of the current element.
+A string representing the class or space-separated classes of the current element.
 
 ## Examples
 

--- a/files/en-us/web/api/element/id/index.md
+++ b/files/en-us/web/api/element/id/index.md
@@ -8,10 +8,7 @@ browser-compat: api.Element.id
 
 {{ ApiRef("DOM") }}
 
-The **`id`** property of the {{domxref("Element")}} interface
-represents the element's identifier, reflecting the
-[**`id`**](/en-US/docs/Web/HTML/Reference/Global_attributes/id)
-global attribute.
+The **`id`** property of the {{domxref("Element")}} interface reflects the element's [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) content attribute.
 
 If the `id` value is not the empty string, it must be unique in a document.
 

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Element.slot
 The **`slot`** property of the {{domxref("Element")}} interface
 returns the name of the shadow DOM slot the element is inserted in,
 reflecting the
-[**`slot`**](/en-US/docs/Web/HTML/Reference/Global_attributes/slot)
+[`slot`](/en-US/docs/Web/HTML/Reference/Global_attributes/slot)
 global attribute.
 
 A slot is a placeholder inside a [web component](/en-US/docs/Web/API/Web_components) that users can fill with their own markup (see [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots) for more information).

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -9,7 +9,10 @@ browser-compat: api.Element.slot
 {{APIRef("Shadow DOM")}}
 
 The **`slot`** property of the {{domxref("Element")}} interface
-returns the name of the shadow DOM slot the element is inserted in.
+returns the name of the shadow DOM slot the element is inserted in,
+reflecting the
+[**`slot`**](/en-US/docs/Web/HTML/Reference/Global_attributes/slot)
+global attribute.
 
 A slot is a placeholder inside a [web component](/en-US/docs/Web/API/Web_components) that users can fill with their own markup (see [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots) for more information).
 

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -8,11 +8,7 @@ browser-compat: api.Element.slot
 
 {{APIRef("Shadow DOM")}}
 
-The **`slot`** property of the {{domxref("Element")}} interface
-returns the name of the shadow DOM slot the element is inserted in,
-reflecting the
-[`slot`](/en-US/docs/Web/HTML/Reference/Global_attributes/slot)
-global attribute.
+The **`slot`** property of the {{domxref("Element")}} interface returns the name of the shadow DOM slot the element is inserted in. It reflects the element's [`slot`](/en-US/docs/Web/HTML/Reference/Global_attributes/slot) attribute.
 
 A slot is a placeholder inside a [web component](/en-US/docs/Web/API/Web_components) that users can fill with their own markup (see [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots) for more information).
 

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Element.slot
 
 {{APIRef("Shadow DOM")}}
 
-The **`slot`** property of the {{domxref("Element")}} interface returns the name of the shadow DOM slot the element is inserted in. It reflects the element's [`slot`](/en-US/docs/Web/HTML/Reference/Global_attributes/slot) attribute.
+The **`slot`** property of the {{domxref("Element")}} interface returns the name of the shadow DOM slot the element is inserted in. It reflects the element's [`slot`](/en-US/docs/Web/HTML/Reference/Global_attributes/slot) content attribute.
 
 A slot is a placeholder inside a [web component](/en-US/docs/Web/API/Web_components) that users can fill with their own markup (see [Using templates and slots](/en-US/docs/Web/API/Web_components/Using_templates_and_slots) for more information).
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This change defines that `Element.slot` reflects the `slot` global attribute, even if the element is not actually slotted.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

I was misled by the current definition, which led me to think that the property represents the name of the slot where the element is actually placed.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
