### PR TITLE
Fix typo in Multicolumn Layout - Handling Overflow guide

### DIFF
--- a/files/en-us/web/css/guides/multicol_layout/handling_overflow/index.md
+++ b/files/en-us/web/css/guides/multicol_layout/handling_overflow/index.md
@@ -211,7 +211,7 @@ The HTML contains basic text content, which we have hidden for brevity.
 </p>
 ```
 
-We give our content some styles. Most notably, we set the `<body>` element's {{cssxref("column-count")}} to `2`, and its `column-height` to `95vh` so that each row of columns fills up the viewport. We don't need to explicitly set `column-wrap` to `wrap`: when `column-height` is set to a {{cssxref("&lt;length>")}} value, the initial value of `column-wrap` (`auto`) resolves to `wrap`, which is usually the behavior you'll want.
+We give our content some styles. Most notably, we set the `<body>` element's {{cssxref("column-count")}} to `3`, and its `column-height` to `95vh` so that each row of columns fills up the viewport. We don't need to explicitly set `column-wrap` to `wrap`: when `column-height` is set to a {{cssxref("&lt;length>")}} value, the initial value of `column-wrap` (`auto`) resolves to `wrap`, which is usually the behavior you'll want.
 
 ```css
 body {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

I fixed a typo in the Handling Overflow page of the Multicolumn Layout guides.

### Motivation

There was a mismatch between the value 2 mentioned in the text that introduces the example, and the value 3 that was actually used in the example.

### Additional details

None.

### Related issues and pull requests

None.
