### PR TITLE
See also link formatting on GlobalPrivacyControl

### DIFF
--- a/files/en-us/web/api/navigator/globalprivacycontrol/index.md
+++ b/files/en-us/web/api/navigator/globalprivacycontrol/index.md
@@ -38,5 +38,5 @@ console.log(navigator.globalPrivacyControl);
 ## See also
 
 - {{HTTPHeader("Sec-GPC")}} header
-- [globalprivacycontrol.org](https://globalprivacycontrol.org/)
-- [Do Not Track on Wikipedia](https://en.wikipedia.org/wiki/Do_Not_Track)
+- [GlobalPrivacyControl.org](https://globalprivacycontrol.org/)
+- [Do Not Track](https://en.wikipedia.org/wiki/Do_Not_Track) on Wikipedia


### PR DESCRIPTION
1. Capitalizing words in a URL enables screen readers to read words as words rather than a string of letters.
2. generally we put the source outside the link, directly after it, in external links in the see also section
