### PR TITLE
fix(svg): render red stroke in <use> example

### DIFF
--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -43,7 +43,6 @@ This element implements the {{domxref("SVGUseElement")}} interface.
 ## Example
 
 The following example shows how to use the `<use>` element to draw a circle with a different fill and stroke color.
-In the last circle, `stroke="red"` will be ignored because stroke was already set on `myCircle`.
 
 ```css hidden
 html,
@@ -55,7 +54,7 @@ svg {
 
 ```html
 <svg viewBox="0 0 30 10" xmlns="http://www.w3.org/2000/svg">
-  <circle id="myCircle" cx="5" cy="5" r="4" stroke="blue" />
+  <circle id="myCircle" cx="5" cy="5" r="4" />
   <use href="#myCircle" x="10" fill="blue" />
   <use href="#myCircle" x="20" fill="white" stroke="red" />
 </svg>

--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -42,7 +42,7 @@ This element implements the {{domxref("SVGUseElement")}} interface.
 
 ## Example
 
-The following example shows how to use the `<use>` element to draw a circle with a different fill and stroke color.
+The following example shows how to use the `<use>` element to draw multiple circles with different fill and stroke colors.
 
 ```css hidden
 html,


### PR DESCRIPTION
### Summary

Fixes #44640

The Example section on the `<use>` page says it draws "a circle with a different fill and stroke color," and the last copy sets `stroke="red"`. But the referenced `#myCircle` already set `stroke="blue"`, and a `<use>` copy cannot override a presentation attribute that the referenced element already defines, so the red was ignored and the circle rendered blue.

### Change

Remove `stroke="blue"` from the referenced circle so the `stroke="red"` on the last copy renders, matching what the surrounding text describes. The attribute-override behavior is still explained in the Usage notes section, so nothing is lost.
