### PR TITLE
base element unsafe in default sanitizer configuration

### DIFF
--- a/files/en-us/web/api/html_sanitizer_api/default_sanitizer_configuration/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/default_sanitizer_configuration/index.md
@@ -14,8 +14,9 @@ This configuration removes the following sorts of items:
 1. Those that are known to be XSS-unsafe:
    - {{htmlelement("base")}}, {{htmlelement("embed")}}, {{htmlelement("frame")}}, {{htmlelement("iframe")}}, {{htmlelement("object")}}, {{htmlelement("script")}}, and {{SVGElement("use")}}.
    - All event handler content attributes, such as `onafterprint`, `onbeforeinput`, and so on.
-2. Additional items that are deprecated, or that might be used in clickjacking, spoofing, or other attacks.
-3. Comments and `data-*` attributes.
+2. Items that might be used in clickjacking, spoofing, or other attacks.
+3. Deprecated items.
+4. Comments and `data-*` attributes.```
 
 It therefore provides a sanitizer with a minimal attack surface, which is still suitable for the majority of sanitization use cases.
 

--- a/files/en-us/web/api/html_sanitizer_api/default_sanitizer_configuration/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/default_sanitizer_configuration/index.md
@@ -16,7 +16,7 @@ This configuration removes the following sorts of items:
    - All event handler content attributes, such as `onafterprint`, `onbeforeinput`, and so on.
 2. Items that might be used in clickjacking, spoofing, or other attacks.
 3. Deprecated items.
-4. Comments and `data-*` attributes.```
+4. Comments and `data-*` attributes.
 
 It therefore provides a sanitizer with a minimal attack surface, which is still suitable for the majority of sanitization use cases.
 

--- a/files/en-us/web/api/html_sanitizer_api/default_sanitizer_configuration/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/default_sanitizer_configuration/index.md
@@ -12,9 +12,9 @@ This same configuration is implicitly used if you call the [safe sanitization me
 This configuration removes the following sorts of items:
 
 1. Those that are known to be XSS-unsafe:
-   - {{htmlelement("embed")}}, {{htmlelement("frame")}}, {{htmlelement("iframe")}}, {{htmlelement("object")}}, {{htmlelement("script")}}, and {{SVGElement("use")}}.
+   - {{htmlelement("base")}}, {{htmlelement("embed")}}, {{htmlelement("frame")}}, {{htmlelement("iframe")}}, {{htmlelement("object")}}, {{htmlelement("script")}}, and {{SVGElement("use")}}.
    - All event handler content attributes, such as `onafterprint`, `onbeforeinput`, and so on.
-2. Additional items that might be used in clickjacking, spoofing, or other attacks.
+2. Additional items that are deprecated, or that might be used in clickjacking, spoofing, or other attacks.
 3. Comments and `data-*` attributes.
 
 It therefore provides a sanitizer with a minimal attack surface, which is still suitable for the majority of sanitization use cases.

--- a/files/en-us/web/api/sanitizer/removeunsafe/index.md
+++ b/files/en-us/web/api/sanitizer/removeunsafe/index.md
@@ -29,7 +29,7 @@ None.
 ## Description
 
 The **`removeUnsafe()`** method configures the sanitizer so that it will remove all elements and attributes that are considered XSS-unsafe by the browser.
-This includes the elements {{htmlelement("embed")}}, {{htmlelement("frame")}}, {{htmlelement("iframe")}}, {{htmlelement("object")}}, {{htmlelement("script")}}, and {{SVGElement("use")}}, and the event handler content attributes such as `onafterprint`, `onbeforeinput`, and so on.
+This includes the elements {{htmlelement("base")}}, {{htmlelement("embed")}}, {{htmlelement("frame")}}, {{htmlelement("iframe")}}, {{htmlelement("object")}}, {{htmlelement("script")}}, and {{SVGElement("use")}}, and the event handler content attributes such as `onafterprint`, `onbeforeinput`, and so on.
 
 Note that if you're using the sanitizer with one of the "safe" HTML setters, such as {{domxref("Element.setHTML()")}} and {{domxref("ShadowRoot.setHTML()")}}, you do not need to call this method to make the sanitizer safe.
 When used in these setters the same elements and attributes are removed from the input, without modifying the `Sanitizer` instance that is passed.


### PR DESCRIPTION
Fixes #44673

The `<base>` element is now explicitly marked as unsafe in https://github.com/whatwg/html/pull/12664 (rather than "uncategorized"). This updates the https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API/Default_sanitizer_configuration list to add it to the list of explicitly unsafe elements.

I also noted that some elements are removed by default because they are deprecated, not necessarily attack vectors. This is the case for elements like `<acronym>`.

The actual default configuration has not changed, since base was already omitted as a potential attack.

I also updated [`Sanitizer/removeUnsafe()`](https://developer.mozilla.org/en-US/docs/Web/API/Sanitizer/removeUnsafe) with the needed change, but we shouldn't merge this until the BCD goes in
- [ ] https://github.com/mdn/browser-compat-data/pull/30033

