### PR TITLE
Fix inaccuracy about NaN sign bit

### DIFF
--- a/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
@@ -221,7 +221,7 @@ console.log(f2b(nan2)); // Uint8Array(8) [0, 0, 0, 0, 0, 0, 248, 255]
 ```
 
 > [!NOTE]
-> Implementations are allowed to canonicalize the bit representation of `NaN`, so `nan2`, when converted back to floating point, may have the same bit representation as `NaN`
+> Implementations are allowed to canonicalize the bit representation of `NaN`, so `nan2`, when converted back to floating point, may have the same bit representation as the original `NaN`.
 
 ## See also
 

--- a/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
@@ -211,7 +211,7 @@ const f2b = (x) => new Uint8Array(new Float64Array([x]).buffer);
 const b2f = (x) => new Float64Array(x.buffer)[0];
 // Get a byte representation of NaN
 const n = f2b(NaN);
-// Change the first bit, which is the sign bit and doesn't matter for NaN
+// Change the first bit, which is ignored for NaN values
 n[0] = 1;
 const nan2 = b2f(n);
 console.log(nan2); // NaN
@@ -219,6 +219,9 @@ console.log(Object.is(nan2, NaN)); // true
 console.log(f2b(NaN)); // Uint8Array(8) [0, 0, 0, 0, 0, 0, 248, 127]
 console.log(f2b(nan2)); // Uint8Array(8) [1, 0, 0, 0, 0, 0, 248, 127]
 ```
+
+> [!NOTE]
+> This example relies on platform dependent behavior. It will not work on Safari, Firefox or on big-endian machines.
 
 ## See also
 

--- a/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/guide/equality_comparisons_and_sameness/index.md
@@ -211,17 +211,17 @@ const f2b = (x) => new Uint8Array(new Float64Array([x]).buffer);
 const b2f = (x) => new Float64Array(x.buffer)[0];
 // Get a byte representation of NaN
 const n = f2b(NaN);
-// Change the first bit, which is ignored for NaN values
-n[0] = 1;
+// Change the first bit, which is the sign bit and doesn't matter for NaN
+n[7] |= 0x80;
 const nan2 = b2f(n);
 console.log(nan2); // NaN
 console.log(Object.is(nan2, NaN)); // true
 console.log(f2b(NaN)); // Uint8Array(8) [0, 0, 0, 0, 0, 0, 248, 127]
-console.log(f2b(nan2)); // Uint8Array(8) [1, 0, 0, 0, 0, 0, 248, 127]
+console.log(f2b(nan2)); // Uint8Array(8) [0, 0, 0, 0, 0, 0, 248, 255]
 ```
 
 > [!NOTE]
-> This example relies on platform dependent behavior. It will not work on Safari, Firefox or on big-endian machines.
+> Implementations are allowed to canonicalize the bit representation of `NaN`, so `nan2`, when converted back to floating point, may have the same bit representation as `NaN`
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

 - Fix inaccuracy about changing NaN sign bit
 - Add note about platform dependance in the example


### Motivation

Previously this example claimed that the example code was changing the sign bit of the float, which doesn't effect NaN values.  However, the example was actually modifying the fraction component (which also doesn't affect NaN values).

These changes correct that inaccuracy by being less specific about why the bit change still results in a NaN value.

### Additional details

https://en.wikipedia.org/wiki/NaN#Encoding

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
