### PR TITLE
HTML Table Basics: Fix grammatical run-on and improve readability in colgroup/col note

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/html_table_basics/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/html_table_basics/index.md
@@ -677,7 +677,7 @@ Let's look at how the above code renders:
 Notice how the different columns receive the styles specified in the classes.
 
 > [!NOTE]
-> Even though `<colgroup>` and `<col>` mainly facilitate styling, they are an HTML feature, therefore we've covered them here rather than in our CSS modules. Is it also fair to say that they are a _limited_ feature — as shown on the [`<colgroup>` reference page](/en-US/docs/Web/HTML/Reference/Elements/colgroup#usage_notes), only a limited subset of styles can be applied to a `<col>` element, and most of the other settings that were historically available have been deprecated (removed, or flagged for removal).
+> Even though `<colgroup>` and `<col>` mainly facilitate styling, they are an HTML feature, so we've covered them here rather than in our CSS modules. It is also fair to say that they are a _limited_ feature — as shown on the [`<colgroup>` reference page](/en-US/docs/Web/HTML/Reference/Elements/colgroup#usage_notes), only a limited subset of styles can be applied to a `<col>` element, and most of the other settings that were historically available have been deprecated (removed, or flagged for removal).
 
 ## Interactive recap of table concepts
 


### PR DESCRIPTION
[HTML Table Basics link (highlighted)](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics#interactive_recap_of_table_concepts:~:text=Note%3A%20Even,flagged%20for%20removal).

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Fixes a comma splice and an awkward run-on question in the note section regarding the `<colgroup>` and `<col>` elements. The phrasing has been updated to use "so" for better flow and transformed from an incomplete question into a clear, direct statement.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Improving the grammatical correctness of the note enhances the clarity and readability of the documentation for developers learning about these HTML features.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
N/A
### Related issues and pull requests
N/A
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
