### PR TITLE
Fix typo in action.isEnabled() details parameter description

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/isenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/isenabled/index.md
@@ -22,7 +22,7 @@ let gettingIsEnabled = browser.action.isEnabled(
 ### Parameters
 
 - `details` {{optional_inline}}
-  - : `integer` or `object`. An an `integer` it defines the ID of a tab to check. As an `object` it contains:
+  - : `integer` or `object`. As an `integer` it defines the ID of a tab to check. As an `object` it contains:
     - `tabId` {{optional_inline}}
       - : `integer`. ID of a tab to check.
     - `windowId` {{optional_inline}}


### PR DESCRIPTION
### Description

Fixes a small grammatical typo in the `details` parameter description for `browser.action.isEnabled()`. The text read "**An an** `integer` it defines the ID of a tab to check", which should be "**As an** `integer` …".

### Motivation

The following clause in the same sentence already reads "**As an** `object` it contains:", so the parallel structure makes the intended wording unambiguous. The fix makes the sentence grammatical and consistent.

### Additional details

Prose-only, single-word change; no code, links, or formatting affected.

### Related issues and pull requests

None.