### PR TITLE
FF153 Relnote: select element HTML parser

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -18,9 +18,11 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- ### Developer Tools -->
 
-<!-- ### HTML -->
+### HTML
 
-<!-- No notable changes. -->
+- HTML parsing rules for {{htmlelement("select")}} elements have been updated to allow all nested elements to be parsed into DOM rather than just `<option>`, `<optgroup>`, and `<hr>`.
+  This enables possible future support of [customizable select elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select).
+  ([Firefox bug 2019977](https://bugzil.la/2019977)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/web/html/reference/elements/select/index.md
+++ b/files/en-us/web/html/reference/elements/select/index.md
@@ -79,6 +79,18 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
 ## Usage notes
 
+### Options inside wrapper elements
+
+The `<select>` element builds its list of options from all `<option>` descendants, not just its direct children.
+This means that options can be wrapped in other elements, such as {{HTMLElement("div")}} elements, and they will still appear as selectable options in the dropdown and be included in form submission.
+Wrapper elements are useful for styling in [customizable select elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select) but have no effect on the select's behavior: they don't create groups, labels, or separators.
+To group options under a heading, use an {{HTMLElement("optgroup")}}; an {{HTMLElement("option")}} counts as part of an `<optgroup>` if the group is an ancestor, so wrapper elements may also be used inside a group without breaking the association.
+
+> [!NOTE]
+> Browsers with modern parsing behavior preserve all elements written inside a `<select>` in the DOM — including wrapper elements, {{HTMLElement("button")}}, and {{HTMLElement("selectedcontent")}}.
+> Older browsers instead remove non-permitted elements while parsing, keeping only the `<option>`, `<optgroup>`, and `<hr>` structure.
+> As a result, styling, markup, or scripting that depends on the removed elements will not work on older browsers.
+
 ### Selecting multiple options
 
 On a desktop computer, there are a number of ways to select multiple options in a `<select>` element with a `multiple` attribute:


### PR DESCRIPTION
FF153 adds support for a less restrictive HTML parser for `<select>` elements in https://bugzilla.mozilla.org/show_bug.cgi?id=2019977.

This allows nested elements to be parsed into DOM rather than only the allowed elements. Its a precursor to _customised select elements_. This adds the release note and an explanation of the change in `<iframe>`, without promising future delivery of that feature.

As I see it, makes little real difference to FF. Inspection shows the nested DOM is preserved, but we can't set the `appearance` so we can't style it.

Related docs work can be tracked in #44462

@SebastianZ You might have some interest in this.