### PR TITLE
fix(html): correct colspan upper limit

### DIFF
--- a/files/en-us/web/html/reference/elements/td/index.md
+++ b/files/en-us/web/html/reference/elements/td/index.md
@@ -86,7 +86,7 @@ caption {
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 
 - `colspan`
-  - : Contains a non-negative integer value that indicates how many columns the data cell spans or extends. The default value is `1`. User agents dismiss values higher than 1000 as incorrect, setting to the default value (`1`).
+  - : Contains a non-negative integer value that indicates how many columns the data cell spans or extends. The default value is `1`. Values higher than `1000` are clipped to `1000`.
 - `headers`
   - : Contains a list of space-separated strings, each corresponding to the `id` attribute of the {{HTMLElement("th")}} elements that provide headings for this table cell.
 - `rowspan`

--- a/files/en-us/web/html/reference/elements/th/index.md
+++ b/files/en-us/web/html/reference/elements/th/index.md
@@ -88,7 +88,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 - `abbr`
   - : A short, abbreviated description of the header cell's content provided as an alternative label to use for the header cell when referencing the cell in other contexts. Some user-agents, such as screen readers, may present this description before the content itself.
 - `colspan`
-  - : A non-negative integer value indicating how many columns the header cell spans or extends. The default value is `1`. User agents dismiss values higher than 1000 as incorrect, defaulting such values to `1`.
+  - : A non-negative integer value indicating how many columns the header cell spans or extends. The default value is `1`. Values higher than `1000` are clipped to `1000`.
 - `headers`
   - : A list of space-separated strings corresponding to the `id` attributes of the `<th>` elements that provide the headers for this header cell.
 - `rowspan`


### PR DESCRIPTION
### Description

Correct the documented `colspan` upper-limit behavior on the `<td>` and `<th>` reference pages. Values greater than `1000` are clipped to `1000`, rather than treated as invalid and reset to `1`.

### Motivation

The existing descriptions conflict with the table-cell processing algorithm in the HTML Standard. Updating both cell-element pages keeps the shared `colspan` behavior accurate and consistent for readers.

### Additional details

- [HTML Standard table-cell processing algorithm](https://html.spec.whatwg.org/multipage/tables.html#processing-model-2)
- Repository pre-commit checks passed: URL issues, changed xrefs, front matter, MarkdownLint, and Prettier.
- Targeted CSpell passed with no issues; `npm test` passed all 5 tests.
- A local Rari page build could not complete because this sparse checkout omits the global CSS reference index; GitHub CI runs against the full checkout.

Disclosure: This change was prepared with OpenAI Codex assistance. I reviewed the contribution guidelines, specification source, final diff, and validation results.

### Related issues and pull requests

Fixes #44715
