### PR TITLE
Fix simple code example oversight

### DIFF
--- a/files/en-us/web/css/reference/values/anchor/index.md
+++ b/files/en-us/web/css/reference/values/anchor/index.md
@@ -154,7 +154,7 @@ This example positions the right edge of the positioned element flush to the anc
 ```css
 .positionedElement {
   right: anchor(left);
-  margin-left: 10px;
+  margin-right: 10px;
 }
 ```
 


### PR DESCRIPTION
If the element is positioned with its right edge touching the left side of its anchor, then the margin of the positioned element needs to be on the right side to space them apart

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

The code example puts the margin on the wrong side.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
