### PR TITLE
Clarify where the <style> element can be used

### DIFF
--- a/files/en-us/web/html/reference/elements/style/index.md
+++ b/files/en-us/web/html/reference/elements/style/index.md
@@ -37,7 +37,7 @@ p {
 }
 ```
 
-The `<style>` element must be included inside the {{htmlelement("head")}} of the document. In general, it is better to put your styles in external stylesheets and apply them using {{htmlelement("link")}} elements.
+The `<style>` element is typically included inside the {{htmlelement("head")}} of the document. It can also be used anywhere metadata content is permitted, such as inside a {{htmlelement("template")}} element.,
 
 If you include multiple `<style>` and `<link>` elements in your document, they will be applied to the DOM in the order they are included in the document — make sure you include them in the correct order, to avoid unexpected cascade issues.
 
@@ -94,10 +94,29 @@ In the following example, we apply a short stylesheet to a document:
 
 {{EmbedLiveSample('A_basic_stylesheet', '100%', '100')}}
 
+### Using `<style>` inside `<template>`
+
+A `<style>` element can also be placed inside a {{HTMLElement("template")}} element. The styles remain inactive until the template content is instantiated and inserted into the document.
+
+```html
+<template id="card-template">
+  <style>
+    .card {
+      border: 1px solid #ccc;
+      padding: 1rem;
+      border-radius: 0.5rem;
+    }
+  </style>
+
+  <div class="card">
+    Template content
+  </div>
+</template>
+```
+
 ### Multiple style elements
 
 In this example we've included two `<style>` elements — notice how the conflicting declarations in the later `<style>` element override those in the earlier one, if they have equal [specificity](/en-US/docs/Web/CSS/Guides/Cascade/Specificity).
-
 ```html
 <!doctype html>
 <html lang="en-US">

--- a/files/en-us/web/html/reference/elements/style/index.md
+++ b/files/en-us/web/html/reference/elements/style/index.md
@@ -37,7 +37,7 @@ p {
 }
 ```
 
-The `<style>` element is typically included inside the {{htmlelement("head")}} of the document. It can also be used anywhere metadata content is permitted, such as inside a {{htmlelement("template")}} element.,
+The `<style>` element is typically included inside the {{htmlelement("head")}} of the document. It can also be used anywhere metadata content is permitted, such as inside a {{htmlelement("template")}} element.
 
 If you include multiple `<style>` and `<link>` elements in your document, they will be applied to the DOM in the order they are included in the document — make sure you include them in the correct order, to avoid unexpected cascade issues.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This updates the `<style>` element documentation to clarify that the `<style>` element is not limited to the `<head>` element.

The page now explains that `<style>` can be used wherever metadata content is permitted, such as inside a `<template>` element, in accordance with the HTML specification.

Fixes #41900

<!-- ✍️ This updates the `<style>` element documentation to clarify that it is not limited to the `<head>` element.

The page now explains that `<style>` can be used wherever metadata content is permitted, such as inside a `<template>` element, which aligns with the HTML specification.

Fixes #41900 -->

### Example
### Using `<style>` inside `<template>`

The `<style>` element can also be placed inside a {{HTMLElement("template")}} element because it accepts metadata content.

```html
<template id="card-template">
  <style>
    p {
      color: rebeccapurple;
    }
  </style>

  <p>Styled template content</p>
</template>
``` 


<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
