### PR TITLE
docs(webapi): clarify Document selectionchange behavior and differences from input/textarea

### DIFF
--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -23,6 +23,7 @@ The event object itself does not contain the updated selection details. You can 
 > [!NOTE]
 > This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
 >
+>
 > - **Representation:** Document selections use DOM node positions and require {{domxref("Document.getSelection()")}} for inspection. Text controls maintain independent selections within their internal text values, using character offsets inspected via `selectionStart`, `selectionEnd`, and `selectionDirection`.
 > - **Bubbling:** The document-level event fires directly on the {{domxref("Document")}} and does not bubble. The text-control `selectionchange` event fires on the input/textarea element and bubbles up the DOM tree.
 >   See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` and the {{domxref("HTMLTextAreaElement.selectionchange_event", "selectionchange")}} event of `HTMLTextAreaElement` for more details.

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -23,7 +23,6 @@ The event object itself does not contain the updated selection details. You can 
 > [!NOTE]
 > This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
 >
->
 > - **Representation:** Document selections use DOM node positions and require {{domxref("Document.getSelection()")}} for inspection. Text controls maintain independent selections within their internal text values, using character offsets inspected via `selectionStart`, `selectionEnd`, and `selectionDirection`.
 > - **Bubbling:** The document-level event fires directly on the {{domxref("Document")}} and does not bubble. The text-control `selectionchange` event fires on the input/textarea element and bubbles up the DOM tree.
 >   See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` and the {{domxref("HTMLTextAreaElement.selectionchange_event", "selectionchange")}} event of `HTMLTextAreaElement` for more details.

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -5,6 +5,7 @@ slug: Web/API/Document/selectionchange_event
 page-type: web-api-event
 browser-compat: api.Document.selectionchange_event
 ---
+
 {{APIRef("Selection API")}}
 
 The browser fires the **`selectionchange`** event of the [Selection API](/en-US/docs/Web/API/Selection) when the current {{domxref("Selection")}} of a {{domxref("Document")}} changes. A document selection represents either a range of selected content across DOM nodes or a collapsed caret position.

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -12,7 +12,6 @@ The browser fires the **`selectionchange`** event of the [Selection API](/en-US/
 
 The browser triggers this event when:
 
-
 - A user or script creates or clears a selection.
 - The start or end boundary point of a selected range moves.
 - A selected range changes completely.

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -12,6 +12,7 @@ The browser fires the **`selectionchange`** event of the [Selection API](/en-US/
 
 The browser triggers this event when:
 
+
 - A user or script creates or clears a selection.
 - The start or end boundary point of a selected range moves.
 - A selected range changes completely.

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -20,7 +20,8 @@ The event object itself does not contain the updated selection details. You can 
 > [!NOTE]
 > This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
 > - **Representation:** Document selections use DOM node positions and require {{domxref("Document.getSelection()")}} for inspection. Text controls maintain independent selections within their internal text values, using character offsets inspected via `selectionStart`, `selectionEnd`, and `selectionDirection`.
-> - **Bubbling:** The document-level event fires directly on the {{domxref("Document")}} and does not bubble. The text-control `selectionchange` event fires on the input element and bubbles up the DOM tree. See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` for more details.
+> - **Bubbling:** The document-level event fires directly on the {{domxref("Document")}} and does not bubble. The text-control `selectionchange` event fires on the input/textarea element and bubbles up the DOM tree.
+>   See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` and the {{domxref("HTMLTextAreaElement.selectionchange_event", "selectionchange")}} event of `HTMLTextAreaElement` for more details.
 
 ## Syntax
 

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -35,7 +35,7 @@ The `Document` object `selectionchange` event is fired when:
 - A selected range changes completely.
 - A selection collapses to a single caret position.
 
-The event object itself does not contain the updated selection details. You can retrieve the current selection by calling {{domxref("Document.getSelection()", "document.getSelection()")}} within your event listener. 
+The event object itself does not contain the updated selection details. You can retrieve the current selection by calling {{domxref("Document.getSelection()", "document.getSelection()")}} within your event listener.
 
 This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
 

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -11,6 +11,7 @@ browser-compat: api.Document.selectionchange_event
 The browser fires the **`selectionchange`** event of the [Selection API](/en-US/docs/Web/API/Selection) when the current {{domxref("Selection")}} of a {{domxref("Document")}} changes. A document selection represents either a range of selected content across DOM nodes or a collapsed caret position.
 
 The browser triggers this event when:
+
 - A user or script creates or clears a selection.
 - The start or end boundary point of a selected range moves.
 - A selected range changes completely.
@@ -20,6 +21,7 @@ The event object itself does not contain the updated selection details. You can 
 
 > [!NOTE]
 > This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
+>
 > - **Representation:** Document selections use DOM node positions and require {{domxref("Document.getSelection()")}} for inspection. Text controls maintain independent selections within their internal text values, using character offsets inspected via `selectionStart`, `selectionEnd`, and `selectionDirection`.
 > - **Bubbling:** The document-level event fires directly on the {{domxref("Document")}} and does not bubble. The text-control `selectionchange` event fires on the input/textarea element and bubbles up the DOM tree.
 >   See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` and the {{domxref("HTMLTextAreaElement.selectionchange_event", "selectionchange")}} event of `HTMLTextAreaElement` for more details.

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -10,21 +10,7 @@ browser-compat: api.Document.selectionchange_event
 
 The browser fires the **`selectionchange`** event of the [Selection API](/en-US/docs/Web/API/Selection) when the current {{domxref("Selection")}} of a {{domxref("Document")}} changes. A document selection represents either a range of selected content across DOM nodes or a collapsed caret position.
 
-The browser triggers this event when:
-
-- A user or script creates or clears a selection.
-- The start or end boundary point of a selected range moves.
-- A selected range changes completely.
-- A selection collapses to a single caret position.
-
-The event object itself does not contain the updated selection details. You can retrieve the current selection by calling {{domxref("Document.getSelection()", "document.getSelection()")}} within your event listener. This event is not cancelable and does not bubble.
-
-> [!NOTE]
-> This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
->
-> - **Representation:** Document selections use DOM node positions and require {{domxref("Document.getSelection()")}} for inspection. Text controls maintain independent selections within their internal text values, using character offsets inspected via `selectionStart`, `selectionEnd`, and `selectionDirection`.
-> - **Bubbling:** The document-level event fires directly on the {{domxref("Document")}} and does not bubble. The text-control `selectionchange` event fires on the input/textarea element and bubbles up the DOM tree.
->   See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` and the {{domxref("HTMLTextAreaElement.selectionchange_event", "selectionchange")}} event of `HTMLTextAreaElement` for more details.
+This event is not cancelable and does not bubble.
 
 ## Syntax
 
@@ -40,7 +26,27 @@ onselectionchange = (event) => {}
 
 A generic {{domxref("Event")}}.
 
+## Description
+
+The `Document` object `selectionchange` event is fired when:
+
+- A user or script creates or clears a selection.
+- The start or end boundary point of a selected range moves.
+- A selected range changes completely.
+- A selection collapses to a single caret position.
+
+The event object itself does not contain the updated selection details. You can retrieve the current selection by calling {{domxref("Document.getSelection()", "document.getSelection()")}} within your event listener. 
+
+This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
+
+- Document selections use DOM node positions and require {{domxref("Document.getSelection()")}} for inspection. Text inputs maintain independent selections within their internal text values, using character offsets inspected via `selectionStart`, `selectionEnd`, and `selectionDirection`.
+- The document-level `selectionchange` event fires directly on the {{domxref("Document")}} and does not bubble. The text input `selectionchange` event fires on the input/textarea element and bubbles up the DOM tree.
+
+See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` and the {{domxref("HTMLTextAreaElement.selectionchange_event", "selectionchange")}} event of `HTMLTextAreaElement` for more details of the text input events.
+
 ## Examples
+
+### Basic usage
 
 ```js
 // addEventListener version

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -5,26 +5,31 @@ slug: Web/API/Document/selectionchange_event
 page-type: web-api-event
 browser-compat: api.Document.selectionchange_event
 ---
-
 {{APIRef("Selection API")}}
 
-The **`selectionchange`** event of the [Selection API](/en-US/docs/Web/API/Selection) is fired when the current {{domxref("Selection")}} of a {{domxref("Document")}} is changed.
+The browser fires the **`selectionchange`** event of the [Selection API](/en-US/docs/Web/API/Selection) when the current {{domxref("Selection")}} of a {{domxref("Document")}} changes. A document selection represents either a range of selected content across DOM nodes or a collapsed caret position.
 
-This event is not cancelable and does not bubble.
+The browser triggers this event when:
+- A user or script creates or clears a selection.
+- The start or end boundary point of a selected range moves.
+- A selected range changes completely.
+- A selection collapses to a single caret position.
 
-The event can be handled by adding an event listener for `selectionchange` or using the `onselectionchange` event handler.
+The event object itself does not contain the updated selection details. You can retrieve the current selection by calling {{domxref("Document.getSelection()", "document.getSelection()")}} within your event listener. This event is not cancelable and does not bubble.
 
 > [!NOTE]
-> This event is not quite the same as the `selectionchange` events fired when the text selection in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element is changed. See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` for more details.
+> This event differs significantly from the `selectionchange` event fired on {{HTMLElement("input")}} and {{HTMLElement("textarea")}} text controls:
+> - **Representation:** Document selections use DOM node positions and require {{domxref("Document.getSelection()")}} for inspection. Text controls maintain independent selections within their internal text values, using character offsets inspected via `selectionStart`, `selectionEnd`, and `selectionDirection`.
+> - **Bubbling:** The document-level event fires directly on the {{domxref("Document")}} and does not bubble. The text-control `selectionchange` event fires on the input element and bubbles up the DOM tree. See the {{domxref("HTMLInputElement.selectionchange_event", "selectionchange")}} event of `HTMLInputElement` for more details.
 
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js-nolint
-addEventListener("selectionchange", (event) => { })
+addEventListener("selectionchange", (event) => {})
 
-onselectionchange = (event) => { }
+onselectionchange = (event) => {}
 ```
 
 ## Event type


### PR DESCRIPTION
### Description

Clarifies the triggering conditions for the `Document: selectionchange` event and explicitly contrasts its behavior (representation and bubbling) with the `selectionchange` event fired on `<input>` and `<textarea>` text controls.

### Motivation

Developers frequently confuse the document-level selection event with text-control selection events, leading to bugs around event bubbling and selection retrieval. This update provides clear bullet points for trigger conditions and an explicit comparison note to help readers quickly understand the differences and use the correct API for their use case.

### Additional details

- Updated prose to follow the Google Developer Documentation Style Guide (active voice, present tense, second person, zero condescending buzzwords).
- Structured the comparison between `Document` and text controls to clearly distinguish DOM node selection vs. internal character offset selection (`selectionStart`/`selectionEnd`).

### Related issues and pull requests

Fixes #44680