### PR TITLE
improve readability of a paragraph in QuerySelector()

### DIFF
--- a/files/en-us/web/api/document/queryselector/index.md
+++ b/files/en-us/web/api/document/queryselector/index.md
@@ -37,7 +37,7 @@ querySelector(selectors)
 ### Return value
 
 An {{domxref("Element")}} object representing the first element in the document
-that matches the specified set of [CSS selectors](/en-US/docs/Web/CSS/Guides/Selectors), or `null` is returned if there are no matches.
+that matches the specified set of [CSS selectors](/en-US/docs/Web/CSS/Guides/Selectors), or `null` if there are no matches.
 
 If you need a list of all elements matching the specified selectors, you should use
 {{domxref("Document.querySelectorAll", "querySelectorAll()")}} instead.


### PR DESCRIPTION
### Description
I removed a couple of words from the paragraph to make the sentence simpler and clearer. 

### Motivation
I feel the inconsistent style makes it harder to understand than necessary. Now both outcomes are started in the same manner and it's consisted with style of 'return value' paragraph on other pages.

### Additional details
None

### Related issues and pull requests
Not related to any issues I could find.
