### PR TITLE
Add WebDriver classic virtual sensor and pressure source commands

### DIFF
--- a/files/en-us/web/webdriver/reference/classic/commands/createvirtualpressuresource/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/createvirtualpressuresource/index.md
@@ -1,0 +1,76 @@
+---
+title: Create Virtual Pressure Source
+short-title: Create Virtual Pressure Source
+slug: Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource
+page-type: webdriver-command
+browser-compat: webdriver.classic.CreateVirtualPressureSource
+sidebar: webdriver
+---
+
+The _Create Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API creates a virtual pressure source of a given type that overrides the platform pressure source of the same type. This lets tests exercise the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API) with predetermined pressure states instead of relying on real hardware.
+
+## Syntax
+
+| Method                                                | URI template                           |
+| ----------------------------------------------------- | -------------------------------------- |
+| [`POST`](/en-US/docs/Web/HTTP/Reference/Methods/POST) | `/session/{session id}/pressuresource` |
+
+### URL parameters
+
+- `session id`
+  - : Identifier of the session.
+
+### Payload
+
+The input is an object:
+
+- `type`
+  - : A string identifying the pressure source type to create. Currently the only widely supported value is `"cpu"`.
+- `supported` {{optional_inline}}
+  - : A boolean indicating whether the virtual pressure source is able to provide samples. Defaults to `true`.
+
+### Return value
+
+`null` if successful.
+
+### Errors
+
+- [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
+  - : Session does not exist.
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : The `type` is not a supported pressure source type, or a virtual pressure source of that type already exists.
+
+## Examples
+
+### Creating a virtual pressure source
+
+With a WebDriver server running on `localhost:4444`, assume an active session has been created. To create a virtual `"cpu"` pressure source, send its type as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+  -d '{"type": "cpu"}' \
+  http://localhost:4444/session/ID/pressuresource
+```
+
+The server responds with a null value to indicate success:
+
+```http
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+
+{"value":null}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Update Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/UpdateVirtualPressureSource) command
+- [Delete Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/DeleteVirtualPressureSource) command
+- [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API)

--- a/files/en-us/web/webdriver/reference/classic/commands/createvirtualpressuresource/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/createvirtualpressuresource/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.classic.CreateVirtualPressureSource
 sidebar: webdriver
 ---
 
-The _Create Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API creates a virtual pressure source of a given type that overrides the platform pressure source of the same type. This lets tests exercise the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API) with predetermined pressure states instead of relying on real hardware.
+The _Create Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API creates a virtual pressure source of a given type, which overrides the platform pressure source of the same type. This lets tests exercise the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API) with predetermined pressure states instead of relying on real hardware.
 
 ## Syntax
 
@@ -25,7 +25,7 @@ The _Create Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Referen
 The input is an object:
 
 - `type`
-  - : A string identifying the pressure source type to create. Currently the only widely supported value is `"cpu"`.
+  - : A string identifying the pressure source type to create. Currently, the only widely supported value is `"cpu"`.
 - `supported` {{optional_inline}}
   - : A boolean indicating whether the virtual pressure source is able to provide samples. Defaults to `true`.
 
@@ -44,7 +44,7 @@ The input is an object:
 
 ### Creating a virtual pressure source
 
-With a WebDriver server running on `localhost:4444`, assume an active session has been created. To create a virtual `"cpu"` pressure source, send its type as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+With a WebDriver server running on `localhost:4444`, assume an active session has been created. To create a virtual `"cpu"` pressure source, send its type in the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
 
 ```bash
 curl -i -H "Content-Type: application/json" \
@@ -52,7 +52,7 @@ curl -i -H "Content-Type: application/json" \
   http://localhost:4444/session/ID/pressuresource
 ```
 
-The server responds with a null value to indicate success:
+The server responds with a `null` value to indicate success:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
@@ -1,0 +1,81 @@
+---
+title: Create Virtual Sensor
+short-title: Create Virtual Sensor
+slug: Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor
+page-type: webdriver-command
+browser-compat: webdriver.classic.CreateVirtualSensor
+sidebar: webdriver
+---
+
+The _Create Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API creates a virtual sensor of a given type that overrides the platform sensor of the same type. This lets tests exercise the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) with predetermined readings instead of relying on real hardware. While the virtual sensor exists, it replaces any real sensor of the same type for the [top-level browsing context](/en-US/docs/Glossary/Browsing_context).
+
+## Syntax
+
+| Method                                                | URI template                   |
+| ----------------------------------------------------- | ------------------------------ |
+| [`POST`](/en-US/docs/Web/HTTP/Reference/Methods/POST) | `/session/{session id}/sensor` |
+
+### URL parameters
+
+- `session id`
+  - : Identifier of the session.
+
+### Payload
+
+The input is an object:
+
+- `type`
+  - : A string identifying the virtual sensor type to create, for example `"ambient-light"`, `"accelerometer"`, or `"gyroscope"`. Only one virtual sensor of a given type can exist at a time in the top-level browsing context.
+- `connected` {{optional_inline}}
+  - : A boolean indicating whether the sensor is able to provide readings. Defaults to `true`.
+- `maxSamplingFrequency` {{optional_inline}}
+  - : A number specifying the upper bound, in hertz, of the sampling frequency the virtual sensor supports.
+- `minSamplingFrequency` {{optional_inline}}
+  - : A number specifying the lower bound, in hertz, of the sampling frequency the virtual sensor supports.
+
+### Return value
+
+`null` if successful.
+
+### Errors
+
+- [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
+  - : Session does not exist.
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : The `type` is not a string or is not a supported virtual sensor type, a virtual sensor of that type already exists, or the supplied frequency values are invalid (for example, not a number or `minSamplingFrequency` is greater than `maxSamplingFrequency`).
+
+## Examples
+
+### Creating a virtual sensor
+
+With a WebDriver server running on `localhost:4444`, assume an active session has been created. To create a virtual [`AmbientLightSensor`](/en-US/docs/Web/API/AmbientLightSensor), send its type as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+  -d '{"type": "ambient-light"}' \
+  http://localhost:4444/session/ID/sensor
+```
+
+The server responds with a null value to indicate success:
+
+```http
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+
+{"value":null}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Update Virtual Sensor Reading](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/UpdateVirtualSensorReading) command
+- [Get Virtual Sensor Information](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/GetVirtualSensorInformation) command
+- [Delete Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/DeleteVirtualSensor) command
+- [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs)

--- a/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
@@ -29,9 +29,9 @@ The input is an object:
 - `connected` {{optional_inline}}
   - : A boolean indicating whether the sensor is able to provide readings. Defaults to `true`.
 - `maxSamplingFrequency` {{optional_inline}}
-  - : A number specifying the upper bound, in hertz, of the sampling frequency the virtual sensor supports.
+  - : A number, in hertz, specifying the upper bound of the sampling frequency that the virtual sensor supports.
 - `minSamplingFrequency` {{optional_inline}}
-  - : A number specifying the lower bound, in hertz, of the sampling frequency the virtual sensor supports.
+  - : A number, in hertz, specifying the lower bound of the sampling frequency that the virtual sensor supports.
 
 ### Return value
 
@@ -42,13 +42,13 @@ The input is an object:
 - [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
   - : Session does not exist.
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
-  - : The `type` is not a string or is not a supported virtual sensor type, a virtual sensor of that type already exists, or the supplied frequency values are invalid (for example, not a number or `minSamplingFrequency` is greater than `maxSamplingFrequency`).
+  - : The `type` is not a string, is not a supported virtual sensor type, or a virtual sensor of that type already exists. The specified sampling frequency values are invalid if they are not a number or if `minSamplingFrequency` is greater than `maxSamplingFrequency`.
 
 ## Examples
 
 ### Creating a virtual sensor
 
-With a WebDriver server running on `localhost:4444`, assume an active session has been created. To create a virtual [`AmbientLightSensor`](/en-US/docs/Web/API/AmbientLightSensor), send its type as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+With a WebDriver server running on `localhost:4444`, assume an active session has been created. To create a virtual [`AmbientLightSensor`](/en-US/docs/Web/API/AmbientLightSensor), send its type in the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
 
 ```bash
 curl -i -H "Content-Type: application/json" \
@@ -56,7 +56,7 @@ curl -i -H "Content-Type: application/json" \
   http://localhost:4444/session/ID/sensor
 ```
 
-The server responds with a null value to indicate success:
+The server responds with a `null` value to indicate success:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
@@ -25,7 +25,7 @@ The _Create Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classi
 The input is an object:
 
 - `type`
-  - : A string identifying the virtual sensor type to create, for example `"ambient-light"`, `"accelerometer"`, or `"gyroscope"`. Only one virtual sensor of a given type can exist at a time in the top-level browsing context.
+  - : A string identifying the virtual sensor type to create. Possible values include `"ambient-light"`, `"accelerometer"`, and `"gyroscope"`. Only one virtual sensor of a given type can exist at a time in the top-level browsing context.
 - `connected` {{optional_inline}}
   - : A boolean indicating whether the sensor is able to provide readings. Defaults to `true`.
 - `maxSamplingFrequency` {{optional_inline}}

--- a/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/createvirtualsensor/index.md
@@ -7,7 +7,10 @@ browser-compat: webdriver.classic.CreateVirtualSensor
 sidebar: webdriver
 ---
 
-The _Create Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API creates a virtual sensor of a given type that overrides the platform sensor of the same type. This lets tests exercise the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) with predetermined readings instead of relying on real hardware. While the virtual sensor exists, it replaces any real sensor of the same type for the [top-level browsing context](/en-US/docs/Glossary/Browsing_context).
+The _Create Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API creates a virtual sensor of a given type, which overrides the platform sensor of the same type. This lets tests exercise the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) with predetermined readings instead of relying on real hardware. While the virtual sensor exists, new connections to a sensor of the same type in the top-level [browsing context](/en-US/docs/Glossary/Browsing_context) use the virtual sensor instead of the platform sensor.
+
+> [!NOTE]
+> Sensor instances of the same type can coexist and use different device sensors. A sensor already connected to a real, hardware sensor continues receiving readings from it and switches to the virtual sensor only if it connects again.
 
 ## Syntax
 

--- a/files/en-us/web/webdriver/reference/classic/commands/deletevirtualpressuresource/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/deletevirtualpressuresource/index.md
@@ -1,0 +1,67 @@
+---
+title: Delete Virtual Pressure Source
+short-title: Delete Virtual Pressure Source
+slug: Web/WebDriver/Reference/Classic/Commands/DeleteVirtualPressureSource
+page-type: webdriver-command
+browser-compat: webdriver.classic.DeleteVirtualPressureSource
+sidebar: webdriver
+---
+
+The _Delete Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API removes a virtual pressure source previously created with the [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command. After the virtual pressure source is deleted, the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API) once again uses the real platform pressure source of that type, if one is available.
+
+## Syntax
+
+| Method                                                    | URI template                                  |
+| --------------------------------------------------------- | --------------------------------------------- |
+| [`DELETE`](/en-US/docs/Web/HTTP/Reference/Methods/DELETE) | `/session/{session id}/pressuresource/{type}` |
+
+### URL parameters
+
+- `session id`
+  - : Identifier of the session.
+- `type`
+  - : The pressure source type to delete, for example `"cpu"`.
+
+### Return value
+
+`null` if successful.
+
+### Errors
+
+- [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
+  - : Session does not exist.
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : The `type` is not a supported pressure source type.
+
+## Examples
+
+### Deleting a virtual pressure source
+
+With a WebDriver server running on `localhost:4444`, assume a virtual `"cpu"` pressure source has been created for the active session. To remove it, send a `DELETE` request with the pressure source type appended to the endpoint, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+
+```bash
+curl -i -X DELETE http://localhost:4444/session/ID/pressuresource/cpu
+```
+
+The server responds with a null value to indicate success:
+
+```http
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+
+{"value":null}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command
+- [Update Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/UpdateVirtualPressureSource) command
+- [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API)

--- a/files/en-us/web/webdriver/reference/classic/commands/deletevirtualpressuresource/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/deletevirtualpressuresource/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.classic.DeleteVirtualPressureSource
 sidebar: webdriver
 ---
 
-The _Delete Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API removes a virtual pressure source previously created with the [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command. After the virtual pressure source is deleted, the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API) once again uses the real platform pressure source of that type, if one is available.
+The _Delete Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API removes a virtual pressure source previously created using the [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command. After the virtual pressure source is deleted, the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API) once again uses the real platform pressure source of that type, if one is available.
 
 ## Syntax
 
@@ -43,7 +43,7 @@ With a WebDriver server running on `localhost:4444`, assume a virtual `"cpu"` pr
 curl -i -X DELETE http://localhost:4444/session/ID/pressuresource/cpu
 ```
 
-The server responds with a null value to indicate success:
+The server responds with a `null` value to indicate success:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/webdriver/reference/classic/commands/deletevirtualsensor/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/deletevirtualsensor/index.md
@@ -1,0 +1,68 @@
+---
+title: Delete Virtual Sensor
+short-title: Delete Virtual Sensor
+slug: Web/WebDriver/Reference/Classic/Commands/DeleteVirtualSensor
+page-type: webdriver-command
+browser-compat: webdriver.classic.DeleteVirtualSensor
+sidebar: webdriver
+---
+
+The _Delete Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API removes a virtual sensor previously created with the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. After the virtual sensor is deleted, the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) once again use the real platform sensor of that type, if one is available.
+
+## Syntax
+
+| Method                                                    | URI template                          |
+| --------------------------------------------------------- | ------------------------------------- |
+| [`DELETE`](/en-US/docs/Web/HTTP/Reference/Methods/DELETE) | `/session/{session id}/sensor/{type}` |
+
+### URL parameters
+
+- `session id`
+  - : Identifier of the session.
+- `type`
+  - : The virtual sensor type to delete, for example `"ambient-light"`.
+
+### Return value
+
+`null` if successful.
+
+### Errors
+
+- [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
+  - : Session does not exist.
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : No virtual sensor of the given `type` exists.
+
+## Examples
+
+### Deleting a virtual sensor
+
+With a WebDriver server running on `localhost:4444`, assume a virtual `"ambient-light"` sensor has been created for the active session. To remove it, send a `DELETE` request with the sensor type appended to the endpoint, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+
+```bash
+curl -i -X DELETE http://localhost:4444/session/ID/sensor/ambient-light
+```
+
+The server responds with a null value to indicate success:
+
+```http
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+
+{"value":null}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command
+- [Update Virtual Sensor Reading](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/UpdateVirtualSensorReading) command
+- [Get Virtual Sensor Information](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/GetVirtualSensorInformation) command
+- [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs)

--- a/files/en-us/web/webdriver/reference/classic/commands/deletevirtualsensor/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/deletevirtualsensor/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.classic.DeleteVirtualSensor
 sidebar: webdriver
 ---
 
-The _Delete Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API removes a virtual sensor previously created with the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. After the virtual sensor is deleted, the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) once again use the real platform sensor of that type, if one is available.
+The _Delete Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API removes a virtual sensor previously created using the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. After the virtual sensor is deleted, the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) once again use the real platform sensor of that type, if one is available.
 
 ## Syntax
 
@@ -43,7 +43,7 @@ With a WebDriver server running on `localhost:4444`, assume a virtual `"ambient-
 curl -i -X DELETE http://localhost:4444/session/ID/sensor/ambient-light
 ```
 
-The server responds with a null value to indicate success:
+The server responds with a `null` value to indicate success:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/webdriver/reference/classic/commands/deletevirtualsensor/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/deletevirtualsensor/index.md
@@ -20,7 +20,7 @@ The _Delete Virtual Sensor_ [command](/en-US/docs/Web/WebDriver/Reference/Classi
 - `session id`
   - : Identifier of the session.
 - `type`
-  - : The virtual sensor type to delete, for example `"ambient-light"`.
+  - : The virtual sensor type to delete. Possible values include `"ambient-light"`, `"accelerometer"`, and `"gyroscope"`.
 
 ### Return value
 

--- a/files/en-us/web/webdriver/reference/classic/commands/getvirtualsensorinformation/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/getvirtualsensorinformation/index.md
@@ -1,0 +1,71 @@
+---
+title: Get Virtual Sensor Information
+short-title: Get Virtual Sensor Information
+slug: Web/WebDriver/Reference/Classic/Commands/GetVirtualSensorInformation
+page-type: webdriver-command
+browser-compat: webdriver.classic.GetVirtualSensorInformation
+sidebar: webdriver
+---
+
+The _Get Virtual Sensor Information_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns information about a virtual sensor previously created with the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. It reports the sampling frequency currently requested by the page, which lets a test confirm that the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) are consuming readings at the expected rate.
+
+## Syntax
+
+| Method                                              | URI template                          |
+| --------------------------------------------------- | ------------------------------------- |
+| [`GET`](/en-US/docs/Web/HTTP/Reference/Methods/GET) | `/session/{session id}/sensor/{type}` |
+
+### URL parameters
+
+- `session id`
+  - : Identifier of the session.
+- `type`
+  - : The virtual sensor type to query, for example `"ambient-light"`.
+
+### Return value
+
+An object with the following field:
+
+- `requestedSamplingFrequency`
+  - : A number giving the sampling frequency, in hertz, currently requested for the virtual sensor. This value is bounded by the minimum and maximum sampling frequencies that were set when the sensor was created.
+
+### Errors
+
+- [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
+  - : Session does not exist.
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : No virtual sensor of the given `type` exists.
+
+## Examples
+
+### Getting virtual sensor information
+
+With a WebDriver server running on `localhost:4444`, assume a virtual `"ambient-light"` sensor has been created for the active session. To read its information, append the sensor type to the endpoint, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+
+```bash
+curl -i http://localhost:4444/session/ID/sensor/ambient-light
+```
+
+The server responds with the currently requested sampling frequency:
+
+```http
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+
+{"value":{"requestedSamplingFrequency":60}}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command
+- [Update Virtual Sensor Reading](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/UpdateVirtualSensorReading) command
+- [Delete Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/DeleteVirtualSensor) command
+- [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs)

--- a/files/en-us/web/webdriver/reference/classic/commands/getvirtualsensorinformation/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/getvirtualsensorinformation/index.md
@@ -20,7 +20,7 @@ The _Get Virtual Sensor Information_ [command](/en-US/docs/Web/WebDriver/Referen
 - `session id`
   - : Identifier of the session.
 - `type`
-  - : The virtual sensor type to query, for example `"ambient-light"`.
+  - : The virtual sensor type to query. Possible values include `"ambient-light"`, `"accelerometer"`, and `"gyroscope"`.
 
 ### Return value
 

--- a/files/en-us/web/webdriver/reference/classic/commands/getvirtualsensorinformation/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/getvirtualsensorinformation/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.classic.GetVirtualSensorInformation
 sidebar: webdriver
 ---
 
-The _Get Virtual Sensor Information_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns information about a virtual sensor previously created with the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. It reports the sampling frequency currently requested by the page, which lets a test confirm that the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) are consuming readings at the expected rate.
+The _Get Virtual Sensor Information_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API returns information about a virtual sensor previously created using the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. It reports the sampling frequency currently requested by the page, which lets a test confirm that the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) are consuming readings at the expected rate.
 
 ## Syntax
 
@@ -27,7 +27,7 @@ The _Get Virtual Sensor Information_ [command](/en-US/docs/Web/WebDriver/Referen
 An object with the following field:
 
 - `requestedSamplingFrequency`
-  - : A number giving the sampling frequency, in hertz, currently requested for the virtual sensor. This value is bounded by the minimum and maximum sampling frequencies that were set when the sensor was created.
+  - : A number, in hertz, providing the sampling frequency currently requested for the virtual sensor. This value is bounded by the minimum and maximum sampling frequencies that were set when the sensor was created.
 
 ### Errors
 

--- a/files/en-us/web/webdriver/reference/classic/commands/updatevirtualpressuresource/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/updatevirtualpressuresource/index.md
@@ -1,0 +1,80 @@
+---
+title: Update Virtual Pressure Source
+short-title: Update Virtual Pressure Source
+slug: Web/WebDriver/Reference/Classic/Commands/UpdateVirtualPressureSource
+page-type: webdriver-command
+browser-compat: webdriver.classic.UpdateVirtualPressureSource
+sidebar: webdriver
+---
+
+The _Update Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API sets a new sample for a virtual pressure source previously created with the [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command. The new sample is delivered to the page through the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API), letting tests drive pressure-dependent behavior with predetermined data.
+
+## Syntax
+
+| Method                                                | URI template                                  |
+| ----------------------------------------------------- | --------------------------------------------- |
+| [`POST`](/en-US/docs/Web/HTTP/Reference/Methods/POST) | `/session/{session id}/pressuresource/{type}` |
+
+### URL parameters
+
+- `session id`
+  - : Identifier of the session.
+- `type`
+  - : The pressure source type to update, for example `"cpu"`.
+
+### Payload
+
+The input is an object:
+
+- `sample`
+  - : A string giving the pressure state to report. One of `"nominal"`, `"fair"`, `"serious"`, or `"critical"`.
+- `ownContributionEstimate` {{optional_inline}}
+  - : A number between `0` and `1` estimating the fraction of the reported pressure that is caused by the page itself.
+
+### Return value
+
+`null` if successful.
+
+### Errors
+
+- [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
+  - : Session does not exist.
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : The `sample` is not a valid pressure state, or `ownContributionEstimate` is not a valid number.
+- `unsupported operation`
+  - : No virtual pressure source of the given `type` has been created.
+
+## Examples
+
+### Updating a virtual pressure source
+
+With a WebDriver server running on `localhost:4444`, assume a virtual `"cpu"` pressure source has been created for the active session. To report a new pressure state, send the `sample` value as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+  -d '{"sample": "critical"}' \
+  http://localhost:4444/session/ID/pressuresource/cpu
+```
+
+The server responds with a null value to indicate success:
+
+```http
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+
+{"value":null}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command
+- [Delete Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/DeleteVirtualPressureSource) command
+- [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API)

--- a/files/en-us/web/webdriver/reference/classic/commands/updatevirtualpressuresource/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/updatevirtualpressuresource/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.classic.UpdateVirtualPressureSource
 sidebar: webdriver
 ---
 
-The _Update Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API sets a new sample for a virtual pressure source previously created with the [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command. The new sample is delivered to the page through the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API), letting tests drive pressure-dependent behavior with predetermined data.
+The _Update Virtual Pressure Source_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API sets a new sample for a virtual pressure source previously created using the [Create Virtual Pressure Source](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualPressureSource) command. The new sample is delivered to the page through the [Compute Pressure API](/en-US/docs/Web/API/Compute_Pressure_API), letting tests drive pressure-dependent behavior with predetermined data.
 
 ## Syntax
 
@@ -48,7 +48,7 @@ The input is an object:
 
 ### Updating a virtual pressure source
 
-With a WebDriver server running on `localhost:4444`, assume a virtual `"cpu"` pressure source has been created for the active session. To report a new pressure state, send the `sample` value as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+With a WebDriver server running on `localhost:4444`, assume a virtual `"cpu"` pressure source has been created for the active session. To report a new pressure state, send the `sample` value in the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
 
 ```bash
 curl -i -H "Content-Type: application/json" \
@@ -56,7 +56,7 @@ curl -i -H "Content-Type: application/json" \
   http://localhost:4444/session/ID/pressuresource/cpu
 ```
 
-The server responds with a null value to indicate success:
+The server responds with a `null` value to indicate success:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
@@ -1,0 +1,77 @@
+---
+title: Update Virtual Sensor Reading
+short-title: Update Virtual Sensor Reading
+slug: Web/WebDriver/Reference/Classic/Commands/UpdateVirtualSensorReading
+page-type: webdriver-command
+browser-compat: webdriver.classic.UpdateVirtualSensorReading
+sidebar: webdriver
+---
+
+The _Update Virtual Sensor Reading_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API sets a new reading for a virtual sensor previously created with the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. The new value is delivered to the page through the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs), letting tests drive sensor-dependent behavior with predetermined data.
+
+## Syntax
+
+| Method                                                | URI template                          |
+| ----------------------------------------------------- | ------------------------------------- |
+| [`POST`](/en-US/docs/Web/HTTP/Reference/Methods/POST) | `/session/{session id}/sensor/{type}` |
+
+### URL parameters
+
+- `session id`
+  - : Identifier of the session.
+- `type`
+  - : The virtual sensor type to update, for example `"ambient-light"`.
+
+### Payload
+
+The input is an object:
+
+- `reading`
+  - : An object representing the new sensor reading. The properties it must contain depend on the sensor `type`; for example, an `"ambient-light"` sensor expects an `illuminance` value.
+
+### Return value
+
+`null` if successful.
+
+### Errors
+
+- [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
+  - : Session does not exist.
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : The `reading` is not an object, or it is not a valid reading for the given sensor `type`.
+
+## Examples
+
+### Updating a virtual sensor reading
+
+With a WebDriver server running on `localhost:4444`, assume a virtual `"ambient-light"` sensor has been created for the active session. To set a new reading, send the `reading` object as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+
+```bash
+curl -i -H "Content-Type: application/json" \
+  -d '{"reading": {"illuminance": 42}}' \
+  http://localhost:4444/session/ID/sensor/ambient-light
+```
+
+The server responds with a null value to indicate success:
+
+```http
+HTTP/1.1 200 OK
+content-type: application/json; charset=utf-8
+
+{"value":null}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command
+- [Get Virtual Sensor Information](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/GetVirtualSensorInformation) command
+- [Delete Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/DeleteVirtualSensor) command
+- [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs)

--- a/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
@@ -20,7 +20,7 @@ The _Update Virtual Sensor Reading_ [command](/en-US/docs/Web/WebDriver/Referenc
 - `session id`
   - : Identifier of the session.
 - `type`
-  - : The virtual sensor type to update, for example `"ambient-light"`.
+  - : The virtual sensor type to update. Possible values include `"ambient-light"`, `"accelerometer"`, and `"gyroscope"`.
 
 ### Payload
 

--- a/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
@@ -44,7 +44,7 @@ The input is an object:
 
 ### Updating a virtual sensor reading
 
-With a WebDriver server running on `localhost:4444`, assume a virtual `"ambient-light"` sensor has been created for the active session. To set a new reading, send the `reading` object as the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
+With a WebDriver server running on `localhost:4444`, assume a virtual `"ambient-light"` sensor has been created for the active session. To set a new reading, send the `reading` object in the request payload, replacing `ID` with the `sessionId` from the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) response:
 
 ```bash
 curl -i -H "Content-Type: application/json" \
@@ -52,7 +52,7 @@ curl -i -H "Content-Type: application/json" \
   http://localhost:4444/session/ID/sensor/ambient-light
 ```
 
-The server responds with a null value to indicate success:
+The server responds with a `null` value to indicate success:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/updatevirtualsensorreading/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.classic.UpdateVirtualSensorReading
 sidebar: webdriver
 ---
 
-The _Update Virtual Sensor Reading_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API sets a new reading for a virtual sensor previously created with the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. The new value is delivered to the page through the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs), letting tests drive sensor-dependent behavior with predetermined data.
+The _Update Virtual Sensor Reading_ [command](/en-US/docs/Web/WebDriver/Reference/Classic/Commands) of the [WebDriver](/en-US/docs/Web/WebDriver) API provides a new reading for a virtual sensor previously created using the [Create Virtual Sensor](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/CreateVirtualSensor) command. The new reading is made available to platform sensors through the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs), letting tests drive sensor-dependent behavior with predetermined data.
 
 ## Syntax
 
@@ -38,7 +38,7 @@ The input is an object:
 - [`invalid session id`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidSessionID)
   - : Session does not exist.
 - [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
-  - : The `reading` is not an object, or it is not a valid reading for the given sensor `type`.
+  - : The `type` is not a supported virtual sensor type, no virtual sensor of that type exists, the `reading` is not an object, or the reading is not valid for the given sensor `type`.
 
 ## Examples
 


### PR DESCRIPTION
### Description

**New pages**

```
WebDriver/Reference/Classic/Commands/
├── CreateVirtualSensor
├── GetVirtualSensorInformation
├── UpdateVirtualSensorReading
├── DeleteVirtualSensor
├── CreateVirtualPressureSource
├── UpdateVirtualPressureSource
└── DeleteVirtualPressureSource
```

### Motivation

Document WebDriver classic commands that have BCD entries but no MDN pages.