### PR TITLE
Fix misleading createAttributeNS() namespace guidance and examples

### DIFF
--- a/files/en-us/web/api/document/createattributens/index.md
+++ b/files/en-us/web/api/document/createattributens/index.md
@@ -23,13 +23,12 @@ createAttributeNS(namespaceURI, qualifiedName)
 
 - `namespaceURI`
   - : A string that specifies the {{DOMxRef("Attr.namespaceURI", "namespaceURI")}} to associate with the attribute, or the empty string.
-    Some important namespace URIs are:
-    - [HTML](/en-US/docs/Web/HTML)
-      - : `http://www.w3.org/1999/xhtml`
-    - [SVG](/en-US/docs/Web/SVG)
-      - : `http://www.w3.org/2000/svg`
-    - [MathML](/en-US/docs/Web/MathML)
-      - : `http://www.w3.org/1998/Math/MathML`
+    In HTML documents, most attributes are in the **null namespace** — use the empty string for these.
+    Use a specific namespace URI only when creating a namespaced attribute, such as `xml:lang` or `xml:space`.
+    Some namespace URIs are:
+    - XML: `http://www.w3.org/XML/1998/namespace` (for `xml:lang`, `xml:space`)
+    - XMLNS: `http://www.w3.org/2000/xmlns/` (for `xmlns`, `xmlns:*`)
+    - XLink: `http://www.w3.org/1999/xlink` (for `xlink:href`, `xlink:title`, etc.)
 - `qualifiedName`
   - : A string containing the qualified name of the new attribute.
     The {{DOMxRef("Attr.name", "name")}} property of the created attribute is initialized with this value.
@@ -68,15 +67,44 @@ The new {{domxref("Attr")}} node.
 
 ## Examples
 
-### Basic usage
+### Creating a namespaced attribute
+
+This example creates an `xml:lang` attribute with the XML namespace and attaches it to a paragraph element.
+This attribute specifies the language of the element's content for XML processing.
+
+```html
+<p id="greeting">Bonjour!</p>
+```
 
 ```js
-const node = document.getElementById("svg");
-const a = document.createAttributeNS("http://www.w3.org/2000/svg", "viewBox");
-a.value = "0 0 100 100";
-node.setAttributeNode(a);
-console.log(node.getAttribute("viewBox")); // "0 0 100 100"
+const el = document.getElementById("greeting");
+const a = document.createAttributeNS(
+  "http://www.w3.org/XML/1998/namespace",
+  "xml:lang",
+);
+a.value = "fr";
+el.setAttributeNode(a);
 ```
+
+### Creating an unprefixed attribute
+
+In HTML documents, unprefixed attributes (such as SVG presentation attributes like `viewBox`) are in the null namespace.
+Use the empty string for the `namespaceURI` parameter to match this.
+
+```js
+const svg = document.getElementById("svg");
+const a = document.createAttributeNS("", "viewBox");
+a.value = "0 0 100 100";
+svg.setAttributeNode(a);
+console.log(svg.getAttribute("viewBox")); // "0 0 100 100"
+```
+
+> [!NOTE]
+> In most cases, you can use {{domxref("Element.setAttribute()")}} instead of `createAttributeNS()` for unprefixed attributes:
+>
+> ```js
+> svg.setAttribute("viewBox", "0 0 100 100");
+> ```
 
 ## Specifications
 

--- a/files/en-us/web/api/document/createattributens/index.md
+++ b/files/en-us/web/api/document/createattributens/index.md
@@ -78,12 +78,12 @@ This attribute specifies the language of the element's content for XML processin
 
 ```js
 const el = document.getElementById("greeting");
-const a = document.createAttributeNS(
+const attr = document.createAttributeNS(
   "http://www.w3.org/XML/1998/namespace",
   "xml:lang",
 );
-a.value = "fr";
-el.setAttributeNode(a);
+attr.value = "fr";
+el.setAttributeNode(attr);
 ```
 
 ### Creating an unprefixed attribute
@@ -91,20 +91,23 @@ el.setAttributeNode(a);
 In HTML documents, unprefixed attributes (such as SVG presentation attributes like `viewBox`) are in the null namespace.
 Use the empty string for the `namespaceURI` parameter to match this.
 
+```html
+<svg id="svg"></svg>
+```
+
 ```js
 const svg = document.getElementById("svg");
-const a = document.createAttributeNS("", "viewBox");
-a.value = "0 0 100 100";
-svg.setAttributeNode(a);
+const attr = document.createAttributeNS("", "viewBox");
+attr.value = "0 0 100 100";
+svg.setAttributeNode(attr);
 console.log(svg.getAttribute("viewBox")); // "0 0 100 100"
 ```
 
-> [!NOTE]
-> In most cases, you can use {{domxref("Element.setAttribute()")}} instead of `createAttributeNS()` for unprefixed attributes:
->
-> ```js
-> svg.setAttribute("viewBox", "0 0 100 100");
-> ```
+Note that, in most cases, you can use {{domxref("Element.setAttribute()")}} instead of `createAttributeNS()` for unprefixed attributes:
+
+```js
+svg.setAttribute("viewBox", "0 0 100 100");
+```
 
 ## Specifications
 


### PR DESCRIPTION
## Summary

Fixes #44619.

This PR updates the `Document.createAttributeNS()` documentation to correctly describe how `namespaceURI` should be used when creating attributes.

The previous documentation used `createAttributeNS("http://www.w3.org/2000/svg", "viewBox")` as an example, which is misleading for HTML documents because unprefixed attributes (including SVG presentation attributes such as `viewBox`) are in the null namespace.

## What changed

### Updated `namespaceURI` documentation

- Clarified that unprefixed attributes in HTML documents belong to the **null namespace** and should use an empty string (`""`) for `namespaceURI`.
- Replaced the previous HTML/SVG/MathML namespace list with namespace URIs that are actually used for attributes:
  - XML
  - XMLNS
  - XLink

### Improved examples

- Replaced the misleading `viewBox` example.
- Added a namespaced attribute example using `xml:lang`.
- Added a correct example demonstrating how to create an unprefixed `viewBox` attribute using the null namespace.
- Added a note recommending `Element.setAttribute()` for common unprefixed attribute use cases.

## Why

The previous documentation suggested creating `viewBox` using the SVG namespace:

```js
document.createAttributeNS(
  "http://www.w3.org/2000/svg",
  "viewBox",
);
```

Although this creates a namespaced attribute, HTML documents treat unprefixed attributes as belonging to the null namespace. Using the SVG namespace can therefore produce unexpected behavior and does not match how parser-created attributes behave.

The updated documentation reflects the DOM and HTML specifications and demonstrates the correct usage for both namespaced and unprefixed attributes.

## Verification

- ✅ Verified the page renders correctly using the local MDN preview.
- ✅ Verified the updated examples render correctly.
- ✅ Verified there are no broken-link warnings.
- ✅ Verified `npm start` completes successfully.

## Screenshots

### Updated `namespaceURI` guidance

Shows the updated explanation of null-namespace attributes and the revised namespace URI guidance.

<img width="1920" height="1080" alt="Screenshot from 2026-07-15 22-55-29" src="https://github.com/user-attachments/assets/c86e9099-d728-44b4-b95c-c866f3b7c723" />

### Updated examples

<img width="1920" height="1080" alt="Screenshot from 2026-07-15 22-54-27" src="https://github.com/user-attachments/assets/5da2514d-52ab-4981-990b-2d99162d7ca4" />


