### PR TITLE
Fix MediaSession action handler example

### DIFF
--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -116,31 +116,24 @@ if ("mediaSession" in navigator) {
 }
 ```
 
-The following example sets up two functions for playing and pausing, then uses them as callbacks with the relevant action handlers.
+Assuming the page contains an {{HTMLElement("audio")}} element, the following example sets up action handlers that play and pause the element and update the media session's playback state.
 
 ```js
+const audio = document.querySelector("audio");
+
 const actionHandlers = [
-  // play
   [
     "play",
     async () => {
-      // play our audio
-      await audioEl.play();
-      // set playback state
+      await audio.play();
       navigator.mediaSession.playbackState = "playing";
-      // update our status element
-      updateStatus(allMeta[index], "Action: play  |  Track is playing…");
     },
   ],
   [
     "pause",
     () => {
-      // pause out audio
-      audioEl.pause();
-      // set playback state
+      audio.pause();
       navigator.mediaSession.playbackState = "paused";
-      // update our status element
-      updateStatus(allMeta[index], "Action: pause  |  Track has been paused…");
     },
   ],
 ];
@@ -148,7 +141,7 @@ const actionHandlers = [
 for (const [action, handler] of actionHandlers) {
   try {
     navigator.mediaSession.setActionHandler(action, handler);
-  } catch (error) {
+  } catch {
     console.log(`The media session action "${action}" is not supported yet.`);
   }
 }


### PR DESCRIPTION
### Description

Clarifies the `MediaSession` play and pause action-handler example by selecting the page's `<audio>` element and removing calls to undefined demo-only status helpers. It also omits the unused `catch` binding in the same example.

### Motivation

The current sample references `audioEl`, `updateStatus`, `allMeta`, and `index` without defining them, which makes the example difficult to understand or reuse. The updated example is focused on the documented media-session behavior and defines every value it uses.

### Additional details

Validation completed:

- Prettier, Markdownlint, and CSpell on the changed page
- Repository test suite (5/5)
- JavaScript syntax and play/pause handler behavior checks
- Rari single-page build with no reported issues
- Repository pre-commit URL, cross-reference, front-matter, Prettier, and Markdownlint checks

### Related issues and pull requests

Fixes #41250
