### PR TITLE
ci(dependabot): refine commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       - "automated pr"
       - "dependencies"
       - "javascript"
+    commit-message:
+      prefix: chore
+      prefix-development: build
+      include: scope
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,4 +24,5 @@ updates:
       - "dependencies"
       - "github actions"
     commit-message:
-      prefix: "ci(deps): "
+      prefix: ci
+      include: scope


### PR DESCRIPTION
### Description

Updates the Dependabot config, refining the commit prefixes.

### Motivation

Avoid that npm packages get the `ci(deps)` prefix.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Same as https://github.com/mdn/translated-content/pull/37058.
