### PR TITLE
fix: link `{{jsxref("Function")}}` in callback parameter descriptions

### DIFF
--- a/files/en-us/web/api/window/queuemicrotask/index.md
+++ b/files/en-us/web/api/window/queuemicrotask/index.md
@@ -36,7 +36,7 @@ queueMicrotask(callback)
 ### Parameters
 
 - `callback`
-  - : A {{jsxref("function")}} to be executed when the browser engine determines it is
+  - : A {{jsxref("Function")}} to be executed when the browser engine determines it is
     safe to call your code. Enqueued microtasks are executed after all pending tasks have
     completed but before yielding control to the browser's event loop.
 

--- a/files/en-us/web/api/window/setinterval/index.md
+++ b/files/en-us/web/api/window/setinterval/index.md
@@ -33,7 +33,7 @@ setInterval(func, delay, param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `func`
-  - : A {{jsxref("function")}} to be executed every `delay` milliseconds.
+  - : A {{jsxref("Function")}} to be executed every `delay` milliseconds.
     The first execution happens after `delay` milliseconds.
 - `code`
   - : A {{domxref("TrustedScript")}} or a string of arbitrary code that is compiled and executed every `delay` milliseconds.

--- a/files/en-us/web/api/window/settimeout/index.md
+++ b/files/en-us/web/api/window/settimeout/index.md
@@ -33,7 +33,7 @@ setTimeout(func, delay, param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `func`
-  - : A {{jsxref("function")}} to be executed after the timer expires.
+  - : A {{jsxref("Function")}} to be executed after the timer expires.
 - `code`
   - : A {{domxref("TrustedScript")}} or a string of arbitrary code that is compiled and executed after `delay` milliseconds.
     This can be used instead of passing a function, but is _strongly discouraged_ for the same reasons that make using {{jsxref("Global_Objects/eval", "eval()")}} a security risk.

--- a/files/en-us/web/api/workerglobalscope/queuemicrotask/index.md
+++ b/files/en-us/web/api/workerglobalscope/queuemicrotask/index.md
@@ -36,7 +36,7 @@ queueMicrotask(callback)
 ### Parameters
 
 - `callback`
-  - : A {{jsxref("function")}} to be executed when the browser engine determines it is
+  - : A {{jsxref("Function")}} to be executed when the browser engine determines it is
     safe to call your code. Enqueued microtasks are executed after all pending tasks have
     completed but before yielding control to the browser's event loop.
 

--- a/files/en-us/web/api/workerglobalscope/setinterval/index.md
+++ b/files/en-us/web/api/workerglobalscope/setinterval/index.md
@@ -39,7 +39,7 @@ setInterval(func, delay, param1, param3, /* …, */ paramN)
 ### Parameters
 
 - `func`
-  - : A {{jsxref("function")}} to be executed every `delay` milliseconds.
+  - : A {{jsxref("Function")}} to be executed every `delay` milliseconds.
     The first execution happens after `delay` milliseconds.
 - `code`
   - : A {{domxref("TrustedScript")}} or a string of arbitrary code that is compiled and executed every `delay` milliseconds.

--- a/files/en-us/web/api/workerglobalscope/settimeout/index.md
+++ b/files/en-us/web/api/workerglobalscope/settimeout/index.md
@@ -33,7 +33,7 @@ setTimeout(func, delay, param1, param2, /* …, */ paramN)
 ### Parameters
 
 - `func`
-  - : A {{jsxref("function")}} to be executed after the timer expires.
+  - : A {{jsxref("Function")}} to be executed after the timer expires.
 - `code`
   - : A {{domxref("TrustedScript")}} or a string of arbitrary code that is compiled and executed every `delay` milliseconds.
     This can be used instead of passing a function, but is _strongly discouraged_ for the same reasons that make using {{jsxref("Global_Objects/eval", "eval()")}} a security risk.

--- a/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/promise/index.md
@@ -39,7 +39,7 @@ new Promise(executor)
 ### Parameters
 
 - `executor`
-  - : A {{jsxref("function")}} to be executed by the constructor. It receives two functions as parameters: `resolveFunc` and `rejectFunc`. Any errors thrown in the `executor` will cause the promise to be rejected, and the return value will be neglected. The semantics of `executor` are detailed below.
+  - : A {{jsxref("Function")}} to be executed by the constructor. It receives two functions as parameters: `resolveFunc` and `rejectFunc`. Any errors thrown in the `executor` will cause the promise to be rejected, and the return value will be neglected. The semantics of `executor` are detailed below.
 
 ### Return value
 


### PR DESCRIPTION
### Description

Replace the ambiguous lowercase `{{jsxref("function")}}` with `{{jsxref("Function")}}` (the global `Function` object) in 7 callback-parameter descriptions across the `Window`/`WorkerGlobalScope` timer methods and the `Promise()` constructor.

### Motivation

An upcoming version of the Rari build system (mdn/rari#715) resolves `jsxref` names against an index of `Web/JavaScript/Reference/*` pages. Lowercase `function` is ambiguous between the `function` operator and the `function` statement, so it no longer resolves to a single page and produces a broken link. The current build tolerates it via redirect-following, so this is not yet a visible issue — this change is a preemptive cleanup so the pages keep resolving once that build change lands. Each of these descriptions refers to a generic JavaScript function (a callback), so the global `Function` object is the appropriate unambiguous target.

### Additional details

Affected pages:

- `Window.setInterval()`, `Window.setTimeout()`, `Window.queueMicrotask()`
- `WorkerGlobalScope.setInterval()`, `WorkerGlobalScope.setTimeout()`, `WorkerGlobalScope.queueMicrotask()`
- `Promise()` constructor

### Related issues and pull requests

Relates to mdn/rari#715.
