### PR TITLE
Fix broken links, HTTP→HTTPS upgrades, and article/typo corrections

### DIFF
--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -16,7 +16,7 @@ If the attribute is present, it can have one of the following forms:
 > [!NOTE]
 > The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
 
-Here's an example of a HTML boolean attribute `checked`:
+Here's an example of an HTML boolean attribute `checked`:
 
 ```html
 <!-- The following checkboxes will be checked on initial rendering -->

--- a/files/en-us/glossary/markup/index.md
+++ b/files/en-us/glossary/markup/index.md
@@ -16,7 +16,7 @@ Within a text file such as an HTML file, elements are _marked up_ using {{glossa
 - **Procedural Markup:**
   - : Combined with text to provide instructions on text processing to programs. This text is visibly manipulated by the author.
 - **Descriptive Markup:**
-  - : Labels sections of documents as to how the program should handle them. For example, the HTML {{HTMLElement("td")}} defines a cell in a HTML table.
+  - : Labels sections of documents as to how the program should handle them. For example, the HTML {{HTMLElement("td")}} defines a cell in an HTML table.
 
 ## See also
 

--- a/files/en-us/glossary/xhtml/index.md
+++ b/files/en-us/glossary/xhtml/index.md
@@ -19,7 +19,7 @@ The following example shows an HTML document and corresponding "XHTML" document,
     <title>HTML</title>
   </head>
   <body>
-    <p>I am a HTML document</p>
+    <p>I am an HTML document</p>
   </body>
 </html>
 ```

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/index.md
@@ -20,7 +20,7 @@ Adding a new document is relatively straightforward, especially if you can start
 There are a few things to keep in mind:
 
 - Documents are written in Markdown in an `index.md` file.
-- For example, if you're creating a new document for a HTTP header called `foo`, create a new folder at `files/en-us/web/http/reference/headers/foo` and put the Markdown file in this folder (`files/en-us/web/http/reference/headers/foo/index.md`).
+- For example, if you're creating a new document for an HTTP header called `foo`, create a new folder at `files/en-us/web/http/reference/headers/foo` and put the Markdown file in this folder (`files/en-us/web/http/reference/headers/foo/index.md`).
 - A document's `index.md` file must start with front-matter that defines the `title`, `slug`, and, most of the time, `page-type`.
   You might find it helpful to refer to the front-matter within a similar document's `index.md`.
 

--- a/files/en-us/mozilla/firefox/releases/119/index.md
+++ b/files/en-us/mozilla/firefox/releases/119/index.md
@@ -65,7 +65,7 @@ This article provides information about the changes in Firefox 119 that affect d
 
 - Added the [`script.realmCreated`](https://w3c.github.io/webdriver-bidi/#event-script-realmCreated) and [`script.realmDestroyed`](https://w3c.github.io/webdriver-bidi/#event-script-realmDestroyed) events that allow users to monitor the lifetime of JavaScript Realms of a given browsing context. Such a Realm is basically an isolated execution environment (`sandbox`) with its own unique global object (window) ([Firefox bug 1788657](https://bugzil.la/1788657), [Firefox bug 1788659](https://bugzil.la/1788659)).
 
-- The `browsingContext.userPromptOpened` event was accidentally sent when a HTTP Authentication dialog was opened ([Firefox bug 1853302](https://bugzil.la/1853302)).
+- The `browsingContext.userPromptOpened` event was accidentally sent when an HTTP Authentication dialog was opened ([Firefox bug 1853302](https://bugzil.la/1853302)).
 
 - Unwanted events with the `context` field set to `null` will no longer be emitted. Because the underlying browsing context has been closed such events are no longer valid ([Firefox bug 1847563](https://bugzil.la/1847563)).
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -62,7 +62,7 @@ No notable changes.
 #### WebDriver BiDi
 
 - Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
-- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an HTTP proxy wouldn't allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
+- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug where setting an HTTP proxy did not allow navigation to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
 - Fixed a bug where `browsingContext.create` would fail after a `browsingContext.print` command was interrupted by closing a tab with the `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
 - Updated the `session.end` command to resume all requests which were blocked by network interceptions ([Firefox bug 1974426](https://bugzil.la/1974426)).
 

--- a/files/en-us/mozilla/firefox/releases/142/index.md
+++ b/files/en-us/mozilla/firefox/releases/142/index.md
@@ -62,7 +62,7 @@ No notable changes.
 #### WebDriver BiDi
 
 - Implemented the new `emulation.setLocaleOverride` command which allows clients to override a locale in JavaScript APIs ([Firefox bug 1968952](https://bugzil.la/1968952)).
-- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting a HTTP proxy wouldn't allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
+- Improved setting a proxy with `browsingContext.createUserContext`: added support for host patterns like `.mozilla.org` in `noProxy` property ([Firefox bug 1977180](https://bugzil.la/1977180)) and fixed a bug when setting an HTTP proxy wouldn't allow to navigate to HTTPS URLs ([Firefox bug 1977168](https://bugzil.la/1977168)).
 - Fixed a bug where `browsingContext.create` would fail after a `browsingContext.print` command was interrupted by closing a tab with the `browsingContext.close` command ([Firefox bug 1841125](https://bugzil.la/1841125)).
 - Updated the `session.end` command to resume all requests which were blocked by network interceptions ([Firefox bug 1974426](https://bugzil.la/1974426)).
 

--- a/files/en-us/web/api/attr/index.md
+++ b/files/en-us/web/api/attr/index.md
@@ -22,7 +22,7 @@ The name is deemed _local_ when it ignores the eventual namespace prefix and dee
 | `myAttr`  | `mynamespace`  | `myns`           | `myAttr`             | `myns:myAttr`            |
 
 > [!NOTE]
-> This interface represents only attributes present in the tree representation of the {{domxref("Element")}}, being a SVG, an HTML or a MathML element. It doesn't represent the _property_ of an interface associated with such element, such as {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
+> This interface represents only attributes present in the tree representation of the {{domxref("Element")}}, being an SVG, an HTML or a MathML element. It doesn't represent the _property_ of an interface associated with such element, such as {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
 
 ## Instance properties
 

--- a/files/en-us/web/api/attr/index.md
+++ b/files/en-us/web/api/attr/index.md
@@ -22,7 +22,7 @@ The name is deemed _local_ when it ignores the eventual namespace prefix and dee
 | `myAttr`  | `mynamespace`  | `myns`           | `myAttr`             | `myns:myAttr`            |
 
 > [!NOTE]
-> This interface represents only attributes present in the tree representation of the {{domxref("Element")}}, being an SVG, an HTML or a MathML element. It doesn't represent the _property_ of an interface associated with such element, such as {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
+> This interface represents only attributes present in the tree representation of an {{domxref("Element")}}—an SVG, HTML, or MathML element. It doesn't represent the IDL properties of the interface associated with that element, such as the properties of {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
 
 ## Instance properties
 

--- a/files/en-us/web/api/attr/index.md
+++ b/files/en-us/web/api/attr/index.md
@@ -22,7 +22,7 @@ The name is deemed _local_ when it ignores the eventual namespace prefix and dee
 | `myAttr`  | `mynamespace`  | `myns`           | `myAttr`             | `myns:myAttr`            |
 
 > [!NOTE]
-> This interface represents only attributes present in the tree representation of an {{domxref("Element")}}—an SVG, HTML, or MathML element. It doesn't represent the IDL properties of the interface associated with that element, such as the properties of {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
+> This interface represents only attributes present in the tree representation of an SVG, HTML, or MathML {{domxref("Element")}}. It doesn't represent the properties of the interface associated with that element, such as the properties of {{domxref("HTMLTableElement")}} for a {{HTMLElement("table")}} element. (See {{Glossary("Attribute", "this article")}} for more information about attributes and how they are _reflected_ into properties.)
 
 ## Instance properties
 

--- a/files/en-us/web/api/attr/namespaceuri/index.md
+++ b/files/en-us/web/api/attr/namespaceuri/index.md
@@ -28,7 +28,7 @@ A string containing the URI of the namespace, or `null` if the attribute is not 
 
 ## Example
 
-The following example shows the results for a prefixed attribute in a case of an HTML element, and of a SVG element.
+The following example shows the results for a prefixed attribute in a case of an HTML element, and of an SVG element.
 As HTML doesn't handle namespaces, it will always return `null` in that case.
 In the case of the SVG element, it will return the URI of the XML namespace, `http://www.w3.org/XML/1998/namespace`.
 

--- a/files/en-us/web/api/attr/namespaceuri/index.md
+++ b/files/en-us/web/api/attr/namespaceuri/index.md
@@ -28,7 +28,7 @@ A string containing the URI of the namespace, or `null` if the attribute is not 
 
 ## Example
 
-The following example shows the results for a prefixed attribute in a case of an HTML element, and of an SVG element.
+The following example shows the result for a prefixed attribute on an HTML element and on an SVG element.
 As HTML doesn't handle namespaces, it will always return `null` in that case.
 In the case of the SVG element, it will return the URI of the XML namespace, `http://www.w3.org/XML/1998/namespace`.
 

--- a/files/en-us/web/api/node/nodename/index.md
+++ b/files/en-us/web/api/node/nodename/index.md
@@ -28,7 +28,7 @@ A string. Values for the different types of nodes are:
   - : The value of {{domxref("DocumentType.name")}}
 - {{domxref("Element")}}
   - : The value of {{domxref("Element.tagName")}}, that is the _uppercase_ name of the element tag if an HTML element,
-    or the _lowercase_ element tag if an XML element (like a SVG or MathML element).
+    or the _lowercase_ element tag if an XML element (like an SVG or MathML element).
 - {{domxref("ProcessingInstruction")}}
   - : The value of {{domxref("ProcessingInstruction.target")}}
 - {{domxref("Text")}}

--- a/files/en-us/web/api/webgluniformlocation/index.md
+++ b/files/en-us/web/api/webgluniformlocation/index.md
@@ -18,7 +18,7 @@ The `WebGLUniformLocation` object does not define any methods or properties of i
 
 ## Examples
 
-### Getting an uniform location
+### Getting a uniform location
 
 ```js
 const canvas = document.getElementById("canvas");

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -68,7 +68,7 @@ Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
 Additionally, the server can decide on extension/subprotocol requests here; see [Miscellaneous](#miscellaneous) for details. The `Sec-WebSocket-Accept` header is important in that the server must derive it from the {{HTTPHeader("Sec-WebSocket-Key")}} that the client sent to it. To get it, concatenate the client's `Sec-WebSocket-Key` and the string `"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"` together (it's a "[magic string](https://en.wikipedia.org/wiki/Magic_string)"), take the [SHA-1 hash](https://en.wikipedia.org/wiki/SHA-1) of the result, and return the [base64](https://en.wikipedia.org/wiki/Base64) encoding of that hash.
 
 > [!NOTE]
-> This seemingly overcomplicated process exists so that it's obvious to the client whether the server supports WebSockets. This is important because security issues might arise if the server accepts a WebSockets connection but interprets the data as a HTTP request.
+> This seemingly overcomplicated process exists so that it's obvious to the client whether the server supports WebSockets. This is important because security issues might arise if the server accepts a WebSockets connection but interprets the data as an HTTP request.
 
 So if the Key was `"dGhlIHNhbXBsZSBub25jZQ=="`, the `Sec-WebSocket-Accept` header's value is `"s3pPLMBiTxaQ9kYGzzhZRbK+xOo="`. Once the server sends these headers, the handshake is complete and you can start swapping data!
 

--- a/files/en-us/web/css/reference/properties/stop-opacity/index.md
+++ b/files/en-us/web/css/reference/properties/stop-opacity/index.md
@@ -51,7 +51,7 @@ With `0` or `0%` set, the stop is fully transparent. With `1` or `100%` set, the
 
 ## Examples
 
-### Defining the opacity of a SVG gradient color stop
+### Defining the opacity of an SVG gradient color stop
 
 This example demonstrates the basic use case of `stop-opacity`, and how the CSS `stop-opacity` property takes precedence over the `stop-opacity` attribute.
 
@@ -135,7 +135,7 @@ polygon:nth-of-type(3) {
 
 #### Results
 
-{{EmbedLiveSample("Defining the opacity of a SVG gradient color stop", "300", "200")}}
+{{EmbedLiveSample("Defining the opacity of an SVG gradient color stop", "300", "200")}}
 
 The first star is fully opaque. The fill of the second star is 80% opaque because the color stops are slightly translucent; the `stop-opacity: 0.8;` overrode the `stop-opacity="1"` element attribute value. The fill of the last star is barely noticeable with color stops that are 25% opaque. Note the stroke is the same opaque dark grey in all cases.
 

--- a/files/en-us/web/css/reference/selectors/_doublecolon_first-letter/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_first-letter/index.md
@@ -146,7 +146,7 @@ p::first-letter {
 
 ### Styling first letter in SVG text element
 
-In this example, we use the `::first-letter` pseudo-element to style the first letter of a SVG {{SVGElement("text")}} element.
+In this example, we use the `::first-letter` pseudo-element to style the first letter of an SVG {{SVGElement("text")}} element.
 
 > [!NOTE]
 > At time of writing this feature has [limited support](#browser_compatibility).

--- a/files/en-us/web/css/reference/selectors/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_first-line/index.md
@@ -97,7 +97,7 @@ Only a small subset of CSS properties can be used with the `::first-line` pseudo
 
 {{EmbedLiveSample('styling_first_line_of_a_paragraph', 350, 130)}}
 
-### Styling the first line of a SVG text element
+### Styling the first line of an SVG text element
 
 In this example, we style the first line of an SVG {{SVGElement("text")}} element using the `::first-line` pseudo-element.
 

--- a/files/en-us/web/http/guides/messages/index.md
+++ b/files/en-us/web/http/guides/messages/index.md
@@ -272,7 +272,7 @@ In requests, there are the following pseudo-headers:
 
 In responses, there is only one pseudo-header, and that's the `:status` which provides the code of the response.
 
-We can make a HTTP/2 request using [nghttp](https://github.com/nghttp2/nghttp2) to fetch `example.com`, which will print out the request in a form that's more readable.
+We can make an HTTP/2 request using [nghttp](https://github.com/nghttp2/nghttp2) to fetch `example.com`, which will print out the request in a form that's more readable.
 You can make the request using this command where the `-n` option discards the downloaded data and `-v` is for 'verbose' output, showing reception and transmission of frames:
 
 ```bash

--- a/files/en-us/web/http/guides/overview/index.md
+++ b/files/en-us/web/http/guides/overview/index.md
@@ -192,7 +192,7 @@ There are two types of HTTP messages, requests and responses, each with its own 
 
 An example HTTP request:
 
-![Overview of a HTTP GET request with headers](https://mdn.github.io/shared-assets/images/diagrams/http/overview/http-request.svg)
+![Overview of an HTTP GET request with headers](https://mdn.github.io/shared-assets/images/diagrams/http/overview/http-request.svg)
 
 Requests consist of the following elements:
 

--- a/files/en-us/web/http/guides/range_requests/index.md
+++ b/files/en-us/web/http/guides/range_requests/index.md
@@ -47,7 +47,7 @@ The {{HTTPHeader("Content-Length")}} header is also helpful as it indicates the 
 
 ## Requesting a specific range from a server
 
-If the server supports range requests, you can specify which part (or parts) of the document you want the server to return by including the {{HTTPHeader("Range")}} header in a HTTP request.
+If the server supports range requests, you can specify which part (or parts) of the document you want the server to return by including the {{HTTPHeader("Range")}} header in an HTTP request.
 
 ### Single part ranges
 

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -48,7 +48,7 @@ Beginners are encouraged to start with the foundational guides before exploring 
     This adds the ability to store and exchange a small amount of data which effectively adds state to some client-server interactions.
 - [Redirections in HTTP](/en-US/docs/Web/HTTP/Guides/Redirections)
   - : URL redirection, also known as URL forwarding, is a technique to give more than one URL address to a page, a form, a whole website, or a web application.
-    HTTP has a special kind of response, called a HTTP redirect, for this operation.
+    HTTP has a special kind of response, called an HTTP redirect, for this operation.
 - [HTTP conditional requests](/en-US/docs/Web/HTTP/Guides/Conditional_requests)
   - : In conditional requests, the outcome of a request depends on the value of a validator in the request.
     This method is used heavily in [caching](/en-US/docs/Web/HTTP/Guides/Caching) and use cases such as resuming a download, preventing lost updates when modifying a document on the server, and more.
@@ -125,7 +125,7 @@ Helpful tools and resources for understanding and debugging HTTP.
 The [HTTP reference](/en-US/docs/Web/HTTP/Reference) documentation contains detailed information about headers, request methods, status responses, and lists relevant specifications and standards documents.
 
 - [HTTP headers](/en-US/docs/Web/HTTP/Reference/Headers)
-  - : Message headers are used to send metadata about a resource or a HTTP message, and to describe the behavior of the client or the server.
+  - : Message headers are used to send metadata about a resource or an HTTP message, and to describe the behavior of the client or the server.
 - [HTTP request methods](/en-US/docs/Web/HTTP/Reference/Methods)
   - : Request methods indicate the purpose of the request and what is expected if the request is successful.
     The most common methods are {{HTTPMethod("GET")}} and {{HTTPMethod("POST")}} for retrieving and sending data to servers, respectively, but there are other methods which serve different purposes.

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -53,7 +53,7 @@ Content-Digest: <digest-algorithm>=<digest-value>,<digest-algorithm>=<digest-val
 ## Description
 
 A `Digest` header was defined in previous specifications, but it proved problematic as the scope of what the digest applied to was not clear.
-Specifically, it was difficult to distinguish whether a digest applied to the entire resource representation or to the specific content of a HTTP message.
+Specifically, it was difficult to distinguish whether a digest applied to the entire resource representation or to the specific content of an HTTP message.
 As such, two separate headers were specified (`Content-Digest` and `Repr-Digest`) to convey HTTP message content digests and resource representation digests, respectively.
 
 ## Examples

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -55,7 +55,7 @@ Unless working with legacy systems (which is unlikely since most will expect the
 ## Description
 
 A `Digest` header was defined in previous specifications, but it proved problematic as the scope of what the digest applied to was not clear.
-Specifically, it was difficult to distinguish whether a digest applied to the entire resource representation or to the specific content of a HTTP message.
+Specifically, it was difficult to distinguish whether a digest applied to the entire resource representation or to the specific content of an HTTP message.
 As such, two separate headers were specified (`Content-Digest` and `Repr-Digest`) to convey HTTP message content digests and resource representation digests, respectively.
 
 ## Examples

--- a/files/en-us/web/http/reference/headers/server-timing/index.md
+++ b/files/en-us/web/http/reference/headers/server-timing/index.md
@@ -102,7 +102,7 @@ Server-Timing: custom-metric;dur=123.4
 ```
 
 > [!WARNING]
-> Only the browser's DevTools can use the `Server-Timing` header as a HTTP trailer to display information in the Network -> Timings tab.
+> Only the browser's DevTools can use the `Server-Timing` header as an HTTP trailer to display information in the Network -> Timings tab.
 > The Fetch API cannot access HTTP trailers.
 > See [Browser compatibility](#browser_compatibility) for more information.
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/cross_browser_video_player/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/cross_browser_video_player/index.md
@@ -93,7 +93,7 @@ Finally we close off the `<figure>` element with a {{htmlelement("figcaption")}}
 ```html live-sample___video-player
   <figcaption>
     &copy; Blender Foundation |
-    <a href="http://mango.blender.org">mango.blender.org</a>
+    <a href="https://mango.blender.org">mango.blender.org</a>
   </figcaption>
 </figure>
 ```

--- a/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -58,7 +58,7 @@ The markup for the custom controls now looks as follows:
 ```html hidden live-sample___video-player-styled
   <figcaption>
     &copy; Blender Foundation |
-    <a href="http://mango.blender.org">mango.blender.org</a>
+    <a href="https://mango.blender.org">mango.blender.org</a>
   </figcaption>
 </figure>
 ```

--- a/files/en-us/web/media/guides/autoplay/index.md
+++ b/files/en-us/web/media/guides/autoplay/index.md
@@ -92,7 +92,7 @@ if (navigator.getAutoplayPolicy("mediaelement") === "allowed") {
   video.muted = true;
 } else if (navigator.getAutoplayPolicy("mediaelement") === "disallowed") {
   // Set a default placeholder image.
-  video.poster = "http://example.com/poster_image_url";
+  video.poster = "https://example.com/poster_image_url";
 }
 ```
 
@@ -107,7 +107,7 @@ if (navigator.getAutoplayPolicy(video) === "allowed") {
   video.muted = true;
 } else if (navigator.getAutoplayPolicy(video) === "disallowed") {
   // Set a default placeholder image.
-  video.poster = "http://example.com/poster_image_url";
+  video.poster = "https://example.com/poster_image_url";
 }
 ```
 

--- a/files/en-us/web/media/guides/formats/video_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/video_codecs/index.md
@@ -1085,7 +1085,7 @@ HEVC is a proprietary format and is covered by a number of patents. Licensing is
       <th scope="row">Specifications</th>
       <td>
         <a href="https://www.itu.int/rec/T-REC-H.265"
-          >http://www.itu.int/rec/T-REC-H.265</a
+          >https://www.itu.int/rec/T-REC-H.265</a
         ><br /><a href="https://www.iso.org/standard/69668.html"
           >https://www.iso.org/standard/69668.html</a
         >

--- a/files/en-us/web/xml/guides/opensearch/index.md
+++ b/files/en-us/web/xml/guides/opensearch/index.md
@@ -101,13 +101,13 @@ If your site offers multiple search engines, you can support autodiscovery for t
   rel="search"
   type="application/opensearchdescription+xml"
   title="MySite: By Author"
-  href="http://example.com/mysiteauthor.xml" />
+  href="https://example.com/mysiteauthor.xml" />
 
 <link
   rel="search"
   type="application/opensearchdescription+xml"
   title="MySite: By Title"
-  href="http://example.com/mysitetitle.xml" />
+  href="https://example.com/mysitetitle.xml" />
 ```
 
 This way, your site can offer two engines to search: one by author and another by title.


### PR DESCRIPTION
This PR fixes various content quality issues that were identified throughout MDN Web Docs: broken links, insecure links, incorrect article use, and a typo in the headings. The changes are only editorial, and do not affect the functionality as rendered.

What has changed and why (explain your reasoning)
HTTP to HTTPS link redirection (6 files) There were still some external links that had not switched from plain http:// to https.External links not switched from http:// to https (6 files) Some external links were still pointing to the old http protocol. This is not only insecure, but also in conflict with MDN's guidelines about using secure connections. Updated:

The video codecs are listed in the guide under itu.int/rec/T-REC-H.265
mango.blender.org - both cross-browser video player and video player styling guides
The autoplay guide contains references to URLs of posters at example.com.
The following example shows XML href references in the OpenSearch guide.Below is an example of XML href references for the OpenSearch guide.
"a HTTP" → "an HTTP" (11 files) The indefinite article before an initialism that starts with a vowel sound should be "an", not "a". An HTTP request (not a HTTP request) starts with an "HTTP" sound which is "aitch-tee-tee-pee", not "a". Addressed in the following documents: HTTP overview, Headers overview, and Firefox release notes.

"a SVG" → "an SVG" (5 files) Same rule applies to SVG ("ess-vee-gee"). It was fixed in the pages of CSS selectors references, Web API attr and node reference pages and the stop-opacity property page.

"a HTML" was changed to "an HTML" in the HTML boolean attribute glossary entry, the markup glossary page and the XHTML glossary page.

Getting an uniform location → Getting a uniform location (1 file) To start the word "uniform" with the "yoo" sounds, it needs the "a". Improved the WebGLUniformLocation reference page's section heading.