### PR TITLE
Update Firefox 153 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -108,7 +108,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### General
 
 - Improved the window manipulation commands in Marionette and WebDriver BiDi to allow individual window geometry properties, such as x, y, width, and height, to be adjusted independently. ([Firefox bug 1941404](https://bugzil.la/1941404)).
-- Fixed the computation of an element's center point by ignoring zero-sized rectangles. ([Firefox bug 2038932](https://bugzil.la/2038932)).
+- Fixed a bug where click and pointer action commands could fail if the element's first DOMRect (e.g. inline elements spanning multiple lines) was zero-sized. ([Firefox bug 2038932](https://bugzil.la/2038932))
 
 #### WebDriver BiDi
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -103,13 +103,25 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Improved the window manipulation commands in Marionette and WebDriver BiDi to allow individual window geometry properties, such as x, y, width, and height, to be adjusted independently. ([Firefox bug 1941404](https://bugzil.la/1941404)).
+- Fixed the computation of an element's center point by ignoring zero-sized rectangles. ([Firefox bug 2038932](https://bugzil.la/2038932)).
 
-<!-- #### Marionette -->
+#### WebDriver BiDi
+
+- Extended the `emulation.setLocaleOverride` command to also apply a locale emulation to dedicated and shared workers. ([Firefox bug 2015655](https://bugzil.la/2015655)).
+- Extended the `emulation.setTimezoneOverride` command to also apply a timezone emulation to dedicated and shared workers. ([Firefox bug 2015657](https://bugzil.la/2015657)).
+- Updated the `browsingContext.create` command to no longer emit `browsingContext.domContentLoaded` and `browsingContext.load` events for the initial `about:blank` page when creating new top-level browsing contexts, and to now emit the `browsingContext.contextCreated` event at the end of the creation process. ([Firefox bug 1930594](https://bugzil.la/1930594)).
+- Fixed a bug where functions created by the `script.addPreloadScript` command stopped working after several navigations. ([Firefox bug 2046390](https://bugzil.la/2046390)).
+
+#### Marionette
+
+- Restricted navigation to privileged pages (certain `about:*` pages, `chrome://`, and `resource://` URLs) when operating in content scope. ([Firefox bug 1579790](https://bugzil.la/1579790)).
+- Fixed the `Take Element Screenshot` command from WebDriver Classic to crop screenshots of elements which exceed the viewport. ([Firefox bug 2013176](https://bugzil.la/2013176)).
+- Fixed the `Perform Actions` command to properly await internal action finalization, preventing potential race conditions. ([Firefox bug 2031596](https://bugzil.la/2031596)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -108,7 +108,8 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### General
 
 - Improved the window manipulation commands in Marionette and WebDriver BiDi to allow individual window geometry properties, such as x, y, width, and height, to be adjusted independently. ([Firefox bug 1941404](https://bugzil.la/1941404)).
-- Fixed a bug where click and pointer action commands could fail if the element's first DOMRect (e.g., inline elements spanning multiple lines) was zero-sized. ([Firefox bug 2038932](https://bugzil.la/2038932))
+- Fixed a bug where click and pointer action commands could fail if the element's first DOMRect (e.g., inline elements spanning multiple lines) was zero-sized. ([Firefox bug 2038932](https://bugzil.la/2038932)).
+- Restricted navigation to privileged pages (certain `about:*` pages, `chrome://`, and `resource://` URLs) when operating in content scope. ([Firefox bug 1579790](https://bugzil.la/1579790)).
 
 #### WebDriver BiDi
 
@@ -119,7 +120,6 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Marionette
 
-- Restricted navigation to privileged pages (certain `about:*` pages, `chrome://`, and `resource://` URLs) when operating in content scope. ([Firefox bug 1579790](https://bugzil.la/1579790)).
 - Fixed the `Take Element Screenshot` command from WebDriver Classic to crop screenshots of elements which exceed the viewport. ([Firefox bug 2013176](https://bugzil.la/2013176)).
 - Fixed the `Perform Actions` command to properly await internal action finalization, preventing potential race conditions. ([Firefox bug 2031596](https://bugzil.la/2031596)).
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -115,7 +115,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - Extended the `emulation.setLocaleOverride` command to also apply a locale emulation to dedicated and shared workers. ([Firefox bug 2015655](https://bugzil.la/2015655)).
 - Extended the `emulation.setTimezoneOverride` command to also apply a timezone emulation to dedicated and shared workers. ([Firefox bug 2015657](https://bugzil.la/2015657)).
 - Updated the `browsingContext.create` command to no longer emit `browsingContext.domContentLoaded` and `browsingContext.load` events for the initial `about:blank` page when creating new top-level browsing contexts, and to now emit the `browsingContext.contextCreated` event at the end of the creation process. ([Firefox bug 1930594](https://bugzil.la/1930594)).
-- Fixed a bug where functions created by the `script.addPreloadScript` command stopped working after several navigations. ([Firefox bug 2046390](https://bugzil.la/2046390)).
+- Fixed a bug where functions created by the `script.addPreloadScript` command might have stopped working after several navigations. ([Firefox bug 2046390](https://bugzil.la/2046390)).
 
 #### Marionette
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -108,7 +108,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### General
 
 - Improved the window manipulation commands in Marionette and WebDriver BiDi to allow individual window geometry properties, such as x, y, width, and height, to be adjusted independently. ([Firefox bug 1941404](https://bugzil.la/1941404)).
-- Fixed a bug where click and pointer action commands could fail if the element's first DOMRect (e.g. inline elements spanning multiple lines) was zero-sized. ([Firefox bug 2038932](https://bugzil.la/2038932))
+- Fixed a bug where click and pointer action commands could fail if the element's first DOMRect (e.g., inline elements spanning multiple lines) was zero-sized. ([Firefox bug 2038932](https://bugzil.la/2038932))
 
 #### WebDriver BiDi
 


### PR DESCRIPTION
Changes for WebDriver conformance for the Firefox 153 release based on the [release note worthy bugs in this list](https://bugzilla.mozilla.org/buglist.cgi?include_fields=id,component,resolution,assigned_to,summary,bug_type,whiteboard,mentors&product=Remote%20Protocol&resolution=FIXED&f1=cf_status_firefox153&o1=equals&v1=fixed&f2=cf_status_firefox152&o2=notequals&v2=fixed&f3=status_whiteboard&o3=notsubstring&v3=%5Bwptsync%20downstream%5D&f4=status_whiteboard&o4=substring&v4=%5Bwebdriver%3Arelnote%5D&component=Agent&component=Marionette&component=WebDriver%20BiDi).

@juliandescottes and @lutien can you please review?