### PR TITLE
Add border-shape guide to the CSS sidebar

### DIFF
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -29,6 +29,10 @@ sidebar:
       - /Web/CSS/Guides/Backgrounds_and_borders/Using_multiple_backgrounds
       - /Web/CSS/Guides/Backgrounds_and_borders/Resizing_background_images
       - /Web/CSS/Guides/Backgrounds_and_borders/Scaling_SVG_backgrounds
+  - title: Borders_and_box_decorations
+    details: closed
+    children:
+      - /Web/CSS/Guides/Borders_and_box_decorations/Border_shape_nav_menu
   - title: Box alignment
     details: closed
     children:
@@ -415,6 +419,7 @@ l10n:
     Anchor_positioning: Anchor positioning
     Animations: Animations
     Backgrounds_and_Borders: Backgrounds and borders
+    Borders_and_box_decorations: Borders and box decorations
     Box_model: Box model
     Cascade: Cascade
     Colors: Colors


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

In https://github.com/mdn/content/pull/44191, I added docs for the `border-shape` CSS property, including a guide to show how to create an interesting irregular-shaped nav menu. I tried to add the guide to the CSS sidebar as part of that PR, but the unit tests kept crapping out, so I left it.

This PR finishes the job. The unit tests are now running fine, so it must have just been an outdated dependency.



<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
