### PR TITLE
[Wasm] Add Specifications section to WebAssembly.Exception stack property page

### DIFF
--- a/files/en-us/webassembly/reference/javascript_interface/exception/stack/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/exception/stack/index.md
@@ -104,6 +104,10 @@ new WebAssembly.Exception(tag, [param], { traceStack: true });
 Passing in `{traceStack: true}` tells the WebAssembly virtual machine that it should attach a stack trace to the returned `WebAssembly.Exception`.
 Without this, the stack would be `undefined`.
 
+## Specifications
+
+This feature is not part of any current specification.
+
 ## Browser compatibility
 
 {{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

The [`WebAssembly.Exception.prototype.stack`](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/JavaScript_interface/Exception/stack) page is missing a "Specifications" section. It is a non-standard prop, but it should still have a spec section, which says it is not part of a specification.

This PR adds it in, with standard MDN wording used to state that it isn't part of a spec.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
