### PR TITLE
Add that an empty string refers to the current page URL in Share API

### DIFF
--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -32,7 +32,7 @@ share(data)
 
     Possible values are:
     - `url` {{optional_inline}}
-      - : A string representing a URL to be shared.
+      - : A string representing a URL to be shared. A value of `''` refers to the current page URL.
     - `text` {{optional_inline}}
       - : A string representing text to be shared.
     - `title` {{optional_inline}}

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -32,7 +32,7 @@ share(data)
 
     Possible values are:
     - `url` {{optional_inline}}
-      - : A string representing a URL to be shared. A value of `''` refers to the current page URL.
+      - : A string representing a URL to be shared. An empty string (`""`) refers to the current page URL.
     - `text` {{optional_inline}}
       - : A string representing text to be shared.
     - `title` {{optional_inline}}


### PR DESCRIPTION
…Docs

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR adds details under the possible values of the data parameter of the navigator.share function inside the url section saying that setting the url to an empty string (`""`) refers to the current page. this is based on [this specification](https://w3c.github.io/web-share/#sharing-text-and-links:~:text=Note%20that%20a%20url%20of%20%27%27%20refers%20to%20the%20current%20page%20URL%2C%20just%20as%20it%20would%20in%20a%20link.%20Any%20other%20absolute%20or%20relative%20URL%20can%20also%20be%20used.)

### Motivation

So I was diving deeper into the API specs and saw this and thought this could be very helpful for developers using this API and would also help MDN to get closer to the spec.

### Additional details

https://w3c.github.io/web-share/#sharing-text-and-links:~:text=Note%20that%20a%20url%20of%20%27%27%20refers%20to%20the%20current%20page%20URL%2C%20just%20as%20it%20would%20in%20a%20link.%20Any%20other%20absolute%20or%20relative%20URL%20can%20also%20be%20used.

### Related issues and pull requests

Fixes https://github.com/mdn/content/pull/44741

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
