### PR TITLE
chore(dev): replace deprecated `fred-server|ssr` command

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -136,10 +136,10 @@ jobs:
 
           npx @mdn/rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
 
-          # Workaround, as fred-ssr doesn't copy assets.
+          # Workaround, as `fred ssr` doesn't copy assets.
           cp -vR node_modules/@mdn/fred/out/. "$BUILD_OUT_ROOT"
 
-          npx --package=@mdn/fred fred-ssr
+          npx --package=@mdn/fred fred ssr
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -139,7 +139,7 @@ jobs:
           # Workaround, as `fred ssr` doesn't copy assets.
           cp -vR node_modules/@mdn/fred/out/. "$BUILD_OUT_ROOT"
 
-          npx --package=@mdn/fred fred ssr
+          npx @mdn/fred ssr
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:typos-group-by-file": "cspell --no-progress --gitignore --quiet --reporter cspell-group-by-file-reporter --config .vscode/cspell.json \"**/*.md\"",
     "lint:typos-words-only": "cspell --no-progress --gitignore --words-only --unique --config .vscode/cspell.json \"**/*.md\"",
     "lint:yml": "prettier -c \"**/*.yml\"",
-    "start": "npm run --silent info:fred && npm run up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files NODE_ENV=production FRED_PLAYGROUND_LOCAL=true FRED_PLAYGROUND_PORT=5043 FRED_PORT=5042 FRED_WRITER_MODE=true fred-server",
+    "start": "npm run --silent info:fred && npm run up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files NODE_ENV=production FRED_PLAYGROUND_LOCAL=true FRED_PLAYGROUND_PORT=5043 FRED_PORT=5042 FRED_WRITER_MODE=true fred server",
     "test": "node --test",
     "up-to-date-check": "node scripts/up-to-date-check.js"
   },


### PR DESCRIPTION
### Description

Replace the deprecated `fred-server|ssr` command with `fred server|ssr`.

### Motivation

The `fred-server|ssr` command is deprecated: mdn/fred#1697:

<img width="1011" height="213" alt="image" src="https://github.com/user-attachments/assets/5db2d557-6ab0-4afa-b270-d71065e8bec1" />
