### PR TITLE
Ff153 devtools access heading

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -18,7 +18,7 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### Developer Tools
 
-- The developer tools now indicate the heading level in the accessibility highlighter and accessibility tree, where previously only the fact that it was a heading was provided.
+- The developer tools now provide the heading level for a heading element in the accessibility highlighter and accessibility tree (previously just the fact that it was a heading was shown).
   The information can be found in the [Accessibility Inspector panel](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/index.html).
   ([Firefox bug 1588784](https://bugzil.la/1588784) and [Firefox bug 2044904](https://bugzil.la/2044904)).
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -16,7 +16,11 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Changes for web developers
 
-<!-- ### Developer Tools -->
+### Developer Tools
+
+- The developer tools now indicate the heading level in the accessibility highlighter and accessibility tree, where previously only the fact that it was a heading was provided.
+  The information can be found in the [Accessibility Inspector panel](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/index.html).
+  ([Firefox bug 1588784](https://bugzil.la/1588784) and [Firefox bug 2044904](https://bugzil.la/2044904)).
 
 ### HTML
 


### PR DESCRIPTION
FF153 devtools now indicate heading level in the accessibility tools (tree and highlight). This adds a release note.

Related docs work can be tracked in #44578