### PR TITLE
Update Wasm value types pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/value_types/exnref/index.md
+++ b/files/en-us/webassembly/reference/value_types/exnref/index.md
@@ -97,6 +97,14 @@ The [`WebAssembly.Exception`](/en-US/docs/WebAssembly/Reference/JavaScript_inter
 > [!NOTE]
 > You cannot call a Wasm function from JavaScript that has an `exnref` value as a parameter or result. Trying to do so will result in an error.
 
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
 ## See also
 
 - [`throw_ref`](/en-US/docs/WebAssembly/Reference/Exception_handling/throw_ref) instruction

--- a/files/en-us/webassembly/reference/value_types/externref/index.md
+++ b/files/en-us/webassembly/reference/value_types/externref/index.md
@@ -3,8 +3,7 @@ title: "externref: Wasm value type"
 short-title: externref
 slug: WebAssembly/Reference/Value_types/externref
 page-type: webassembly-instruction
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/types.html#reference-types
+browser-compat: webassembly.types.externref
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/value_types/f32/index.md
+++ b/files/en-us/webassembly/reference/value_types/f32/index.md
@@ -3,7 +3,7 @@ title: "f32: Wasm value type"
 short-title: f32
 slug: WebAssembly/Reference/Value_types/f32
 page-type: webassembly-instruction
-spec-urls: https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype
+browser-compat: webassembly.types.f32
 sidebar: webassemblysidebar
 ---
 
@@ -40,6 +40,10 @@ Arithmetic instructions ([`f32.add`](/en-US/docs/WebAssembly/Reference/Numeric/a
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/value_types/f64/index.md
+++ b/files/en-us/webassembly/reference/value_types/f64/index.md
@@ -3,7 +3,7 @@ title: "f64: Wasm value type"
 short-title: f64
 slug: WebAssembly/Reference/Value_types/f64
 page-type: webassembly-instruction
-spec-urls: https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype
+browser-compat: webassembly.types.f64
 sidebar: webassemblysidebar
 ---
 
@@ -40,6 +40,10 @@ Arithmetic instructions ([`f64.add`](/en-US/docs/WebAssembly/Reference/Numeric/a
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/value_types/funcref/index.md
+++ b/files/en-us/webassembly/reference/value_types/funcref/index.md
@@ -3,8 +3,7 @@ title: "funcref: Wasm value type"
 short-title: funcref
 slug: WebAssembly/Reference/Value_types/funcref
 page-type: webassembly-instruction
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/types.html#reference-types
+browser-compat: webassembly.types.funcref
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/value_types/i32/index.md
+++ b/files/en-us/webassembly/reference/value_types/i32/index.md
@@ -3,7 +3,7 @@ title: "i32: Wasm value type"
 short-title: i32
 slug: WebAssembly/Reference/Value_types/i32
 page-type: webassembly-instruction
-spec-urls: https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype
+browser-compat: webassembly.types.i32
 sidebar: webassemblysidebar
 ---
 
@@ -41,6 +41,10 @@ At the JavaScript boundary, `i32` values cross as JavaScript [`Number`](/en-US/d
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/value_types/i64/index.md
+++ b/files/en-us/webassembly/reference/value_types/i64/index.md
@@ -3,7 +3,7 @@ title: "i64: Wasm value type"
 short-title: i64
 slug: WebAssembly/Reference/Value_types/i64
 page-type: webassembly-instruction
-spec-urls: https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype
+browser-compat: webassembly.types.i64
 sidebar: webassemblysidebar
 ---
 
@@ -50,6 +50,10 @@ When moving from JavaScript over to Wasm, a `BigInt` passed as an `i64` argument
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/value_types/v128/index.md
+++ b/files/en-us/webassembly/reference/value_types/v128/index.md
@@ -3,7 +3,7 @@ title: "v128: Wasm value type"
 short-title: v128
 slug: WebAssembly/Reference/Value_types/v128
 page-type: webassembly-instruction
-browser-compat: webassembly.simd
+browser-compat: webassembly.types.v128
 sidebar: webassemblysidebar
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm value types](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Value_types) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30058.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
