### PR TITLE
Update Wasm definitions pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/definitions/index.md
+++ b/files/en-us/webassembly/reference/definitions/index.md
@@ -21,7 +21,3 @@ This set of pages details the top-level module definition features available in 
   - : Creates a new table.
 - [`tag`](/en-US/docs/WebAssembly/Reference/Definitions/tag)
   - : Declares an exception type that can be thrown in the module.
-
-## Specifications
-
-{{Specifications}}

--- a/files/en-us/webassembly/reference/definitions/table/index.md
+++ b/files/en-us/webassembly/reference/definitions/table/index.md
@@ -3,7 +3,7 @@ title: "table: Wasm definition"
 short-title: table
 slug: WebAssembly/Reference/Definitions/table
 page-type: webassembly-instruction
-spec-urls: https://webassembly.github.io/spec/core/syntax/modules.html#syntax-table
+browser-compat: webassembly.definitions.table
 sidebar: webassemblysidebar
 ---
 
@@ -219,6 +219,10 @@ This makes sense, as the exported `accessTable()` function has an index value pa
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/definitions/types/func/index.md
+++ b/files/en-us/webassembly/reference/definitions/types/func/index.md
@@ -3,7 +3,7 @@ title: "func: Wasm type definition"
 short-title: func
 slug: WebAssembly/Reference/Definitions/types/func
 page-type: webassembly-instruction
-spec-urls: https://webassembly.github.io/spec/core/syntax/types.html#syntax-functype
+browser-compat: webassembly.definitions.func
 sidebar: webassemblysidebar
 ---
 
@@ -72,6 +72,10 @@ Calling `dispatch(0, 3, 4)` invokes `$add` and returns `7`; calling `dispatch(1,
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm definitions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Definitions) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30062.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
