### PR TITLE
docs(wasm): correct min_u output description

### DIFF
--- a/files/en-us/webassembly/reference/simd/arithmetic/min_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/min_u/index.md
@@ -57,7 +57,7 @@ value_type.min_u
 - `input2`
   - : The second input value.
 - `output`
-  - : The output value. A new `v128` of the same type as the inputs, with each lane set to the greater of that lane index's value on the two inputs.
+  - : The output value. A new `v128` of the same type as the inputs, with each lane set to the lower of that lane index's value on the two inputs.
 
 ### Binary encoding
 


### PR DESCRIPTION
## Summary

Fixes #44626.

This PR corrects the output description for the `min_u` SIMD instruction.

## What changed

- Replaced "greater" with "lower" in the **Type → output** section.

## Why

The page introduction correctly describes `min_u` as returning the lower value for each lane, but the output description incorrectly stated "greater". This change makes the documentation consistent with the instruction semantics.

## Verification

- ✅ Verified the page renders correctly using the local MDN preview.
- ✅ Verified the output description now matches the instruction behavior.
- ✅ `npm test` passes (12/12).

<img width="1920" height="1080" alt="Screenshot from 2026-07-17 15-14-46" src="https://github.com/user-attachments/assets/4dcffca1-f08b-4d78-a96e-c1d5a73d6a9f" />
