### PR TITLE
Update Wasm control flow instruction pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/control_flow/block/index.md
+++ b/files/en-us/webassembly/reference/control_flow/block/index.md
@@ -3,6 +3,7 @@ title: "block: Wasm text instruction"
 short-title: block
 slug: WebAssembly/Reference/Control_flow/block
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.block
 sidebar: webassemblysidebar
 ---
 
@@ -81,3 +82,11 @@ await WebAssembly.instantiateStreaming(fetch(url), { console }).then(
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `block`     | `0x02`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/br/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br/index.md
@@ -3,6 +3,7 @@ title: "br: Wasm text instruction"
 short-title: br
 slug: WebAssembly/Reference/Control_flow/br
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.br
 sidebar: webassemblysidebar
 ---
 
@@ -56,3 +57,11 @@ await WebAssembly.instantiateStreaming(fetch(url), { console });
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `br`        | `0x0c`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/br_if/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_if/index.md
@@ -3,6 +3,7 @@ title: "br_if: Wasm text instruction"
 short-title: br_if
 slug: WebAssembly/Reference/Control_flow/br_if
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.br_if
 sidebar: webassemblysidebar
 ---
 
@@ -67,3 +68,11 @@ await WebAssembly.instantiateStreaming(fetch(url), { console });
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `br_if`     | `0x0d`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/br_table/index.md
+++ b/files/en-us/webassembly/reference/control_flow/br_table/index.md
@@ -3,6 +3,7 @@ title: "br_table: Wasm text instruction"
 short-title: br_table
 slug: WebAssembly/Reference/Control_flow/br_table
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.br_table
 sidebar: webassemblysidebar
 ---
 
@@ -83,3 +84,11 @@ i32.const 1
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `br_table`  | `0x0e`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/call/index.md
+++ b/files/en-us/webassembly/reference/control_flow/call/index.md
@@ -3,6 +3,7 @@ title: "call: Wasm text instruction"
 short-title: call
 slug: WebAssembly/Reference/Control_flow/call
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.call
 sidebar: webassemblysidebar
 ---
 
@@ -91,6 +92,14 @@ call $greet
 | `call_indirect`        | `0x11`        |
 | `return_call`          | `0x12`        |
 | `return_call_indirect` | `0x13`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/control_flow/drop/index.md
+++ b/files/en-us/webassembly/reference/control_flow/drop/index.md
@@ -3,6 +3,7 @@ title: "drop: Wasm text instruction"
 short-title: drop
 slug: WebAssembly/Reference/Control_flow/drop
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.drop
 sidebar: webassemblysidebar
 ---
 
@@ -49,3 +50,11 @@ drop
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `drop`      | `0x1a`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/end/index.md
+++ b/files/en-us/webassembly/reference/control_flow/end/index.md
@@ -3,6 +3,7 @@ title: "end: Wasm text instruction"
 short-title: end
 slug: WebAssembly/Reference/Control_flow/end
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.end
 sidebar: webassemblysidebar
 ---
 
@@ -44,3 +45,11 @@ end
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `end`       | `0x0b`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/if...else/index.md
+++ b/files/en-us/webassembly/reference/control_flow/if...else/index.md
@@ -3,6 +3,7 @@ title: "if...else: Wasm text instruction"
 short-title: if...else
 slug: WebAssembly/Reference/Control_flow/if...else
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.if_else
 sidebar: webassemblysidebar
 ---
 
@@ -73,3 +74,11 @@ i32.const 0
 | ----------- | ------------- |
 | `if`        | `0x04`        |
 | `else`      | `0x05`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/loop/index.md
+++ b/files/en-us/webassembly/reference/control_flow/loop/index.md
@@ -3,6 +3,7 @@ title: "loop: Wasm text instruction"
 short-title: loop
 slug: WebAssembly/Reference/Control_flow/loop
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.loop
 sidebar: webassemblysidebar
 ---
 
@@ -68,3 +69,11 @@ await WebAssembly.instantiateStreaming(fetch(url), { console });
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `loop`      | `0x03`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/nop/index.md
+++ b/files/en-us/webassembly/reference/control_flow/nop/index.md
@@ -3,6 +3,7 @@ title: "nop: Wasm text instruction"
 short-title: nop
 slug: WebAssembly/Reference/Control_flow/nop
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.nop
 sidebar: webassemblysidebar
 ---
 
@@ -34,3 +35,11 @@ nop
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `nop`       | `0x01`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/return/index.md
+++ b/files/en-us/webassembly/reference/control_flow/return/index.md
@@ -3,6 +3,7 @@ title: "return: Wasm text instruction"
 short-title: return
 slug: WebAssembly/Reference/Control_flow/return
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.return
 sidebar: webassemblysidebar
 ---
 
@@ -52,3 +53,11 @@ return
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `return`    | `0x0f`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/select/index.md
+++ b/files/en-us/webassembly/reference/control_flow/select/index.md
@@ -3,6 +3,7 @@ title: "select: Wasm text instruction"
 short-title: select
 slug: WebAssembly/Reference/Control_flow/select
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.select
 sidebar: webassemblysidebar
 ---
 
@@ -73,3 +74,11 @@ select (result f32)
 | ----------- | ------------- |
 | `select`    | `0x1b`        |
 | `select t`  | `0x1c`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/control_flow/unreachable/index.md
+++ b/files/en-us/webassembly/reference/control_flow/unreachable/index.md
@@ -3,6 +3,7 @@ title: "unreachable: Wasm text instruction"
 short-title: unreachable
 slug: WebAssembly/Reference/Control_flow/unreachable
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.unreachable
 sidebar: webassemblysidebar
 ---
 
@@ -35,3 +36,11 @@ unreachable
 | Instruction   | Binary opcode |
 | ------------- | ------------- |
 | `unreachable` | `0x00`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm control flow instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Control_flow) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30065.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
