### PR TITLE
Update Wasm memory instruction pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/memory/copy/index.md
+++ b/files/en-us/webassembly/reference/memory/copy/index.md
@@ -1,12 +1,9 @@
 ---
-title: "copy: Wasm text instruction"
+title: "copy: Wasm memory instruction"
 short-title: copy
 slug: WebAssembly/Reference/Memory/copy
 page-type: webassembly-instruction
-browser-compat:
-  - webassembly.bulk-memory-operations
-  - webassembly.multiMemory
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory
+browser-compat: webassembly.instructions.memory_copy
 sidebar: webassemblysidebar
 ---
 
@@ -62,6 +59,3 @@ memory.copy (memory $destMem) (memory $sourceMem) ;; Copy memory from "$sourceMe
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> The `multiMemory` compatibility table indicates versions in which `copy` can be used with a specified memory.

--- a/files/en-us/webassembly/reference/memory/fill/index.md
+++ b/files/en-us/webassembly/reference/memory/fill/index.md
@@ -1,12 +1,9 @@
 ---
-title: "fill: Wasm text instruction"
+title: "fill: Wasm memory instruction"
 short-title: fill
 slug: WebAssembly/Reference/Memory/fill
 page-type: webassembly-instruction
-browser-compat:
-  - webassembly.bulk-memory-operations
-  - webassembly.multiMemory
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory
+browser-compat: webassembly.instructions.memory_fill
 sidebar: webassemblysidebar
 ---
 
@@ -62,6 +59,3 @@ memory.fill (memory $memoryName) ;; Fill memory with name "$memoryName"
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> The `multiMemory` compatibility table indicates versions in which `fill` can be used with a specified memory.

--- a/files/en-us/webassembly/reference/memory/grow/index.md
+++ b/files/en-us/webassembly/reference/memory/grow/index.md
@@ -1,12 +1,9 @@
 ---
-title: "grow: Wasm text instruction"
+title: "grow: Wasm memory instruction"
 short-title: grow
 slug: WebAssembly/Reference/Memory/grow
 page-type: webassembly-instruction
-browser-compat:
-  - webassembly.api.Memory.grow
-  - webassembly.multiMemory
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory
+browser-compat: webassembly.instructions.memory_grow
 sidebar: webassemblysidebar
 ---
 
@@ -181,6 +178,3 @@ The WAT files could be loaded using the same JavaScript code as the first exampl
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> The `multiMemory` compatibility table indicates versions in which `grow` can be used with a specified memory.

--- a/files/en-us/webassembly/reference/memory/index.md
+++ b/files/en-us/webassembly/reference/memory/index.md
@@ -7,15 +7,15 @@ sidebar: webassemblysidebar
 
 WebAssembly memory instructions.
 
+- [`copy`](/en-US/docs/WebAssembly/Reference/Memory/copy)
+  - : Copy data from one region in memory to another.
+- [`fill`](/en-US/docs/WebAssembly/Reference/Memory/fill)
+  - : Set all values in a region to a specific byte.
 - [`grow`](/en-US/docs/WebAssembly/Reference/Memory/grow)
   - : Increase the size of the memory instance.
-- [`size`](/en-US/docs/WebAssembly/Reference/Memory/size)
-  - : Get the size of the memory instance.
 - [`load`](/en-US/docs/WebAssembly/Reference/Memory/load)
   - : Load a number from memory.
+- [`size`](/en-US/docs/WebAssembly/Reference/Memory/size)
+  - : Get the size of the memory instance.
 - [`store`](/en-US/docs/WebAssembly/Reference/Memory/store)
   - : Store a number in memory.
-- [`copy`](/en-US/docs/WebAssembly/Reference/Memory/copy)
-  - : Copy data from one region in memory to another
-- [`fill`](/en-US/docs/WebAssembly/Reference/Memory/fill)
-  - : Set all values in a region to a specific byte

--- a/files/en-us/webassembly/reference/memory/load/index.md
+++ b/files/en-us/webassembly/reference/memory/load/index.md
@@ -1,12 +1,9 @@
 ---
-title: "load: Wasm text instruction"
+title: "load: Wasm memory instruction"
 short-title: load
 slug: WebAssembly/Reference/Memory/load
 page-type: webassembly-instruction
-browser-compat:
-  - webassembly.api.Memory
-  - webassembly.multiMemory
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory
+browser-compat: webassembly.instructions.memory_load
 sidebar: webassemblysidebar
 ---
 
@@ -200,6 +197,3 @@ The WAT files could be loaded using the same JavaScript code as the first exampl
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> The `multiMemory` compatibility table indicates versions in which `load` can be used with a specified memory.

--- a/files/en-us/webassembly/reference/memory/size/index.md
+++ b/files/en-us/webassembly/reference/memory/size/index.md
@@ -1,12 +1,9 @@
 ---
-title: "size: Wasm text instruction"
+title: "size: Wasm memory instruction"
 short-title: size
 slug: WebAssembly/Reference/Memory/size
 page-type: webassembly-instruction
-browser-compat:
-  - webassembly.api.Memory
-  - webassembly.multiMemory
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory
+browser-compat: webassembly.instructions.memory_size
 sidebar: webassemblysidebar
 ---
 
@@ -154,6 +151,3 @@ The WAT files could be loaded using the same JavaScript code as the first exampl
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> The `multiMemory` compatibility table indicates versions in which `size` can be used with a specified memory.

--- a/files/en-us/webassembly/reference/memory/store/index.md
+++ b/files/en-us/webassembly/reference/memory/store/index.md
@@ -1,12 +1,9 @@
 ---
-title: "store: Wasm text instruction"
+title: "store: Wasm memory instruction"
 short-title: store
 slug: WebAssembly/Reference/Memory/store
 page-type: webassembly-instruction
-browser-compat:
-  - webassembly.api.Memory
-  - webassembly.multiMemory
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory
+browser-compat: webassembly.instructions.memory_store
 sidebar: webassemblysidebar
 ---
 
@@ -105,6 +102,3 @@ i32.store (memory $memoryName)  ;; store in memory with name "$memoryName"
 ## Browser compatibility
 
 {{Compat}}
-
-> [!NOTE]
-> The `multiMemory` compatibility table indicates versions in which `store` can be used with a specified memory.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm memory instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Memory) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30072.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
