### PR TITLE
Add note about offline_enabled being unsupported in Manifest V3

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
@@ -31,6 +31,9 @@ sidebar: addonsidebar
 
 {{Non-standard_Header}}
 
+> [!NOTE]
+> `offline_enabled` is not supported in Manifest V3, which Chrome has supported generally since Chrome 88. This key only applies to Manifest V2 extensions and apps.
+
 Whether the app or extension is expected to work offline. When Chrome detects that it is offline, apps with this field set to true will be highlighted on the New Tab page.
 
 As of Chrome 35, apps (ChromeOS only from 2018) are assumed to be offline enabled and the default value of `"offline_enabled"` is `true` unless `"webview"` permission is requested. In this case, network connectivity is assumed to be required and `"offline_enabled"` defaults to `false`.


### PR DESCRIPTION
Fixes #44817. Adds a note clarifying that offline_enabled is a Manifest V2-only key and has no effect in Manifest V3 (supported in Chrome 88+).

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Adds a note to the `offline_enabled` manifest key page clarifying that it is only applicable to Manifest V2, and has no effect in Manifest V3.

### Motivation

Chrome deprecated `offline_enabled` when it moved to Manifest V3 (generally supported since Chrome 88). The current page did not mention this, which could confuse readers still relying on this key. Adding a clear note prevents that confusion.

### Additional details
- https://developer.chrome.com/docs/extensions/mv2/manifest/offline-enabled
- https://developer.chrome.com/docs/extensions/develop/migrate/manifest


### Related issues and pull requests

Fixes #44817
