### PR TITLE
Fix typo: "dependant" → "dependent" across 8 pages

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/lang/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lang/index.md
@@ -77,7 +77,7 @@ The HTML features a {{htmlelement("select")}} element that allows you to choose 
 
 #### JavaScript
 
-In the JavaScript, we first grab references to the `<canvas>` element, its `CanvasRenderingContext2D`, and the `<select>` element, then load the language-dependant font using the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API). Once the font is loaded, we run an `init()` function. This function defines another function — `drawText()`, which draws some text to the canvas context that uses the loaded font, adds a [`change`](/en-US/docs/Web/API/HTMLElement/change_event) [event listener](/en-US/docs/Web/API/EventTarget/addEventListener) to the `<select>` element, then calls `drawText()` so that the text is immediately drawn to the canvas when the page first loads.
+In the JavaScript, we first grab references to the `<canvas>` element, its `CanvasRenderingContext2D`, and the `<select>` element, then load the language-dependent font using the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API). Once the font is loaded, we run an `init()` function. This function defines another function — `drawText()`, which draws some text to the canvas context that uses the loaded font, adds a [`change`](/en-US/docs/Web/API/HTMLElement/change_event) [event listener](/en-US/docs/Web/API/EventTarget/addEventListener) to the `<select>` element, then calls `drawText()` so that the text is immediately drawn to the canvas when the page first loads.
 
 ```js live-example___canvas-l10n
 const canvasElem = document.querySelector("canvas");

--- a/files/en-us/web/api/languagedetector/create_static/index.md
+++ b/files/en-us/web/api/languagedetector/create_static/index.md
@@ -30,7 +30,7 @@ LanguageDetector.create(options)
     - `monitor` {{optional_inline}}
       - : A callback function with a {{domxref("CreateMonitor")}} argument that enables monitoring download progress of the AI model.
     - `signal` {{optional_inline}}
-      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependant on when {{domxref("AbortController.abort()")}} is called:
+      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependent on when {{domxref("AbortController.abort()")}} is called:
         - If `abort()` is called before the `create()` promise resolves, the `create()` operation is cancelled.
         - If `abort()` is called after the `create()` promise fulfills, it has the same effect as calling {{domxref("LanguageDetector.destroy()")}}: The resources assigned to the resulting `LanguageDetector` instance are released, and any ongoing and subsequent `LanguageDetector` method calls will reject with an `AbortError`.
 

--- a/files/en-us/web/api/languagedetector/inputquota/index.md
+++ b/files/en-us/web/api/languagedetector/inputquota/index.md
@@ -16,7 +16,7 @@ The **`inputQuota`** read-only property of the {{domxref("LanguageDetector")}} i
 
 A number specifying the available input quota.
 
-This number is implementation-dependant. For example, it might be {{jsxref("Infinity")}} if there are no limits beyond the user's memory and the maximum length of JavaScript strings, or it might be a number of tokens in the case of AI models that use a token/credits scheme.
+This number is implementation-dependent. For example, it might be {{jsxref("Infinity")}} if there are no limits beyond the user's memory and the maximum length of JavaScript strings, or it might be a number of tokens in the case of AI models that use a token/credits scheme.
 
 The only guarantee is that `inputQuota` - {{domxref("LanguageDetector.measureInputUsage", "measureInputUsage()")}} will be non-negative if there is sufficient quota to detect the text's language.
 

--- a/files/en-us/web/api/languagedetector/measureinputusage/index.md
+++ b/files/en-us/web/api/languagedetector/measureinputusage/index.md
@@ -32,7 +32,7 @@ measureInputUsage(input, options)
 
 A {{jsxref("Promise")}} that fulfills with a number specifying the {{domxref("LanguageDetector.inputQuota", "inputQuota")}} usage of the given input text.
 
-This number is implementation-dependant; if it is less than the {{domxref("LanguageDetector.inputQuota", "inputQuota")}}, the string's language can be detected.
+This number is implementation-dependent; if it is less than the {{domxref("LanguageDetector.inputQuota", "inputQuota")}}, the string's language can be detected.
 
 ### Exceptions
 

--- a/files/en-us/web/api/summarizer/create_static/index.md
+++ b/files/en-us/web/api/summarizer/create_static/index.md
@@ -41,7 +41,7 @@ Summarizer.create(options)
     - `sharedContext`
       - : A {{domxref("Summarizer.sharedContext", "sharedContext")}} string describing the context the pieces of text to summarize are being used in, which helps the `Summarizer` generate more suitable summaries.
     - `signal`
-      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependant on when {{domxref("AbortController.abort()")}} is called:
+      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependent on when {{domxref("AbortController.abort()")}} is called:
         - If `abort()` is called before the `create()` promise resolves, the `create()` operation is cancelled.
         - If `abort()` is called after the `create()` promise fulfills, it has the same effect as calling {{domxref("Summarizer.destroy()")}}: The resources assigned to the resulting `Summarizer` instance are released, and any ongoing and subsequent `Summarizer` method calls will reject with an `AbortError`.
     - `type`

--- a/files/en-us/web/api/translator/create_static/index.md
+++ b/files/en-us/web/api/translator/create_static/index.md
@@ -32,7 +32,7 @@ Translator.create(options)
     - `monitor` {{optional_inline}}
       - : A callback function with a {{domxref("CreateMonitor")}} argument that enables monitoring download progress of the AI model.
     - `signal` {{optional_inline}}
-      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependant on when {{domxref("AbortController.abort()")}} is called:
+      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependent on when {{domxref("AbortController.abort()")}} is called:
         - If `abort()` is called before the `create()` promise resolves, the `create()` operation is cancelled.
         - If `abort()` is called after the `create()` promise fulfills, it has the same effect as calling {{domxref("Translator.destroy()")}}: The resources assigned to the resulting `Translator` instance are released, and any ongoing and subsequent `Translator` method calls will reject with an `AbortError`.
 

--- a/files/en-us/web/api/translator/inputquota/index.md
+++ b/files/en-us/web/api/translator/inputquota/index.md
@@ -16,7 +16,7 @@ The **`inputQuota`** read-only property of the {{domxref("Translator")}} interfa
 
 A number specifying the available input quota.
 
-This number is implementation-dependant. For example, it might be {{jsxref("Infinity")}} if there are no limits beyond the user's memory and the maximum length of JavaScript strings, or it might be a number of tokens in the case of AI models that use a token/credits scheme.
+This number is implementation-dependent. For example, it might be {{jsxref("Infinity")}} if there are no limits beyond the user's memory and the maximum length of JavaScript strings, or it might be a number of tokens in the case of AI models that use a token/credits scheme.
 
 The only guarantee is that `inputQuota` - {{domxref("Translator.measureInputUsage", "measureInputUsage()")}} will be non-negative if there is sufficient quota to translate the text.
 

--- a/files/en-us/web/api/translator/measureinputusage/index.md
+++ b/files/en-us/web/api/translator/measureinputusage/index.md
@@ -32,7 +32,7 @@ measureInputUsage(input, options)
 
 A {{jsxref("Promise")}} that fulfills with a number specifying the {{domxref("Translator.inputQuota", "inputQuota")}} usage of the given input text.
 
-This number is implementation-dependant; if it is less than the {{domxref("Translator.inputQuota", "inputQuota")}}, the string can be translated.
+This number is implementation-dependent; if it is less than the {{domxref("Translator.inputQuota", "inputQuota")}}, the string can be translated.
 
 ### Exceptions
 


### PR DESCRIPTION
MDN uses American English spelling. "Dependant" is the British noun form; as an adjective it should be "dependent".

Fixed in 8 pages (mostly the built-in AI API docs): `LanguageDetector`/`Summarizer`/`Translator` `create()`, `inputQuota`, and `measureInputUsage()` pages, plus `CanvasRenderingContext2D.lang`.

Spelling-only change; no content changes.