### PR TITLE
Fix typo: "withing" → "within" in 3 pages

### DIFF
--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -48,7 +48,7 @@ To only provide an `endMark`, you need to provide an empty `measureOptions` obje
             - `track` {{optional_inline}} {{experimental_inline}}
               - : String of the name of the custom track (required for `track-entry`)
             - `trackGroup` {{optional_inline}} {{experimental_inline}}
-              - : String of the name of the grouping withing a custom track (required for `track-entry`)
+              - : String of the name of the grouping within a custom track (required for `track-entry`)
             - `properties` {{optional_inline}} {{experimental_inline}}
               - : Array of key-value pairs. Values can be any JSON-compatible type.
             - `tooltipText` {{optional_inline}} {{experimental_inline}}

--- a/files/en-us/web/css/guides/images/replaced_element_properties/index.md
+++ b/files/en-us/web/css/guides/images/replaced_element_properties/index.md
@@ -21,7 +21,7 @@ The CSS images module defines two properties which can be used to specify how th
 
 ### The `object-fit` property
 
-The `object-fit` property specifies how the replaced element's content object should be fitted to the containing element's box. The property defines how images, videos and other embeddable media formats respond to the height and width of the replaced element's content box. If the height, width, or aspect-ratio of an element differ from the resource that will be occupying space reserved for the element, the `fill`, `contain`, `cover`, `scale-down`, and `none` values define whether the browser should scale the resource, cover the allocated space, contain the asset withing the space, or allow the resource to be distorted.
+The `object-fit` property specifies how the replaced element's content object should be fitted to the containing element's box. The property defines how images, videos and other embeddable media formats respond to the height and width of the replaced element's content box. If the height, width, or aspect-ratio of an element differ from the resource that will be occupying space reserved for the element, the `fill`, `contain`, `cover`, `scale-down`, and `none` values define whether the browser should scale the resource, cover the allocated space, contain the asset within the space, or allow the resource to be distorted.
 
 When contained or scaled down, any areas of the box not covered by the replaced element will show the element's background.
 

--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -458,7 +458,7 @@ All HTML and SVG elements support event handler attributes defined on the [`Glob
 
 While event handler attributes, like {{domxref("Element/blur_event", "onblur")}} and {{domxref("Element/auxclick_event", "onauxclick")}}, apply to all elements, they may not have any effect. For example, the {{domxref("HTMLTrackElement/cuechange_event", "oncuechange")}} attribute can be applied to any element, but it is only relevant to the {{htmlelement("track")}} element.
 
-Event handler attributes are discouraged, considered unsafe, and may be blocked by [content security policies (CSP)](/en-US/docs/Web/Security/Practical_implementation_guides/CSP). Use the event name withing an {{domxref("EventTarget.addEventListener", "addEventListener()")}} method instead.
+Event handler attributes are discouraged, considered unsafe, and may be blocked by [content security policies (CSP)](/en-US/docs/Web/Security/Practical_implementation_guides/CSP). Use the event name within an {{domxref("EventTarget.addEventListener", "addEventListener()")}} method instead.
 
 ## See also
 


### PR DESCRIPTION
Fixes the misspelling "withing" → "within" in three pages:

- `Performance.measure()` (track-entry grouping description)
- CSS replaced element properties guide (`object-fit` description)
- SVG attribute reference (event handler attributes note)

Spelling-only change; no content changes.