### PR TITLE
FF153 CSS basic shape closest-/farthest-corner

### DIFF
--- a/files/en-us/web/css/reference/values/basic-shape/circle/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/circle/index.md
@@ -70,9 +70,9 @@ border-shape: circle(60%);
     - `farthest-side`
       - : The radius is the length from the center of the circle to the farthest side of the reference box, so that the circle's boundary just touches that side.
     - `closest-corner`
-      - : The radius is the length from the center of the circle to the closest corner of the reference box, so that the circle passes through that corner.
+      - : The radius is the length from the center of the circle to the closest corner of the reference box, so that the circle's boundary passes through that corner.
     - `farthest-corner`
-      - : The radius is the length from the center of the circle to the farthest corner of the reference box, so that the circle passes through that corner.
+      - : The radius is the length from the center of the circle to the farthest corner of the reference box, so that the circle's boundary passes through that corner.
 
 - `<position>`
   - : Moves the center of the circle. May be a {{cssxref("length")}}, or a {{cssxref("percentage")}}, or a values such as `left`. The `<position>` value defaults to center if omitted.

--- a/files/en-us/web/css/reference/values/basic-shape/circle/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/circle/index.md
@@ -122,47 +122,93 @@ img {
 
 This example allows you to test the effect of moving the center point of the circle when using each of the four `<shape-radius>` keywords.
 
-The code defines a reference box (`#refbox`) that contains a `.fill` element.
-We set a `clip-path` on `#refbox` to clip the box and the fill to the computed circle (the colored circle is the fill's gradient, clipped to a circle geometry).
-The geometry that is used depends on the selected radius keyword and the position of the center within the reference box.
+#### HTML
 
-Because `closest-corner` and `farthest-corner` are a newer addition to `circle()`, the code feature-tests each keyword with {{domxref("CSS.supports_static", "CSS.supports()")}} before enabling it.
-Any keyword your browser doesn't support is disabled in the dropdown (and labeled "not supported").
+The HTML first defines controls for selecting a chosen radius keyword and setting the position where the circle is to be displayed, followed by a {{htmlelement("pre")}} element for displaying the {{cssxref("clip-path")}} that the control values select.
+After this a `#support-note` element is provided for indicating when particular radius keywords are not supported.
 
 ```html live-sample___circle-keywords-interactive
 <div class="controls">
-  <label>
-    Shape radius:
-    <select id="radius-keyword">
-      <option value="closest-side">closest-side</option>
-      <option value="closest-corner">closest-corner</option>
-      <option value="farthest-side">farthest-side</option>
-      <option value="farthest-corner" selected>farthest-corner</option>
-    </select>
-  </label>
-  <label>
-    Position X: <input type="range" id="pos-x" min="0" max="200" value="120" />
-  </label>
-  <label>
-    Position Y: <input type="range" id="pos-y" min="0" max="120" value="40" />
-  </label>
+  <div class="controls-row">
+    <label>
+      Shape radius:
+      <select id="radius-keyword">
+        <option value="closest-side">closest-side</option>
+        <option value="closest-corner">closest-corner</option>
+        <option value="farthest-side">farthest-side</option>
+        <option value="farthest-corner" selected>farthest-corner</option>
+      </select>
+    </label>
+  </div>
+  <div class="controls-row">
+    <label>
+      Position X:
+      <input type="range" id="pos-x" min="0" max="200" value="120" />
+    </label>
+    <label>
+      Position Y:
+      <input type="range" id="pos-y" min="0" max="120" value="40" />
+    </label>
+  </div>
 </div>
 
-<p id="support-note"></p>
+<pre id="declaration"></pre>
 
+<p id="support-note"></p>
+```
+
+The HTML then defines a number of {{htmlelement("div")}} elements that are used to render the circle, reference box and center marker.
+The most important elements are the reference box (`#refbox`) and the `.fill` element it contains, which define the gradient that is drawn (as discussed in the following CSS section).
+A `clipPath` is set on the reference box in JavaScript to clip that gradient to a circular shape.
+
+```html live-sample___circle-keywords-interactive
 <div class="canvas">
-  <div class="outline"></div>
   <div class="refbox" id="refbox">
     <div class="fill"></div>
   </div>
   <div class="outline"></div>
   <div class="center-marker" id="center-marker"></div>
 </div>
-
-<pre id="declaration"></pre>
 ```
 
+Note that the `.outline` and `.center-marker` are provided to make it easier to see the reference box and the center of the clipping circle, which would otherwise be invisible.
+The `.outline` element must be placed after `#refbox` in the markup: since it isn't clipped itself, painting it after the reference box means its dashed border always renders on top of the `.fill` gradient, even when the clipping circle extends beyond the reference box.
+
+#### CSS
+
+The CSS for the canvas, reference box and fill elements are shown below.
+Note that the `.fill` defines a gradient that overflows the reference box, filling most of the canvas.
+This is the gradient that we will clip using the `circle()` (we do this by setting the CSS clip path dynamically in our JavaScript code).
+
 ```css live-sample___circle-keywords-interactive
+.canvas {
+  position: relative;
+  width: 640px;
+  height: 480px;
+  overflow: hidden;
+  border: 1px solid #888;
+}
+
+.refbox {
+  position: absolute;
+  top: 180px;
+  left: 220px;
+  width: 200px;
+  height: 120px;
+  box-sizing: border-box;
+}
+
+.fill {
+  position: absolute;
+  inset: -240px;
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
+}
+```
+
+The CSS for the controls and other elements is not shown, as it isn't needed to understand the `circle()` method.
+Interested readers can view it in the example playground.
+
+```css live-sample___circle-keywords-interactive hidden
 body {
   display: flex;
   flex-direction: column;
@@ -172,37 +218,31 @@ body {
 
 .controls {
   display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.controls-row {
+  display: flex;
   flex-wrap: wrap;
   gap: 20px;
   align-items: center;
 }
+```
 
-.canvas {
-  position: relative;
-  width: 640px;
-  height: 480px;
-  overflow: hidden;
-  border: 1px solid #888;
-}
-
-.outline,
-.refbox {
+```css live-sample___circle-keywords-interactive hidden
+.outline {
   position: absolute;
   top: 180px;
   left: 220px;
   width: 200px;
   height: 120px;
+  box-sizing: border-box;
 }
 
 .outline {
   border: 3px dashed #e6007a;
   pointer-events: none;
-}
-
-.fill {
-  position: absolute;
-  inset: -240px;
-  background: linear-gradient(to bottom right, #ff5522, #0055ff);
 }
 
 .center-marker {
@@ -216,10 +256,23 @@ body {
   pointer-events: none;
 }
 
+#declaration {
+  margin: 0;
+}
+
 #support-note {
+  margin: 0;
   color: #b3001b;
 }
 ```
+
+#### JavaScript
+
+The JavaScript for the example is shown below.
+First we get handles to each of the elements used by the example.
+
+Then we define `checkSupport()` method to feature-test whether each radius keyword is supported and enable/disable the associated selection options.
+This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
 
 ```js live-sample___circle-keywords-interactive
 const select = document.getElementById("radius-keyword");
@@ -252,15 +305,22 @@ function checkSupport() {
     }
   }
 }
+```
 
+Next we define an `update()` function that is called whenever the input controls are changed.
+This sets the clip path on the reference box based on the selected keyword and position, and moves the center marker to match.
+
+```js live-sample___circle-keywords-interactive
 function update() {
   const keyword = select.value;
   const x = Number(posX.value);
   const y = Number(posY.value);
-  const value = `circle(${keyword} at ${x}px ${y}px)`;
 
-  // Set the clip path when the keyword or center position changes
+  // Build the clip-path value and apply it to the reference box
+  const value = `circle(${keyword} at ${x}px ${y}px)`;
   refbox.style.clipPath = value;
+
+  // Update the displayed declaration text and marker position
   declaration.textContent = `clip-path: ${value};`;
   marker.style.left = `${refbox.offsetLeft + x}px`;
   marker.style.top = `${refbox.offsetTop + y}px`;
@@ -273,9 +333,13 @@ checkSupport();
 update();
 ```
 
-Change the position of the center and the keyword used to see their relative effects.
+#### Result
 
-{{EmbedLiveSample("circle-keywords-interactive", "", "620px")}}
+Change the position of the center and the keyword used to see their relative effects.
+Note that the reference box, together with the selected radius keyword and position, is used to calculate the clipping circle.
+This circle can extend beyond the reference box (for example, with `closest-corner` or `farthest-corner`); the `.fill` gradient is deliberately sized larger than the reference box so that it always fully covers the clipped circle, however far it extends.
+
+{{EmbedLiveSample("circle-keywords-interactive", "", "640px")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/basic-shape/circle/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/circle/index.md
@@ -31,6 +31,10 @@ clip-path: circle(closest-side at 5rem 6rem);
 clip-path: circle(farthest-side);
 ```
 
+```css interactive-example-choice
+clip-path: circle(closest-corner at 70% 70%);
+```
+
 ```html interactive-example
 <section class="default-example" id="default-example">
   <div class="transition-all" id="example-element"></div>
@@ -60,11 +64,15 @@ border-shape: circle(60%);
 ### Values
 
 - `<shape-radius>`
-  - : This may be a {{cssxref("length")}}, or a {{cssxref("percentage")}} or values `closest-side` and `farthest-side`.
+  - : This may be a {{cssxref("length")}}, a {{cssxref("percentage")}}, or any of the following keyword values:
     - `closest-side`
-      - : Uses the length from the center of the shape to the closest side of the reference box. For circles, this is the closest side in any dimension.
+      - : The radius is the length from the center of the circle to the closest side of the reference box, so that the circle's boundary just touches that side.
     - `farthest-side`
-      - : Uses the length from the center of the shape to the farthest side of the reference box. For circles, this is the farthest side in any dimension.
+      - : The radius is the length from the center of the circle to the farthest side of the reference box, so that the circle's boundary just touches that side.
+    - `closest-corner`
+      - : The radius is the length from the center of the circle to the closest corner of the reference box, so that the circle passes through that corner.
+    - `farthest-corner`
+      - : The radius is the length from the center of the circle to the farthest corner of the reference box, so that the circle passes through that corner.
 
 - `<position>`
   - : Moves the center of the circle. May be a {{cssxref("length")}}, or a {{cssxref("percentage")}}, or a values such as `left`. The `<position>` value defaults to center if omitted.
@@ -109,6 +117,166 @@ img {
 ```
 
 {{EmbedLiveSample("circle", "", "300px")}}
+
+### Radius keyword interactive example
+
+This example allows you to test the effect of moving the center point of the circle when using each of the four `<shape-radius>` keywords.
+
+The code defines a reference box (`#refbox`) that contains a `.fill` element.
+We set a `clip-path` on `#refbox` to clip the box and the fill to the computed circle (the colored circle is the fill's gradient, clipped to a circle geometry).
+The geometry that is used depends on the selected radius keyword and the position of the center within the reference box.
+
+Because `closest-corner` and `farthest-corner` are a newer addition to `circle()`, the code feature-tests each keyword with {{domxref("CSS.supports_static", "CSS.supports()")}} before enabling it.
+Any keyword your browser doesn't support is disabled in the dropdown (and labeled "not supported").
+
+```html live-sample___circle-keywords-interactive
+<div class="controls">
+  <label>
+    Shape radius:
+    <select id="radius-keyword">
+      <option value="closest-side">closest-side</option>
+      <option value="closest-corner">closest-corner</option>
+      <option value="farthest-side">farthest-side</option>
+      <option value="farthest-corner" selected>farthest-corner</option>
+    </select>
+  </label>
+  <label>
+    Position X: <input type="range" id="pos-x" min="0" max="200" value="120" />
+  </label>
+  <label>
+    Position Y: <input type="range" id="pos-y" min="0" max="120" value="40" />
+  </label>
+</div>
+
+<p id="support-note"></p>
+
+<div class="canvas">
+  <div class="outline"></div>
+  <div class="refbox" id="refbox">
+    <div class="fill"></div>
+  </div>
+  <div class="outline"></div>
+  <div class="center-marker" id="center-marker"></div>
+</div>
+
+<pre id="declaration"></pre>
+```
+
+```css live-sample___circle-keywords-interactive
+body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: center;
+}
+
+.canvas {
+  position: relative;
+  width: 640px;
+  height: 480px;
+  overflow: hidden;
+  border: 1px solid #888;
+}
+
+.outline,
+.refbox {
+  position: absolute;
+  top: 180px;
+  left: 220px;
+  width: 200px;
+  height: 120px;
+}
+
+.outline {
+  border: 3px dashed #e6007a;
+  pointer-events: none;
+}
+
+.fill {
+  position: absolute;
+  inset: -240px;
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
+}
+
+.center-marker {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: white;
+  border: 2px solid black;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+#support-note {
+  color: #b3001b;
+}
+```
+
+```js live-sample___circle-keywords-interactive
+const select = document.getElementById("radius-keyword");
+const posX = document.getElementById("pos-x");
+const posY = document.getElementById("pos-y");
+const refbox = document.getElementById("refbox");
+const declaration = document.getElementById("declaration");
+const marker = document.getElementById("center-marker");
+const supportNote = document.getElementById("support-note");
+
+// Feature-test each keyword, since closest-corner/farthest-corner are a
+// newer addition to circle() and may not be supported everywhere yet.
+function checkSupport() {
+  const unsupported = [];
+  for (const option of select.options) {
+    if (!CSS.supports("clip-path", `circle(${option.value} at 0px 0px)`)) {
+      option.disabled = true;
+      option.textContent += " (not supported)";
+      unsupported.push(option.value);
+    }
+  }
+  if (unsupported.length > 0) {
+    supportNote.textContent = `Your browser doesn't support: ${unsupported.join(", ")}.`;
+  }
+  if (select.selectedOptions[0]?.disabled) {
+    const firstSupported = [...select.options].find(
+      (option) => !option.disabled,
+    );
+    if (firstSupported) {
+      select.value = firstSupported.value;
+    }
+  }
+}
+
+function update() {
+  const keyword = select.value;
+  const x = Number(posX.value);
+  const y = Number(posY.value);
+  const value = `circle(${keyword} at ${x}px ${y}px)`;
+
+  // Set the clip path when the keyword or center position changes
+  refbox.style.clipPath = value;
+  declaration.textContent = `clip-path: ${value};`;
+  marker.style.left = `${refbox.offsetLeft + x}px`;
+  marker.style.top = `${refbox.offsetTop + y}px`;
+}
+
+select.addEventListener("change", update);
+posX.addEventListener("input", update);
+posY.addEventListener("input", update);
+checkSupport();
+update();
+```
+
+Change the position of the center and the keyword used to see their relative effects.
+
+{{EmbedLiveSample("circle-keywords-interactive", "", "620px")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/basic-shape/circle/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/circle/index.md
@@ -176,7 +176,7 @@ The `.outline` element must be placed after `#refbox` in the markup: since it is
 
 #### CSS
 
-The CSS for the canvas, reference box and fill elements are shown below.
+The CSS for the canvas, reference box, and fill elements is shown below.
 Note that the `.fill` defines a gradient that overflows the reference box, filling most of the canvas.
 This is the gradient that we will clip using the `circle()` (we do this by setting the CSS clip path dynamically in our JavaScript code).
 
@@ -268,10 +268,9 @@ body {
 
 #### JavaScript
 
-The JavaScript for the example is shown below.
 First we get handles to each of the elements used by the example.
 
-Then we define `checkSupport()` method to feature-test whether each radius keyword is supported and enable/disable the associated selection options.
+Then we define the `checkSupport()` function used to feature-test whether each radius keyword is supported and enable/disable the associated selection options.
 This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
 
 ```js live-sample___circle-keywords-interactive
@@ -335,7 +334,7 @@ update();
 
 #### Result
 
-Change the position of the center and the keyword used to see their relative effects.
+Change the position of the circle center and the keyword used to see their relative effects.
 Note that the reference box, together with the selected radius keyword and position, is used to calculate the clipping circle.
 This circle can extend beyond the reference box (for example, with `closest-corner` or `farthest-corner`); the `.fill` gradient is deliberately sized larger than the reference box so that it always fully covers the clipped circle, however far it extends.
 

--- a/files/en-us/web/css/reference/values/basic-shape/circle/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/circle/index.md
@@ -270,9 +270,6 @@ body {
 
 First we get handles to each of the elements used by the example.
 
-Then we define the `checkSupport()` function used to feature-test whether each radius keyword is supported and enable/disable the associated selection options.
-This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
-
 ```js live-sample___circle-keywords-interactive
 const select = document.getElementById("radius-keyword");
 const posX = document.getElementById("pos-x");
@@ -281,8 +278,12 @@ const refbox = document.getElementById("refbox");
 const declaration = document.getElementById("declaration");
 const marker = document.getElementById("center-marker");
 const supportNote = document.getElementById("support-note");
+```
 
-// Feature-test each keyword
+Then we define the `checkSupport()` function used to feature-test whether each radius keyword is supported and enable/disable the associated selection options.
+This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
+
+```js live-sample___circle-keywords-interactive
 function checkSupport() {
   const unsupported = [];
   for (const option of select.options) {

--- a/files/en-us/web/css/reference/values/basic-shape/circle/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/circle/index.md
@@ -230,8 +230,7 @@ const declaration = document.getElementById("declaration");
 const marker = document.getElementById("center-marker");
 const supportNote = document.getElementById("support-note");
 
-// Feature-test each keyword, since closest-corner/farthest-corner are a
-// newer addition to circle() and may not be supported everywhere yet.
+// Feature-test each keyword
 function checkSupport() {
   const unsupported = [];
   for (const option of select.options) {

--- a/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
@@ -70,7 +70,7 @@ An ellipse is essentially a squashed circle and so `ellipse()` acts in a very si
 ### Values
 
 - `<shape-radius>`
-  - : Two radii, x and y in that order. These may be a {{cssxref("length")}}, a {{cssxref("percentage")}}, or any of the following keyword values:
+  - : Two radii, x and y, in that order. These may be a {{cssxref("length")}}, a {{cssxref("percentage")}}, or any of the following keyword values:
     - `closest-side`
       - : The radius is the length from the center of the ellipse to the closest side of the reference box in the given radius direction, so that the ellipse's boundary just touches that side.
     - `farthest-side`

--- a/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
@@ -326,9 +326,6 @@ body {
 
 First we get handles to each of the elements used by the example.
 
-Then we define a `checkSupport()` function to feature-test whether each radius keyword is supported and enable/disable the associated options in both dropdowns.
-This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
-
 ```js live-sample___ellipse-keywords-interactive
 const selectX = document.getElementById("radius-x-keyword");
 const selectY = document.getElementById("radius-y-keyword");
@@ -338,9 +335,12 @@ const refbox = document.getElementById("refbox");
 const declaration = document.getElementById("declaration");
 const marker = document.getElementById("center-marker");
 const supportNote = document.getElementById("support-note");
+```
 
-// Feature-test each keyword, since closest-corner/farthest-corner are a
-// newer addition to ellipse() and may not be supported everywhere yet.
+Then we define a `checkSupport()` function to feature-test whether each radius keyword is supported and enable/disable the associated options in both dropdowns.
+This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
+
+```js live-sample___ellipse-keywords-interactive
 function checkSupport() {
   const unsupported = new Set();
   for (const option of selectX.options) {

--- a/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
@@ -166,56 +166,105 @@ body {
 
 This example allows you to test the effect of moving the center point of the ellipse when using each of the four `<shape-radius>` keywords — chosen independently for the x-radius and the y-radius.
 
-The code defines a reference box (`#refbox`) that contains a `.fill` element.
-We set a `clip-path` on `#refbox` to clip the box and the fill to the computed ellipse (the colored ellipse is the fill's gradient, clipped to an ellipse geometry).
-The geometry that is used depends on the selected x-radius and y-radius keywords and the position of the center within the reference box.
-
 Because `closest-corner` and `farthest-corner` are a newer addition to `ellipse()`, the script feature-tests each keyword with {{domxref("CSS.supports_static", "CSS.supports()")}} before enabling it.
 Any keyword your browser doesn't yet support is disabled in both dropdowns (and labeled "not supported").
 
+#### HTML
+
+The HTML first defines controls for selecting the x-radius and y-radius keywords and setting the position where the ellipse is to be displayed, followed by a {{htmlelement("pre")}} element for displaying the {{cssxref("clip-path")}} that the control values select.
+After this a `#support-note` element is provided for indicating when particular radius keywords are not supported.
+
 ```html live-sample___ellipse-keywords-interactive
 <div class="controls">
-  <label>
-    X radius:
-    <select id="radius-x-keyword">
-      <option value="closest-side">closest-side</option>
-      <option value="closest-corner">closest-corner</option>
-      <option value="farthest-side">farthest-side</option>
-      <option value="farthest-corner" selected>farthest-corner</option>
-    </select>
-  </label>
-  <label>
-    Y radius:
-    <select id="radius-y-keyword">
-      <option value="closest-side">closest-side</option>
-      <option value="closest-corner">closest-corner</option>
-      <option value="farthest-side" selected>farthest-side</option>
-      <option value="farthest-corner">farthest-corner</option>
-    </select>
-  </label>
-  <label>
-    Position X: <input type="range" id="pos-x" min="0" max="200" value="120" />
-  </label>
-  <label>
-    Position Y: <input type="range" id="pos-y" min="0" max="120" value="40" />
-  </label>
+  <div class="controls-row">
+    <label>
+      X radius:
+      <select id="radius-x-keyword">
+        <option value="closest-side">closest-side</option>
+        <option value="closest-corner">closest-corner</option>
+        <option value="farthest-side">farthest-side</option>
+        <option value="farthest-corner" selected>farthest-corner</option>
+      </select>
+    </label>
+    <label>
+      Y radius:
+      <select id="radius-y-keyword">
+        <option value="closest-side">closest-side</option>
+        <option value="closest-corner">closest-corner</option>
+        <option value="farthest-side" selected>farthest-side</option>
+        <option value="farthest-corner">farthest-corner</option>
+      </select>
+    </label>
+  </div>
+  <div class="controls-row">
+    <label>
+      Position X:
+      <input type="range" id="pos-x" min="0" max="200" value="120" />
+    </label>
+    <label>
+      Position Y:
+      <input type="range" id="pos-y" min="0" max="120" value="40" />
+    </label>
+  </div>
 </div>
 
-<p id="support-note"></p>
+<pre id="declaration"></pre>
 
+<p id="support-note"></p>
+```
+
+The HTML then defines a number of {{htmlelement("div")}} elements that are used to render the ellipse, reference box and center marker.
+The most important elements are the reference box (`#refbox`) and the `.fill` element it contains, which define the gradient that is drawn (as discussed in the following CSS section).
+A `clipPath` is set on the reference box in JavaScript to clip that gradient to an elliptical shape.
+
+```html live-sample___ellipse-keywords-interactive
 <div class="canvas">
-  <div class="outline"></div>
   <div class="refbox" id="refbox">
     <div class="fill"></div>
   </div>
   <div class="outline"></div>
   <div class="center-marker" id="center-marker"></div>
 </div>
-
-<pre id="declaration"></pre>
 ```
 
+Note that the `.outline` and `.center-marker` are provided to make it easier to see the reference box and the center of the clipping ellipse, which would otherwise be invisible.
+The `.outline` element must be placed after `#refbox` in the markup: since it isn't clipped itself, painting it after the reference box means its dashed border always renders on top of the `.fill` gradient, even when the clipping ellipse extends beyond the reference box.
+
+#### CSS
+
+The CSS for the canvas, reference box and fill elements are shown below.
+Note that the `.fill` defines a gradient that overflows the reference box, filling most of the canvas.
+This is the gradient that we will clip using the `ellipse()` function (we do this by setting the CSS clip path dynamically in our JavaScript code).
+
 ```css live-sample___ellipse-keywords-interactive
+.canvas {
+  position: relative;
+  width: 640px;
+  height: 480px;
+  overflow: hidden;
+  border: 1px solid #888;
+}
+
+.refbox {
+  position: absolute;
+  top: 180px;
+  left: 220px;
+  width: 200px;
+  height: 120px;
+  box-sizing: border-box;
+}
+
+.fill {
+  position: absolute;
+  inset: -240px;
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
+}
+```
+
+The CSS for the controls and other elements is not shown, as it isn't needed to understand the `ellipse()` method.
+Interested readers can view it in the example playground.
+
+```css live-sample___ellipse-keywords-interactive hidden
 body {
   display: flex;
   flex-direction: column;
@@ -225,37 +274,31 @@ body {
 
 .controls {
   display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.controls-row {
+  display: flex;
   flex-wrap: wrap;
   gap: 20px;
   align-items: center;
 }
+```
 
-.canvas {
-  position: relative;
-  width: 640px;
-  height: 480px;
-  overflow: hidden;
-  border: 1px solid #888;
-}
-
-.outline,
-.refbox {
+```css live-sample___ellipse-keywords-interactive hidden
+.outline {
   position: absolute;
   top: 180px;
   left: 220px;
   width: 200px;
   height: 120px;
+  box-sizing: border-box;
 }
 
 .outline {
   border: 3px dashed #e6007a;
   pointer-events: none;
-}
-
-.fill {
-  position: absolute;
-  inset: -240px;
-  background: linear-gradient(to bottom right, #ff5522, #0055ff);
 }
 
 .center-marker {
@@ -269,10 +312,23 @@ body {
   pointer-events: none;
 }
 
+#declaration {
+  margin: 0;
+}
+
 #support-note {
+  margin: 0;
   color: #b3001b;
 }
 ```
+
+#### JavaScript
+
+The JavaScript for the example is shown below.
+First we get handles to each of the elements used by the example.
+
+Then we define `checkSupport()` to feature-test whether each radius keyword is supported and enable/disable the associated options in both dropdowns.
+This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
 
 ```js live-sample___ellipse-keywords-interactive
 const selectX = document.getElementById("radius-x-keyword");
@@ -314,16 +370,23 @@ function checkSupport() {
     supportNote.textContent = `Your browser doesn't support: ${[...unsupported].join(", ")}.`;
   }
 }
+```
 
+Next we define an `update()` function that is called whenever the input controls are changed.
+This sets the clip path on the reference box based on the selected x-radius and y-radius keywords and position, and moves the center marker to match.
+
+```js live-sample___ellipse-keywords-interactive
 function update() {
   const xKeyword = selectX.value;
   const yKeyword = selectY.value;
   const x = Number(posX.value);
   const y = Number(posY.value);
-  const value = `ellipse(${xKeyword} ${yKeyword} at ${x}px ${y}px)`;
 
-  // Set the clip path when either keyword or the center position changes
+  // Build the clip-path value and apply it to the reference box
+  const value = `ellipse(${xKeyword} ${yKeyword} at ${x}px ${y}px)`;
   refbox.style.clipPath = value;
+
+  // Update the displayed declaration text and marker position
   declaration.textContent = `clip-path: ${value};`;
   marker.style.left = `${refbox.offsetLeft + x}px`;
   marker.style.top = `${refbox.offsetTop + y}px`;
@@ -337,7 +400,11 @@ checkSupport();
 update();
 ```
 
+#### Result
+
 Change the position of the center and the keyword for each radius to see their relative effects.
+Note that the reference box, together with the selected x-radius and y-radius keywords and position, is used to calculate the clipping ellipse.
+This ellipse can extend beyond the reference box (for example, with `closest-corner` or `farthest-corner`); the `.fill` gradient is deliberately sized larger than the reference box so that it always fully covers the clipped ellipse, however far it extends.
 
 {{EmbedLiveSample("ellipse-keywords-interactive", "", "680px")}}
 

--- a/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
@@ -213,7 +213,7 @@ After this a `#support-note` element is provided for indicating when particular 
 <p id="support-note"></p>
 ```
 
-The HTML then defines a number of {{htmlelement("div")}} elements that are used to render the ellipse, reference box and center marker.
+The HTML then defines several {{htmlelement("div")}} elements used to render the ellipse, reference box, and center marker.
 The most important elements are the reference box (`#refbox`) and the `.fill` element it contains, which define the gradient that is drawn (as discussed in the following CSS section).
 A `clipPath` is set on the reference box in JavaScript to clip that gradient to an elliptical shape.
 
@@ -232,7 +232,7 @@ The `.outline` element must be placed after `#refbox` in the markup: since it is
 
 #### CSS
 
-The CSS for the canvas, reference box and fill elements are shown below.
+The CSS for the canvas, reference box, and fill elements is shown below.
 Note that the `.fill` defines a gradient that overflows the reference box, filling most of the canvas.
 This is the gradient that we will clip using the `ellipse()` function (we do this by setting the CSS clip path dynamically in our JavaScript code).
 
@@ -324,10 +324,9 @@ body {
 
 #### JavaScript
 
-The JavaScript for the example is shown below.
 First we get handles to each of the elements used by the example.
 
-Then we define `checkSupport()` to feature-test whether each radius keyword is supported and enable/disable the associated options in both dropdowns.
+Then we define a `checkSupport()` function to feature-test whether each radius keyword is supported and enable/disable the associated options in both dropdowns.
 This uses the {{domxref("CSS.supports_static", "CSS.supports()")}} method to check for keyword support.
 
 ```js live-sample___ellipse-keywords-interactive

--- a/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/ellipse/index.md
@@ -27,6 +27,18 @@ clip-path: ellipse(closest-side closest-side at 5rem 6rem);
 clip-path: ellipse(closest-side farthest-side);
 ```
 
+```css interactive-example-choice
+clip-path: ellipse(closest-corner closest-corner at 25% 25%);
+```
+
+```css interactive-example-choice
+clip-path: ellipse(closest-side closest-corner at 25% 25%);
+```
+
+```css interactive-example-choice
+clip-path: ellipse(closest-side farthest-corner at 25% 25%);
+```
+
 ```html interactive-example
 <section class="default-example" id="default-example">
   <div class="transition-all" id="example-element"></div>
@@ -58,11 +70,15 @@ An ellipse is essentially a squashed circle and so `ellipse()` acts in a very si
 ### Values
 
 - `<shape-radius>`
-  - : Two radii, x and y in that order. These may be a {{cssxref("length")}}, or a {{cssxref("percentage")}} or values `closest-side` and `farthest-side`.
+  - : Two radii, x and y in that order. These may be a {{cssxref("length")}}, a {{cssxref("percentage")}}, or any of the following keyword values:
     - `closest-side`
-      - : Uses the length from the center of the shape to the closest side of the reference box. For ellipses, this is the closest side in the radius dimension.
+      - : The radius is the length from the center of the ellipse to the closest side of the reference box in the given radius direction, so that the ellipse's boundary just touches that side.
     - `farthest-side`
-      - : Uses the length from the center of the shape to the farthest side of the reference box. For ellipses, this is the farthest side in the radius dimension.
+      - : The radius is the length from the center of the ellipse to the farthest side of the reference box in the given radius direction, so that the ellipse's boundary just touches that side.
+    - `closest-corner`
+      - : The radius is the length from the center of the ellipse to the closest corner of the reference box in the given radius direction.
+    - `farthest-corner`
+      - : The radius is the length from the center of the ellipse to the farthest corner of the reference box in the given radius direction.
 
 - `<position>`
   - : Moves the center of the ellipse. May be a {{cssxref("length")}}, or a {{cssxref("percentage")}}, or a values such as `left`. The `<position>` value defaults to center if omitted.
@@ -145,6 +161,185 @@ body {
 ```
 
 {{EmbedLiveSample("ellipse-keywords", "", "300px")}}
+
+### Radius keyword interactive example
+
+This example allows you to test the effect of moving the center point of the ellipse when using each of the four `<shape-radius>` keywords — chosen independently for the x-radius and the y-radius.
+
+The code defines a reference box (`#refbox`) that contains a `.fill` element.
+We set a `clip-path` on `#refbox` to clip the box and the fill to the computed ellipse (the colored ellipse is the fill's gradient, clipped to an ellipse geometry).
+The geometry that is used depends on the selected x-radius and y-radius keywords and the position of the center within the reference box.
+
+Because `closest-corner` and `farthest-corner` are a newer addition to `ellipse()`, the script feature-tests each keyword with {{domxref("CSS.supports_static", "CSS.supports()")}} before enabling it.
+Any keyword your browser doesn't yet support is disabled in both dropdowns (and labeled "not supported").
+
+```html live-sample___ellipse-keywords-interactive
+<div class="controls">
+  <label>
+    X radius:
+    <select id="radius-x-keyword">
+      <option value="closest-side">closest-side</option>
+      <option value="closest-corner">closest-corner</option>
+      <option value="farthest-side">farthest-side</option>
+      <option value="farthest-corner" selected>farthest-corner</option>
+    </select>
+  </label>
+  <label>
+    Y radius:
+    <select id="radius-y-keyword">
+      <option value="closest-side">closest-side</option>
+      <option value="closest-corner">closest-corner</option>
+      <option value="farthest-side" selected>farthest-side</option>
+      <option value="farthest-corner">farthest-corner</option>
+    </select>
+  </label>
+  <label>
+    Position X: <input type="range" id="pos-x" min="0" max="200" value="120" />
+  </label>
+  <label>
+    Position Y: <input type="range" id="pos-y" min="0" max="120" value="40" />
+  </label>
+</div>
+
+<p id="support-note"></p>
+
+<div class="canvas">
+  <div class="outline"></div>
+  <div class="refbox" id="refbox">
+    <div class="fill"></div>
+  </div>
+  <div class="outline"></div>
+  <div class="center-marker" id="center-marker"></div>
+</div>
+
+<pre id="declaration"></pre>
+```
+
+```css live-sample___ellipse-keywords-interactive
+body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  align-items: center;
+}
+
+.canvas {
+  position: relative;
+  width: 640px;
+  height: 480px;
+  overflow: hidden;
+  border: 1px solid #888;
+}
+
+.outline,
+.refbox {
+  position: absolute;
+  top: 180px;
+  left: 220px;
+  width: 200px;
+  height: 120px;
+}
+
+.outline {
+  border: 3px dashed #e6007a;
+  pointer-events: none;
+}
+
+.fill {
+  position: absolute;
+  inset: -240px;
+  background: linear-gradient(to bottom right, #ff5522, #0055ff);
+}
+
+.center-marker {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: white;
+  border: 2px solid black;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+#support-note {
+  color: #b3001b;
+}
+```
+
+```js live-sample___ellipse-keywords-interactive
+const selectX = document.getElementById("radius-x-keyword");
+const selectY = document.getElementById("radius-y-keyword");
+const posX = document.getElementById("pos-x");
+const posY = document.getElementById("pos-y");
+const refbox = document.getElementById("refbox");
+const declaration = document.getElementById("declaration");
+const marker = document.getElementById("center-marker");
+const supportNote = document.getElementById("support-note");
+
+// Feature-test each keyword, since closest-corner/farthest-corner are a
+// newer addition to ellipse() and may not be supported everywhere yet.
+function checkSupport() {
+  const unsupported = new Set();
+  for (const option of selectX.options) {
+    const test = `ellipse(${option.value} ${option.value} at 0px 0px)`;
+    if (!CSS.supports("clip-path", test)) {
+      unsupported.add(option.value);
+    }
+  }
+  for (const select of [selectX, selectY]) {
+    for (const option of select.options) {
+      if (unsupported.has(option.value)) {
+        option.disabled = true;
+        option.textContent += " (not supported)";
+      }
+    }
+    if (select.selectedOptions[0]?.disabled) {
+      const firstSupported = [...select.options].find(
+        (option) => !option.disabled,
+      );
+      if (firstSupported) {
+        select.value = firstSupported.value;
+      }
+    }
+  }
+  if (unsupported.size > 0) {
+    supportNote.textContent = `Your browser doesn't support: ${[...unsupported].join(", ")}.`;
+  }
+}
+
+function update() {
+  const xKeyword = selectX.value;
+  const yKeyword = selectY.value;
+  const x = Number(posX.value);
+  const y = Number(posY.value);
+  const value = `ellipse(${xKeyword} ${yKeyword} at ${x}px ${y}px)`;
+
+  // Set the clip path when either keyword or the center position changes
+  refbox.style.clipPath = value;
+  declaration.textContent = `clip-path: ${value};`;
+  marker.style.left = `${refbox.offsetLeft + x}px`;
+  marker.style.top = `${refbox.offsetTop + y}px`;
+}
+
+selectX.addEventListener("change", update);
+selectY.addEventListener("change", update);
+posX.addEventListener("input", update);
+posY.addEventListener("input", update);
+checkSupport();
+update();
+```
+
+Change the position of the center and the keyword for each radius to see their relative effects.
+
+{{EmbedLiveSample("ellipse-keywords-interactive", "", "680px")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/basic-shape/index.md
+++ b/files/en-us/web/css/reference/values/basic-shape/index.md
@@ -72,9 +72,10 @@ The parameters common across the syntax of some basic shape functions include:
   - : Defines rounded corners for [rectangles by container insets](#syntax_for_rectangles_by_container_insets), [rectangles by distance](#syntax_for_rectangles_by_distance), and [rectangles with dimensions](#syntax_for_rectangles_with_dimensions) using the same syntax as the CSS {{cssxref("border-radius")}} shorthand property.
 
 - `<shape-radius>`
-  - : Defines the radius for a [circle](#syntax_for_circles) or an [ellipse](#syntax_for_ellipses). Valid values include {{cssxref("length")}}, {{cssxref("percentage")}}, `closest-side` (the default), and `farthest-side`. Negative values are invalid.
+  - : Defines the radius for a [circle](#syntax_for_circles) or an [ellipse](#syntax_for_ellipses). Valid values include {{cssxref("length")}}, {{cssxref("percentage")}}, `closest-side` (the default), `farthest-side`, `closest-corner`, and `farthest-corner`. Negative values are invalid.
 
     The `closest-side` keyword value uses the length from the center of the shape to the closest side of the reference box to create the radius length. The `farthest-side` keyword value uses the length from the center of the shape to the farthest side of the reference box.
+    Similarly, the `closest-corner` and `farthest-corner` use the length from the center of the shape to the closest and farthest corners, respectively.
 
 - `<position>`
   - : Defines the center {{cssxref("&lt;position&gt;")}} of a [circle](#syntax_for_circles) or an [ellipse](#syntax_for_ellipses). It defaults to `center` if omitted.


### PR DESCRIPTION
FF153 adds support for the `farthest-corner` and `closest-corner` radius values for [`ellipse()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/basic-shape/ellipse) and [`circle()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/basic-shape/circle) in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=2037673

This updates the docs to include the feature. It adds the two new keywords, and an example that allows you to see the effect of selecting the keywords and also moving the center of the circle within its reference box.

Related docs work can be tracked in #44459