### PR TITLE
Fix a/an usage

### DIFF
--- a/files/en-us/glossary/boolean/html/index.md
+++ b/files/en-us/glossary/boolean/html/index.md
@@ -16,7 +16,7 @@ If the attribute is present, it can have one of the following forms:
 > [!NOTE]
 > The strings "true" and "false" are invalid values. To set the attribute to `false`, the attribute should be omitted altogether. Though modern browsers treat _any_ string value as `true`, you should not rely on that behavior.
 
-Here's an example of a HTML boolean attribute `checked`:
+Here's an example of an HTML boolean attribute `checked`:
 
 ```html
 <!-- The following checkboxes will be checked on initial rendering -->

--- a/files/en-us/glossary/markup/index.md
+++ b/files/en-us/glossary/markup/index.md
@@ -16,7 +16,7 @@ Within a text file such as an HTML file, elements are _marked up_ using {{glossa
 - **Procedural Markup:**
   - : Combined with text to provide instructions on text processing to programs. This text is visibly manipulated by the author.
 - **Descriptive Markup:**
-  - : Labels sections of documents as to how the program should handle them. For example, the HTML {{HTMLElement("td")}} defines a cell in a HTML table.
+  - : Labels sections of documents as to how the program should handle them. For example, the HTML {{HTMLElement("td")}} defines a cell in an HTML table.
 
 ## See also
 

--- a/files/en-us/glossary/xhtml/index.md
+++ b/files/en-us/glossary/xhtml/index.md
@@ -19,7 +19,7 @@ The following example shows an HTML document and corresponding "XHTML" document,
     <title>HTML</title>
   </head>
   <body>
-    <p>I am a HTML document</p>
+    <p>I am an HTML document</p>
   </body>
 </html>
 ```

--- a/files/en-us/web/api/cssfontfeaturevaluesmap/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesmap/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CSSFontFeatureValuesMap
 
 The **`CSSFontFeatureValuesMap`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents an iterable and read-only set of the [CSSFontFeatureValuesRule](/en-US/docs/Web/API/CSSFontFeatureValuesRule) properties, such as [`swash`](/en-US/docs/Web/API/CSSFontFeatureValuesRule/swash), [`annotation`](/en-US/docs/Web/API/CSSFontFeatureValuesRule/annotation), [`ornaments`](/en-US/docs/Web/API/CSSFontFeatureValuesRule/ornaments), etc.
 
-An `CSSFontFeatureValuesMap` instance is a read-only [Map-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is the user-defined name used to reference a font feature, and the corresponding value is the index for the font feature within the font.
+A `CSSFontFeatureValuesMap` instance is a read-only [Map-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis), in which each key is the user-defined name used to reference a font feature, and the corresponding value is the index for the font feature within the font.
 
 ## Instance properties
 

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -80,7 +80,7 @@ execCommand(commandName, showDefaultUI, valueArgument)
     - `insertHorizontalRule`
       - : Inserts a {{HTMLElement("hr")}} element at the insertion point, or replaces the selection with it.
     - `insertHTML`
-      - : Inserts an {{domxref("TrustedHTML")}} instance or string of HTML markup at the insertion point (deletes selection).
+      - : Inserts a {{domxref("TrustedHTML")}} instance or string of HTML markup at the insertion point (deletes selection).
         This requires valid HTML markup.
 
         > [!WARNING]

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -44,7 +44,7 @@ This is to prevent a potential security vulnerability ([mutation XSS](https://ww
 
 ### Shadow DOM considerations
 
-The serialization of the DOM tree read from the property does not include {{glossary("shadow tree", "shadow roots")}} — if you want to get a HTML string that includes shadow roots, you must instead use the {{domxref("Element.getHTML()")}} or {{domxref("ShadowRoot.getHTML()")}} methods.
+The serialization of the DOM tree read from the property does not include {{glossary("shadow tree", "shadow roots")}} — if you want to get an HTML string that includes shadow roots, you must instead use the {{domxref("Element.getHTML()")}} or {{domxref("ShadowRoot.getHTML()")}} methods.
 
 Similarly, when setting element content using `innerHTML`, the HTML string is parsed into DOM elements that do not contain shadow roots.
 So for example [`<template>`](/en-US/docs/Web/HTML/Reference/Elements/template) is parsed into as {{domxref("HTMLTemplateElement")}}, whether or not the [`shadowrootmode`](/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode) attribute is specified.

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -50,7 +50,7 @@ You could add a key/value pair to this using {{domxref("FormData.append", "appen
 formData.append("username", "Chris");
 ```
 
-### Prepopulating from a HTML form element
+### Prepopulating from an HTML form element
 
 You can specify the optional `form` and `submitter` arguments when creating the `FormData` object, to prepopulate it with values from the specified form.
 

--- a/files/en-us/web/api/htmliframeelement/srcdoc/index.md
+++ b/files/en-us/web/api/htmliframeelement/srcdoc/index.md
@@ -25,7 +25,7 @@ Getting the property returns a string containing the HTML serialization of the f
 This is `undefined` if the value is not set.
 
 Setting the property accepts either a {{domxref("TrustedHTML")}} object or a string.
-It parses this input as a HTML document and replaces the content of the frame with the result.
+It parses this input as an HTML document and replaces the content of the frame with the result.
 
 ### Exceptions
 

--- a/files/en-us/web/api/htmlmetaelement/index.md
+++ b/files/en-us/web/api/htmlmetaelement/index.md
@@ -17,7 +17,7 @@ This interface inherits all of the properties and methods described in the {{dom
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{HTMLElement("meta#charset")}}
-  - : The character encoding for a HTML document.
+  - : The character encoding for an HTML document.
 - {{domxref("HTMLMetaElement.content")}}
   - : The 'value' part of the name-value pairs of the document metadata.
 - {{domxref("HTMLMetaElement.httpEquiv")}}

--- a/files/en-us/web/api/idbindex/getallrecords/index.md
+++ b/files/en-us/web/api/idbindex/getallrecords/index.md
@@ -72,7 +72,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 This example queries an {{domxref("IDBIndex")}} for up to 100 records whose `lastName` values come after `"Smith"`, with results sorted in reverse order.
 
 The code first creates a transaction on an {{domxref("IDBDatabase")}} named `db` (omitting the code to open the database), and then uses it to get an {{domxref("IDBObjectStore")}} containing a contacts list, and from that an `IDBIndex` on the `lastName` property.
-It then calls `getAllRecords()` on the index, returning a {{domxref("IDBRequest")}} instance.
+It then calls `getAllRecords()` on the index, returning an {{domxref("IDBRequest")}} instance.
 Event listeners are added to this request for the `success` and `error` events.
 On success, the result `event.target.result` is logged (this is also available as `request.result`).
 This result contains an array of `IDBRecord` instances.

--- a/files/en-us/web/api/idbobjectstore/getallrecords/index.md
+++ b/files/en-us/web/api/idbobjectstore/getallrecords/index.md
@@ -73,7 +73,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 This example queries an {{domxref("IDBObjectStore")}} for up to 100 records whose keys come after `"myKey"`, with results sorted in reverse order.
 
 The code first creates a transaction on an {{domxref("IDBDatabase")}} named `db` (omitting the code to open the database), and then uses it to get an `IDBObjectStore` containing a contacts list.
-It then calls `getAllRecords()` on the object store, returning a {{domxref("IDBRequest")}} instance.
+It then calls `getAllRecords()` on the object store, returning an {{domxref("IDBRequest")}} instance.
 Event listeners are added to this request for the `success` and `error` events.
 On success, the result `event.target.result` is logged (this also available as `request.result`).
 This result contains an array of `IDBRecord` instances.

--- a/files/en-us/web/api/idbrecord/index.md
+++ b/files/en-us/web/api/idbrecord/index.md
@@ -35,7 +35,7 @@ _None._
 This example queries an {{domxref("IDBObjectStore")}} for up to 100 records whose keys come after `"myKey"`, with results sorted in reverse order.
 
 The code first creates a transaction on an {{domxref("IDBDatabase")}} named `db` (omitting the code to open the database), and then uses it to get an `IDBObjectStore` containing a contacts list.
-It then calls `getAllRecords()` on the object store, returning a {{domxref("IDBRequest")}} instance.
+It then calls `getAllRecords()` on the object store, returning an {{domxref("IDBRequest")}} instance.
 Event listeners are added to this request for the `success` and `error` events.
 On success, the result `event.target.result` is logged (this is also available as `request.result`).
 This result contains an array of `IDBRecord` instances.

--- a/files/en-us/web/api/performance/interactioncount/index.md
+++ b/files/en-us/web/api/performance/interactioncount/index.md
@@ -16,7 +16,7 @@ This is useful when calculating {{Glossary("Interaction_to_next_paint", "Interac
 
 ## Value
 
-A number, which is initially `0`, and increments by `1` with each discrete interaction as measured by {{domxref("PerformanceEventTiming")}}, where an {{domxref("PerformanceEventTiming.interactionId")}} is assigned.
+A number, which is initially `0`, and increments by `1` with each discrete interaction as measured by {{domxref("PerformanceEventTiming")}}, where an {{domxref("PerformanceEventTiming.interactionId", "interactionId")}} is assigned.
 
 ## Examples
 

--- a/files/en-us/web/api/webcodecs_api/codec_selection/index.md
+++ b/files/en-us/web/api/webcodecs_api/codec_selection/index.md
@@ -170,7 +170,7 @@ AAC encoding is universally supported on Safari versions that support {{domxref(
 
 ### MP3 and PCM
 
-MP3 and PCM are not widely supported as encoding targets, with MP3 encoding not currently supported by any major browser. PCM (uncompressed audio) is available as a {{domxref("AudioData")}} format for raw audio processing, but support for encoding with `AudioEncoder` is limited.
+MP3 and PCM are not widely supported as encoding targets, with MP3 encoding not currently supported by any major browser. PCM (uncompressed audio) is available as an {{domxref("AudioData")}} format for raw audio processing, but support for encoding with `AudioEncoder` is limited.
 
 ### Audio codec string reference
 

--- a/files/en-us/web/api/webcodecs_api/index.md
+++ b/files/en-us/web/api/webcodecs_api/index.md
@@ -41,7 +41,7 @@ The only difference is that it has one additional field: `type`, which can be "k
 
 ### Audio
 
-An `AudioData` object represents a number of individual audio samples (1024 is a typical number). Audio sample data can be extracted as a {{jsxref("Float32Array")}} via the `copyTo` method. There is no direct integration with the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API); however, the extracted `Float32Array` samples can be copied directly into a {{domxref("AudioBuffer")}} for playback.
+An `AudioData` object represents a number of individual audio samples (1024 is a typical number). Audio sample data can be extracted as a {{jsxref("Float32Array")}} via the `copyTo` method. There is no direct integration with the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API); however, the extracted `Float32Array` samples can be copied directly into an {{domxref("AudioBuffer")}} for playback.
 
 Likewise, the `EncodedAudioChunk` represents the encoded (compressed) version of an `AudioData` object, containing compressed audio sample data.
 

--- a/files/en-us/web/http/guides/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/guides/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -73,7 +73,7 @@ Next, you should configure your server to map the .pac filename extension to the
 
 > [!NOTE]
 >
-> - The JavaScript function should always be saved to a file by itself but not be embedded in a HTML file or any other file.
+> - The JavaScript function should always be saved to a file by itself but not be embedded in an HTML file or any other file.
 > - The examples at the end of this document are complete. There is no additional syntax needed to save it into a file and use it. (Of course, the JavaScripts must be edited to reflect your site's domain name and/or subnets.)
 
 ## Predefined functions and environment

--- a/files/en-us/web/http/reference/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/script-src/index.md
@@ -195,7 +195,7 @@ Policies for inline resources with hashes like `script-src 'sha256-{HASHED_INLIN
 ```
 
 Instead of allowing `'unsafe-inline'`, you can use the `'unsafe-hashes'` source expression if code can't be updated to equivalent {{domxref("EventTarget.addEventListener", "addEventListener")}} calls.
-Given a HTML page that includes the following inline event handler:
+Given an HTML page that includes the following inline event handler:
 
 ```html
 <!-- I want to use addEventListener, but I can't :( -->

--- a/files/en-us/web/javascript/reference/statements/import/with/index.md
+++ b/files/en-us/web/javascript/reference/statements/import/with/index.md
@@ -114,7 +114,7 @@ Failed to load module script: Expected a JavaScript module script but the server
 
 #### CSS Modules (`{ type: "css" }`)
 
-The HTML spec defines the `css` type, which imports a stylesheet into a script as an {{domxref("CSSStyleSheet")}} object.
+The HTML spec defines the `css` type, which imports a stylesheet into a script as a {{domxref("CSSStyleSheet")}} object.
 
 The code below shows how you might import a style and add it to your document.
 The import will throw an exception if `example_styles.css` is served with any media type other than `"text/css"`.

--- a/files/en-us/web/mathml/guides/authoring/index.md
+++ b/files/en-us/web/mathml/guides/authoring/index.md
@@ -234,7 +234,7 @@ After running that command, a file `output.html` containing the following HTML o
 There are more sophisticated tools that aim at converting an arbitrary LaTeX document into a document with MathML content. For example, using [LaTeXML](https://math.nist.gov/~BMiller/LaTeXML/) the following commands will convert `foo.tex` into an HTML or EPUB document:
 
 ```bash
-latexmlc --dest foo.html foo.tex # Generate a HTML document foo.html
+latexmlc --dest foo.html foo.tex # Generate an HTML document foo.html
 latexmlc --dest foo.epub foo.tex # Generate an EPUB document foo.epub
 ```
 

--- a/files/en-us/web/mathml/tutorials/for_beginners/getting_started/index.md
+++ b/files/en-us/web/mathml/tutorials/for_beginners/getting_started/index.md
@@ -153,7 +153,7 @@ As an exercise, figure out how to write the following expressions using only the
 
 ## Summary
 
-In this article, we have taken a look at how to use the `<math>` element to insert a mathematical formula inside a HTML document. We have learned about rendering differences between `<math>` elements that use `display="block"` or not. In addition, we stumbled upon a couple of other MathML elements: `<mfrac>` for fractions, `<mrow>` for grouping and finally a few text elements. We will analyze these [text containers](/en-US/docs/Web/MathML/Tutorials/For_beginners/Text_containers) further in the next article.
+In this article, we have taken a look at how to use the `<math>` element to insert a mathematical formula inside an HTML document. We have learned about rendering differences between `<math>` elements that use `display="block"` or not. In addition, we stumbled upon a couple of other MathML elements: `<mfrac>` for fractions, `<mrow>` for grouping and finally a few text elements. We will analyze these [text containers](/en-US/docs/Web/MathML/Tutorials/For_beginners/Text_containers) further in the next article.
 
 ## See also
 

--- a/files/en-us/web/security/defenses/local_network_access/index.md
+++ b/files/en-us/web/security/defenses/local_network_access/index.md
@@ -99,7 +99,7 @@ Some addresses, such as private IP literals (for example, `192.168.0.1`) and `.l
 
 You can control access to local and loopback addresses at the document level using the {{httpheader('Permissions-Policy/local-network','local-network')}} and {{httpheader('Permissions-Policy/loopback-network','loopback-network')}} {{httpheader('Permissions-Policy')}} directives.
 
-The default allowlist for these directives is `self`, which means that requests will be allowed in the current document and embedded browsing contexts in the same origin only. To allow local or loopback requests at the document level for a particular origin, use these directives in an `Permissions-Policy` HTTP header:
+The default allowlist for these directives is `self`, which means that requests will be allowed in the current document and embedded browsing contexts in the same origin only. To allow local or loopback requests at the document level for a particular origin, use these directives in a `Permissions-Policy` HTTP header:
 
 ```http
 Permissions-Policy: local-network=("https://example.com")

--- a/files/en-us/web/security/threat_modeling/index.md
+++ b/files/en-us/web/security/threat_modeling/index.md
@@ -214,7 +214,7 @@ In our threat modeling above, we focus on the four key questions as defined in t
 
 ## See also
 
-- [Threat model frameworks an resources](/en-US/docs/Web/Security/Threat_modeling/Frameworks)
+- [Threat model frameworks and resources](/en-US/docs/Web/Security/Threat_modeling/Frameworks)
 - [Example threat model](/en-US/docs/Web/Security/Threat_modeling/Example_threat_model)
 - [Security](/en-US/docs/Web/Security)
 - [Threat Modeling Manifesto](https://www.threatmodelingmanifesto.org)

--- a/files/en-us/web/xml/xslt/guides/common_errors/index.md
+++ b/files/en-us/web/xml/xslt/guides/common_errors/index.md
@@ -7,7 +7,7 @@ sidebar: xmlsidebar
 
 ## MIME types
 
-Your server needs to send both the source and the stylesheet with a XML mime type, `text/xml` or `application/xml`. To find out the current type, load the file in Mozilla and look at the page info. Or use a download tool, those usually tell the mime type.
+Your server needs to send both the source and the stylesheet with an XML mime type, `text/xml` or `application/xml`. To find out the current type, load the file in Mozilla and look at the page info. Or use a download tool, those usually tell the mime type.
 
 In Firefox 6 and forward, you can also use the official XSLT mimetype: `application/xslt+xml`.
 

--- a/files/en-us/webassembly/guides/rust_to_wasm/index.md
+++ b/files/en-us/webassembly/guides/rust_to_wasm/index.md
@@ -345,7 +345,7 @@ wasm.greet("WebAssembly with npm");
 
 This imports the module from the `node_modules` folder and calls the `greet` function, passing `"WebAssembly with npm"` as a string. Note how there's nothing special here, yet we're calling into Rust code. As far as the JavaScript code can tell, this is just a normal module.
 
-Finally, we need to add a HTML file to load the JavaScript. Create an `index.html` file and add the following:
+Finally, we need to add an HTML file to load the JavaScript. Create an `index.html` file and add the following:
 
 ```html
 <!doctype html>

--- a/files/en-us/webassembly/reference/javascript_interface/exception/exception/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/exception/exception/index.md
@@ -68,7 +68,7 @@ For a working example, see the [`throw`](/en-US/docs/WebAssembly/Reference/Excep
 
 ### Manual usage
 
-This example shows manual creation of an `WebAssembly.Exception` instance.
+This example shows manual creation of a `WebAssembly.Exception` instance.
 
 ```js
 // Create tag and use it to create an exception

--- a/files/en-us/webassembly/reference/numeric/ne/index.md
+++ b/files/en-us/webassembly/reference/numeric/ne/index.md
@@ -71,7 +71,7 @@ value_type.ne
 - `input2`
   - : The second input value.
 - `output`
-  - : An value indicating whether the two input values are not equal.
+  - : A value indicating whether the two input values are not equal.
 
 For a non-SIMD `ne`, the input values will be basic numeric values such as `3` or `3.5`. If the two input values are not equal, `1` will be pushed on to the stack as an output, otherwise `0` will be pushed on to the stack.
 

--- a/files/en-us/webassembly/reference/simd/bitwise/any_true/index.md
+++ b/files/en-us/webassembly/reference/simd/bitwise/any_true/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.simd.any_true
 sidebar: webassemblysidebar
 ---
 
-The **`any_true`** [SIMD bitwise instruction](/en-US/docs/WebAssembly/Reference/SIMD/bitwise) tests whether an `v128` input value contains any non-zero bits.
+The **`any_true`** [SIMD bitwise instruction](/en-US/docs/WebAssembly/Reference/SIMD/bitwise) tests whether a `v128` input value contains any non-zero bits.
 
 {{InteractiveExample("Wat Demo: any_true", "tabbed-taller")}}
 


### PR DESCRIPTION
Fixes indefinite article usage before vowel-sound initialisms: "a HTML" → "an HTML" in 12 pages and "a XML" → "an XML" in the XSLT common errors guide.

Affected pages include glossary entries (boolean/HTML, markup, XHTML), `Element.innerHTML`, the `FormData` constructor, `HTMLIFrameElement.srcdoc`, `HTMLMetaElement`, the PAC file guide, CSP `script-src`, both MathML guides, and the Rust-to-Wasm tutorial.

Grammar-only change; no content changes.