### PR TITLE
Use American English: "labelled" → "labeled", "artefact" → "artifact"

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/grids/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/grids/index.md
@@ -43,7 +43,7 @@ A grid is a collection of horizontal and vertical lines creating a pattern again
 
 A grid will typically have **columns**, **rows**, and then gaps between each row and column. The gaps are commonly referred to as **gutters**.
 
-![CSS grid with parts labelled as rows, columns and gutters. Rows are the horizontal segments of the grid and Columns are the vertical segments of the grid. The space between two rows is called as 'row gutter' and the space between 2 columns is called as 'column gutter'.](grid.png)
+![CSS grid with parts labeled as rows, columns and gutters. Rows are the horizontal segments of the grid and Columns are the vertical segments of the grid. The space between two rows is called as 'row gutter' and the space between 2 columns is called as 'column gutter'.](grid.png)
 
 ## Creating your grid in CSS
 

--- a/files/en-us/learn_web_development/core/structuring_content/debugging_html/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/debugging_html/index.md
@@ -95,7 +95,7 @@ You can open the devtools in a similar way in each browser — see [How to open 
 For this article, the only relevant devtools function is the **DOM inspector**, which shows the currently-rendered HTML DOM and allows you to edit it. Let's look at this now:
 
 1. Open the devtools in your browser.
-2. Open the DOM inspector. It is in the same place in each browser — the first tab in the devtools at the start of the row. In Firefox it is labelled _Inspector_, while in Safari, Edge, and Chrome it is labeled _Elements_. This should be the tab selected by default when you first open the devtools, but select it if it isn't.
+2. Open the DOM inspector. It is in the same place in each browser — the first tab in the devtools at the start of the row. In Firefox it is labeled _Inspector_, while in Safari, Edge, and Chrome it is labeled _Elements_. This should be the tab selected by default when you first open the devtools, but select it if it isn't.
 3. Examine the DOM tree structure shown in the tab, and note how you can click the little expansion arrows at the start of each DOM node to expand and collapse them and reveal their descendant nodes. You can also use the up and down cursor keys to move up and down the nodes, and the right and left cursor keys to expand and collapse the nodes.
 4. Also try hovering over the nodes (or selecting them with the cursor keys) and note how the currently-hovered (or selected) element is highlighted in the viewport.
 5. You can also edit the rendered DOM. We won't use the editing functionality in this article, but take some time to look up how to do this if you are curious.

--- a/files/en-us/learn_web_development/extensions/client-side_apis/client-side_storage/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/client-side_storage/index.md
@@ -143,7 +143,7 @@ Let's apply this new-found knowledge by writing a working example to give you an
 
 You can find the example HTML at [personal-greeting.html](https://github.com/mdn/learning-area/blob/main/javascript/apis/client-side-storage/web-storage/personal-greeting.html) — this contains a website with a header, content, and footer, and a form for entering your name.
 
-![A Screenshot of a website that has a header, content and footer sections. The header has a welcome text to the left-hand side and a button labelled 'forget' to the right-hand side. The content has a heading followed by a two paragraphs of dummy text. The footer reads 'Copyright nobody. Use the code as you like'.](web-storage-demo.png)
+![A Screenshot of a website that has a header, content and footer sections. The header has a welcome text to the left-hand side and a button labeled 'forget' to the right-hand side. The content has a heading followed by a two paragraphs of dummy text. The footer reads 'Copyright nobody. Use the code as you like'.](web-storage-demo.png)
 
 Let's build up the example, so you can understand how it works.
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/delete_author_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/delete_author_form/index.md
@@ -149,7 +149,7 @@ p
 
 The control should now appear as a link, as shown below on the _Author detail_ page.
 
-![The Author details section of the Local library application. The left column has a vertical navigation bar. The right section contains the author details with a heading that has the Author's name followed by the life dates of the author and lists the books written by the author below it. There is a button labelled 'Delete Author' at the bottom.](locallibary_express_author_detail_delete.png)
+![The Author details section of the Local library application. The left column has a vertical navigation bar. The right section contains the author details with a heading that has the Author's name followed by the life dates of the author and lists the books written by the author below it. There is a button labeled 'Delete Author' at the bottom.](locallibary_express_author_detail_delete.png)
 
 ## What does it look like?
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/update_book_form/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/forms/update_book_form/index.md
@@ -159,7 +159,7 @@ Run the application, open your browser to `http://localhost:3000/`, select the _
 
 The form should look just like the _Create book_ page, only with a title of 'Update book', and pre-populated with record values.
 
-![The update book section of the Local library application. The left column has a vertical navigation bar. The right column has a form to update the book with a heading that reads 'Update book'. There are five input fields labelled Title, Author, Summary, ISBN, Genre. Genre is a checkbox option field. There is a button labelled 'Submit' at the end.](locallibary_express_book_update_noerrors.png)
+![The update book section of the Local library application. The left column has a vertical navigation bar. The right column has a form to update the book with a heading that reads 'Update book'. There are five input fields labeled Title, Author, Summary, ISBN, Genre. Genre is a checkbox option field. There is a button labeled 'Submit' at the end.](locallibary_express_book_update_noerrors.png)
 
 > [!NOTE]
 > The other pages for updating objects can be implemented in much the same way. We've left that as a challenge.

--- a/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
+++ b/files/en-us/learn_web_development/getting_started/web_standards/how_the_web_works/index.md
@@ -42,7 +42,7 @@ This theory is not essential to writing web code in the short term, but before l
 
 Computers connected to the internet are called **clients** and **servers**. A simplified diagram of how they interact might look like this:
 
-![Two circles representing client and server. An arrow labelled request is going from client to server, and an arrow labelled responses is going from server to client](simple-client-server.png)
+![Two circles representing client and server. An arrow labeled request is going from client to server, and an arrow labeled responses is going from server to client](simple-client-server.png)
 
 - Clients are the typical web user's internet-connected devices (for example, your computer connected to your Wi-Fi, or your phone connected to your mobile network) and web-accessing software available on those devices (usually a web browser like Firefox or Chrome).
 - Servers are computers that store webpages, sites, or apps. When a client wants to access a webpage, a copy of the webpage code is downloaded from the server to the client machine, where it is rendered by the browser and displayed to the user.

--- a/files/en-us/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
+++ b/files/en-us/learn_web_development/getting_started/your_first_website/styling_the_content/index.md
@@ -200,7 +200,7 @@ Let's return to our example and use CSS to improve the appearance of the text. W
 
 Something you'll notice about CSS as you use it more is that a lot of it is about boxes. Most HTML elements on a page can be thought of as boxes that sit on top of (or alongside) other boxes. You can set values on these boxes for size, color, positioning, etc. This is referred to as [**the box model**](/en-US/docs/Learn_web_development/Core/Styling_basics/Box_model).
 
-![Three boxes sat inside one another. From outside to in they are labelled margin, border and padding](box-model.png)
+![Three boxes sat inside one another. From outside to in they are labeled margin, border and padding](box-model.png)
 
 Each box that takes up space on your page has properties like:
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -83,7 +83,7 @@ console.log(numberFormat.format(654321.987));
 
 Use the `format` getter function for formatting all numbers in an array.
 Note that the function is bound to the {{jsxref("Intl.NumberFormat")}} from which it was obtained, so it can be passed directly to {{jsxref("Array.prototype.map")}}.
-This is considered a historical artefact, as part of a convention which is no longer followed for new features, but is preserved to maintain compatibility with existing programs.
+This is considered a historical artifact, as part of a convention which is no longer followed for new features, but is preserved to maintain compatibility with existing programs.
 
 ```js
 const a = [123456.789, 987654.321, 456789.123];

--- a/files/en-us/web/security/defenses/certificate_transparency/index.md
+++ b/files/en-us/web/security/defenses/certificate_transparency/index.md
@@ -11,7 +11,7 @@ In this way, certificate authorities (CAs) can be subject to much greater public
 
 ## Background
 
-CT logs are built upon the foundation of the _Merkle tree_ data structure. Nodes are labelled with the _cryptographic hashes_ of their child nodes. Leaf nodes contain hashes of actual pieces of data. The label of the root node therefore depends on all other nodes in the tree.
+CT logs are built upon the foundation of the _Merkle tree_ data structure. Nodes are labeled with the _cryptographic hashes_ of their child nodes. Leaf nodes contain hashes of actual pieces of data. The label of the root node therefore depends on all other nodes in the tree.
 
 In the context of certificate transparency, the data hashed by the leaf nodes are the certificates that have been issued by the various different CAs operating today. Certificate inclusion can be verified via an _audit proof_ which can be generated and verified efficiently, in logarithmic O(log n) time.
 


### PR DESCRIPTION
Per the [writing style guide](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#spelling), MDN uses American English spelling.

- "labelled" → "labeled" in 8 pages (prose and image alt text in Learn web development and the Certificate Transparency guide)
- "artefact" → "artifact" in the `Intl.NumberFormat.prototype.format()` docs

Deliberately excluded: verbatim Firefox error messages ("functions cannot be labelled"), `aria-labelledby` contexts, the `favourite-colour` example extension, and the style guide's own incorrect-spelling examples.

Spelling-only change; no content changes.