### PR TITLE
CSS value intro sentence position

### DIFF
--- a/files/en-us/web/css/reference/properties/all/index.md
+++ b/files/en-us/web/css/reference/properties/all/index.md
@@ -79,9 +79,9 @@ all: revert;
 all: revert-layer;
 ```
 
-The `all` property is specified as one of the CSS global keyword values. Note that none of these values affect the {{cssxref("unicode-bidi")}} and {{cssxref("direction")}} properties.
-
 ### Values
+
+The `all` property is specified as one of the CSS global keyword values. Note that none of these values affect the {{cssxref("unicode-bidi")}} and {{cssxref("direction")}} properties.
 
 - {{cssxref("initial")}}
   - : Specifies that all the element's properties should be changed to their [initial values](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#initial_value).

--- a/files/en-us/web/css/reference/properties/animation-iteration-count/index.md
+++ b/files/en-us/web/css/reference/properties/animation-iteration-count/index.md
@@ -129,7 +129,7 @@ animation-iteration-count: unset;
 
 ### Values
 
-The **`animation-iteration-count`** property is specified as one or more comma-separated values.
+This property is specified as one or more comma-separated values:
 
 - `infinite`
   - : The animation will repeat forever.

--- a/files/en-us/web/css/reference/properties/animation-iteration-count/index.md
+++ b/files/en-us/web/css/reference/properties/animation-iteration-count/index.md
@@ -127,9 +127,9 @@ animation-iteration-count: revert-layer;
 animation-iteration-count: unset;
 ```
 
-The **`animation-iteration-count`** property is specified as one or more comma-separated values.
-
 ### Values
+
+The **`animation-iteration-count`** property is specified as one or more comma-separated values.
 
 - `infinite`
   - : The animation will repeat forever.

--- a/files/en-us/web/css/reference/properties/animation-range/index.md
+++ b/files/en-us/web/css/reference/properties/animation-range/index.md
@@ -52,9 +52,9 @@ animation-range: revert-layer;
 animation-range: unset;
 ```
 
-The `animation-range` shorthand property is specified as one or more single animation ranges, separated by commas. Each animation range is specified as one to four space separated values composed of `<timeline-range-name>` values, `<length-percentage>` values, and/or the keyword `normal`.
-
 ### Values
+
+The `animation-range` shorthand property is specified as one or more single animation ranges, separated by commas. Each animation range is specified as one to four space separated values composed of `<timeline-range-name>` values, `<length-percentage>` values, and/or the keyword `normal`.
 
 - `<animation-range-start>`
   - : The keyword `normal`, a `<length-percentage>`, a {{cssxref("timeline-range-name")}}, or a `<timeline-range-name> <length-percentage>` pair, representing the {{cssxref("animation-range-start")}}. If a `<timeline-range-name>` is set without a `<length-percentage>`, the `<length-percentage>` defaults to `0%`.

--- a/files/en-us/web/css/reference/properties/aspect-ratio/index.md
+++ b/files/en-us/web/css/reference/properties/aspect-ratio/index.md
@@ -7,9 +7,7 @@ browser-compat: css.properties.aspect-ratio
 sidebar: cssref
 ---
 
-The **`aspect-ratio`** [CSS](/en-US/docs/Web/CSS) property allows you to define the desired width-to-height ratio of an element's box. This means that even if the parent container or viewport size changes, the browser will adjust the element's dimensions to maintain the specified width-to-height ratio. The specified {{glossary("aspect ratio")}} is used in the calculation of auto sizes and some other layout functions.
-
-At least one of the box's sizes needs to be automatic in order for `aspect-ratio` to have any effect. If neither the width nor height is an automatic size, then the provided aspect ratio has no effect on the box's preferred sizes.
+The **`aspect-ratio`** [CSS](/en-US/docs/Web/CSS) property allows you to define the desired width-to-height ratio of an element's box.
 
 {{InteractiveExample("CSS Demo: aspect-ratio")}}
 
@@ -65,11 +63,9 @@ aspect-ratio: revert-layer;
 aspect-ratio: unset;
 ```
 
-This property is specified as one or both of the keyword auto or a `<ratio>`. If both are given, and the element is a {{ glossary("replaced elements", "replaced element")}}, such as [`<img>`](/en-US/docs/Web/HTML/Reference/Elements/img), then the given ratio is used until the content is loaded. After the content is loaded, the `auto` value is applied, so the intrinsic aspect ratio of the loaded content is used.
-
-If the element is not a replaced element, then the given `ratio` is used.
-
 ### Values
+
+This property is specified as one or both of the keyword auto or a `<ratio>`.
 
 - `auto`
   - : {{glossary("Replaced elements")}} with an intrinsic aspect ratio use _that_ aspect ratio, otherwise the box has no preferred aspect ratio. Size calculations involving intrinsic aspect ratio always work with the content box dimensions.
@@ -79,6 +75,16 @@ If the element is not a replaced element, then the given `ratio` is used.
 
 - `auto && <ratio>`
   - : When both `auto` and a `<ratio>` are specified together, `auto` is used if the element is a replaced element with a natural aspect ratio, like an `<img>` element. Otherwise, the specified ratio of `width` / `height` is used as the preferred aspect ratio.
+
+## Description
+
+The `aspect-ratio` property defines a desired width-to-height ratio of an element's box. This means that even if the parent container or viewport size changes, the browser will adjust the element's dimensions to maintain the specified width-to-height ratio. The specified {{glossary("aspect ratio")}} is used in the calculation of auto sizes and some other layout functions.
+
+At least one of the box's sizes needs to be automatic in order for `aspect-ratio` to have any effect. If neither the width nor height is an automatic size, then the provided aspect ratio has no effect on the box's preferred sizes.
+
+This property is specified as one or both of the keyword auto or a `<ratio>`. If both are given, and the element is a {{ glossary("replaced elements", "replaced element")}}, such as [`<img>`](/en-US/docs/Web/HTML/Reference/Elements/img), then the given ratio is used until the content is loaded. After the content is loaded, the `auto` value is applied, so the intrinsic aspect ratio of the loaded content is used.
+
+If the element is not a replaced element, then the given `ratio` is used.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/aspect-ratio/index.md
+++ b/files/en-us/web/css/reference/properties/aspect-ratio/index.md
@@ -65,7 +65,7 @@ aspect-ratio: unset;
 
 ### Values
 
-This property is specified as one or both of the keyword auto or a `<ratio>`.
+This property is specified as one or both of the keyword `auto` or a `<ratio>`.
 
 - `auto`
   - : {{glossary("Replaced elements")}} with an intrinsic aspect ratio use _that_ aspect ratio, otherwise the box has no preferred aspect ratio. Size calculations involving intrinsic aspect ratio always work with the content box dimensions.

--- a/files/en-us/web/css/reference/properties/backface-visibility/index.md
+++ b/files/en-us/web/css/reference/properties/backface-visibility/index.md
@@ -94,9 +94,9 @@ backface-visibility: revert-layer;
 backface-visibility: unset;
 ```
 
-The `backface-visibility` property is specified as one of the keywords listed below.
-
 ### Values
+
+The `backface-visibility` property is specified as one of the following keywords listed:
 
 - `visible`
   - : The back face is visible when turned towards the user.

--- a/files/en-us/web/css/reference/properties/backface-visibility/index.md
+++ b/files/en-us/web/css/reference/properties/backface-visibility/index.md
@@ -96,7 +96,7 @@ backface-visibility: unset;
 
 ### Values
 
-The `backface-visibility` property is specified as one of the following keywords listed:
+This property is specified as one of the following keywords:
 
 - `visible`
   - : The back face is visible when turned towards the user.

--- a/files/en-us/web/css/reference/properties/background-color/index.md
+++ b/files/en-us/web/css/reference/properties/background-color/index.md
@@ -84,9 +84,9 @@ background-color: revert-layer;
 background-color: unset;
 ```
 
-The `background-color` property is specified as a single `<color>` value.
-
 ### Values
+
+The `background-color` property is specified as a single `<color>` value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The uniform color of the background. It is rendered behind any {{cssxref("background-image")}} that is specified, although the color will still be visible through any transparency in the image.

--- a/files/en-us/web/css/reference/properties/background-color/index.md
+++ b/files/en-us/web/css/reference/properties/background-color/index.md
@@ -86,7 +86,7 @@ background-color: unset;
 
 ### Values
 
-The `background-color` property is specified as a single `<color>` value:
+This property is specified as a single `<color>` value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The uniform color of the background. It is rendered behind any {{cssxref("background-image")}} that is specified, although the color will still be visible through any transparency in the image.

--- a/files/en-us/web/css/reference/properties/background-color/index.md
+++ b/files/en-us/web/css/reference/properties/background-color/index.md
@@ -86,7 +86,7 @@ background-color: unset;
 
 ### Values
 
-This property is specified as a single `<color>` value:
+This property is specified as one `<color>` value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The uniform color of the background. It is rendered behind any {{cssxref("background-image")}} that is specified, although the color will still be visible through any transparency in the image.

--- a/files/en-us/web/css/reference/properties/background-image/index.md
+++ b/files/en-us/web/css/reference/properties/background-image/index.md
@@ -67,20 +67,20 @@ background-image: revert-layer;
 background-image: unset;
 ```
 
-Each background image is specified either as the keyword `none` or as an {{cssxref("image")}} value.
-
-To specify multiple background images, supply multiple values, separated by a comma.
-
 ### Values
+
+This property is specified as the keyword `none` or as a comma-separated list of {{cssxref("image")}} values.
 
 - `none`
   - : Is a keyword denoting the absence of images.
 - `<image>`
-  - : Is an {{cssxref("image")}} denoting the image to display. There can be several of them, separated by commas, as [multiple backgrounds](/en-US/docs/Web/CSS/Guides/Backgrounds_and_borders/Using_multiple_backgrounds) are supported.
+  - : Is an {{cssxref("image")}} denoting the image to display.
 
 ## Description
 
-The background images are drawn on stacking context layers on top of each other. The first layer specified is drawn as if it is closest to the user.
+The `background-image` property sets background images on an element.
+
+You can define [multiple backgrounds](/en-US/docs/Web/CSS/Guides/Backgrounds_and_borders/Using_multiple_backgrounds) on an element by specifying a list of comma-separated image. The background images are drawn on stacking context layers on top of each other. The first layer specified is drawn as if it is closest to the user.
 
 The [borders](/en-US/docs/Web/CSS/Reference/Properties/border) of the element are then drawn on top of them, and the {{cssxref("background-color")}} is drawn beneath them. How the images are drawn relative to the box and its borders is defined by the {{cssxref("background-clip")}} and {{cssxref("background-origin")}} CSS properties.
 

--- a/files/en-us/web/css/reference/properties/background-origin/index.md
+++ b/files/en-us/web/css/reference/properties/background-origin/index.md
@@ -62,9 +62,9 @@ background-origin: revert-layer;
 background-origin: unset;
 ```
 
-The `background-origin` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `border-box`
   - : The background is positioned relative to the border box.

--- a/files/en-us/web/css/reference/properties/background-position-x/index.md
+++ b/files/en-us/web/css/reference/properties/background-position-x/index.md
@@ -79,9 +79,9 @@ background-position-x: revert-layer;
 background-position-x: unset;
 ```
 
-The `background-position-x` property is specified as one or more values, separated by commas.
-
 ### Values
+
+This property is specified as one or more comma-separated values:
 
 - `left`
   - : Aligns the left edge of the background image with the left edge of the background position layer.

--- a/files/en-us/web/css/reference/properties/background-position-y/index.md
+++ b/files/en-us/web/css/reference/properties/background-position-y/index.md
@@ -79,9 +79,9 @@ background-position-y: revert-layer;
 background-position-y: unset;
 ```
 
-The `background-position-y` property is specified as one or more values, separated by commas.
-
 ### Values
+
+This property is specified as one or more comma-separated values:
 
 - `top`
   - : Aligns the top edge of the background image with the top edge of the background position layer.

--- a/files/en-us/web/css/reference/properties/border-bottom-color/index.md
+++ b/files/en-us/web/css/reference/properties/border-bottom-color/index.md
@@ -69,9 +69,9 @@ border-bottom-color: revert-layer;
 border-bottom-color: unset;
 ```
 
-The `border-bottom-color` property is specified as a single value.
-
 ### Values
+
+This property is specified as one value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the bottom border.

--- a/files/en-us/web/css/reference/properties/border-collapse/index.md
+++ b/files/en-us/web/css/reference/properties/border-collapse/index.md
@@ -72,9 +72,9 @@ border-collapse: revert-layer;
 border-collapse: unset;
 ```
 
-The `border-collapse` property is specified as a single keyword, which may be chosen from the list below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `collapse`
   - : Adjacent cells have shared borders (the collapsed-border table rendering model).

--- a/files/en-us/web/css/reference/properties/border-left-color/index.md
+++ b/files/en-us/web/css/reference/properties/border-left-color/index.md
@@ -69,9 +69,9 @@ border-left-color: revert-layer;
 border-left-color: unset;
 ```
 
-The `border-left-color` property is specified as a single value.
-
 ### Values
+
+This property is specified as one value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the left border.

--- a/files/en-us/web/css/reference/properties/border-right-color/index.md
+++ b/files/en-us/web/css/reference/properties/border-right-color/index.md
@@ -69,9 +69,9 @@ border-right-color: revert-layer;
 border-right-color: unset;
 ```
 
-The `border-right-color` property is specified as a single value.
-
 ### Values
+
+This property is specified as one value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the right border.

--- a/files/en-us/web/css/reference/properties/border-top-color/index.md
+++ b/files/en-us/web/css/reference/properties/border-top-color/index.md
@@ -69,9 +69,9 @@ border-top-color: revert-layer;
 border-top-color: unset;
 ```
 
-The `border-top-color` property is specified as a single value.
-
 ### Values
+
+This property is specified as a single value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the top border.

--- a/files/en-us/web/css/reference/properties/border-top-color/index.md
+++ b/files/en-us/web/css/reference/properties/border-top-color/index.md
@@ -71,7 +71,7 @@ border-top-color: unset;
 
 ### Values
 
-This property is specified as a single value:
+This property is specified as one `<color>` value:
 
 - {{cssxref("&lt;color&gt;")}}
   - : The color of the top border.

--- a/files/en-us/web/css/reference/properties/box-align/index.md
+++ b/files/en-us/web/css/reference/properties/box-align/index.md
@@ -37,9 +37,9 @@ box-lines: initial;
 box-lines: unset;
 ```
 
-The `box-align` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `start`
   - : The box aligns contents at the start, leaving any extra space at the end.

--- a/files/en-us/web/css/reference/properties/box-decoration-break/index.md
+++ b/files/en-us/web/css/reference/properties/box-decoration-break/index.md
@@ -65,9 +65,9 @@ box-decoration-break: revert-layer;
 box-decoration-break: unset;
 ```
 
-The `box-decoration-break` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `slice`
   - : The element is initially rendered as if its box were not fragmented, after which the rendering for this hypothetical box is sliced into pieces for each line/column/page. Note that the hypothetical box can be different for each fragment since it uses its own height if the break occurs in the inline direction, and its own width if the break occurs in the block direction. See the CSS specification for details.

--- a/files/en-us/web/css/reference/properties/box-direction/index.md
+++ b/files/en-us/web/css/reference/properties/box-direction/index.md
@@ -32,9 +32,9 @@ box-direction: revert-layer;
 box-direction: unset;
 ```
 
-The `box-direction` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `normal`
   - : The box lays out its contents from the start (the left or top edge).

--- a/files/en-us/web/css/reference/properties/box-lines/index.md
+++ b/files/en-us/web/css/reference/properties/box-lines/index.md
@@ -40,9 +40,9 @@ box-lines: initial;
 box-lines: unset;
 ```
 
-The `box-lines` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `single`
   - : Box elements lay out in a single row or column.

--- a/files/en-us/web/css/reference/properties/box-orient/index.md
+++ b/files/en-us/web/css/reference/properties/box-orient/index.md
@@ -32,9 +32,9 @@ box-orient: initial;
 box-orient: unset;
 ```
 
-The `box-orient` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `horizontal`
   - : The box lays out its contents horizontally.

--- a/files/en-us/web/css/reference/properties/box-pack/index.md
+++ b/files/en-us/web/css/reference/properties/box-pack/index.md
@@ -34,9 +34,9 @@ box-pack: initial;
 box-pack: unset;
 ```
 
-The `box-pack` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `start`
   - : The box packs contents at the start, leaving any extra space at the end.

--- a/files/en-us/web/css/reference/properties/caption-side/index.md
+++ b/files/en-us/web/css/reference/properties/caption-side/index.md
@@ -92,9 +92,9 @@ caption-side: revert-layer;
 caption-side: unset;
 ```
 
-The `caption-side` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `top`
   - : The caption box should be positioned at the block start side of the table.

--- a/files/en-us/web/css/reference/properties/color-scheme/index.md
+++ b/files/en-us/web/css/reference/properties/color-scheme/index.md
@@ -62,9 +62,9 @@ color-scheme: revert-layer;
 color-scheme: unset;
 ```
 
-The `color-scheme` property's value must be one of the following keywords.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `normal`
   - : Indicates that the element can be rendered using the page's [color scheme](/en-US/docs/Web/HTML/Reference/Elements/meta/name/color-scheme) settings. If the page does not have a color scheme set, the element is rendered using the page's default color settings.

--- a/files/en-us/web/css/reference/properties/column-span/index.md
+++ b/files/en-us/web/css/reference/properties/column-span/index.md
@@ -72,9 +72,9 @@ column-span: revert-layer;
 column-span: unset;
 ```
 
-The `column-span` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `none`
   - : The element does not span multiple columns.

--- a/files/en-us/web/css/reference/properties/column-width/index.md
+++ b/files/en-us/web/css/reference/properties/column-width/index.md
@@ -70,9 +70,9 @@ column-width: revert-layer;
 column-width: unset;
 ```
 
-The `column-width` property is specified as one of the values listed below.
-
 ### Values
+
+This property is specified as one of the following values:
 
 - {{cssxref("&lt;length&gt;")}}
   - : Indicates the optimal column width. The actual column width may differ from the specified value: it may be wider when necessary to fill available space, and narrower when the available space is too small. The value must be strictly positive or the declaration is invalid. Percentage values are also invalid.

--- a/files/en-us/web/css/reference/properties/empty-cells/index.md
+++ b/files/en-us/web/css/reference/properties/empty-cells/index.md
@@ -73,9 +73,9 @@ empty-cells: revert-layer;
 empty-cells: unset;
 ```
 
-The `empty-cells` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `show`
   - : Borders and backgrounds are drawn like in normal cells.

--- a/files/en-us/web/css/reference/properties/flex-grow/index.md
+++ b/files/en-us/web/css/reference/properties/flex-grow/index.md
@@ -69,9 +69,9 @@ flex-grow: revert-layer;
 flex-grow: unset;
 ```
 
-The `flex-grow` property is specified as a single `<number>`.
-
 ### Values
+
+This property is specified as a `<number>`:
 
 - `<number>`
   - : See {{cssxref("&lt;number&gt;")}}. Negative values are invalid. Defaults to 0, which prevents the flex item from growing.

--- a/files/en-us/web/css/reference/properties/float/index.md
+++ b/files/en-us/web/css/reference/properties/float/index.md
@@ -102,9 +102,9 @@ float: revert-layer;
 float: unset;
 ```
 
-The `float` property is specified as a single keyword, chosen from the list of values below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `left`
   - : The element must float on the left side of its containing block.

--- a/files/en-us/web/css/reference/properties/font-variant-numeric/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-numeric/index.md
@@ -119,12 +119,9 @@ font-variant-numeric: revert-layer;
 font-variant-numeric: unset;
 ```
 
-This property can take one of two forms:
-
-- either the keyword value `normal`
-- or one or more of the other values listed below, space-separated, in any order.
-
 ### Values
+
+This property is specified either as `normal` or a space-separated list of the following values:
 
 - `normal`
   - : This keyword leads to the deactivation of the use of such alternate glyphs.

--- a/files/en-us/web/css/reference/properties/font-variant-position/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-position/index.md
@@ -31,9 +31,9 @@ font-variant-position: revert-layer;
 font-variant-position: unset;
 ```
 
-The `font-variant-position` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `normal`
   - : Deactivates alternate superscript and subscript glyphs.

--- a/files/en-us/web/css/reference/properties/forced-color-adjust/index.md
+++ b/files/en-us/web/css/reference/properties/forced-color-adjust/index.md
@@ -24,9 +24,9 @@ forced-color-adjust: revert-layer;
 forced-color-adjust: unset;
 ```
 
-The `forced-color-adjust` property's value must be one of the following keywords.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : The element's colors are adjusted by the {{Glossary("user agent")}} in forced colors mode. This is the default value.

--- a/files/en-us/web/css/reference/properties/hyphens/index.md
+++ b/files/en-us/web/css/reference/properties/hyphens/index.md
@@ -56,9 +56,9 @@ hyphens: revert-layer;
 hyphens: unset;
 ```
 
-The `hyphens` property is specified as a single keyword value chosen from the list below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `none`
   - : Words are not broken at line breaks, even if characters inside the words suggest line break points. Lines will only wrap at whitespace.

--- a/files/en-us/web/css/reference/properties/isolation/index.md
+++ b/files/en-us/web/css/reference/properties/isolation/index.md
@@ -64,9 +64,9 @@ isolation: revert-layer;
 isolation: unset;
 ```
 
-The `isolation` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : A new stacking context is created only if one of the properties applied to the element requires it.

--- a/files/en-us/web/css/reference/properties/list-style-position/index.md
+++ b/files/en-us/web/css/reference/properties/list-style-position/index.md
@@ -84,9 +84,9 @@ list-style-position: revert-layer;
 list-style-position: unset;
 ```
 
-The `list-style-position` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `inside`
   - : The {{cssxref("::marker")}} is the first element among the list item's contents.

--- a/files/en-us/web/css/reference/properties/object-fit/index.md
+++ b/files/en-us/web/css/reference/properties/object-fit/index.md
@@ -70,9 +70,9 @@ object-fit: revert-layer;
 object-fit: unset;
 ```
 
-The `object-fit` property is specified as a single keyword chosen from the list of values below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `contain`
   - : The replaced content is scaled to maintain its {{glossary("aspect ratio")}} while fitting within the element's content box. The entire object is made to fill the box, while preserving its aspect ratio, so the object will be ["letterboxed"](<https://en.wikipedia.org/wiki/Letterboxing_(filming)>) or ["pillarboxed"](https://en.wikipedia.org/wiki/Pillarbox) if its aspect ratio does not match the aspect ratio of the box.

--- a/files/en-us/web/css/reference/properties/outline-style/index.md
+++ b/files/en-us/web/css/reference/properties/outline-style/index.md
@@ -73,9 +73,9 @@ outline-style: revert-layer;
 outline-style: unset;
 ```
 
-The `outline-style` property is specified as any one of the values listed below.
-
 ### Values
+
+This property is specified as one of the following values:
 
 - `auto`
   - : Permits the user agent to render a custom outline style.

--- a/files/en-us/web/css/reference/properties/outline-width/index.md
+++ b/files/en-us/web/css/reference/properties/outline-width/index.md
@@ -66,9 +66,9 @@ outline-width: revert-layer;
 outline-width: unset;
 ```
 
-The `outline-width` property is specified as any one of the values listed below.
-
 ### Values
+
+This property is specified as one of the following values:
 
 - {{cssxref("&lt;length&gt;")}}
   - : The width of the outline specified as a `<length>`.

--- a/files/en-us/web/css/reference/properties/overflow-inline/index.md
+++ b/files/en-us/web/css/reference/properties/overflow-inline/index.md
@@ -30,9 +30,9 @@ overflow-inline: revert-layer;
 overflow-inline: unset;
 ```
 
-The `overflow-inline` property is specified as a single {{CSSXref("overflow_value", "&lt;overflow&gt;")}} keyword value.
-
 ### Values
+
+This property is specified as one of the following {{CSSXref("overflow_value", "&lt;overflow&gt;")}} keyword values:
 
 - `visible`
   - : Content is not clipped and may be rendered outside the padding box's inline start and end edges.

--- a/files/en-us/web/css/reference/properties/overflow-wrap/index.md
+++ b/files/en-us/web/css/reference/properties/overflow-wrap/index.md
@@ -68,9 +68,9 @@ overflow-wrap: revert-layer;
 overflow-wrap: unset;
 ```
 
-The `overflow-wrap` property is specified as a single keyword chosen from the list of values below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `normal`
   - : Lines may only break at normal word break points (such as a space between two words).

--- a/files/en-us/web/css/reference/properties/overflow/index.md
+++ b/files/en-us/web/css/reference/properties/overflow/index.md
@@ -79,9 +79,9 @@ overflow: revert-layer;
 overflow: unset;
 ```
 
-The `overflow` property is specified as one or two {{CSSXref("overflow_value", "&lt;overflow&gt;")}} keyword values.
-
 ### Values
+
+This property is specified as one or two space-separated {{CSSXref("overflow_value", "&lt;overflow&gt;")}} keyword values:
 
 - `visible`
   - : Overflow content is not clipped and may be visible outside the element's padding box. The element box is not a {{glossary("scroll container")}}. This is the default value.

--- a/files/en-us/web/css/reference/properties/overscroll-behavior-block/index.md
+++ b/files/en-us/web/css/reference/properties/overscroll-behavior-block/index.md
@@ -27,9 +27,9 @@ overscroll-behavior-block: revert-layer;
 overscroll-behavior-block: unset;
 ```
 
-The `overscroll-behavior-block` property is specified as a keyword chosen from the list of values below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : The default scroll overflow behavior occurs as normal.

--- a/files/en-us/web/css/reference/properties/overscroll-behavior-inline/index.md
+++ b/files/en-us/web/css/reference/properties/overscroll-behavior-inline/index.md
@@ -27,9 +27,9 @@ overscroll-behavior-inline: revert-layer;
 overscroll-behavior-inline: unset;
 ```
 
-The `overscroll-behavior-inline` property is specified as a keyword chosen from the list of values below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : The default scroll overflow behavior occurs as normal.

--- a/files/en-us/web/css/reference/properties/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/reference/properties/overscroll-behavior-x/index.md
@@ -27,9 +27,9 @@ overscroll-behavior-x: revert-layer;
 overscroll-behavior-x: unset;
 ```
 
-The `overscroll-behavior-x` property is specified as a keyword chosen from the list of values below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : The default scroll overflow behavior occurs as normal.

--- a/files/en-us/web/css/reference/properties/print-color-adjust/index.md
+++ b/files/en-us/web/css/reference/properties/print-color-adjust/index.md
@@ -24,9 +24,9 @@ print-color-adjust: revert-layer;
 print-color-adjust: unset;
 ```
 
-The `print-color-adjust` property's value must be one of the following keywords.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `economy`
   - : The user agent is allowed to make adjustments to the element as it deems appropriate and prudent in order to optimize the output for the device it's being rendered for.

--- a/files/en-us/web/css/reference/properties/resize/index.md
+++ b/files/en-us/web/css/reference/properties/resize/index.md
@@ -73,9 +73,9 @@ resize: revert-layer;
 resize: unset;
 ```
 
-The `resize` property is specified as a single keyword value from the list below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `none`
   - : The element offers no user-controllable method for resizing it.

--- a/files/en-us/web/css/reference/properties/scroll-behavior/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-behavior/index.md
@@ -82,9 +82,9 @@ scroll-behavior: revert-layer;
 scroll-behavior: unset;
 ```
 
-The `scroll-behavior` property is specified as one of the keyword values listed below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : The scrolling box scrolls instantly.

--- a/files/en-us/web/css/reference/properties/text-align/index.md
+++ b/files/en-us/web/css/reference/properties/text-align/index.md
@@ -77,9 +77,9 @@ text-align: revert-layer;
 text-align: unset;
 ```
 
-The `text-align` property is specified as a single keyword from the list below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `start`
   - : The same as `left` if direction is left-to-right and `right` if direction is right-to-left.

--- a/files/en-us/web/css/reference/properties/text-decoration-line/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-line/index.md
@@ -85,9 +85,9 @@ text-decoration-line: revert-layer;
 text-decoration-line: unset;
 ```
 
-The `text-decoration-line` property is specified as `none`, or **one or more** space-separated values from the list below.
-
 ### Values
+
+This property is specified either as `none` or a space-separated list of keyword values:
 
 - `none`
   - : Produces no text decoration.

--- a/files/en-us/web/css/reference/properties/text-decoration-line/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-line/index.md
@@ -87,7 +87,7 @@ text-decoration-line: unset;
 
 ### Values
 
-This property is specified either as `none` or a space-separated list of keyword values:
+This property is specified either as `none` or a space-separated list of keyword values chosen from the list below:
 
 - `none`
   - : Produces no text decoration.

--- a/files/en-us/web/css/reference/properties/text-orientation/index.md
+++ b/files/en-us/web/css/reference/properties/text-orientation/index.md
@@ -50,9 +50,9 @@ text-orientation: revert-layer;
 text-orientation: unset;
 ```
 
-The `text-orientation` property is specified as a single keyword from the list below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `mixed`
   - : Rotates the characters of horizontal scripts 90° clockwise. Lays out the characters of vertical scripts naturally. Default value.

--- a/files/en-us/web/css/reference/properties/text-overflow/index.md
+++ b/files/en-us/web/css/reference/properties/text-overflow/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.text-overflow
 sidebar: cssref
 ---
 
-The **`text-overflow`** [CSS](/en-US/docs/Web/CSS) property sets how hidden overflow content is signaled to users. It can be clipped, display an ellipsis (`…`), or display a custom string.
+The **`text-overflow`** [CSS](/en-US/docs/Web/CSS) property sets how hidden overflow content is signaled to users.
 
 {{InteractiveExample("CSS Demo: text-overflow")}}
 
@@ -52,15 +52,6 @@ text-overflow: "";
 }
 ```
 
-The `text-overflow` property doesn't force an overflow to occur. To make text overflow its container, you have to set other CSS properties: {{cssxref("overflow")}} and {{cssxref("white-space")}}. For example:
-
-```css
-overflow: hidden;
-white-space: nowrap;
-```
-
-The `text-overflow` property only affects content that is overflowing a block container element in its _inline_ progression direction (not text overflowing at the bottom of a box, for example).
-
 ## Syntax
 
 ```css
@@ -76,9 +67,9 @@ text-overflow: revert-layer;
 text-overflow: unset;
 ```
 
-The `text-overflow` property may be specified using one or two values. If one value is given, it specifies overflow behavior for the end of the line (the right end for left-to-right text, the left end for right-to-left text). If two values are given, the first specifies overflow behavior for the left end of the line, and the second specifies it for the right end of the line. The property accepts either a keyword value (`clip` or `ellipsis`) or a `<string>` value.
-
 ### Values
+
+This property is specified as one or two space-separated values, including:
 
 - `clip`
   - : The default for this property. This keyword value will truncate the text at the limit of the [content area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction), therefore the truncation can happen in the middle of a character. To clip at the transition between characters you can specify `text-overflow` as an empty string, if that is supported in your target browsers: `text-overflow: '';`.
@@ -86,6 +77,21 @@ The `text-overflow` property may be specified using one or two values. If one va
   - : This keyword value will display an ellipsis (`'…'`, `U+2026 HORIZONTAL ELLIPSIS`) to represent clipped text. The ellipsis is displayed inside the [content area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction), decreasing the amount of text displayed. If there is not enough space to display the ellipsis, it is clipped.
 - `<string>`
   - : The {{cssxref("&lt;string&gt;")}} to be used to represent clipped text. The string is displayed inside the [content area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction), shortening the size of the displayed text. If there is not enough space to display the string itself, it is clipped.
+
+## Description
+
+The `text-overflow` property sets how hidden overflow content is signaled to users. It can be clipped, display an ellipsis (`…`), or display a custom string.
+
+The `text-overflow` property doesn't force an overflow to occur. To make text overflow its container, you have to set other CSS properties: {{cssxref("overflow")}} and {{cssxref("white-space")}}. For example:
+
+```css
+overflow: hidden;
+white-space: nowrap;
+```
+
+The `text-overflow` property only affects content that is overflowing a block container element in its _inline_ progression direction (not text overflowing at the bottom of a box, for example).
+
+The `text-overflow` property may be specified using one or two values. If one value is given, it specifies overflow behavior for the end of the line (the right end for left-to-right text, the left end for right-to-left text). If two values are given, the first specifies overflow behavior for the left end of the line, and the second specifies it for the right end of the line. The property accepts either a keyword value (`clip` or `ellipsis`) or a `<string>` value.
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/text-size-adjust/index.md
+++ b/files/en-us/web/css/reference/properties/text-size-adjust/index.md
@@ -35,9 +35,9 @@ text-size-adjust: revert-layer;
 text-size-adjust: unset;
 ```
 
-The `text-size-adjust` property is specified as `none`, `auto`, or a `<percentage>`.
-
 ### Values
+
+This property is specified as one of the following values:
 
 - `none`
   - : Disables the browser's inflation algorithm.

--- a/files/en-us/web/css/reference/properties/text-underline-offset/index.md
+++ b/files/en-us/web/css/reference/properties/text-underline-offset/index.md
@@ -60,9 +60,9 @@ text-underline-offset: revert-layer;
 text-underline-offset: unset;
 ```
 
-The `text-underline-offset` property is specified as a single value from the list below.
-
 ### Values
+
+This property is specified as one of the following values:
 
 - `auto`
   - : The browser chooses the appropriate offset for underlines.

--- a/files/en-us/web/css/reference/properties/text-wrap/index.md
+++ b/files/en-us/web/css/reference/properties/text-wrap/index.md
@@ -87,9 +87,9 @@ text-wrap: revert-layer;
 text-wrap: unset;
 ```
 
-The `text-wrap` property is specified as a single keyword chosen from the list of values below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `wrap`
   - : Text is wrapped across lines at appropriate characters (for example spaces, in languages like English that use space separators) to minimize overflow. This is the default value.

--- a/files/en-us/web/css/reference/properties/transform/index.md
+++ b/files/en-us/web/css/reference/properties/transform/index.md
@@ -96,9 +96,9 @@ transform: revert-layer;
 transform: unset;
 ```
 
-The `transform` property may be specified as either the keyword value `none` or as one or more `<transform-function>` values.
-
 ### Values
+
+This property is specified as either the keyword value `none` or as a space-separated list of `<transform-function>` values.
 
 - {{cssxref("&lt;transform-function&gt;")}}
   - : One or more of the [CSS transform functions](/en-US/docs/Web/CSS/Reference/Values/transform-function) to be applied.

--- a/files/en-us/web/css/reference/properties/user-modify/index.md
+++ b/files/en-us/web/css/reference/properties/user-modify/index.md
@@ -32,9 +32,9 @@ user-modify: revert;
 user-modify: unset;
 ```
 
-The `-moz-user-modify` property is specified as one of the keyword values from the list below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `read-only`
   - : Default value. Contents are read-only.

--- a/files/en-us/web/css/reference/properties/z-index/index.md
+++ b/files/en-us/web/css/reference/properties/z-index/index.md
@@ -147,9 +147,9 @@ z-index: revert-layer;
 z-index: unset;
 ```
 
-The `z-index` property is specified as either the keyword `auto` or an `<integer>`.
-
 ### Values
+
+This property is specified as one of the following values:
 
 - `auto`
   - : The box does not establish a new local stacking context. The stack level of the generated box in the current stacking context is `0`.


### PR DESCRIPTION
CSS properties include a "Values" section. 
Sometimes there is an intro to the values. sometimes there isn't.
Sometimes that intro is above the values title, sometimes it's after it.
This is the first PR in an attempt to make things consistent. This PR addresses all the properties that had a simple sentence preceding the values header that didn't need a whole bunch of other work done and three properties that had a bit more work... mainly moving descriptive text into a description section.