### PR TITLE
added FF release note for link-parameters and param()

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -406,6 +406,20 @@ The {{cssxref("sibling-count")}} and {{cssxref("sibling-index")}} function are n
 - `layout.css.tree-counting-functions.enabled`
   - : Set to `true` to enable.
 
+### Updating attributes of external recourses
+
+The {{cssxref("link-parameters")}} CSS property and {{cssxref("param")}} CSS function are now supported. This allows the user to update attributes of external resources, such as SVGs, that have their attributes set with the {{cssxref("env")}} CSS function. This means that single external resource can be used rather than creating multiple variations that only have different colors or other values. ([Firefox bug 2046153](https://bugzil.la/2046153)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 154           | Yes                 |
+| Developer Edition | 153           | No                  |
+| Beta              | 153           | No                  |
+| Release           | 153           | No                  |
+
+- `layout.css.link-parameters.enabled`
+  - : Set to `true` to enable.
+
 ## SVG
 
 **No experimental features in this release cycle.**

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -162,6 +162,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **Updating attributes of external recourses**: `layout.css.link-parameters.enabled`
 
   The {{cssxref("link-parameters")}} CSS property and {{cssxref("param")}} CSS function are now supported. This allows the user to update attributes of external resources, such as SVGs, that have their attributes set with the {{cssxref("env")}} CSS function. This means that single external resource can be used rather than creating multiple variations that only have different colors or other values. ([Firefox bug 2046153](https://bugzil.la/2046153)).
+
 - **CSS basic shapes allow `farthest-corner` and `closest-corner` keywords** (Nightly): `layout.css.ellipse-corners.enabled`
 
   The `farthest-corner` and `closest-corner` keywords can now be used for specifying the radii values of the [`ellipse()`](/en-US/docs/Web/CSS/Reference/Values/basic-shape/ellipse) and [`circle()`](/en-US/docs/Web/CSS/Reference/Values/basic-shape/circle) CSS basic shapes.

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -154,3 +154,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
   The {{cssxref("sibling-count")}} and {{cssxref("sibling-index")}} function are now supported. The `sibling-count()` function returns the number sibling elements as well as the element itself. The `sibling-index()` function returns the index number of the element in relation to its siblings, this starts from `1` and not `0`.
   ([Firefox bug 2042063](https://bugzil.la/2042063)).
+
+- **Updating attributes of external recourses**: `layout.css.link-parameters.enabled`
+
+  The {{cssxref("link-parameters")}} CSS property and {{cssxref("param")}} CSS function are now supported. This allows the user to update attributes of external resources, such as SVGs, that have their attributes set with the {{cssxref("env")}} CSS function. This means that single external resource can be used rather than creating multiple variations that only have different colors or other values. ([Firefox bug 2046153](https://bugzil.la/2046153)).


### PR DESCRIPTION
### Description

- Added Experimental Firefox Release note
- Added Firefox 153 Release note to Experimental section

### Motivation

- Working on [MDN issue #44466](https://github.com/mdn/content/issues/44466)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/44852)
- [BCD PR](https://github.com/mdn/browser-compat-data/pull/30088)
- [Associated BCD PR](https://github.com/mdn/browser-compat-data/pull/29909)
- [Data PR](https://github.com/mdn/data/pull/1082)
