### PR TITLE
Update Wasm numeric instructions pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/numeric/abs/index.md
+++ b/files/en-us/webassembly/reference/numeric/abs/index.md
@@ -1,12 +1,13 @@
 ---
-title: "abs: Wasm text instruction"
+title: "abs: Wasm numeric instruction"
 short-title: abs
 slug: WebAssembly/Reference/Numeric/abs
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.abs
 sidebar: webassemblysidebar
 ---
 
-The **`abs`** instruction, short for _absolute_, is used to get the absolute value of a number. That is, it returns x if x is positive, and the negation of x if x is negative.
+The **`abs`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _absolute_, is used to get the absolute value of a number. That is, it returns x if x is positive, and the negation of x if x is negative.
 
 {{InteractiveExample("Wat Demo: abs", "tabbed-standard")}}
 
@@ -135,3 +136,11 @@ The output is as follows:
 {{embedlivesample("simd_abs", "100%", 100)}}
 
 The result is `12`, because the value stored in lane `3` of the input value is `-12`, as we are outputting the absolute equivalent.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/add/index.md
+++ b/files/en-us/webassembly/reference/numeric/add/index.md
@@ -1,12 +1,13 @@
 ---
-title: "add: Wasm text instruction"
+title: "add: Wasm numeric instruction"
 short-title: add
 slug: WebAssembly/Reference/Numeric/add
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.add
 sidebar: webassemblysidebar
 ---
 
-The **`add`** instruction is used for adding up two numbers, similar to the **`+`** operator in other languages.
+The **`add`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for adding up two numbers, similar to the **`+`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: add", "tabbed-taller")}}
 
@@ -143,3 +144,11 @@ The output is as follows:
 {{embedlivesample("simd_add", "100%", 100)}}
 
 The result is `24`, because the value stored in lane `3` of each of the input values is `12`. Once added together, the output value's lane `3` will contain the value `24`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/and/index.md
+++ b/files/en-us/webassembly/reference/numeric/and/index.md
@@ -1,12 +1,13 @@
 ---
-title: "and: Wasm text instruction"
+title: "and: Wasm numeric instruction"
 short-title: and
 slug: WebAssembly/Reference/Numeric/and
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.and
 sidebar: webassemblysidebar
 ---
 
-The **`and`** instruction is used for performing a bitwise AND, similar to the **`&`** operator in other languages.
+The **`and`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for performing a bitwise AND, similar to the **`&`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: and", "tabbed-taller")}}
 
@@ -146,3 +147,11 @@ The output is as follows:
       -------------------
 AND = 0000 0001 0000 0000 = 256
 ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/ceil/index.md
+++ b/files/en-us/webassembly/reference/numeric/ceil/index.md
@@ -1,12 +1,13 @@
 ---
-title: "ceil: Wasm text instruction"
+title: "ceil: Wasm numeric instruction"
 short-title: ceil
 slug: WebAssembly/Reference/Numeric/ceil
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.ceil
 sidebar: webassemblysidebar
 ---
 
-The **`ceil`** instruction is used for getting the value of a number rounded up to the next integer.
+The **`ceil`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for getting the value of a number rounded up to the next integer.
 
 {{InteractiveExample("Wat Demo: ceil", "tabbed-standard")}}
 
@@ -126,3 +127,11 @@ The output is as follows:
 {{embedlivesample("simd_ceil", "100%", 100)}}
 
 `2001` is output because this is the result of rounding up lane 1 of the input value (`2000.1`) to the nearest integer.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/clz/index.md
+++ b/files/en-us/webassembly/reference/numeric/clz/index.md
@@ -1,12 +1,13 @@
 ---
-title: "clz: Wasm text instruction"
+title: "clz: Wasm numeric instruction"
 short-title: clz
 slug: WebAssembly/Reference/Numeric/clz
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.clz
 sidebar: webassemblysidebar
 ---
 
-The **`clz`** instructions, short for _count leading zeros_, are used to count the amount of zeros at the start of the numbers binary representation.
+The **`clz`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric)s, short for _count leading zeros_, are used to count the amount of zeros at the start of the numbers binary representation.
 
 {{InteractiveExample("Wat Demo: clz", "tabbed-taller")}}
 
@@ -54,3 +55,11 @@ i32.clz
 | ----------- | ------------- |
 | `i32.clz`   | `0x67`        |
 | `i64.clz`   | `0x79`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/const/index.md
+++ b/files/en-us/webassembly/reference/numeric/const/index.md
@@ -1,12 +1,13 @@
 ---
-title: "const: Wasm text instruction"
+title: "const: Wasm numeric instruction"
 short-title: const
 slug: WebAssembly/Reference/Numeric/const
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.const
 sidebar: webassemblysidebar
 ---
 
-The **`const`** [WebAssembly numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used to declare numbers.
+The **`const`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used to declare numbers.
 
 {{InteractiveExample("Wat Demo: const", "tabbed-standard")}}
 
@@ -64,3 +65,11 @@ value_type.const
 | `f32.const`  | `0x43 f:float32`       | `f32.const 2.5` => `0x43 0x00 0x00 0x20 0x40`                                                                                     |
 | `f64.const`  | `0x44 f:float64`       | `f64.const 2.5` => `0x44 0x00 0x00 0x00 0x00 0x00 0x00 0x04 0x40`                                                                 |
 | `v128.const` | `0xfd 0x0c (b:byte)¹⁶` | `v128.const i32x4 0x9 0xa 0xb 0xc` => `0xfd 0x0c 0x09 0x00 0x00 0x00 0x0a 0x00 0x00 0x00 0x0b 0x00 0x00 0x00 0x0c 0x00 0x00 0x00` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/convert/index.md
+++ b/files/en-us/webassembly/reference/numeric/convert/index.md
@@ -1,12 +1,13 @@
 ---
-title: "convert: Wasm text instruction"
+title: "convert: Wasm numeric instruction"
 short-title: convert
 slug: WebAssembly/Reference/Numeric/convert
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.convert
 sidebar: webassemblysidebar
 ---
 
-The **`convert`** instructions are used for converting integer numbers to floating point numbers. There are signed and unsigned versions of this instruction.
+The **`convert`** [numeric instructions](/en-US/docs/WebAssembly/Reference/Numeric) are used for converting integer numbers to floating point numbers. There are signed and unsigned versions of this instruction.
 
 {{InteractiveExample("Wat Demo: convert", "tabbed-taller")}}
 
@@ -53,3 +54,11 @@ f32.convert_i32_s
 | `f64.convert_i32_u` | `0xb8`        |
 | `f64.convert_i64_s` | `0xb9`        |
 | `f64.convert_i64_u` | `0xba`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/copysign/index.md
+++ b/files/en-us/webassembly/reference/numeric/copysign/index.md
@@ -1,12 +1,13 @@
 ---
-title: "copysign: Wasm text instruction"
+title: "copysign: Wasm numeric instruction"
 short-title: copysign
 slug: WebAssembly/Reference/Numeric/copysign
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.copysign
 sidebar: webassemblysidebar
 ---
 
-The **`copysign`** instructions are used to copy just the sign bit from one number to another.
+The **`copysign`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used to copy just the sign bit from one number to another.
 
 {{InteractiveExample("Wat Demo: copysign", "tabbed-taller")}}
 
@@ -47,3 +48,11 @@ f32.copysign
 | -------------- | ------------- |
 | `f32.copysign` | `0x98`        |
 | `f64.copysign` | `0xa6`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/ctz/index.md
+++ b/files/en-us/webassembly/reference/numeric/ctz/index.md
@@ -1,12 +1,13 @@
 ---
-title: "ctz: Wasm text instruction"
+title: "ctz: Wasm numeric instruction"
 short-title: ctz
 slug: WebAssembly/Reference/Numeric/ctz
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.ctz
 sidebar: webassemblysidebar
 ---
 
-The **`ctz`** instructions, short for _count trailing zeros_, are used to count the amount of zeros at the end of the numbers binary representation.
+The **`ctz`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _count trailing zeros_, is used to count the amount of zeros at the end of the numbers binary representation.
 
 {{InteractiveExample("Wat Demo: ctz", "tabbed-taller")}}
 
@@ -54,3 +55,11 @@ i32.ctz
 | ----------- | ------------- |
 | `i32.ctz`   | `0x68`        |
 | `i64.ctz`   | `0x7a`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/demote/index.md
+++ b/files/en-us/webassembly/reference/numeric/demote/index.md
@@ -1,12 +1,13 @@
 ---
-title: "demote: Wasm text instruction"
+title: "demote: Wasm numeric instruction"
 short-title: demote
 slug: WebAssembly/Reference/Numeric/demote
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.demote
 sidebar: webassemblysidebar
 ---
 
-The **`demote`** instructions are used to convert (demote) numbers of type `f64` to type `f32`.
+The **`demote`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used to convert (demote) numbers of type `f64` to type `f32`.
 
 {{InteractiveExample("Wat Demo: demote", "tabbed-taller")}}
 
@@ -46,3 +47,11 @@ f32.demote_f64
 | Instruction      | Binary opcode |
 | ---------------- | ------------- |
 | `f32.demote_f64` | `0xb6`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/div/index.md
+++ b/files/en-us/webassembly/reference/numeric/div/index.md
@@ -1,12 +1,13 @@
 ---
-title: "div: Wasm text instruction"
+title: "div: Wasm numeric instruction"
 short-title: div
 slug: WebAssembly/Reference/Numeric/div
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.div
 sidebar: webassemblysidebar
 ---
 
-The **`div`** instruction, short for _division_, is used for dividing one number by another, similar to the **`/`** operator in other languages.
+The **`div`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _division_, is used for dividing one number by another, similar to the **`/`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: div", "tabbed-taller")}}
 
@@ -131,3 +132,11 @@ The output is as follows:
 {{embedlivesample("simd_div", "100%", 100)}}
 
 The result is `33.3...`, because the value stored in lane `3` of output value is the result of `100 / 3`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/eq/index.md
+++ b/files/en-us/webassembly/reference/numeric/eq/index.md
@@ -1,12 +1,13 @@
 ---
-title: "eq: Wasm text instruction"
+title: "eq: Wasm numeric instruction"
 short-title: eq
 slug: WebAssembly/Reference/Numeric/eq
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.eq
 sidebar: webassemblysidebar
 ---
 
-The **`eq`** instruction, short for _equal_, checks if two numbers are equal.
+The **`eq`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _equal_, checks if two numbers are equal.
 
 {{InteractiveExample("Wat Demo: eq", "tabbed-taller")}}
 
@@ -151,3 +152,11 @@ The output is as follows:
 {{embedlivesample("simd_eq", "100%", 100)}}
 
 The result is `0` because the values stored in lane `7` of the two input values are not equal.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/eqz/index.md
+++ b/files/en-us/webassembly/reference/numeric/eqz/index.md
@@ -1,12 +1,13 @@
 ---
-title: "eqz: Wasm text instruction"
+title: "eqz: Wasm numeric instruction"
 short-title: eqz
 slug: WebAssembly/Reference/Numeric/eqz
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.eqz
 sidebar: webassemblysidebar
 ---
 
-The **`eqz`** instruction checks if a number is equal to zero.
+The **`eqz`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) checks if a number is equal to zero.
 
 {{InteractiveExample("Wat Demo: eqz", "tabbed-taller")}}
 
@@ -67,6 +68,14 @@ value_type.eqz
 | ----------- | ------------- | ---------------------- |
 | `i32.eqz`   | `0x45`        | `i32.eqz` => `0x45`    |
 | `i64.eqz`   | `0x50`        | `i64.eqz` => `0x50`    |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/extend/index.md
+++ b/files/en-us/webassembly/reference/numeric/extend/index.md
@@ -1,12 +1,13 @@
 ---
-title: "extend: Wasm text instruction"
+title: "extend: Wasm numeric instruction"
 short-title: extend
 slug: WebAssembly/Reference/Numeric/extend
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.extend
 sidebar: webassemblysidebar
 ---
 
-The **`extend`** instructions are used to convert (extend) numbers of type `i32` to type `i64`. There are signed and unsigned versions of this instruction.
+The **`extend`** [numeric instructions](/en-US/docs/WebAssembly/Reference/Numeric) are used to convert (extend) numbers of type `i32` to type `i64`. There are signed and unsigned versions of this instruction.
 
 {{InteractiveExample("Wat Demo: extend", "tabbed-taller")}}
 
@@ -47,3 +48,11 @@ i64.extend_i32_s
 | ------------------ | ------------- |
 | `i64.extend_i32_s` | `0xac`        |
 | `i64.extend_i32_u` | `0xad`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/floor/index.md
+++ b/files/en-us/webassembly/reference/numeric/floor/index.md
@@ -1,12 +1,13 @@
 ---
-title: "floor: Wasm text instruction"
+title: "floor: Wasm numeric instruction"
 short-title: floor
 slug: WebAssembly/Reference/Numeric/floor
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.floor
 sidebar: webassemblysidebar
 ---
 
-The **`floor`** instruction is used for getting the value of a number rounded down to the next integer.
+The **`floor`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for getting the value of a number rounded down to the next integer.
 
 `floor` differs from [**`trunc`**](/en-US/docs/WebAssembly/Reference/Numeric/trunc) when used on negative numbers — `floor` will round down in those cases while `trunc` will round up.
 
@@ -128,3 +129,11 @@ The output is as follows:
 {{embedlivesample("simd_floor", "100%", 100)}}
 
 `3` is output because this is the result of rounding down lane 0 of the input value (`3.9`) to the nearest integer.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/ge/index.md
+++ b/files/en-us/webassembly/reference/numeric/ge/index.md
@@ -1,12 +1,13 @@
 ---
-title: "ge: Wasm text instruction"
+title: "ge: Wasm numeric instruction"
 short-title: ge
 slug: WebAssembly/Reference/Numeric/ge
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.ge
 sidebar: webassemblysidebar
 ---
 
-The **`ge`** instruction, short for _greater or equal_, checks if a floating point number is greater than or equal to another floating point number.
+The **`ge`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _greater or equal_, checks if a floating point number is greater than or equal to another floating point number.
 
 Integer types have separate greater than or equal to signed ([**`ge_s`**](/en-US/docs/WebAssembly/Reference/Numeric/ge_s)) and unsigned ([**`ge_u`**](/en-US/docs/WebAssembly/Reference/Numeric/ge_u)) instructions.
 
@@ -142,6 +143,14 @@ The output is as follows:
 {{embedlivesample("simd_ge", "100%", 100)}}
 
 The result is `1` because the value stored in lane `3` of the first input value is greater than or equal to the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/ge_s/index.md
+++ b/files/en-us/webassembly/reference/numeric/ge_s/index.md
@@ -1,12 +1,13 @@
 ---
-title: "ge_s: Wasm text instruction"
+title: "ge_s: Wasm numeric instruction"
 short-title: ge_s
 slug: WebAssembly/Reference/Numeric/ge_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.ge_s
 sidebar: webassemblysidebar
 ---
 
-The **`ge_s`** instruction, short for _greater or equal signed_, checks if a signed integer is greater than or equal to another signed integer.
+The **`ge_s`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _greater or equal signed_, checks if a signed integer is greater than or equal to another signed integer.
 
 There are other `ge` instructions available:
 
@@ -149,6 +150,14 @@ The output is as follows:
 {{embedlivesample("simd_ge_s", "100%", 100)}}
 
 The result is `1` because the value stored in lane `3` of the first input value is greater than or equal to the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/ge_u/index.md
+++ b/files/en-us/webassembly/reference/numeric/ge_u/index.md
@@ -1,12 +1,13 @@
 ---
-title: "ge_u: Wasm text instruction"
+title: "ge_u: Wasm numeric instruction"
 short-title: ge_u
 slug: WebAssembly/Reference/Numeric/ge_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.ge_u
 sidebar: webassemblysidebar
 ---
 
-The **`ge_u`** instruction, short for _greater or equal unsigned_, checks if an unsigned integer is greater than or equal to another unsigned integer.
+The **`ge_u`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _greater or equal unsigned_, checks if an unsigned integer is greater than or equal to another unsigned integer.
 
 There are other `ge` instructions available:
 
@@ -147,6 +148,14 @@ The output is as follows:
 {{embedlivesample("simd_ge_u", "100%", 100)}}
 
 The result is `1` because the value stored in lane `3` of the first input value is greater than or equal to the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/gt/index.md
+++ b/files/en-us/webassembly/reference/numeric/gt/index.md
@@ -1,12 +1,13 @@
 ---
-title: "gt: Wasm text instruction"
+title: "gt: Wasm numeric instruction"
 short-title: gt
 slug: WebAssembly/Reference/Numeric/gt
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.gt
 sidebar: webassemblysidebar
 ---
 
-The **`gt`** instruction, short for _greater than_, checks if a floating point number is greater than another floating point number.
+The **`gt`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _greater than_, checks if a floating point number is greater than another floating point number.
 
 Integer types have separate greater than signed ([**`gt_s`**](/en-US/docs/WebAssembly/Reference/Numeric/gt_s)) and unsigned ([**`gt_u`**](/en-US/docs/WebAssembly/Reference/Numeric/gt_u)) instructions.
 
@@ -142,6 +143,14 @@ The output is as follows:
 {{embedlivesample("simd_gt", "100%", 100)}}
 
 The result is `1` because the value stored in lane `3` of the first input value is greater than the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/gt_s/index.md
+++ b/files/en-us/webassembly/reference/numeric/gt_s/index.md
@@ -1,12 +1,13 @@
 ---
-title: "gt_s: Wasm text instruction"
+title: "gt_s: Wasm numeric instruction"
 short-title: gt_s
 slug: WebAssembly/Reference/Numeric/gt_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.gt_s
 sidebar: webassemblysidebar
 ---
 
-The **`gt_s`** instruction, short for _greater than signed_, checks if a signed integer is greater than another signed integer.
+The **`gt_s`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _greater than signed_, checks if a signed integer is greater than another signed integer.
 
 There are other `gt` instructions available:
 
@@ -149,6 +150,14 @@ The output is as follows:
 {{embedlivesample("simd_gt_s", "100%", 100)}}
 
 The result is `1` because the value stored in lane `3` of the first input value is greater than the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/gt_u/index.md
+++ b/files/en-us/webassembly/reference/numeric/gt_u/index.md
@@ -1,12 +1,13 @@
 ---
-title: "gt_u: Wasm text instruction"
+title: "gt_u: Wasm numeric instruction"
 short-title: gt_u
 slug: WebAssembly/Reference/Numeric/gt_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.gt_u
 sidebar: webassemblysidebar
 ---
 
-The **`gt_u`** instruction, short for _greater than unsigned_, checks if an unsigned integer is greater than another unsigned integer.
+The **`gt_u`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _greater than unsigned_, checks if an unsigned integer is greater than another unsigned integer.
 
 There are other `gt` instructions available:
 
@@ -147,6 +148,14 @@ The output is as follows:
 {{embedlivesample("simd_gt_u", "100%", 100)}}
 
 The result is `1` because the value stored in lane `3` of the first input value is greater than the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/le/index.md
+++ b/files/en-us/webassembly/reference/numeric/le/index.md
@@ -1,12 +1,13 @@
 ---
-title: "le: Wasm text instruction"
+title: "le: Wasm numeric instruction"
 short-title: le
 slug: WebAssembly/Reference/Numeric/le
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.le
 sidebar: webassemblysidebar
 ---
 
-The **`le`** instruction, short for _less or equal_, checks if a floating point number is less than or equal to another floating point number.
+The **`le`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _less or equal_, checks if a floating point number is less than or equal to another floating point number.
 
 Integer types have separate less than or equal to signed ([**`le_s`**](/en-US/docs/WebAssembly/Reference/Numeric/le_s)) and unsigned ([**`le_u`**](/en-US/docs/WebAssembly/Reference/Numeric/le_u)) instructions.
 
@@ -142,6 +143,14 @@ The output is as follows:
 {{embedlivesample("simd_le", "100%", 100)}}
 
 The result is `0` because the value stored in lane `3` of the first input value is not less than or equal to the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/le_s/index.md
+++ b/files/en-us/webassembly/reference/numeric/le_s/index.md
@@ -1,12 +1,13 @@
 ---
-title: "le_s: Wasm text instruction"
+title: "le_s: Wasm numeric instruction"
 short-title: le_s
 slug: WebAssembly/Reference/Numeric/le_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.le_s
 sidebar: webassemblysidebar
 ---
 
-The **`le_s`** instruction, short for _less or equal signed_, checks if a signed integer is less than or equal to another signed integer.
+The **`le_s`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _less or equal signed_, checks if a signed integer is less than or equal to another signed integer.
 
 There are other `le` instructions available:
 
@@ -149,6 +150,14 @@ The output is as follows:
 {{embedlivesample("simd_le_s", "100%", 100)}}
 
 The result is `0` because the value stored in lane `3` of the first input value is not less than or equal to the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/le_u/index.md
+++ b/files/en-us/webassembly/reference/numeric/le_u/index.md
@@ -1,12 +1,13 @@
 ---
-title: "le_u: Wasm text instruction"
+title: "le_u: Wasm numeric instruction"
 short-title: le_u
 slug: WebAssembly/Reference/Numeric/le_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.le_u
 sidebar: webassemblysidebar
 ---
 
-The **`le_u`** instruction, short for _less or equal unsigned_, checks if an unsigned integer is less than or equal to another unsigned integer.
+The **`le_u`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _less or equal unsigned_, checks if an unsigned integer is less than or equal to another unsigned integer.
 
 There are other `le` instructions available:
 
@@ -147,6 +148,14 @@ The output is as follows:
 {{embedlivesample("simd_le_u", "100%", 100)}}
 
 The result is `0` because the value stored in lane `3` of the first input value is not less than or equal to the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/lt/index.md
+++ b/files/en-us/webassembly/reference/numeric/lt/index.md
@@ -1,12 +1,13 @@
 ---
-title: "lt: Wasm text instruction"
+title: "lt: Wasm numeric instruction"
 short-title: lt
 slug: WebAssembly/Reference/Numeric/lt
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.lt
 sidebar: webassemblysidebar
 ---
 
-The **`lt`** instruction, short for _less than_, checks if a floating point number is less than another floating point number.
+The **`lt`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _less than_, checks if a floating point number is less than another floating point number.
 
 Integer types have separate less than signed ([**`lt_s`**](/en-US/docs/WebAssembly/Reference/Numeric/lt_s)) and unsigned ([**`lt_u`**](/en-US/docs/WebAssembly/Reference/Numeric/lt_u)) instructions.
 
@@ -142,6 +143,14 @@ The output is as follows:
 {{embedlivesample("simd_lt", "100%", 100)}}
 
 The result is `0` because the value stored in lane `3` of the first input value is not less than the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/lt_s/index.md
+++ b/files/en-us/webassembly/reference/numeric/lt_s/index.md
@@ -1,12 +1,13 @@
 ---
-title: "lt_s: Wasm text instruction"
+title: "lt_s: Wasm numeric instruction"
 short-title: lt_s
 slug: WebAssembly/Reference/Numeric/lt_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.lt_s
 sidebar: webassemblysidebar
 ---
 
-The **`lt_s`** instruction, short for _less than signed_, checks if a signed integer is less than another signed integer.
+The **`lt_s`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _less than signed_, checks if a signed integer is less than another signed integer.
 
 There are other `lt` instructions available:
 
@@ -149,6 +150,14 @@ The output is as follows:
 {{embedlivesample("simd_lt_s", "100%", 100)}}
 
 The result is `0` because the value stored in lane `3` of the first input value is not less than the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/lt_u/index.md
+++ b/files/en-us/webassembly/reference/numeric/lt_u/index.md
@@ -1,12 +1,13 @@
 ---
-title: "lt_u: Wasm text instruction"
+title: "lt_u: Wasm numeric instruction"
 short-title: lt_u
 slug: WebAssembly/Reference/Numeric/lt_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.lt_u
 sidebar: webassemblysidebar
 ---
 
-The **`lt_u`** instruction, short for _less than unsigned_, checks if an unsigned integer is less than another unsigned integer.
+The **`lt_u`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _less than unsigned_, checks if an unsigned integer is less than another unsigned integer.
 
 There are other `lt` instructions available:
 
@@ -147,6 +148,14 @@ The output is as follows:
 {{embedlivesample("simd_lt_u", "100%", 100)}}
 
 The result is `0` because the value stored in lane `3` of the first input value is not less than the value stored in lane `3` of the second input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/max/index.md
+++ b/files/en-us/webassembly/reference/numeric/max/index.md
@@ -1,12 +1,13 @@
 ---
-title: "max: Wasm text instruction"
+title: "max: Wasm numeric instruction"
 short-title: max
 slug: WebAssembly/Reference/Numeric/max
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.max
 sidebar: webassemblysidebar
 ---
 
-The **`max`** instruction is used for getting the higher of two floating point numbers.
+The **`max`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for getting the higher of two floating point numbers.
 
 {{InteractiveExample("Wat Demo: max", "tabbed-taller")}}
 
@@ -132,6 +133,14 @@ The output is as follows:
 {{embedlivesample("simd_max", "100%", 100)}}
 
 The result is `1000`. This is because the value stored in lane `3` of the first input value is `1000`, and the value stored in lane `3` of the second input value is `108`. Since `1000` is greater than `108`, the new `f32x4` value outputted by the `f32x4.max` instruction has `1000` set in lane `3`, which we then extract and output to the DOM.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/min/index.md
+++ b/files/en-us/webassembly/reference/numeric/min/index.md
@@ -1,12 +1,13 @@
 ---
-title: "min: Wasm text instruction"
+title: "min: Wasm numeric instruction"
 short-title: min
 slug: WebAssembly/Reference/Numeric/min
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.min
 sidebar: webassemblysidebar
 ---
 
-The **`min`** instruction is used for getting the lower of two numbers.
+The **`min`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for getting the lower of two numbers.
 
 {{InteractiveExample("Wat Demo: min", "tabbed-taller")}}
 
@@ -132,6 +133,14 @@ The output is as follows:
 {{embedlivesample("simd_min", "100%", 100)}}
 
 The result is `108`. This is because the value stored in lane `3` of the first input value is `1000`, and the value stored in lane `3` of the second input value is `108`. Since `108` is less than `1000`, the new `f32x4` value outputted by the `f32x4.min` instruction has `108` set in lane `3`, which we then extract and output to the DOM.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/mul/index.md
+++ b/files/en-us/webassembly/reference/numeric/mul/index.md
@@ -1,12 +1,13 @@
 ---
-title: "mul: Wasm text instruction"
+title: "mul: Wasm numeric instruction"
 short-title: mul
 slug: WebAssembly/Reference/Numeric/mul
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.mul
 sidebar: webassemblysidebar
 ---
 
-The **`mul`** instruction, short for _multiplication_, is used for multiplying one number by another number, similar to the **`*`** operator in other languages.
+The **`mul`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _multiplication_, is used for multiplying one number by another number, similar to the **`*`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: mul", "tabbed-taller")}}
 
@@ -141,3 +142,11 @@ The output is as follows:
 {{embedlivesample("simd_mul", "100%", 100)}}
 
 The result is `108`, because the value stored in lane `3` of output value is the result of `12 * 9`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/ne/index.md
+++ b/files/en-us/webassembly/reference/numeric/ne/index.md
@@ -1,12 +1,13 @@
 ---
-title: "ne: Wasm text instruction"
+title: "ne: Wasm numeric instruction"
 short-title: ne
 slug: WebAssembly/Reference/Numeric/ne
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.ne
 sidebar: webassemblysidebar
 ---
 
-The **`ne`** instruction, short for _not equal_, checks if two numbers are not equal.
+The **`ne`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _not equal_, checks if two numbers are not equal.
 
 {{InteractiveExample("Wat Demo: ne", "tabbed-taller")}}
 
@@ -150,3 +151,11 @@ The output is as follows:
 {{embedlivesample("simd_ne", "100%", 100)}}
 
 `1` is output because the values in lane `1` of the two input values are not equal.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/nearest/index.md
+++ b/files/en-us/webassembly/reference/numeric/nearest/index.md
@@ -1,12 +1,13 @@
 ---
-title: "nearest: Wasm text instruction"
+title: "nearest: Wasm numeric instruction"
 short-title: nearest
 slug: WebAssembly/Reference/Numeric/nearest
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.nearest
 sidebar: webassemblysidebar
 ---
 
-The **`nearest`** instruction is used for rounding the value of a floating point number to the nearest whole number.
+The **`nearest`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for rounding the value of a floating point number to the nearest whole number.
 
 {{InteractiveExample("Wat Demo: nearest", "tabbed-standard")}}
 
@@ -126,3 +127,11 @@ The output is as follows:
 {{embedlivesample("simd_nearest", "100%", 100)}}
 
 `80` is output because it is the nearest whole number to the value in lane `3` of the input value (`80.1`).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/neg/index.md
+++ b/files/en-us/webassembly/reference/numeric/neg/index.md
@@ -1,12 +1,13 @@
 ---
-title: "neg: Wasm text instruction"
+title: "neg: Wasm numeric instruction"
 short-title: neg
 slug: WebAssembly/Reference/Numeric/neg
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.neg
 sidebar: webassemblysidebar
 ---
 
-The **`neg`** instruction, short for _negate_, is used to negate a number. That is, it turns a positive number into a negative number and a negative number into a positive number.
+The **`neg`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _negate_, is used to negate a number. That is, it turns a positive number into a negative number and a negative number into a positive number.
 
 {{InteractiveExample("Wat Demo: neg", "tabbed-standard")}}
 
@@ -134,3 +135,11 @@ The output is as follows:
 {{embedlivesample("simd_neg", "100%", 100)}}
 
 `6` is output because it is the negation of the value in lane `15` of the input value.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/or/index.md
+++ b/files/en-us/webassembly/reference/numeric/or/index.md
@@ -1,12 +1,13 @@
 ---
-title: "or: Wasm text instruction"
+title: "or: Wasm numeric instruction"
 short-title: or
 slug: WebAssembly/Reference/Numeric/or
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.or
 sidebar: webassemblysidebar
 ---
 
-The **`or`** instruction is used for performing a bitwise OR, similar to the **`|`** operator in other languages.
+The **`or`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for performing a bitwise OR, similar to the **`|`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: or", "tabbed-taller")}}
 
@@ -146,3 +147,11 @@ The output is as follows:
       -------------------
  OR = 0000 0011 1001 1110 = 926
 ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/popcnt/index.md
+++ b/files/en-us/webassembly/reference/numeric/popcnt/index.md
@@ -1,12 +1,13 @@
 ---
-title: "popcnt: Wasm text instruction"
+title: "popcnt: Wasm numeric instruction"
 short-title: popcnt
 slug: WebAssembly/Reference/Numeric/popcnt
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.popcnt
 sidebar: webassemblysidebar
 ---
 
-The **`popcnt`** instruction, short for _population count_, is used to count the amount of `1`s in a number's binary representation.
+The **`popcnt`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _population count_, is used to count the amount of `1`s in a number's binary representation.
 
 {{InteractiveExample("Wat Demo: popcnt", "tabbed-taller")}}
 
@@ -130,3 +131,11 @@ The output is as follows:
 {{embedlivesample("simd_popcnt", "100%", 100)}}
 
 `4` is output because the value in lane 15 of the input value is `30`. `30` in binary is `00011110`, which has 4 `1`s in it.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/promote_32/index.md
+++ b/files/en-us/webassembly/reference/numeric/promote_32/index.md
@@ -1,12 +1,13 @@
 ---
-title: "promote_32: Wasm text instruction"
+title: "promote_32: Wasm numeric instruction"
 short-title: promote_32
 slug: WebAssembly/Reference/Numeric/promote_32
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.promote_32
 sidebar: webassemblysidebar
 ---
 
-The **`promote_32`** instruction is used to convert (promote) numbers of type `f32` to type `f64`.
+The **`promote_32`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used to convert (promote) numbers of type `f32` to type `f64`.
 
 {{InteractiveExample("Wat Demo: promote_32", "tabbed-taller")}}
 
@@ -46,3 +47,11 @@ f64.promote_f32
 | Instruction       | Binary opcode |
 | ----------------- | ------------- |
 | `f64.promote_f32` | `0xbb`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/reinterpret/index.md
+++ b/files/en-us/webassembly/reference/numeric/reinterpret/index.md
@@ -1,12 +1,13 @@
 ---
-title: "reinterpret: Wasm text instruction"
+title: "reinterpret: Wasm numeric instruction"
 short-title: reinterpret
 slug: WebAssembly/Reference/Numeric/reinterpret
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.reinterpret
 sidebar: webassemblysidebar
 ---
 
-The **`reinterpret`** instructions are used to reinterpret the bits of a number as a different type.
+The **`reinterpret`** [numeric instructions](/en-US/docs/WebAssembly/Reference/Numeric) are used to reinterpret the bits of a number as a different type.
 
 {{InteractiveExample("Wat Demo: reinterpret", "tabbed-taller")}}
 
@@ -53,3 +54,11 @@ i32.reinterpret_f32
 | `i64.reinterpret_f64` | `0xbd`        |
 | `f32.reinterpret_i32` | `0xbe`        |
 | `f64.reinterpret_i64` | `0xbf`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/rem/index.md
+++ b/files/en-us/webassembly/reference/numeric/rem/index.md
@@ -1,12 +1,13 @@
 ---
-title: "rem: Wasm text instruction"
+title: "rem: Wasm numeric instruction"
 short-title: rem
 slug: WebAssembly/Reference/Numeric/rem
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.rem
 sidebar: webassemblysidebar
 ---
 
-The **`rem`** instructions, short for _remainder_, are used to calculate the remainder left over when one integer is divided by another integer, similar to the **`%`** operator in other languages. The **`rem`** instructions are only available for the integer types and not for the floating point types.
+The **`rem`** [numeric instructions](/en-US/docs/WebAssembly/Reference/Numeric), short for _remainder_, are used to calculate the remainder left over when one integer is divided by another integer, similar to the **`%`** operator in other languages. The **`rem`** instructions are only available for the integer types and not for the floating point types.
 
 {{InteractiveExample("Wat Demo: rem", "tabbed-taller")}}
 
@@ -49,3 +50,11 @@ i32.rem
 | `i32.rem_u` | `0x70`        |
 | `i64.rem_s` | `0x81`        |
 | `i64.rem_u` | `0x82`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/rotl/index.md
+++ b/files/en-us/webassembly/reference/numeric/rotl/index.md
@@ -1,12 +1,13 @@
 ---
-title: "rotl: Wasm text instruction"
+title: "rotl: Wasm numeric instruction"
 short-title: rotl
 slug: WebAssembly/Reference/Numeric/rotl
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.rotl
 sidebar: webassemblysidebar
 ---
 
-The **`rotl`** instructions, short for _rotate-left_, are used for performing a bitwise left-rotate.
+The **`rotl`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _rotate-left_, is used for performing a bitwise left-rotate.
 
 {{InteractiveExample("Wat Demo: rotl", "tabbed-taller")}}
 
@@ -64,3 +65,11 @@ i32.rotl
 | ----------- | ------------- |
 | `i32.rotl`  | `0x77`        |
 | `i64.rotl`  | `0x89`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/rotr/index.md
+++ b/files/en-us/webassembly/reference/numeric/rotr/index.md
@@ -1,12 +1,13 @@
 ---
-title: "rotr: Wasm text instruction"
+title: "rotr: Wasm numeric instruction"
 short-title: rotr
 slug: WebAssembly/Reference/Numeric/rotr
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.rotr
 sidebar: webassemblysidebar
 ---
 
-The **`rotr`** instructions, short for _rotate-right_, are used for performing a bitwise right-rotate.
+The **`rotr`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _rotate-right_, is used for performing a bitwise right-rotate.
 
 {{InteractiveExample("Wat Demo: rotr", "tabbed-taller")}}
 
@@ -64,3 +65,11 @@ i32.rotr
 | ----------- | ------------- |
 | `i32.rotr`  | `0x78`        |
 | `i64.rotr`  | `0x8a`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/shl/index.md
+++ b/files/en-us/webassembly/reference/numeric/shl/index.md
@@ -1,12 +1,13 @@
 ---
-title: "shl: Wasm text instruction"
+title: "shl: Wasm numeric instruction"
 short-title: shl
 slug: WebAssembly/Reference/Numeric/shl
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.shl
 sidebar: webassemblysidebar
 ---
 
-The **`shl`** instruction, short for _shift-left_, is used for performing a bitwise left-shift, similar to the **`<<`** operator in other languages.
+The **`shl`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _shift-left_, is used for performing a bitwise left-shift, similar to the **`<<`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: shl", "tabbed-taller")}}
 
@@ -164,6 +165,14 @@ The output is as follows:
 {{embedlivesample("simd_shl", "100%", 100)}}
 
 The result is `48`, because the value stored in lane `3` of the input value is `12`. Once shifted left by two positions, the output value's lane `3` will contain the value `48`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/shr_s/index.md
+++ b/files/en-us/webassembly/reference/numeric/shr_s/index.md
@@ -1,12 +1,13 @@
 ---
-title: "shr_s: Wasm text instruction"
+title: "shr_s: Wasm numeric instruction"
 short-title: shr_s
 slug: WebAssembly/Reference/Numeric/shr_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.shr_s
 sidebar: webassemblysidebar
 ---
 
-The **`shr_s`** instructions, short for _shift-right signed_, are used for performing a bitwise right-shift on signed integers, similar to the **`>>>`** operator in other languages.
+The **`shr_s`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _shift-right signed_, is used for performing a bitwise right-shift on signed integers, similar to the **`>>>`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: shr_s", "tabbed-taller")}}
 
@@ -149,6 +150,14 @@ The output is as follows:
 {{embedlivesample("simd_shr_s", "100%", 100)}}
 
 The result is `22`, because the value stored in lane `6` of the input value is `91`. Once shifted right by two positions, the output value's lane `6` will contain the value `22`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/shr_u/index.md
+++ b/files/en-us/webassembly/reference/numeric/shr_u/index.md
@@ -1,12 +1,13 @@
 ---
-title: "shr_u: Wasm text instruction"
+title: "shr_u: Wasm numeric instruction"
 short-title: shr_u
 slug: WebAssembly/Reference/Numeric/shr_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.shr_u
 sidebar: webassemblysidebar
 ---
 
-The **`shr_u`** instructions, short for _shift-right unsigned_, are used for performing a bitwise right-shift on unsigned integers, similar to the **`>>>`** operator in other languages.
+The **`shr_u`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _shift-right unsigned_, is used for performing a bitwise right-shift on unsigned integers, similar to the **`>>>`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: shr_u", "tabbed-taller")}}
 
@@ -149,6 +150,14 @@ The output is as follows:
 {{embedlivesample("simd_shr_u", "100%", 100)}}
 
 The result is `22`, because the value stored in lane `6` of the input value is `91`. Once shifted right by two positions, the output value's lane `6` will contain the value `22`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/sqrt/index.md
+++ b/files/en-us/webassembly/reference/numeric/sqrt/index.md
@@ -1,12 +1,13 @@
 ---
-title: "sqrt: Wasm text instruction"
+title: "sqrt: Wasm numeric instruction"
 short-title: sqrt
 slug: WebAssembly/Reference/Numeric/sqrt
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.sqrt
 sidebar: webassemblysidebar
 ---
 
-The **`sqrt`** instruction, short for _square root_, is used to get the square root of a number.
+The **`sqrt`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _square root_, is used to get the square root of a number.
 
 {{InteractiveExample("Wat Demo: sqrt", "tabbed-standard")}}
 
@@ -126,3 +127,11 @@ The output is as follows:
 {{embedlivesample("simd_sqrt", "100%", 100)}}
 
 `28.48683906648823` is output because this is the square root of the value in lane 1 of the input value (`811.5`).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/sub/index.md
+++ b/files/en-us/webassembly/reference/numeric/sub/index.md
@@ -1,12 +1,13 @@
 ---
-title: "sub: Wasm text instruction"
+title: "sub: Wasm numeric instruction"
 short-title: sub
 slug: WebAssembly/Reference/Numeric/sub
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.sub
 sidebar: webassemblysidebar
 ---
 
-The **`sub`** instruction, short for _subtraction_, is used for subtracting one number from another number, similar to the **`-`** operator in other languages.
+The **`sub`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _subtraction_, is used for subtracting one number from another number, similar to the **`-`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: sub", "tabbed-taller")}}
 
@@ -142,3 +143,11 @@ The output is as follows:
 {{embedlivesample("simd_sub", "100%", 100)}}
 
 `-24` is output because this is the result of subtracting lane 7 of the second value (`30`) from lane 7 of the first value (`6`).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/trunc/index.md
+++ b/files/en-us/webassembly/reference/numeric/trunc/index.md
@@ -1,12 +1,13 @@
 ---
-title: "trunc: Wasm text instruction"
+title: "trunc: Wasm numeric instruction"
 short-title: trunc
 slug: WebAssembly/Reference/Numeric/trunc
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.trunc
 sidebar: webassemblysidebar
 ---
 
-The **`trunc`** instruction, short for _truncate_, is used for getting the value of a floating point number without its fractional part.
+The **`trunc`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric), short for _truncate_, is used for getting the value of a floating point number without its fractional part.
 
 `trunc` differs from [**`floor`**](/en-US/docs/WebAssembly/Reference/Numeric/floor) when used on negative numbers — `floor` will round down in those cases while `trunc` will round up.
 
@@ -135,6 +136,14 @@ The output is as follows:
 {{embedlivesample("simd_trunc", "100%", 100)}}
 
 `2000` is output because this is the result of removing the fractional part from lane 1 of the input value (`2000.1`).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/trunc_f32_s/index.md
+++ b/files/en-us/webassembly/reference/numeric/trunc_f32_s/index.md
@@ -1,12 +1,13 @@
 ---
-title: "trunc_f32_s: Wasm text instruction"
+title: "trunc_f32_s: Wasm numeric instruction"
 short-title: trunc_f32_s
 slug: WebAssembly/Reference/Numeric/trunc_f32_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.trunc_f32_s
 sidebar: webassemblysidebar
 ---
 
-The **`trunc_f32_s`** instruction removes the fractional part of an `f32` value and outputs it as a signed integer.
+The **`trunc_f32_s`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) removes the fractional part of an `f32` value and outputs it as a signed integer.
 
 This is a separate instruction, [`trunc`](/en-US/docs/WebAssembly/Reference/Numeric/trunc), which removes the fractional part of a float and outputs a float.
 
@@ -67,6 +68,14 @@ value_type.trunc_f32_s
 | ----------------- | ------------- | --------------------------- |
 | `i32.trunc_f32_s` | `0xa8`        | `i32.trunc_f32_s` => `0xa8` |
 | `i64.trunc_f32_s` | `0xae`        | `i64.trunc_f32_s` => `0xae` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/trunc_f32_u/index.md
+++ b/files/en-us/webassembly/reference/numeric/trunc_f32_u/index.md
@@ -1,12 +1,13 @@
 ---
-title: "trunc_f32_u: Wasm text instruction"
+title: "trunc_f32_u: Wasm numeric instruction"
 short-title: trunc_f32_u
 slug: WebAssembly/Reference/Numeric/trunc_f32_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.trunc_f32_u
 sidebar: webassemblysidebar
 ---
 
-The **`trunc_f32_u`** instruction removes the fractional part of an `f32` value and outputs it as an unsigned integer.
+The **`trunc_f32_u`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) removes the fractional part of an `f32` value and outputs it as an unsigned integer.
 
 This is a separate instruction, [`trunc`](/en-US/docs/WebAssembly/Reference/Numeric/trunc), which removes the fractional part of a float and outputs a float.
 
@@ -67,6 +68,14 @@ value_type.trunc_f32_u
 | ----------------- | ------------- | --------------------------- |
 | `i32.trunc_f32_u` | `0xa9`        | `i32.trunc_f32_u` => `0xa9` |
 | `i64.trunc_f32_u` | `0xaf`        | `i64.trunc_f32_u` => `0xaf` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/trunc_f64_s/index.md
+++ b/files/en-us/webassembly/reference/numeric/trunc_f64_s/index.md
@@ -1,12 +1,13 @@
 ---
-title: "trunc_f64_s: Wasm text instruction"
+title: "trunc_f64_s: Wasm numeric instruction"
 short-title: trunc_f64_s
 slug: WebAssembly/Reference/Numeric/trunc_f64_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.trunc_f64_s
 sidebar: webassemblysidebar
 ---
 
-The **`trunc_f64_s`** instruction removes the fractional part of an `f64` value and outputs it as a signed integer.
+The **`trunc_f64_s`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) removes the fractional part of an `f64` value and outputs it as a signed integer.
 
 This is a separate instruction, [`trunc`](/en-US/docs/WebAssembly/Reference/Numeric/trunc), which removes the fractional part of a float and outputs a float.
 
@@ -67,6 +68,14 @@ value_type.trunc_f64_s
 | ----------------- | ------------- | --------------------------- |
 | `i32.trunc_f64_s` | `0xaa`        | `i32.trunc_f64_s` => `0xaa` |
 | `i64.trunc_f64_s` | `0xb0`        | `i64.trunc_f64_s` => `0xb0` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/trunc_f64_u/index.md
+++ b/files/en-us/webassembly/reference/numeric/trunc_f64_u/index.md
@@ -1,12 +1,13 @@
 ---
-title: "trunc_f64_u: Wasm text instruction"
+title: "trunc_f64_u: Wasm numeric instruction"
 short-title: trunc_f64_u
 slug: WebAssembly/Reference/Numeric/trunc_f64_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.trunc_f64_u
 sidebar: webassemblysidebar
 ---
 
-The **`trunc_f64_u`** instruction removes the fractional part of an `f64` value and outputs it as an unsigned integer.
+The **`trunc_f64_u`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) removes the fractional part of an `f64` value and outputs it as an unsigned integer.
 
 This is a separate instruction, [`trunc`](/en-US/docs/WebAssembly/Reference/Numeric/trunc), which removes the fractional part of a float and outputs a float.
 
@@ -67,6 +68,14 @@ value_type.trunc_f64_u
 | ----------------- | ------------- | --------------------------- |
 | `i32.trunc_f64_u` | `0xab`        | `i32.trunc_f64_u` => `0xab` |
 | `i64.trunc_f64_u` | `0xb1`        | `i64.trunc_f64_u` => `0xb1` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/numeric/wrap_i64/index.md
+++ b/files/en-us/webassembly/reference/numeric/wrap_i64/index.md
@@ -1,12 +1,13 @@
 ---
-title: "wrap_i64: Wasm text instruction"
+title: "wrap_i64: Wasm numeric instruction"
 short-title: wrap_i64
 slug: WebAssembly/Reference/Numeric/wrap_i64
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.wrap_i64
 sidebar: webassemblysidebar
 ---
 
-The **`wrap_i64`** instruction, is used to convert numbers of type `i64` to type `i32`. If the number is larger than what an `i32` can hold this operation will wrap, resulting in a different number.
+The **`wrap_i64`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used to convert numbers of type `i64` to type `i32`. If the number is larger than what an `i32` can hold this operation will wrap, resulting in a different number.
 
 One can think of wrap either as reducing the value [mod](https://en.wikipedia.org/wiki/Modular_arithmetic) 2<sup>32</sup>, or as discarding the high 32 bits to produce a value containing just the low 32 bits.
 
@@ -47,3 +48,11 @@ i32.wrap_i64
 | Instruction    | Binary opcode |
 | -------------- | ------------- |
 | `i32.wrap_i64` | `0xa7`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/numeric/xor/index.md
+++ b/files/en-us/webassembly/reference/numeric/xor/index.md
@@ -1,12 +1,13 @@
 ---
-title: "xor: Wasm text instruction"
+title: "xor: Wasm numeric instruction"
 short-title: xor
 slug: WebAssembly/Reference/Numeric/xor
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.xor
 sidebar: webassemblysidebar
 ---
 
-The **`xor`** instruction is used for performing a bitwise XOR, similar to the **`^`** operator in other languages.
+The **`xor`** [numeric instruction](/en-US/docs/WebAssembly/Reference/Numeric) is used for performing a bitwise XOR, similar to the **`^`** operator in other languages.
 
 {{InteractiveExample("Wat Demo: xor", "tabbed-taller")}}
 
@@ -146,3 +147,11 @@ The output is as follows:
       -------------------
 XOR = 0000 0010 1001 1110 = 670
 ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm numeric instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Definitions) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30073.

While I was here, I also updated all the pages so that they refer to the type of instruction (numeric) in the page title, and link to the numeric instructions landing page in their opening sentence. This makes them more consistent both with the rest of the Wasm reference material, and with MDN as a whole.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
