### PR TITLE
Update Wasm SIMD arithmetic instruction pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/simd/arithmetic/add_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/add_sat_s/index.md
@@ -79,4 +79,3 @@ value_type.add_sat_s
 ## See also
 
 - [`add`](/en-US/docs/WebAssembly/Reference/Numeric/add)
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/add_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/add_sat_s/index.md
@@ -3,7 +3,7 @@ title: "add_sat_s: Wasm SIMD arithmetic instruction"
 short-title: add_sat_s
 slug: WebAssembly/Reference/SIMD/arithmetic/add_sat_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.add_sat_s
+browser-compat: webassembly.instructions.add_sat_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/add_sat_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/add_sat_u/index.md
@@ -79,4 +79,3 @@ value_type.add_sat_u
 ## See also
 
 - [`add`](/en-US/docs/WebAssembly/Reference/Numeric/add)
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/add_sat_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/add_sat_u/index.md
@@ -3,7 +3,7 @@ title: "add_sat_u: Wasm SIMD arithmetic instruction"
 short-title: add_sat_u
 slug: WebAssembly/Reference/SIMD/arithmetic/add_sat_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.add_sat_u
+browser-compat: webassembly.instructions.add_sat_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/avgr_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/avgr_u/index.md
@@ -70,7 +70,3 @@ value_type.avgr_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/avgr_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/avgr_u/index.md
@@ -3,7 +3,7 @@ title: "avgr_u: Wasm SIMD arithmetic instruction"
 short-title: avgr_u
 slug: WebAssembly/Reference/SIMD/arithmetic/avgr_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.avgr_u
+browser-compat: webassembly.instructions.avgr_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/dot_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/dot_i16x8_s/index.md
@@ -3,7 +3,7 @@ title: "dot_i16x8_s: Wasm SIMD arithmetic instruction"
 short-title: dot_i16x8_s
 slug: WebAssembly/Reference/SIMD/arithmetic/dot_i16x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.dot_i16x8_s
+browser-compat: webassembly.instructions.dot_i16x8_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/dot_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/dot_i16x8_s/index.md
@@ -79,7 +79,3 @@ i32x4.dot_i16x8_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_s/index.md
@@ -64,7 +64,3 @@ i32x4.extadd_pairwise_i16x8_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_s/index.md
@@ -3,7 +3,7 @@ title: "extadd_pairwise_i16x8_s: Wasm SIMD arithmetic instruction"
 short-title: extadd_pairwise_i16x8_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i16x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extadd_pairwise_i16x8_s
+browser-compat: webassembly.instructions.extadd_pairwise_i16x8_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_u/index.md
@@ -64,7 +64,3 @@ i32x4.extadd_pairwise_i16x8_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i16x8_u/index.md
@@ -3,7 +3,7 @@ title: "extadd_pairwise_i16x8_u: Wasm SIMD arithmetic instruction"
 short-title: extadd_pairwise_i16x8_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i16x8_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extadd_pairwise_i16x8_u
+browser-compat: webassembly.instructions.extadd_pairwise_i16x8_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_s/index.md
@@ -3,7 +3,7 @@ title: "extadd_pairwise_i8x16_s: Wasm SIMD arithmetic instruction"
 short-title: extadd_pairwise_i8x16_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i8x16_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extadd_pairwise_i8x16_s
+browser-compat: webassembly.instructions.extadd_pairwise_i8x16_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_s/index.md
@@ -64,7 +64,3 @@ i16x8.extadd_pairwise_i8x16_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_u/index.md
@@ -64,7 +64,3 @@ i16x8.extadd_pairwise_i8x16_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extadd_pairwise_i8x16_u/index.md
@@ -3,7 +3,7 @@ title: "extadd_pairwise_i8x16_u: Wasm SIMD arithmetic instruction"
 short-title: extadd_pairwise_i8x16_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i8x16_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extadd_pairwise_i8x16_u
+browser-compat: webassembly.instructions.extadd_pairwise_i8x16_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_s/index.md
@@ -91,7 +91,3 @@ i32x4.extmul_high_i16x8_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_s/index.md
@@ -3,7 +3,7 @@ title: "extmul_high_i16x8_s: Wasm SIMD arithmetic instruction"
 short-title: extmul_high_i16x8_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_high_i16x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_high_i16x8_s
+browser-compat: webassembly.instructions.extmul_high_i16x8_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_u/index.md
@@ -3,7 +3,7 @@ title: "extmul_high_i16x8_u: Wasm SIMD arithmetic instruction"
 short-title: extmul_high_i16x8_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_high_i16x8_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_high_i16x8_u
+browser-compat: webassembly.instructions.extmul_high_i16x8_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i16x8_u/index.md
@@ -91,7 +91,3 @@ i32x4.extmul_high_i16x8_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_s/index.md
@@ -3,7 +3,7 @@ title: "extmul_high_i32x4_s: Wasm SIMD arithmetic instruction"
 short-title: extmul_high_i32x4_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_high_i32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_high_i32x4_s
+browser-compat: webassembly.instructions.extmul_high_i32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_s/index.md
@@ -91,7 +91,3 @@ i64x2.extmul_high_i32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_u/index.md
@@ -3,7 +3,7 @@ title: "extmul_high_i32x4_u: Wasm SIMD arithmetic instruction"
 short-title: extmul_high_i32x4_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_high_i32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_high_i32x4_u
+browser-compat: webassembly.instructions.extmul_high_i32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i32x4_u/index.md
@@ -91,7 +91,3 @@ i64x2.extmul_high_i32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_s/index.md
@@ -91,7 +91,3 @@ i16x8.extmul_high_i8x16_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_s/index.md
@@ -3,7 +3,7 @@ title: "extmul_high_i8x16_s: Wasm SIMD arithmetic instruction"
 short-title: extmul_high_i8x16_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_high_i8x16_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_high_i8x16_s
+browser-compat: webassembly.instructions.extmul_high_i8x16_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_u/index.md
@@ -91,7 +91,3 @@ i16x8.extmul_high_i8x16_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_high_i8x16_u/index.md
@@ -3,7 +3,7 @@ title: "extmul_high_i8x16_u: Wasm SIMD arithmetic instruction"
 short-title: extmul_high_i8x16_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_high_i8x16_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_high_i8x16_u
+browser-compat: webassembly.instructions.extmul_high_i8x16_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_s/index.md
@@ -3,7 +3,7 @@ title: "extmul_low_i16x8_s: Wasm SIMD arithmetic instruction"
 short-title: extmul_low_i16x8_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_low_i16x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_low_i16x8_s
+browser-compat: webassembly.instructions.extmul_low_i16x8_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_s/index.md
@@ -91,7 +91,3 @@ i32x4.extmul_low_i16x8_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_u/index.md
@@ -91,7 +91,3 @@ i32x4.extmul_low_i16x8_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i16x8_u/index.md
@@ -3,7 +3,7 @@ title: "extmul_low_i16x8_u: Wasm SIMD arithmetic instruction"
 short-title: extmul_low_i16x8_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_low_i16x8_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_low_i16x8_u
+browser-compat: webassembly.instructions.extmul_low_i16x8_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_s/index.md
@@ -91,7 +91,3 @@ i64x2.extmul_low_i32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_s/index.md
@@ -3,7 +3,7 @@ title: "extmul_low_i32x4_s: Wasm SIMD arithmetic instruction"
 short-title: extmul_low_i32x4_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_low_i32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_low_i32x4_s
+browser-compat: webassembly.instructions.extmul_low_i32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_u/index.md
@@ -91,7 +91,3 @@ i64x2.extmul_low_i32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i32x4_u/index.md
@@ -3,7 +3,7 @@ title: "extmul_low_i32x4_u: Wasm SIMD arithmetic instruction"
 short-title: extmul_low_i32x4_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_low_i32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_low_i32x4_u
+browser-compat: webassembly.instructions.extmul_low_i32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_s/index.md
@@ -3,7 +3,7 @@ title: "extmul_low_i8x16_s: Wasm SIMD arithmetic instruction"
 short-title: extmul_low_i8x16_s
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_low_i8x16_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_low_i8x16_s
+browser-compat: webassembly.instructions.extmul_low_i8x16_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_s/index.md
@@ -91,7 +91,3 @@ i16x8.extmul_low_i8x16_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_u/index.md
@@ -3,7 +3,7 @@ title: "extmul_low_i8x16_u: Wasm SIMD arithmetic instruction"
 short-title: extmul_low_i8x16_u
 slug: WebAssembly/Reference/SIMD/arithmetic/extmul_low_i8x16_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extmul_low_i8x16_u
+browser-compat: webassembly.instructions.extmul_low_i8x16_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/extmul_low_i8x16_u/index.md
@@ -91,7 +91,3 @@ i16x8.extmul_low_i8x16_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/max_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/max_s/index.md
@@ -3,6 +3,7 @@ title: "max_s: Wasm SIMD arithmetic instruction"
 short-title: max_s
 slug: WebAssembly/Reference/SIMD/arithmetic/max_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.max_s
 sidebar: webassemblysidebar
 ---
 
@@ -66,6 +67,14 @@ value_type.max_s
 | `i8x16.max_s` | `0xfd 120:u32` | `i8x16.max_s` => `0xfd 0x78`      |
 | `i16x8.max_s` | `0xfd 152:u32` | `i16x8.max_s` => `0xfd 0x98 0x01` |
 | `i32x4.max_s` | `0xfd 184:u32` | `i32x4.max_s` => `0xfd 0xb8 0x01` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/max_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/max_u/index.md
@@ -3,6 +3,7 @@ title: "max_u: Wasm SIMD arithmetic instruction"
 short-title: max_u
 slug: WebAssembly/Reference/SIMD/arithmetic/max_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.max_u
 sidebar: webassemblysidebar
 ---
 
@@ -66,6 +67,14 @@ value_type.max_u
 | `i8x16.max_u` | `0xfd 121:u32` | `i8x16.max_u` => `0xfd 0x79`      |
 | `i16x8.max_u` | `0xfd 153:u32` | `i16x8.max_u` => `0xfd 0x99 0x01` |
 | `i32x4.max_u` | `0xfd 185:u32` | `i32x4.max_u` => `0xfd 0xb9 0x01` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/min_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/min_s/index.md
@@ -3,6 +3,7 @@ title: "min_s: Wasm SIMD arithmetic instruction"
 short-title: min_s
 slug: WebAssembly/Reference/SIMD/arithmetic/min_s
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.min_s
 sidebar: webassemblysidebar
 ---
 
@@ -66,6 +67,14 @@ value_type.min_s
 | `i8x16.min_s` | `0xfd 118:u32` | `i8x16.min_s` => `0xfd 0x76`      |
 | `i16x8.min_s` | `0xfd 150:u32` | `i16x8.min_s` => `0xfd 0x96 0x01` |
 | `i32x4.min_s` | `0xfd 182:u32` | `i32x4.min_s` => `0xfd 0xb6 0x01` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/min_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/min_u/index.md
@@ -3,6 +3,7 @@ title: "min_u: Wasm SIMD arithmetic instruction"
 short-title: min_u
 slug: WebAssembly/Reference/SIMD/arithmetic/min_u
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.min_u
 sidebar: webassemblysidebar
 ---
 
@@ -66,6 +67,14 @@ value_type.min_u
 | `i8x16.min_u` | `0xfd 119:u32` | `i8x16.min_u` => `0xfd 0x77`      |
 | `i16x8.min_u` | `0xfd 151:u32` | `i16x8.min_u` => `0xfd 0x97 0x01` |
 | `i32x4.min_u` | `0xfd 183:u32` | `i32x4.min_u` => `0xfd 0xb7 0x01` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/pmax/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/pmax/index.md
@@ -3,6 +3,7 @@ title: "pmax: Wasm SIMD arithmetic instruction"
 short-title: pmax
 slug: WebAssembly/Reference/SIMD/arithmetic/pmax
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.pmax
 sidebar: webassemblysidebar
 ---
 
@@ -64,6 +65,14 @@ value_type.pmax
 | ------------ | -------------- | -------------------------------- |
 | `f32x4.pmax` | `0xfd 235:u32` | `f32x4.pmax` => `0xfd 0xeb 0x01` |
 | `f64x2.pmax` | `0xfd 247:u32` | `f64x2.pmax` => `0xfd 0xf7 0x01` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/pmin/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/pmin/index.md
@@ -3,6 +3,7 @@ title: "pmin: Wasm SIMD arithmetic instruction"
 short-title: pmin
 slug: WebAssembly/Reference/SIMD/arithmetic/pmin
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.pmin
 sidebar: webassemblysidebar
 ---
 
@@ -64,6 +65,14 @@ value_type.pmin
 | ------------ | -------------- | -------------------------------- |
 | `f32x4.pmin` | `0xfd 234:u32` | `f32x4.pmin` => `0xfd 0xea 0x01` |
 | `f64x2.pmin` | `0xfd 246:u32` | `f64x2.pmin` => `0xfd 0xf6 0x01` |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
@@ -83,7 +83,3 @@ i16x8.q15mulr_sat_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
@@ -3,7 +3,7 @@ title: "q15mulr_sat_s: Wasm SIMD arithmetic instruction"
 short-title: q15mulr_sat_s
 slug: WebAssembly/Reference/SIMD/arithmetic/q15mulr_sat_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.q15mulr_sat_s
+browser-compat: webassembly.instructions.q15mulr_sat_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_s/index.md
@@ -3,7 +3,7 @@ title: "sub_sat_s: Wasm SIMD arithmetic instruction"
 short-title: sub_sat_s
 slug: WebAssembly/Reference/SIMD/arithmetic/sub_sat_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.sub_sat_s
+browser-compat: webassembly.instructions.sub_sat_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_s/index.md
@@ -79,4 +79,3 @@ value_type.sub_sat_s
 ## See also
 
 - [`sub`](/en-US/docs/WebAssembly/Reference/Numeric/sub)
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_u/index.md
@@ -79,4 +79,3 @@ value_type.sub_sat_u
 ## See also
 
 - [`sub`](/en-US/docs/WebAssembly/Reference/Numeric/sub)
-- [SIMD arithmetic instructions](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic)

--- a/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_u/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/sub_sat_u/index.md
@@ -3,7 +3,7 @@ title: "sub_sat_u: Wasm SIMD arithmetic instruction"
 short-title: sub_sat_u
 slug: WebAssembly/Reference/SIMD/arithmetic/sub_sat_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.sub_sat_u
+browser-compat: webassembly.instructions.sub_sat_u
 sidebar: webassemblysidebar
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm SIMD arithmetic instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/arithmetic) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30091/.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
