### PR TITLE
Update Wasm SIMD bitwise instruction pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/simd/bitwise/all_true/index.md
+++ b/files/en-us/webassembly/reference/simd/bitwise/all_true/index.md
@@ -3,7 +3,7 @@ title: "all_true: Wasm SIMD bitwise instruction"
 short-title: all_true
 slug: WebAssembly/Reference/SIMD/bitwise/all_true
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.all_true
+browser-compat: webassembly.instructions.all_true
 sidebar: webassemblysidebar
 ---
 
@@ -70,7 +70,3 @@ value_type.all_true
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD bitwise instructions](/en-US/docs/WebAssembly/Reference/SIMD/bitwise)

--- a/files/en-us/webassembly/reference/simd/bitwise/andnot/index.md
+++ b/files/en-us/webassembly/reference/simd/bitwise/andnot/index.md
@@ -3,7 +3,7 @@ title: "andnot: Wasm SIMD bitwise instruction"
 short-title: andnot
 slug: WebAssembly/Reference/SIMD/bitwise/andnot
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.andnot
+browser-compat: webassembly.instructions.andnot
 sidebar: webassemblysidebar
 ---
 
@@ -113,7 +113,3 @@ v128.andnot
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD bitwise instructions](/en-US/docs/WebAssembly/Reference/SIMD/bitwise)

--- a/files/en-us/webassembly/reference/simd/bitwise/any_true/index.md
+++ b/files/en-us/webassembly/reference/simd/bitwise/any_true/index.md
@@ -3,7 +3,7 @@ title: "any_true: Wasm SIMD bitwise instruction"
 short-title: any_true
 slug: WebAssembly/Reference/SIMD/bitwise/any_true
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.any_true
+browser-compat: webassembly.instructions.any_true
 sidebar: webassemblysidebar
 ---
 
@@ -61,7 +61,3 @@ v128.any_true
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD bitwise instructions](/en-US/docs/WebAssembly/Reference/SIMD/bitwise)

--- a/files/en-us/webassembly/reference/simd/bitwise/bitmask/index.md
+++ b/files/en-us/webassembly/reference/simd/bitwise/bitmask/index.md
@@ -3,7 +3,7 @@ title: "bitmask: Wasm SIMD bitwise instruction"
 short-title: bitmask
 slug: WebAssembly/Reference/SIMD/bitwise/bitmask
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.bitmask
+browser-compat: webassembly.instructions.bitmask
 sidebar: webassemblysidebar
 ---
 
@@ -83,7 +83,3 @@ value_type.bitmask
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD bitwise instructions](/en-US/docs/WebAssembly/Reference/SIMD/bitwise)

--- a/files/en-us/webassembly/reference/simd/bitwise/bitselect/index.md
+++ b/files/en-us/webassembly/reference/simd/bitwise/bitselect/index.md
@@ -3,7 +3,7 @@ title: "bitselect: Wasm SIMD bitwise instruction"
 short-title: bitselect
 slug: WebAssembly/Reference/SIMD/bitwise/bitselect
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.bitselect
+browser-compat: webassembly.instructions.bitselect
 sidebar: webassemblysidebar
 ---
 
@@ -94,7 +94,3 @@ v128.bitselect
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD bitwise instructions](/en-US/docs/WebAssembly/Reference/SIMD/bitwise)

--- a/files/en-us/webassembly/reference/simd/bitwise/not/index.md
+++ b/files/en-us/webassembly/reference/simd/bitwise/not/index.md
@@ -3,7 +3,7 @@ title: "not: Wasm SIMD bitwise instruction"
 short-title: not
 slug: WebAssembly/Reference/SIMD/bitwise/not
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.not
+browser-compat: webassembly.instructions.not
 sidebar: webassemblysidebar
 ---
 
@@ -86,7 +86,3 @@ v128.not
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD bitwise instructions](/en-US/docs/WebAssembly/Reference/SIMD/bitwise)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm SIMD bitwise instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/bitwise) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30092.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
