### PR TITLE
Finalize release notes for Firefox 153

### DIFF
--- a/files/en-us/mozilla/firefox/releases/152/index.md
+++ b/files/en-us/mozilla/firefox/releases/152/index.md
@@ -1,8 +1,8 @@
 ---
-title: Firefox 152 release notes for developers (Stable)
-short-title: Firefox 152 (Stable)
+title: Firefox 152 release notes for developers
+short-title: Firefox 152
 slug: Mozilla/Firefox/Releases/152
-page-type: firefox-release-notes-active
+page-type: firefox-release-notes
 sidebar: firefox
 ---
 

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -1,18 +1,13 @@
 ---
-title: Firefox 153 release notes for developers (Beta)
-short-title: Firefox 153 (Beta)
+title: Firefox 153 release notes for developers (Stable)
+short-title: Firefox 153 (Stable)
 slug: Mozilla/Firefox/Releases/153
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
 This article provides information about the changes in Firefox 153 that affect developers.
-Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [July 21, 2026](https://whattrainisitnow.com/release/?version=153).
-
-> [!NOTE]
-> The release notes for this Firefox version are still a work in progress.
-
-<!-- Authors: Please uncomment any headings you are writing notes for -->
+Firefox 153 was released on [July 21, 2026](https://whattrainisitnow.com/release/?version=153).
 
 ## Changes for web developers
 
@@ -30,21 +25,9 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The `muted` attribute has now been updated for the {{htmlelement("audio", "", "#muted")}} and {{htmlelement("video", "", "#muted")}} elements to reflect when it is added to or removed from the DOM. This attribute now also matches the state of the {{cssxref(":muted")}} CSS pseudo-class.
   ([Firefox bug 2037015](https://bugzil.la/2037015)).
 
-<!-- #### Removals -->
-
-<!-- ### MathML -->
-
-<!-- #### Removals -->
-
-<!-- ### SVG -->
-
-<!-- #### Removals -->
-
 ### CSS
 
 - The {{cssxref("::-webkit-scrollbar")}} pseudo-element selector is now recognized, so the `@supports selector(::-webkit-scrollbar)` check returns `true`. Note that this reports the selector as supported even though scrollbar styling via `::-webkit-scrollbar` is not truly implemented. This was added to fix an issue where scrollbars of nested scrollable areas could stack on top of each other. For example, when a scrollbar is set to `display: none` or `width: 0` leaving some content unreachable. ([Firefox bug 2038877](https://bugzil.la/2038877)).
-
-<!-- #### Removals -->
 
 ### JavaScript
 
@@ -61,16 +44,6 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
   It is similar to the normal [`import`](/en-US/docs/Web/JavaScript/Reference/Statements/import) declaration, but instead of loading and evaluating a module, it produces an object representing the module's source code that can be evaluated later.
   Note that this feature is not yet useful for developers, as only the syntax is currently supported: the source representation of WebAssembly modules is implemented separately and is not yet available.
   ([Firefox bug 2043242](https://bugzil.la/2043242)).
-
-<!-- #### Removals -->
-
-<!-- ### HTTP -->
-
-<!-- #### Removals -->
-
-<!-- ### Security -->
-
-<!-- #### Removals -->
 
 ### APIs
 
@@ -101,13 +74,9 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
   In addition the `transportId` property is now available on {{domxref("RTCOutboundRtpStreamStats.transportId","RTCOutboundRtpStreamStats")}}, {{domxref("RTCRemoteOutboundRtpStreamStats.transportId","RTCRemoteOutboundRtpStreamStats")}}, {{domxref("RTCRemoteInboundRtpStreamStats.transportId","RTCRemoteInboundRtpStreamStats")}} and {{domxref("RTCInboundRtpStreamStats.transportId","RTCInboundRtpStreamStats")}}.
   ([Firefox bug 1225723](https://bugzil.la/1225723) and [Firefox bug 2019389](https://bugzil.la/2019389)).
 
-<!-- #### Removals -->
-
 ### WebAssembly
 
 - JavaScript Promise Integration (JS-PI) is now enabled, allowing [WebAssembly](/en-US/docs/WebAssembly) modules to interoperate with asynchronous, {{jsxref("Promise")}}-based JavaScript APIs. This lets WebAssembly code suspend while waiting for a JavaScript promise and resume when the promise settles. See [`WebAssembly.Suspending`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Suspending) for an explanation and working example. ([Firefox bug 2044809](https://bugzil.la/2044809)).
-
-<!-- #### Removals -->
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
@@ -139,10 +108,6 @@ Firefox 153 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - For contextual identities (containers):
   - Adds the {{WebExtAPIRef("contextualIdentities.getSupportedColors()")}} and {{WebExtAPIRef("contextualIdentities.getSupportedIcons()")}} methods to retrieve the supported colors and icons, avoiding the need to hardcode those values. ([Firefox bug 2044712](https://bugzil.la/2044712))
   - Updates the colors available. `"turquoise"` is renamed to `"cyan"`, `"toolbar"` is renamed to `"gray"`, and `"violet"` is added. The legacy names `"turquoise"` and `"toolbar"` are accepted for backward compatibility. To avoid hardcoding color names, use {{WebExtAPIRef("contextualIdentities.getSupportedColors()")}} to retrieve the available colors. ([Firefox bug 2044354](https://bugzil.la/2044354))
-
-<!-- ### Removals -->
-
-<!-- ### Other -->
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -1,13 +1,13 @@
 ---
-title: Firefox 154 release notes for developers (Beta)
-short-title: Firefox 154 (Beta)
-slug: Mozilla/Firefox/Releases/154
+title: Firefox 155 release notes for developers (Nightly)
+short-title: Firefox 155 (Nightly)
+slug: Mozilla/Firefox/Releases/155
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
-This article provides information about the changes in Firefox 154 that affect developers.
-Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [August 18, 2026](https://whattrainisitnow.com/release/?version=154).
+This article provides information about the changes in Firefox 155 that affect developers.
+Firefox 155 is the current [Nightly version of Firefox](https://www.firefox.com/en-US/channel/desktop/#nightly) and ships on [September 1, 2026](https://whattrainisitnow.com/release/?version=155).
 
 > [!NOTE]
 > The release notes for this Firefox version are still a work in progress.
@@ -78,6 +78,6 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Experimental web features
 
-These features are shipping in Firefox 154 but are disabled by default.
+These features are shipping in Firefox 155 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
### Description

Updates pages for Firefox 153 release (July 21, 2026).

- Removed active status from Firefox 152
- Updated Firefox 153 to (Stable)
- Updated Firefox 154 to (Beta)
- Created a new Nightly page for Firefox 155