### PR TITLE
Add BCD and Compat sections to SVG attribute pages

### DIFF
--- a/files/en-us/web/svg/reference/attribute/attributename/index.md
+++ b/files/en-us/web/svg/reference/attribute/attributename/index.md
@@ -2,6 +2,7 @@
 title: attributeName
 slug: Web/SVG/Reference/Attribute/attributeName
 page-type: svg-attribute
+browser-compat: svg.elements.animate.attributeName
 spec-urls: https://svgwg.org/specs/animations/#AttributeNameAttribute
 sidebar: svgref
 ---
@@ -65,6 +66,10 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/calcmode/index.md
+++ b/files/en-us/web/svg/reference/attribute/calcmode/index.md
@@ -2,6 +2,7 @@
 title: calcMode
 slug: Web/SVG/Reference/Attribute/calcMode
 page-type: svg-attribute
+browser-compat: svg.elements.animateMotion.calcMode
 spec-urls: https://svgwg.org/specs/animations/#CalcModeAttribute
 sidebar: svgref
 ---
@@ -50,6 +51,10 @@ You can use this attribute with the following SVG elements:
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/clippathunits/index.md
+++ b/files/en-us/web/svg/reference/attribute/clippathunits/index.md
@@ -2,6 +2,7 @@
 title: clipPathUnits
 slug: Web/SVG/Reference/Attribute/clipPathUnits
 page-type: svg-attribute
+browser-compat: svg.elements.clipPath.clipPathUnits
 spec-urls: https://drafts.csswg.org/css-masking-1/#element-attrdef-clippath-clippathunits
 sidebar: svgref
 ---
@@ -79,3 +80,7 @@ For {{SVGElement('clipPath')}}, `clipPathUnits` define the coordinate system in 
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/dx/index.md
+++ b/files/en-us/web/svg/reference/attribute/dx/index.md
@@ -2,6 +2,11 @@
 title: dx
 slug: Web/SVG/Reference/Attribute/dx
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feDropShadow.dx
+  - svg.elements.feOffset.dx
+  - svg.elements.text.dx
+  - svg.elements.tspan.dx
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fedropshadow-dx
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feoffset-dx
@@ -215,3 +220,7 @@ If there are multiple values, `dx` defines a shift along the x-axis for each ind
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/dy/index.md
+++ b/files/en-us/web/svg/reference/attribute/dy/index.md
@@ -2,6 +2,11 @@
 title: dy
 slug: Web/SVG/Reference/Attribute/dy
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feDropShadow.dy
+  - svg.elements.feOffset.dy
+  - svg.elements.text.dy
+  - svg.elements.tspan.dy
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fedropshadow-dy
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feoffset-dy
@@ -216,3 +221,7 @@ If there are multiple values, `dy` defines a shift along the y-axis for each ind
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/edgemode/index.md
+++ b/files/en-us/web/svg/reference/attribute/edgemode/index.md
@@ -2,6 +2,9 @@
 title: edgeMode
 slug: Web/SVG/Reference/Attribute/edgeMode
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feConvolveMatrix.edgeMode
+  - svg.elements.feGaussianBlur.edgeMode
 spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-feconvolvematrix-edgemode
 sidebar: svgref
 ---
@@ -72,3 +75,7 @@ For {{SVGElement("feGaussianBlur")}}, `edgeMode` determines how to extend the in
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/height/index.md
+++ b/files/en-us/web/svg/reference/attribute/height/index.md
@@ -2,6 +2,15 @@
 title: height
 slug: Web/SVG/Reference/Attribute/height
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.filter.height
+  - svg.elements.foreignObject.height
+  - svg.elements.image.height
+  - svg.elements.mask.height
+  - svg.elements.pattern.height
+  - svg.elements.rect.height
+  - svg.elements.svg.height
+  - svg.elements.use.height
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-height
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-height
@@ -860,6 +869,10 @@ For {{SVGElement('use')}}, `height` defines the vertical length for the referenc
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/in/index.md
+++ b/files/en-us/web/svg/reference/attribute/in/index.md
@@ -2,6 +2,21 @@
 title: in
 slug: Web/SVG/Reference/Attribute/in
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feBlend.in
+  - svg.elements.feColorMatrix.in
+  - svg.elements.feComponentTransfer.in
+  - svg.elements.feComposite.in
+  - svg.elements.feConvolveMatrix.in
+  - svg.elements.feDiffuseLighting.in
+  - svg.elements.feDisplacementMap.in
+  - svg.elements.feDropShadow.in
+  - svg.elements.feGaussianBlur.in
+  - svg.elements.feMergeNode.in
+  - svg.elements.feMorphology.in
+  - svg.elements.feOffset.in
+  - svg.elements.feSpecularLighting.in
+  - svg.elements.feTile.in
 spec-urls: https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-in
 sidebar: svgref
 ---
@@ -143,3 +158,7 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/in2/index.md
+++ b/files/en-us/web/svg/reference/attribute/in2/index.md
@@ -2,6 +2,10 @@
 title: in2
 slug: Web/SVG/Reference/Attribute/in2
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feBlend.in2
+  - svg.elements.feComposite.in2
+  - svg.elements.feDisplacementMap.in2
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fedisplacementmap-in2
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomposite-in2
@@ -107,3 +111,7 @@ For {{SVGElement("feDisplacementMap")}}, `in2` defines the second input image, w
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/kernelunitlength/index.md
+++ b/files/en-us/web/svg/reference/attribute/kernelunitlength/index.md
@@ -2,6 +2,10 @@
 title: kernelUnitLength
 slug: Web/SVG/Reference/Attribute/kernelUnitLength
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feConvolveMatrix.kernelUnitLength
+  - svg.elements.feDiffuseLighting.kernelUnitLength
+  - svg.elements.feSpecularLighting.kernelUnitLength
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespecularlighting-kernelunitlength
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fediffuselighting-kernelunitlength
@@ -114,3 +118,7 @@ If a negative or zero value is specified the default value will be used instead.
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/operator/index.md
+++ b/files/en-us/web/svg/reference/attribute/operator/index.md
@@ -2,6 +2,9 @@
 title: operator
 slug: Web/SVG/Reference/Attribute/operator
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feComposite.operator
+  - svg.elements.feMorphology.operator
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-femorphology-operator
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecomposite-operator
@@ -120,3 +123,7 @@ For {{SVGElement("feMorphology")}}, `operator` defines whether to erode (i.e., t
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/origin/index.md
+++ b/files/en-us/web/svg/reference/attribute/origin/index.md
@@ -2,6 +2,7 @@
 title: origin
 slug: Web/SVG/Reference/Attribute/origin
 page-type: svg-attribute
+browser-compat: svg.elements.animateMotion.origin
 spec-urls: https://svgwg.org/specs/animations/#OriginAttribute
 sidebar: svgref
 ---
@@ -34,6 +35,10 @@ You can use this attribute with the following SVG elements:
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/path/index.md
+++ b/files/en-us/web/svg/reference/attribute/path/index.md
@@ -2,6 +2,9 @@
 title: path
 slug: Web/SVG/Reference/Attribute/path
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.animateMotion.path
+  - svg.elements.textPath.path
 spec-urls:
   - https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementPathAttribute
   - https://svgwg.org/specs/animations/#AnimateMotionElementPathAttribute
@@ -95,3 +98,7 @@ For {{SVGElement("textPath")}}, `path` defines the path onto which the {{Glossar
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/points/index.md
+++ b/files/en-us/web/svg/reference/attribute/points/index.md
@@ -2,6 +2,9 @@
 title: points
 slug: Web/SVG/Reference/Attribute/points
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.polygon.points
+  - svg.elements.polyline.points
 spec-urls:
   - https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolygonElementPointsAttribute
   - https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolylineElementPointsAttribute
@@ -132,3 +135,7 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/preserveaspectratio/index.md
+++ b/files/en-us/web/svg/reference/attribute/preserveaspectratio/index.md
@@ -2,6 +2,12 @@
 title: preserveAspectRatio
 slug: Web/SVG/Reference/Attribute/preserveAspectRatio
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feImage.preserveAspectRatio
+  - svg.elements.image.preserveAspectRatio
+  - svg.elements.svg.preserveAspectRatio
+  - svg.elements.symbol.preserveAspectRatio
+  - svg.elements.view.preserveAspectRatio
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-feimage-preserveaspectratio
   - https://w3c.github.io/svgwg/svg2-draft/coords.html#PreserveAspectRatioAttribute
@@ -688,3 +694,7 @@ For {{SVGElement('view')}}, `preserveAspectRatio` indicates if a uniform scaling
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/refx/index.md
+++ b/files/en-us/web/svg/reference/attribute/refx/index.md
@@ -2,6 +2,7 @@
 title: refX
 slug: Web/SVG/Reference/Attribute/refX
 page-type: svg-attribute
+browser-compat: svg.elements.marker.refX
 spec-urls:
   - https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerElementRefXAttribute
   - https://w3c.github.io/svgwg/svg2-draft/struct.html#SymbolElementRefXAttribute
@@ -100,6 +101,10 @@ Unlike other positioning attributes, `refX` is interpreted as being in the coord
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/refy/index.md
+++ b/files/en-us/web/svg/reference/attribute/refy/index.md
@@ -2,6 +2,7 @@
 title: refY
 slug: Web/SVG/Reference/Attribute/refY
 page-type: svg-attribute
+browser-compat: svg.elements.marker.refY
 spec-urls:
   - https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerElementRefYAttribute
   - https://w3c.github.io/svgwg/svg2-draft/struct.html#SymbolElementRefYAttribute
@@ -100,6 +101,10 @@ Unlike other positioning attributes, `refY` is interpreted as being in the coord
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/rx/index.md
+++ b/files/en-us/web/svg/reference/attribute/rx/index.md
@@ -2,6 +2,9 @@
 title: rx
 slug: Web/SVG/Reference/Attribute/rx
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.ellipse.rx
+  - svg.elements.rect.rx
 spec-urls: https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX
 sidebar: svgref
 ---
@@ -120,6 +123,10 @@ The way the value of the `rx` attribute is interpreted depend on both the {{SVGA
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/ry/index.md
+++ b/files/en-us/web/svg/reference/attribute/ry/index.md
@@ -2,6 +2,9 @@
 title: ry
 slug: Web/SVG/Reference/Attribute/ry
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.ellipse.ry
+  - svg.elements.rect.ry
 spec-urls: https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY
 sidebar: svgref
 ---
@@ -120,6 +123,10 @@ The way the value of the `ry` attribute is interpreted depend on both the {{SVGA
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/specularexponent/index.md
+++ b/files/en-us/web/svg/reference/attribute/specularexponent/index.md
@@ -2,6 +2,9 @@
 title: specularExponent
 slug: Web/SVG/Reference/Attribute/specularExponent
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feSpecularLighting.specularExponent
+  - svg.elements.feSpotLight.specularExponent
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespecularlighting-specularexponent
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-specularexponent
@@ -95,6 +98,10 @@ For {{SVGElement("feSpotLight")}}, `specularExponent` defines the exponent value
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/surfacescale/index.md
+++ b/files/en-us/web/svg/reference/attribute/surfacescale/index.md
@@ -2,6 +2,9 @@
 title: surfaceScale
 slug: Web/SVG/Reference/Attribute/surfaceScale
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.feDiffuseLighting.surfaceScale
+  - svg.elements.feSpecularLighting.surfaceScale
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fediffuselighting-surfacescale
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespecularlighting-surfacescale
@@ -95,6 +98,10 @@ For {{SVGElement("feDiffuseLighting")}}, `surfaceScale` defines the height of th
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/to/index.md
+++ b/files/en-us/web/svg/reference/attribute/to/index.md
@@ -2,6 +2,10 @@
 title: to
 slug: Web/SVG/Reference/Attribute/to
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.animate.to
+  - svg.elements.animateTransform.to
+  - svg.elements.set.to
 spec-urls:
   - https://svgwg.org/specs/animations/#SetElementToAttribute
   - https://svgwg.org/specs/animations/#ToAttribute
@@ -96,3 +100,7 @@ The exact value type for this attribute depend on the value of the attribute tha
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/type/index.md
+++ b/files/en-us/web/svg/reference/attribute/type/index.md
@@ -2,6 +2,13 @@
 title: type
 slug: Web/SVG/Reference/Attribute/type
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.a.type
+  - svg.elements.animateTransform.type
+  - svg.elements.feColorMatrix.type
+  - svg.elements.feTurbulence.type
+  - svg.elements.script.type
+  - svg.elements.style.type
 sidebar: svgref
 ---
 
@@ -195,3 +202,7 @@ SVG elements: {{SVGElement("style")}}, {{SVGElement("script")}}
     </tr>
   </tbody>
 </table>
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/values/index.md
+++ b/files/en-us/web/svg/reference/attribute/values/index.md
@@ -2,6 +2,7 @@
 title: values
 slug: Web/SVG/Reference/Attribute/values
 page-type: svg-attribute
+browser-compat: svg.elements.feColorMatrix.values
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fecolormatrix-values
   - https://svgwg.org/specs/animations/#ValuesAttribute
@@ -91,3 +92,7 @@ For the {{SVGElement("feColorMatrix")}} element, `values` is a list of numbers i
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/viewbox/index.md
+++ b/files/en-us/web/svg/reference/attribute/viewbox/index.md
@@ -2,6 +2,11 @@
 title: viewBox
 slug: Web/SVG/Reference/Attribute/viewBox
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.marker.viewBox
+  - svg.elements.svg.viewBox
+  - svg.elements.symbol.viewBox
+  - svg.elements.view.viewBox
 spec-urls: https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute
 sidebar: svgref
 ---
@@ -268,3 +273,7 @@ The user units of `r="4"` are resolved against the `viewBox` sizes, creating dra
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/width/index.md
+++ b/files/en-us/web/svg/reference/attribute/width/index.md
@@ -2,6 +2,15 @@
 title: width
 slug: Web/SVG/Reference/Attribute/width
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.filter.width
+  - svg.elements.foreignObject.width
+  - svg.elements.image.width
+  - svg.elements.mask.width
+  - svg.elements.pattern.width
+  - svg.elements.rect.width
+  - svg.elements.svg.width
+  - svg.elements.use.width
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-width
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-primitive-width
@@ -909,6 +918,10 @@ This example includes three {{SVGElement("rect")}} elements with varied `width` 
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/x/index.md
+++ b/files/en-us/web/svg/reference/attribute/x/index.md
@@ -2,6 +2,19 @@
 title: x
 slug: Web/SVG/Reference/Attribute/x
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.fePointLight.x
+  - svg.elements.feSpotLight.x
+  - svg.elements.filter.x
+  - svg.elements.foreignObject.x
+  - svg.elements.image.x
+  - svg.elements.mask.x
+  - svg.elements.pattern.x
+  - svg.elements.rect.x
+  - svg.elements.svg.x
+  - svg.elements.text.x
+  - svg.elements.tspan.x
+  - svg.elements.use.x
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-x
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-x
@@ -1255,6 +1268,10 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/y/index.md
+++ b/files/en-us/web/svg/reference/attribute/y/index.md
@@ -2,6 +2,19 @@
 title: y
 slug: Web/SVG/Reference/Attribute/y
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.fePointLight.y
+  - svg.elements.feSpotLight.y
+  - svg.elements.filter.y
+  - svg.elements.foreignObject.y
+  - svg.elements.image.y
+  - svg.elements.mask.y
+  - svg.elements.pattern.y
+  - svg.elements.rect.y
+  - svg.elements.svg.y
+  - svg.elements.text.y
+  - svg.elements.tspan.y
+  - svg.elements.use.y
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-filter-y
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-y
@@ -1254,6 +1267,10 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/z/index.md
+++ b/files/en-us/web/svg/reference/attribute/z/index.md
@@ -2,6 +2,9 @@
 title: z
 slug: Web/SVG/Reference/Attribute/z
 page-type: svg-attribute
+browser-compat:
+  - svg.elements.fePointLight.z
+  - svg.elements.feSpotLight.z
 spec-urls:
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fepointlight-z
   - https://drafts.csswg.org/filter-effects-1/#element-attrdef-fespotlight-z
@@ -94,3 +97,7 @@ svg {
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
### Description
Add `browser-compat` front matter and ## Browser compatibility / {{Compat}} sections to 29 SVG attribute pages that already have BCD data but were not wired up, so compatibility tables render on those pages.
### Motivation
Most SVG attribute reference pages show specs and browser compatibility. These pages already have BCD entries, but without the front matter and {{Compat}} macro readers cannot see support information. This aligns them with existing pages such as `cx` and `r`.
### Additional details

### Related issues and pull requests
