### PR TITLE
FF154 Relnote: RTCDtlsTransport error event

### DIFF
--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -56,7 +56,7 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
-- The [`error`](/en-US/docs/Web/API/RTCDtlsTransport/error_event) event is now fired on {{domxref("RTCDtlsTransport")}} to report DTLS and fingerprinting errors.
+- The {{domxref("RTCDtlsTransport/error_event", "error")}} event is now fired on {{domxref("RTCDtlsTransport")}} to report DTLS and fingerprinting errors.
   ([Firefox bug 1805447](https://bugzil.la/1805447)).
 
 <!-- #### Removals -->

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -50,11 +50,14 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
 
 <!-- #### DOM -->
 
-<!-- #### Media, WebRTC, and Web Audio -->
+#### Media, WebRTC, and Web Audio
+
+- The [`error`](/en-US/docs/Web/API/RTCDtlsTransport/error_event) event is now fired on {{domxref("RTCDtlsTransport")}} to report DTLS and fingerprinting errors.
+  ([Firefox bug 1805447](https://bugzil.la/1805447)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/web/api/rtcdtlstransport/error_event/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/error_event/index.md
@@ -28,13 +28,6 @@ An {{domxref("RTCErrorEvent")}}. Inherits from {{domxref("Event")}}.
 
 {{InheritanceDiagram("RTCErrorEvent")}}
 
-## Event properties
-
-_In addition to the standard properties available on the {{domxref("Event")}} interface, `RTCErrorEvent` also includes the following:_
-
-- {{domxref("RTCErrorEvent.error", "error")}} {{ReadOnlyInline}}
-  - : An {{domxref("RTCError")}} object specifying the error which occurred; this object includes the type of error that occurred, information about where the error occurred (such as which line number in the {{Glossary("SDP")}} or what {{Glossary("SCTP")}} cause code was at issue).
-
 ## Description
 
 Transport-level errors will have one of the following values for the specified error's {{domxref("RTCError")}} property {{domxref("RTCError.errorDetail", "errorDetail")}}:
@@ -45,6 +38,8 @@ Transport-level errors will have one of the following values for the specified e
   - : The remote certificate for the {{domxref("RTCDtlsTransport")}} didn't match any of the fingerprints listed in the SDP. If the remote peer can't match the local certificate against the provided fingerprints, this error doesn't occur, though this situation may result instead in a `dtls-failure` error.
 
 ## Examples
+
+### Basic usage
 
 Given an {{domxref("RTCPeerConnection")}}, `pc`, the following code handles a DTLS transport error:
 

--- a/files/en-us/web/api/rtcdtlstransport/error_event/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/error_event/index.md
@@ -46,12 +46,22 @@ Transport-level errors will have one of the following values for the specified e
 
 ## Examples
 
-In this example, the `onerror` event handler property is used to set the handler for the `error` event.
+Given an {{domxref("RTCPeerConnection")}}, `pc`, the following code handles a DTLS transport error:
 
 ```js
-transport.onerror = (ev) => {
-  const err = ev.error;
+const dtlsTransport = pc.getSenders()[0].transport;
 
+dtlsTransport.addEventListener("error", (ev) => {
+  const err = ev.error;
+  // …
+});
+```
+
+The same code, using the `onerror` event handler property, looks like this:
+
+```js
+dtlsTransport.onerror = (ev) => {
+  const err = ev.error;
   // …
 };
 ```


### PR DESCRIPTION
FF154 adds support for the [`error` event](https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/error_event) on `RTCDtlsTransport` in https://bugzilla.mozilla.org/show_bug.cgi?id=1805447. This adds a release note and a minor tidy to the docs.

Related docs work can be tracked in #44835