### PR TITLE
RTCCertificateStats.issuerCertificateId

### DIFF
--- a/files/en-us/web/api/rtccertificatestats/index.md
+++ b/files/en-us/web/api/rtccertificatestats/index.md
@@ -31,7 +31,6 @@ The following properties are common to all WebRTC statistics objects (See [`RTCS
 
 - {{domxref("RTCCertificateStats.id", "id")}}
   - : A string that uniquely identifies the object that is being monitored to produce this set of statistics.
-
 - {{domxref("RTCCertificateStats.timestamp", "timestamp")}}
   - : A {{domxref("DOMHighResTimeStamp")}} object indicating the time at which the sample was taken for this statistics object.
 - {{domxref("RTCCertificateStats.type", "type")}}

--- a/files/en-us/web/api/rtccertificatestats/index.md
+++ b/files/en-us/web/api/rtccertificatestats/index.md
@@ -13,12 +13,15 @@ The report can be obtained by iterating the {{domxref("RTCStatsReport")}} return
 
 ## Instance properties
 
+- {{domxref("RTCCertificateStats.base64Certificate", "base64Certificate")}}
+  - : A string containing the base-64 representation of the DER-encoded certificate.
 - {{domxref("RTCCertificateStats.fingerprint", "fingerprint")}}
   - : A string containing the certificate fingerprint, which is calculated using the hash function specified in [`fingerprintAlgorithm`](/en-US/docs/Web/API/RTCCertificateStats/fingerprintAlgorithm).
 - {{domxref("RTCCertificateStats.fingerprintAlgorithm", "fingerprintAlgorithm")}}
   - : A string containing the hash function used to compute the certificate [`fingerprint`](/en-US/docs/Web/API/RTCCertificateStats/fingerprint), such as "sha-256".
-- {{domxref("RTCCertificateStats.base64Certificate", "base64Certificate")}}
-  - : A string containing the base-64 representation of the DER-encoded certificate.
+- {{domxref("RTCCertificateStats.issuerCertificateId", "issuerCertificateId")}}
+  - : A string containing the `id` of the {{domxref("RTCCertificateStats")}} object in this report that contains the next certificate in the certificate chain.
+    This will not be set if the current certificate is a self-signed certificate or the end of the certificate chain (a root certificate).
 
 ### Common instance properties
 
@@ -28,12 +31,15 @@ The following properties are common to all WebRTC statistics objects (See [`RTCS
 
 - {{domxref("RTCCertificateStats.id", "id")}}
   - : A string that uniquely identifies the object that is being monitored to produce this set of statistics.
+
 - {{domxref("RTCCertificateStats.timestamp", "timestamp")}}
   - : A {{domxref("DOMHighResTimeStamp")}} object indicating the time at which the sample was taken for this statistics object.
 - {{domxref("RTCCertificateStats.type", "type")}}
   - : A string with the value `"certificate"`, indicating the type of statistics that the object contains.
 
 ## Examples
+
+### Basic usage
 
 Given a variable `myPeerConnection`, which is an instance of {{domxref("RTCPeerConnection")}}, the code below uses `await` to wait for the statistics report, and then iterates it using `RTCStatsReport.forEach()`.
 It then filters the dictionaries for just those reports that have the type of `certificate` and logs the result.

--- a/files/en-us/web/api/rtccertificatestats/issuercertificateid/index.md
+++ b/files/en-us/web/api/rtccertificatestats/issuercertificateid/index.md
@@ -1,0 +1,29 @@
+---
+title: "RTCCertificateStats: issuerCertificateId property"
+short-title: issuerCertificateId
+slug: Web/API/RTCCertificateStats/issuerCertificateId
+page-type: web-api-instance-property
+browser-compat: api.RTCStatsReport.type_certificate.issuerCertificateId
+---
+
+{{APIRef("WebRTC")}}
+
+The **`issuerCertificateId`** property of the {{domxref("RTCCertificateStats")}} dictionary is a string containing the {{domxref("RTCCertificateStats.id", "id")}} of the {{domxref("RTCCertificateStats")}} object in this report that contains the next certificate in the certificate chain.
+
+If there are no further certificates in the chain, such as if this is the root certificate or a self-signed certificate, the value is `undefined`.
+
+Note that WebRTC uses certificates when establishing a DTLS connection.
+By default connections use self-signed certificates, but in enterprise or WebRTC gateway setups signed certificate chains from intermediate and root certificate authorities (CAs) may be used instead.
+This property allows you to walk the chain of certificates if needed.
+
+## Value
+
+A string, or `undefined` if the current certificate is at the end of the certificate chain.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
FF154 added support for [RTCCertificateStats](https://developer.mozilla.org/en-US/docs/Web/API/RTCCertificateStats) in https://bugzilla.mozilla.org/show_bug.cgi?id=2019333

This updates its docs, including for the new property `issuerCertificateId`

Related docs work can be tracked in https://github.com/mdn/content/issues/44837