### PR TITLE
CSS property: value section intro

### DIFF
--- a/files/en-us/web/css/reference/properties/animation-composition/index.md
+++ b/files/en-us/web/css/reference/properties/animation-composition/index.md
@@ -30,10 +30,9 @@ animation-composition: revert-layer;
 animation-composition: unset;
 ```
 
-> [!NOTE]
-> When you specify multiple comma-separated values on an `animation-*` property, they will be applied to the animations in the order in which the {{cssxref("animation-name")}}s appear. If the number of animations and compositions differ, the values listed in the `animation-composition` property will cycle from the first to the last `animation-name`, looping until all the animations have an assigned `animation-composition` value. For more information, see [Setting multiple animation property values](/en-US/docs/Web/CSS/Guides/Animations/Using#setting_multiple_animation_property_values).
-
 ### Values
+
+This property is specified as one or more comma-separated keyword values:
 
 - `replace`
   - : The effect value overrides the underlying value of the property. This is the default value.
@@ -73,6 +72,10 @@ Consider different values for the `animation-composition` property in the above 
 
 > [!NOTE]
 > A composite operation can also be specified in a keyframe. In that case, the specified composite operation is used for each property first within that keyframe and then on each property in the next keyframe.
+
+### Multiple values
+
+When you specify multiple comma-separated values on an `animation-*` property, they will be applied to the animations in the order in which the {{cssxref("animation-name")}}s appear. If the number of animations and compositions differ, the values listed in the `animation-composition` property will cycle from the first to the last `animation-name`, looping until all the animations have an assigned `animation-composition` value. For more information, see [Setting multiple animation property values](/en-US/docs/Web/CSS/Guides/Animations/Using#setting_multiple_animation_property_values).
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/properties/background-attachment/index.md
+++ b/files/en-us/web/css/reference/properties/background-attachment/index.md
@@ -88,9 +88,9 @@ background-attachment: revert-layer;
 background-attachment: unset;
 ```
 
-The `background-attachment` property is specified as one or more of the keyword values, separated by commas.
-
 ### Values
+
+This property is specified as one or more comma-separated keyword values:
 
 - `fixed`
   - : The background is fixed relative to the viewport. Even if an element has a scrolling mechanism, the background doesn't move with the element. If set, the {{cssxref("background-origin")}} property is ignored.

--- a/files/en-us/web/css/reference/properties/background-position/index.md
+++ b/files/en-us/web/css/reference/properties/background-position/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.background-position
 sidebar: cssref
 ---
 
-The **`background-position`** [CSS](/en-US/docs/Web/CSS) property sets the initial position for each background image. The position is relative to the position layer set by {{cssxref("background-origin")}}.
+The **`background-position`** [CSS](/en-US/docs/Web/CSS) property sets the initial position for each background image.
 
 {{InteractiveExample("CSS Demo: background-position")}}
 
@@ -87,31 +87,41 @@ background-position: revert-layer;
 background-position: unset;
 ```
 
-The `background-position` property is specified as one or more `<position>` values, separated by commas.
-
 ### Values
 
-- `<position>`
-  - : A {{cssxref("&lt;position&gt;")}}. A position defines an x/y coordinate, to place an item relative to the edges of an element's box. It can be defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be `center`. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s).
+This property is specified as one or more comma-separated `<position>` values:
 
-    **1-value syntax:** The value may be:
+- `<position>`
+  - : A {{cssxref("&lt;position&gt;")}}. A two-dimensional coordinate, made up of one to two offsets, and optionally one to two offset sides, used to set a location relative to the edges of an element's box.
+
+## Description
+
+The `background-position` property sets the initial position for each background image. The position is relative to the position layer set by {{cssxref("background-origin")}}.
+
+The value is specified as a list of comma-separated image positions, with each image position defined using one to four values. If two non-keyword values are used, the first value represents the horizontal position and the second represents the vertical position. If only one value is specified, the second value is assumed to be `center`. If three or four values are used, the length-percentage values are offsets for the preceding keyword value(s).
+
+- 1-value syntax
+  - : The value may be:
     - The keyword value `center`, which centers the image.
     - One of the keyword values `top`, `left`, `bottom`, or `right`. This specifies an edge against which to place the item. The other dimension is then set to 50%, so the item is placed in the middle of the edge specified.
     - A {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}}. This specifies the X coordinate relative to the left edge, with the Y coordinate set to 50%.
 
-    **2-value syntax:** One value defines X and the other defines Y. Each value may be:
+- 2-value syntax
+  - : One value defines X and the other defines Y. Each value may be:
     - One of the keyword values `top`, `left`, `bottom`, or `right`. If `left` or `right` is given, then this defines X and the other given value defines Y. If `top` or `bottom` is given, then this defines Y and the other value defines X.
     - A {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}}. If the other value is `left` or `right`, then this value defines Y, relative to the top edge. If the other value is `top` or `bottom`, then this value defines X, relative to the left edge. If both values are `<length>` or `<percentage>` values, then the first defines X and the second Y.
     - Note that: If one value is `top` or `bottom`, then the other value may not be `top` or `bottom`. If one value is `left` or `right`, then the other value may not be `left` or `right`. This means, e.g., that `top top` and `left right` are not valid.
     - Order: When pairing keywords, placement is not important as the browser can reorder it; the values `top left` and `left top` will yield the same result. When pairing {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} with a keyword, the placement is important: the value defining X should come first followed by Y, so for example the value `right 20px` is valid while `20px right` is invalid. The values `left 20%` and `20% bottom` are valid as X and Y values are clearly defined and the placement is correct.
     - The default value is `left top` or `0% 0%`.
 
-    **3-value syntax:** Two values are keyword values, and the third is the offset for the preceding value:
+- 3-value syntax
+  - : Two values are keyword values, and the third is the offset for the preceding value:
     - The first value is one of the keyword values `top`, `left`, `bottom`, `right`, or `center`. If `left` or `right` are given here, then this defines X. If `top` or `bottom` are given, then this defines Y and the other keyword value defines X.
     - The {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} value, if it is the second value, is the offset for the first value. If it is the third value, it is the offset for the second value.
     - The single length or percentage value is an offset for the keyword value that precedes it. The combination of one keyword with two {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} values is not valid.
 
-    **4-value syntax:** The first and third values are keyword values defining X and Y. The second and fourth values are offsets for the preceding X and Y keyword values:
+- 4-value syntax
+  - : The first and third values are keyword values defining X and Y. The second and fourth values are offsets for the preceding X and Y keyword values:
     - The first and third values are equal to one of the keyword values `top`, `left`, `bottom`, or `right`. If `left` or `right` is given for the first value, then this defines X and the other value defines Y. If `top` or `bottom` is given for the first value, then this defines Y and the other keyword value defines X.
     - The second and fourth values are {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} values. The second value is the offset for the first keyword. The fourth value is the offset for the second keyword.
 

--- a/files/en-us/web/css/reference/properties/writing-mode/index.md
+++ b/files/en-us/web/css/reference/properties/writing-mode/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.writing-mode
 sidebar: cssref
 ---
 
-The **`writing-mode`** [CSS](/en-US/docs/Web/CSS) property sets whether lines of text are laid out horizontally or vertically, as well as the direction in which blocks progress.
+The **`writing-mode`** [CSS](/en-US/docs/Web/CSS) property sets whether lines of text are laid out horizontally or vertically, as well as the direction in which text flows.
 
 {{InteractiveExample("CSS Demo: writing-mode")}}
 

--- a/files/en-us/web/css/reference/properties/writing-mode/index.md
+++ b/files/en-us/web/css/reference/properties/writing-mode/index.md
@@ -7,7 +7,7 @@ browser-compat: css.properties.writing-mode
 sidebar: cssref
 ---
 
-The **`writing-mode`** [CSS](/en-US/docs/Web/CSS) property sets whether lines of text are laid out horizontally or vertically, as well as the direction in which blocks progress. When set for an entire document, it should be set on the root element (`html` element for HTML documents).
+The **`writing-mode`** [CSS](/en-US/docs/Web/CSS) property sets whether lines of text are laid out horizontally or vertically, as well as the direction in which blocks progress.
 
 {{InteractiveExample("CSS Demo: writing-mode")}}
 
@@ -57,8 +57,6 @@ writing-mode: sideways-lr;
 }
 ```
 
-This property specifies the _block flow direction_, which is the direction in which block-level containers are stacked, and the direction in which inline-level content flows within a block container. Thus, it also determines the ordering of block-level content.
-
 ## Syntax
 
 ```css
@@ -77,9 +75,9 @@ writing-mode: revert-layer;
 writing-mode: unset;
 ```
 
-The `writing-mode` property is specified as one of the values listed below. The flow direction in horizontal scripts is also affected by the [directionality of that script](https://www.w3.org/International/questions/qa-scripts.en), either left-to-right (`ltr`, like English and most other languages) or right-to-left (`rtl`, like Hebrew or Arabic).
-
 ### Values
+
+This property is specified as one of the following keywords:
 
 - `horizontal-tb`
   - : For `ltr` scripts, content flows horizontally from left to right. For `rtl` scripts, content flows horizontally from right to left. The next horizontal line is positioned below the previous line.
@@ -103,6 +101,14 @@ The `writing-mode` property is specified as one of the values listed below. The 
   - : Deprecated except for SVG1 documents. For CSS, use `vertical-lr` instead.
 - `tb-rl`
   - : Deprecated except for SVG1 documents. For CSS, use `vertical-rl` instead.
+
+## Description
+
+The `writing-mode` property sets whether lines of text are laid out horizontally or vertically. It specifies the _block flow direction_, which is the direction in which block-level containers are stacked, and the direction in which inline-level content flows within a block container. Thus, it also determines the ordering of block-level content.
+
+The flow direction in horizontal scripts is also affected by the [directionality of that script](https://www.w3.org/International/questions/qa-scripts.en), either left-to-right (`ltr`, like English and most other languages) or right-to-left (`rtl`, like Hebrew or Arabic).
+
+When set for an entire document, it should be set on the root element (`html` element for HTML documents).
 
 ## Formal definition
 


### PR DESCRIPTION
continutation of https://github.com/mdn/content/pull/44833

CSS properties include a "Values" section.
Sometimes there is an intro to the values. sometimes there isn't.
Sometimes that intro is above the values title, sometimes it's after it.
This is the second PR in an attempt to make things consistent. This PR addresses 2 props that needed a bit of page reorg and one i missed in the previous PR