### PR TITLE
Update Wasm SIMD conversion instruction pages to display BCD and specs

### DIFF
--- a/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_s/index.md
@@ -65,7 +65,3 @@ value_type.convert_i32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_s/index.md
@@ -3,7 +3,7 @@ title: "convert_i32x4_s: Wasm SIMD conversion instruction"
 short-title: convert_i32x4_s
 slug: WebAssembly/Reference/SIMD/conversion/convert_i32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.convert_i32x4_s
+browser-compat: webassembly.instructions.convert_i32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_u/index.md
@@ -3,7 +3,7 @@ title: "convert_i32x4_u: Wasm SIMD conversion instruction"
 short-title: convert_i32x4_u
 slug: WebAssembly/Reference/SIMD/conversion/convert_i32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.convert_i32x4_u
+browser-compat: webassembly.instructions.convert_i32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_i32x4_u/index.md
@@ -65,7 +65,3 @@ value_type.convert_i32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_s/index.md
@@ -3,7 +3,7 @@ title: "convert_low_i32x4_s: Wasm SIMD conversion instruction"
 short-title: convert_low_i32x4_s
 slug: WebAssembly/Reference/SIMD/conversion/convert_low_i32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.convert_low_i32x4_s
+browser-compat: webassembly.instructions.convert_low_i32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_s/index.md
@@ -65,7 +65,3 @@ value_type.convert_low_i32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_u/index.md
@@ -65,7 +65,3 @@ value_type.convert_low_i32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/convert_low_i32x4_u/index.md
@@ -3,7 +3,7 @@ title: "convert_low_i32x4_u: Wasm SIMD conversion instruction"
 short-title: convert_low_i32x4_u
 slug: WebAssembly/Reference/SIMD/conversion/convert_low_i32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.convert_low_i32x4_u
+browser-compat: webassembly.instructions.convert_low_i32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/demote_f64x2_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/demote_f64x2_zero/index.md
@@ -3,7 +3,7 @@ title: "demote_f64x2_zero: Wasm SIMD conversion instruction"
 short-title: demote_f64x2_zero
 slug: WebAssembly/Reference/SIMD/conversion/demote_f64x2_zero
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.demote_f64x2_zero
+browser-compat: webassembly.instructions.demote_f64x2_zero
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/demote_f64x2_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/demote_f64x2_zero/index.md
@@ -65,7 +65,3 @@ value_type.demote_f64x2_zero
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_s/index.md
@@ -62,7 +62,3 @@ i32x4.extend_high_i16x8_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_s/index.md
@@ -3,7 +3,7 @@ title: "extend_high_i16x8_s: Wasm SIMD conversion instruction"
 short-title: extend_high_i16x8_s
 slug: WebAssembly/Reference/SIMD/conversion/extend_high_i16x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_high_i16x8_s
+browser-compat: webassembly.instructions.extend_high_i16x8_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_u/index.md
@@ -62,7 +62,3 @@ i32x4.extend_high_i16x8_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i16x8_u/index.md
@@ -3,7 +3,7 @@ title: "extend_high_i16x8_u: Wasm SIMD conversion instruction"
 short-title: extend_high_i16x8_u
 slug: WebAssembly/Reference/SIMD/conversion/extend_high_i16x8_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_high_i16x8_u
+browser-compat: webassembly.instructions.extend_high_i16x8_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_s/index.md
@@ -62,7 +62,3 @@ i64x2.extend_high_i32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_s/index.md
@@ -3,7 +3,7 @@ title: "extend_high_i32x4_s: Wasm SIMD conversion instruction"
 short-title: extend_high_i32x4_s
 slug: WebAssembly/Reference/SIMD/conversion/extend_high_i32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_high_i32x4_s
+browser-compat: webassembly.instructions.extend_high_i32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_u/index.md
@@ -62,7 +62,3 @@ i64x2.extend_high_i32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i32x4_u/index.md
@@ -3,7 +3,7 @@ title: "extend_high_i32x4_u: Wasm SIMD conversion instruction"
 short-title: extend_high_i32x4_u
 slug: WebAssembly/Reference/SIMD/conversion/extend_high_i32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_high_i32x4_u
+browser-compat: webassembly.instructions.extend_high_i32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_s/index.md
@@ -62,7 +62,3 @@ i16x8.extend_high_i8x16_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_s/index.md
@@ -3,7 +3,7 @@ title: "extend_high_i8x16_s: Wasm SIMD conversion instruction"
 short-title: extend_high_i8x16_s
 slug: WebAssembly/Reference/SIMD/conversion/extend_high_i8x16_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_high_i8x16_s
+browser-compat: webassembly.instructions.extend_high_i8x16_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_u/index.md
@@ -62,7 +62,3 @@ i16x8.extend_high_i8x16_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_high_i8x16_u/index.md
@@ -3,7 +3,7 @@ title: "extend_high_i8x16_u: Wasm SIMD conversion instruction"
 short-title: extend_high_i8x16_u
 slug: WebAssembly/Reference/SIMD/conversion/extend_high_i8x16_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_high_i8x16_u
+browser-compat: webassembly.instructions.extend_high_i8x16_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_s/index.md
@@ -62,7 +62,3 @@ i32x4.extend_low_i16x8_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_s/index.md
@@ -3,7 +3,7 @@ title: "extend_low_i16x8_s: Wasm SIMD conversion instruction"
 short-title: extend_low_i16x8_s
 slug: WebAssembly/Reference/SIMD/conversion/extend_low_i16x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_low_i16x8_s
+browser-compat: webassembly.instructions.extend_low_i16x8_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_u/index.md
@@ -62,7 +62,3 @@ i32x4.extend_low_i16x8_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i16x8_u/index.md
@@ -3,7 +3,7 @@ title: "extend_low_i16x8_u: Wasm SIMD conversion instruction"
 short-title: extend_low_i16x8_u
 slug: WebAssembly/Reference/SIMD/conversion/extend_low_i16x8_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_low_i16x8_u
+browser-compat: webassembly.instructions.extend_low_i16x8_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_s/index.md
@@ -3,7 +3,7 @@ title: "extend_low_i32x4_s: Wasm SIMD conversion instruction"
 short-title: extend_low_i32x4_s
 slug: WebAssembly/Reference/SIMD/conversion/extend_low_i32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_low_i32x4_s
+browser-compat: webassembly.instructions.extend_low_i32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_s/index.md
@@ -62,7 +62,3 @@ i64x2.extend_low_i32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_u/index.md
@@ -62,7 +62,3 @@ i64x2.extend_low_i32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i32x4_u/index.md
@@ -3,7 +3,7 @@ title: "extend_low_i32x4_u: Wasm SIMD conversion instruction"
 short-title: extend_low_i32x4_u
 slug: WebAssembly/Reference/SIMD/conversion/extend_low_i32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_low_i32x4_u
+browser-compat: webassembly.instructions.extend_low_i32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_s/index.md
@@ -62,7 +62,3 @@ i16x8.extend_low_i8x16_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_s/index.md
@@ -3,7 +3,7 @@ title: "extend_low_i8x16_s: Wasm SIMD conversion instruction"
 short-title: extend_low_i8x16_s
 slug: WebAssembly/Reference/SIMD/conversion/extend_low_i8x16_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_low_i8x16_s
+browser-compat: webassembly.instructions.extend_low_i8x16_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_u/index.md
@@ -3,7 +3,7 @@ title: "extend_low_i8x16_u: Wasm SIMD conversion instruction"
 short-title: extend_low_i8x16_u
 slug: WebAssembly/Reference/SIMD/conversion/extend_low_i8x16_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extend_low_i8x16_u
+browser-compat: webassembly.instructions.extend_low_i8x16_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/extend_low_i8x16_u/index.md
@@ -62,7 +62,3 @@ i16x8.extend_low_i8x16_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_s/index.md
@@ -65,7 +65,3 @@ i8x16.narrow_i16x8_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_s/index.md
@@ -3,7 +3,7 @@ title: "narrow_i16x8_s: Wasm SIMD conversion instruction"
 short-title: narrow_i16x8_s
 slug: WebAssembly/Reference/SIMD/conversion/narrow_i16x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.narrow_i16x8_s
+browser-compat: webassembly.instructions.narrow_i16x8_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_u/index.md
@@ -3,7 +3,7 @@ title: "narrow_i16x8_u: Wasm SIMD conversion instruction"
 short-title: narrow_i16x8_u
 slug: WebAssembly/Reference/SIMD/conversion/narrow_i16x8_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.narrow_i16x8_u
+browser-compat: webassembly.instructions.narrow_i16x8_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i16x8_u/index.md
@@ -65,7 +65,3 @@ i8x16.narrow_i16x8_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_s/index.md
@@ -65,7 +65,3 @@ i16x8.narrow_i32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_s/index.md
@@ -3,7 +3,7 @@ title: "narrow_i32x4_s: Wasm SIMD conversion instruction"
 short-title: narrow_i32x4_s
 slug: WebAssembly/Reference/SIMD/conversion/narrow_i32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.narrow_i32x4_s
+browser-compat: webassembly.instructions.narrow_i32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_u/index.md
@@ -65,7 +65,3 @@ i16x8.narrow_i32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/narrow_i32x4_u/index.md
@@ -3,7 +3,7 @@ title: "narrow_i32x4_u: Wasm SIMD conversion instruction"
 short-title: narrow_i32x4_u
 slug: WebAssembly/Reference/SIMD/conversion/narrow_i32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.narrow_i32x4_u
+browser-compat: webassembly.instructions.narrow_i32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/promote_low_f32x4/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/promote_low_f32x4/index.md
@@ -65,7 +65,3 @@ value_type.promote_low_f32x4
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/promote_low_f32x4/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/promote_low_f32x4/index.md
@@ -3,7 +3,7 @@ title: "promote_low_f32x4: Wasm SIMD conversion instruction"
 short-title: promote_low_f32x4
 slug: WebAssembly/Reference/SIMD/conversion/promote_low_f32x4
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.promote_low_f32x4
+browser-compat: webassembly.instructions.promote_low_f32x4
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/replace_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/replace_lane/index.md
@@ -3,7 +3,7 @@ title: "replace_lane: Wasm SIMD conversion instruction"
 short-title: replace_lane
 slug: WebAssembly/Reference/SIMD/conversion/replace_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.replace_lane
+browser-compat: webassembly.instructions.replace_lane
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/shuffle/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/shuffle/index.md
@@ -72,7 +72,3 @@ value_type.shuffle indices
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/shuffle/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/shuffle/index.md
@@ -3,7 +3,7 @@ title: "shuffle: Wasm SIMD conversion instruction"
 short-title: shuffle
 slug: WebAssembly/Reference/SIMD/conversion/shuffle
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.shuffle
+browser-compat: webassembly.instructions.shuffle
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/splat/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/splat/index.md
@@ -3,7 +3,7 @@ title: "splat: Wasm SIMD conversion instruction"
 short-title: splat
 slug: WebAssembly/Reference/SIMD/conversion/splat
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.splat
+browser-compat: webassembly.instructions.splat
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/splat/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/splat/index.md
@@ -92,7 +92,3 @@ value_type.splat
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/swizzle/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/swizzle/index.md
@@ -73,7 +73,3 @@ value_type.swizzle
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/swizzle/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/swizzle/index.md
@@ -3,7 +3,7 @@ title: "swizzle: Wasm SIMD conversion instruction"
 short-title: swizzle
 slug: WebAssembly/Reference/SIMD/conversion/swizzle
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.swizzle
+browser-compat: webassembly.instructions.swizzle
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_s/index.md
@@ -3,7 +3,7 @@ title: "trunc_sat_f32x4_s: Wasm SIMD conversion instruction"
 short-title: trunc_sat_f32x4_s
 slug: WebAssembly/Reference/SIMD/conversion/trunc_sat_f32x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.trunc_sat_f32x4_s
+browser-compat: webassembly.instructions.trunc_sat_f32x4_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_s/index.md
@@ -67,7 +67,3 @@ value_type.trunc_sat_f32x4_s
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_u/index.md
@@ -67,7 +67,3 @@ value_type.trunc_sat_f32x4_u
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_u/index.md
@@ -3,7 +3,7 @@ title: "trunc_sat_f32x4_u: Wasm SIMD conversion instruction"
 short-title: trunc_sat_f32x4_u
 slug: WebAssembly/Reference/SIMD/conversion/trunc_sat_f32x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.trunc_sat_f32x4_u
+browser-compat: webassembly.instructions.trunc_sat_f32x4_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_s_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_s_zero/index.md
@@ -3,7 +3,7 @@ title: "trunc_sat_f64x2_s_zero: Wasm SIMD conversion instruction"
 short-title: trunc_sat_f64x2_s_zero
 slug: WebAssembly/Reference/SIMD/conversion/trunc_sat_f64x2_s_zero
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.trunc_sat_f64x2_s_zero
+browser-compat: webassembly.instructions.trunc_sat_f64x2_s_zero
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_s_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_s_zero/index.md
@@ -67,7 +67,3 @@ value_type.trunc_sat_f64x2_s_zero
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_u_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_u_zero/index.md
@@ -67,7 +67,3 @@ value_type.trunc_sat_f64x2_u_zero
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD conversion instructions](/en-US/docs/WebAssembly/Reference/SIMD/conversion)

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_u_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_u_zero/index.md
@@ -3,7 +3,7 @@ title: "trunc_sat_f64x2_u_zero: Wasm SIMD conversion instruction"
 short-title: trunc_sat_f64x2_u_zero
 slug: WebAssembly/Reference/SIMD/conversion/trunc_sat_f64x2_u_zero
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.trunc_sat_f64x2_u_zero
+browser-compat: webassembly.instructions.trunc_sat_f64x2_u_zero
 sidebar: webassemblysidebar
 ---
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the [Wasm SIMD conversion instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/conversion) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30099.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
