### PR TITLE
Update Wasm SIMD extract, load, and store instruction pages to displa…

### DIFF
--- a/files/en-us/webassembly/reference/simd/extract/extract_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/extract/extract_lane/index.md
@@ -3,7 +3,7 @@ title: "extract_lane: Wasm SIMD extract instruction"
 short-title: extract_lane
 slug: WebAssembly/Reference/SIMD/extract/extract_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extract_lane
+browser-compat: webassembly.instructions.extract_lane
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/extract/extract_lane_s/index.md
+++ b/files/en-us/webassembly/reference/simd/extract/extract_lane_s/index.md
@@ -3,7 +3,7 @@ title: "extract_lane_s: Wasm SIMD extract instruction"
 short-title: extract_lane_s
 slug: WebAssembly/Reference/SIMD/extract/extract_lane_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extract_lane_s
+browser-compat: webassembly.instructions.extract_lane_s
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/extract/extract_lane_u/index.md
+++ b/files/en-us/webassembly/reference/simd/extract/extract_lane_u/index.md
@@ -3,7 +3,7 @@ title: "extract_lane_u: Wasm SIMD extract instruction"
 short-title: extract_lane_u
 slug: WebAssembly/Reference/SIMD/extract/extract_lane_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.extract_lane_u
+browser-compat: webassembly.instructions.extract_lane_u
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/simd/load_store/load/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load/index.md
@@ -3,7 +3,7 @@ title: "load: Wasm SIMD load/store instruction"
 short-title: load
 slug: WebAssembly/Reference/SIMD/load_store/load
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load
+browser-compat: webassembly.instructions.load
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load16_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load16_lane/index.md
@@ -3,7 +3,7 @@ title: "load16_lane: Wasm SIMD load/store instruction"
 short-title: load16_lane
 slug: WebAssembly/Reference/SIMD/load_store/load16_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load16_lane
+browser-compat: webassembly.instructions.load16_lane
 sidebar: webassemblysidebar
 ---
 
@@ -82,7 +82,3 @@ v128.load16_lane mem_idx offset=int align=int lane_value
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load16_splat/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load16_splat/index.md
@@ -3,7 +3,7 @@ title: "load16_splat: Wasm SIMD load/store instruction"
 short-title: load16_splat
 slug: WebAssembly/Reference/SIMD/load_store/load16_splat
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load16_splat
+browser-compat: webassembly.instructions.load16_splat
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load16_splat mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load16x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load16x4_s/index.md
@@ -3,7 +3,7 @@ title: "load16x4_s: Wasm SIMD load/store instruction"
 short-title: load16x4_s
 slug: WebAssembly/Reference/SIMD/load_store/load16x4_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load16x4_s
+browser-compat: webassembly.instructions.load16x4_s
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load16x4_s mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load16x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load16x4_u/index.md
@@ -3,7 +3,7 @@ title: "load16x4_u: Wasm SIMD load/store instruction"
 short-title: load16x4_u
 slug: WebAssembly/Reference/SIMD/load_store/load16x4_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load16x4_u
+browser-compat: webassembly.instructions.load16x4_u
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load16x4_u mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load32_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load32_lane/index.md
@@ -3,7 +3,7 @@ title: "load32_lane: Wasm SIMD load/store instruction"
 short-title: load32_lane
 slug: WebAssembly/Reference/SIMD/load_store/load32_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load32_lane
+browser-compat: webassembly.instructions.load32_lane
 sidebar: webassemblysidebar
 ---
 
@@ -81,7 +81,3 @@ v128.load32_lane mem_idx offset=int align=int lane_value
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load32_splat/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load32_splat/index.md
@@ -3,7 +3,7 @@ title: "load32_splat: Wasm SIMD load/store instruction"
 short-title: load32_splat
 slug: WebAssembly/Reference/SIMD/load_store/load32_splat
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load32_splat
+browser-compat: webassembly.instructions.load32_splat
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load32_splat mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load32_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load32_zero/index.md
@@ -3,7 +3,7 @@ title: "load32_zero: Wasm SIMD load/store instruction"
 short-title: load32_zero
 slug: WebAssembly/Reference/SIMD/load_store/load32_zero
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load32_zero
+browser-compat: webassembly.instructions.load32_zero
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load32_zero mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load32x2_s/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load32x2_s/index.md
@@ -3,7 +3,7 @@ title: "load32x2_s: Wasm SIMD load/store instruction"
 short-title: load32x2_s
 slug: WebAssembly/Reference/SIMD/load_store/load32x2_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load32x2_s
+browser-compat: webassembly.instructions.load32x2_s
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load32x2_s mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load32x2_u/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load32x2_u/index.md
@@ -3,7 +3,7 @@ title: "load32x2_u: Wasm SIMD load/store instruction"
 short-title: load32x2_u
 slug: WebAssembly/Reference/SIMD/load_store/load32x2_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load32x2_u
+browser-compat: webassembly.instructions.load32x2_u
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load32x2_u mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load64_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load64_lane/index.md
@@ -3,7 +3,7 @@ title: "load64_lane: Wasm SIMD load/store instruction"
 short-title: load64_lane
 slug: WebAssembly/Reference/SIMD/load_store/load64_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load64_lane
+browser-compat: webassembly.instructions.load64_lane
 sidebar: webassemblysidebar
 ---
 
@@ -81,7 +81,3 @@ v128.load64_lane mem_idx offset=int align=int lane_idx
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load64_splat/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load64_splat/index.md
@@ -3,7 +3,7 @@ title: "load64_splat: Wasm SIMD load/store instruction"
 short-title: load64_splat
 slug: WebAssembly/Reference/SIMD/load_store/load64_splat
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load64_splat
+browser-compat: webassembly.instructions.load64_splat
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load64_splat mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load64_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load64_zero/index.md
@@ -3,7 +3,7 @@ title: "load64_zero: Wasm SIMD load/store instruction"
 short-title: load64_zero
 slug: WebAssembly/Reference/SIMD/load_store/load64_zero
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load64_zero
+browser-compat: webassembly.instructions.load64_zero
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load64_zero mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load8_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load8_lane/index.md
@@ -3,7 +3,7 @@ title: "load8_lane: Wasm SIMD load/store instruction"
 short-title: load8_lane
 slug: WebAssembly/Reference/SIMD/load_store/load8_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load8_lane
+browser-compat: webassembly.instructions.load8_lane
 sidebar: webassemblysidebar
 ---
 
@@ -81,7 +81,3 @@ v128.load8_lane mem_idx offset=int align=int lane_value
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load8_splat/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load8_splat/index.md
@@ -3,7 +3,7 @@ title: "load8_splat: Wasm SIMD load/store instruction"
 short-title: load8_splat
 slug: WebAssembly/Reference/SIMD/load_store/load8_splat
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load8_splat
+browser-compat: webassembly.instructions.load8_splat
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load8_splat mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load8x8_s/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load8x8_s/index.md
@@ -3,7 +3,7 @@ title: "load8x8_s: Wasm SIMD load/store instruction"
 short-title: load8x8_s
 slug: WebAssembly/Reference/SIMD/load_store/load8x8_s
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load8x8_s
+browser-compat: webassembly.instructions.load8x8_s
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load8x8_s mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/load8x8_u/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/load8x8_u/index.md
@@ -3,7 +3,7 @@ title: "load8x8_u: Wasm SIMD load/store instruction"
 short-title: load8x8_u
 slug: WebAssembly/Reference/SIMD/load_store/load8x8_u
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.load8x8_u
+browser-compat: webassembly.instructions.load8x8_u
 sidebar: webassemblysidebar
 ---
 
@@ -76,7 +76,3 @@ v128.load8x8_u mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/store/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/store/index.md
@@ -3,7 +3,7 @@ title: "store: Wasm SIMD load/store instruction"
 short-title: store
 slug: WebAssembly/Reference/SIMD/load_store/store
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.store
+browser-compat: webassembly.instructions.store
 sidebar: webassemblysidebar
 ---
 
@@ -79,7 +79,3 @@ v128.store mem_idx offset=int align=int
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/store16_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/store16_lane/index.md
@@ -3,7 +3,7 @@ title: "store16_lane: Wasm SIMD load/store instruction"
 short-title: store16_lane
 slug: WebAssembly/Reference/SIMD/load_store/store16_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.store16_lane
+browser-compat: webassembly.instructions.store16_lane
 sidebar: webassemblysidebar
 ---
 
@@ -81,7 +81,3 @@ v128.store16_lane mem_idx offset=int align=int lane_idx
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/store32_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/store32_lane/index.md
@@ -3,7 +3,7 @@ title: "store32_lane: Wasm SIMD load/store instruction"
 short-title: store32_lane
 slug: WebAssembly/Reference/SIMD/load_store/store32_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.store32_lane
+browser-compat: webassembly.instructions.store32_lane
 sidebar: webassemblysidebar
 ---
 
@@ -81,7 +81,3 @@ v128.store32_lane mem_idx offset=int align=int lane_idx
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/store64_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/store64_lane/index.md
@@ -3,7 +3,7 @@ title: "store64_lane: Wasm SIMD load/store instruction"
 short-title: store64_lane
 slug: WebAssembly/Reference/SIMD/load_store/store64_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.store64_lane
+browser-compat: webassembly.instructions.store64_lane
 sidebar: webassemblysidebar
 ---
 
@@ -81,7 +81,3 @@ v128.store64_lane mem_idx offset=int align=int lane_idx
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)

--- a/files/en-us/webassembly/reference/simd/load_store/store8_lane/index.md
+++ b/files/en-us/webassembly/reference/simd/load_store/store8_lane/index.md
@@ -3,7 +3,7 @@ title: "store8_lane: Wasm SIMD load/store instruction"
 short-title: store8_lane
 slug: WebAssembly/Reference/SIMD/load_store/store8_lane
 page-type: webassembly-instruction
-browser-compat: webassembly.simd.store8_lane
+browser-compat: webassembly.instructions.store8_lane
 sidebar: webassemblysidebar
 ---
 
@@ -81,7 +81,3 @@ v128.store8_lane mem_idx offset=int align=int lane_idx
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [SIMD load/store instructions](/en-US/docs/WebAssembly/Reference/SIMD/load_store)


### PR DESCRIPTION
…y BCD and specs

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the Wasm SIMD [extract instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/extract) and [load and store instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/load_store) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30102.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
