### PR TITLE
fix: trailing comma in aria-orientation

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-orientation/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-orientation/index.md
@@ -17,7 +17,7 @@ Several widgets have default orientations:
 
 Horizontal by default:
 
-- [`slider`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/slider_role),
+- [`slider`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/slider_role)
 - [`tablist`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tablist_role)
 - [`toolbar`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/toolbar_role)
 - [`menubar`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menubar_role)


### PR DESCRIPTION
### Description

Remove an unnecessary comma after the slider list item.

### Motivation

Corrects a minor punctuation error for clearer, grammatically correct documentation.

### Additional details

N/A

### Related issues and pull requests

N/A