### PR TITLE
Update Wasm table and variable instruction pages to display BCD and s…

### DIFF
--- a/files/en-us/webassembly/reference/table/fill/index.md
+++ b/files/en-us/webassembly/reference/table/fill/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.table_fill
 sidebar: webassemblysidebar
 ---
 
-The **`table.fill`** [Table instruction](/en-US/docs/WebAssembly/Reference/Table) sets a range of table elements to the same value.
+The **`table.fill`** [table instruction](/en-US/docs/WebAssembly/Reference/Table) sets a range of table elements to the same value.
 
 {{InteractiveExample("Wat Demo: table.fill", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/table/fill/index.md
+++ b/files/en-us/webassembly/reference/table/fill/index.md
@@ -3,8 +3,7 @@ title: "fill: Wasm table instruction"
 short-title: fill
 slug: WebAssembly/Reference/Table/fill
 page-type: webassembly-instruction
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-table
+browser-compat: webassembly.instructions.table_fill
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/table/get/index.md
+++ b/files/en-us/webassembly/reference/table/get/index.md
@@ -3,8 +3,7 @@ title: "get: Wasm table instruction"
 short-title: get
 slug: WebAssembly/Reference/Table/get
 page-type: webassembly-instruction
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-table
+browser-compat: webassembly.instructions.table_get
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/table/get/index.md
+++ b/files/en-us/webassembly/reference/table/get/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.table_get
 sidebar: webassemblysidebar
 ---
 
-The **`table.get`** [Table instruction](/en-US/docs/WebAssembly/Reference/Table) retrieves the reference stored at a particular table index.
+The **`table.get`** [table instruction](/en-US/docs/WebAssembly/Reference/Table) retrieves the reference stored at a particular table index.
 
 {{InteractiveExample("Wat Demo: table.get", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/table/grow/index.md
+++ b/files/en-us/webassembly/reference/table/grow/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.table_grow
 sidebar: webassemblysidebar
 ---
 
-The **`table.grow`** [Table instruction](/en-US/docs/WebAssembly/Reference/Table) increases the size of a table by a specified number of elements.
+The **`table.grow`** [table instruction](/en-US/docs/WebAssembly/Reference/Table) increases the size of a table by a specified number of elements.
 
 {{InteractiveExample("Wat Demo: table.grow", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/table/grow/index.md
+++ b/files/en-us/webassembly/reference/table/grow/index.md
@@ -3,8 +3,7 @@ title: "grow: Wasm table instruction"
 short-title: grow
 slug: WebAssembly/Reference/Table/grow
 page-type: webassembly-instruction
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-table
+browser-compat: webassembly.instructions.table_grow
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/table/index.md
+++ b/files/en-us/webassembly/reference/table/index.md
@@ -2,8 +2,6 @@
 title: WebAssembly table instructions
 slug: WebAssembly/Reference/Table
 page-type: landing-page
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#table-instructions
 sidebar: webassemblysidebar
 ---
 
@@ -11,8 +9,6 @@ This set of pages details the table instructions available in Wasm to create and
 
 > [!NOTE]
 > Equivalent functionality is available to JavaScript via the [`WebAssembly.Table`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table) API.
-
-## Instructions
 
 - [`table.fill`](/en-US/docs/WebAssembly/Reference/Table/fill)
   - : Sets a range of table elements to the same value.
@@ -24,11 +20,3 @@ This set of pages details the table instructions available in Wasm to create and
   - : Changes the value stored in a particular table element.
 - [`table.size`](/en-US/docs/WebAssembly/Reference/Table/size)
   - : Returns the current size of the table.
-
-## Specifications
-
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}

--- a/files/en-us/webassembly/reference/table/set/index.md
+++ b/files/en-us/webassembly/reference/table/set/index.md
@@ -3,8 +3,7 @@ title: "set: Wasm table instruction"
 short-title: set
 slug: WebAssembly/Reference/Table/set
 page-type: webassembly-instruction
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-table
+browser-compat: webassembly.instructions.table_set
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/table/set/index.md
+++ b/files/en-us/webassembly/reference/table/set/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.table_set
 sidebar: webassemblysidebar
 ---
 
-The **`table.set`** [Table instruction](/en-US/docs/WebAssembly/Reference/Table) changes the value stored in a particular table element.
+The **`table.set`** [table instruction](/en-US/docs/WebAssembly/Reference/Table) changes the value stored in a particular table element.
 
 {{InteractiveExample("Wat Demo: table.set", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/table/size/index.md
+++ b/files/en-us/webassembly/reference/table/size/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.table_size
 sidebar: webassemblysidebar
 ---
 
-The **`table.size`** [Table instruction](/en-US/docs/WebAssembly/Reference/Table) returns the current size of the table.
+The **`table.size`** [table instruction](/en-US/docs/WebAssembly/Reference/Table) returns the current size of the table.
 
 {{InteractiveExample("Wat Demo: table.size", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/table/size/index.md
+++ b/files/en-us/webassembly/reference/table/size/index.md
@@ -3,8 +3,7 @@ title: "size: Wasm table instruction"
 short-title: size
 slug: WebAssembly/Reference/Table/size
 page-type: webassembly-instruction
-browser-compat: webassembly.reference-types
-spec-urls: https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-table
+browser-compat: webassembly.instructions.table_size
 sidebar: webassemblysidebar
 ---
 

--- a/files/en-us/webassembly/reference/variables/global.get/index.md
+++ b/files/en-us/webassembly/reference/variables/global.get/index.md
@@ -1,5 +1,5 @@
 ---
-title: "global.get: Wasm text instruction"
+title: "global.get: Wasm variable instruction"
 short-title: global.get
 slug: WebAssembly/Reference/Variables/global.get
 page-type: webassembly-instruction
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.global_get
 sidebar: webassemblysidebar
 ---
 
-The **`global.get`** instruction loads the value of a global variable onto the stack.
+The **`global.get`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) loads the value of a global variable onto the stack.
 
 {{InteractiveExample("Wat Demo: global_get", "tabbed-standard")}}
 

--- a/files/en-us/webassembly/reference/variables/global.set/index.md
+++ b/files/en-us/webassembly/reference/variables/global.set/index.md
@@ -1,13 +1,13 @@
 ---
-title: "global.set: Wasm text instruction"
+title: "global.set: Wasm variable instruction"
 short-title: global.set
 slug: WebAssembly/Reference/Variables/global.set
 page-type: webassembly-instruction
-browser-compat: webassembly.instructions.global_get
+browser-compat: webassembly.instructions.global_set
 sidebar: webassemblysidebar
 ---
 
-The **`global.set`** instruction sets the values of a global variable.
+The **`global.set`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) sets the values of a global variable.
 
 {{InteractiveExample("Wat Demo: global_set", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/variables/global.set/index.md
+++ b/files/en-us/webassembly/reference/variables/global.set/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.global_set
 sidebar: webassemblysidebar
 ---
 
-The **`global.set`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) sets the values of a global variable.
+The **`global.set`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) sets the value of a global variable.
 
 {{InteractiveExample("Wat Demo: global_set", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/variables/local.get/index.md
+++ b/files/en-us/webassembly/reference/variables/local.get/index.md
@@ -1,12 +1,13 @@
 ---
-title: "local.get: Wasm text instruction"
+title: "local.get: Wasm variable instruction"
 short-title: local.get
 slug: WebAssembly/Reference/Variables/local.get
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.local_get
 sidebar: webassemblysidebar
 ---
 
-The **`local.get`** instruction loads the value of a local variable onto the stack.
+The **`local.get`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) loads the value of a local variable onto the stack.
 
 {{InteractiveExample("Wat Demo: local", "tabbed-taller")}}
 
@@ -40,3 +41,11 @@ local.get $val
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `local.get` | `0x20`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/variables/local.set/index.md
+++ b/files/en-us/webassembly/reference/variables/local.set/index.md
@@ -7,7 +7,7 @@ browser-compat: webassembly.instructions.local_set
 sidebar: webassemblysidebar
 ---
 
-The **`local.set`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) sets the values of a local variable.
+The **`local.set`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) sets the value of a local variable.
 
 {{InteractiveExample("Wat Demo: local", "tabbed-taller")}}
 

--- a/files/en-us/webassembly/reference/variables/local.set/index.md
+++ b/files/en-us/webassembly/reference/variables/local.set/index.md
@@ -1,12 +1,13 @@
 ---
-title: "local.set: Wasm text instruction"
+title: "local.set: Wasm variable instruction"
 short-title: local.set
 slug: WebAssembly/Reference/Variables/local.set
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.local_set
 sidebar: webassemblysidebar
 ---
 
-The **`local.set`** instruction sets the values of a local variable.
+The **`local.set`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) sets the values of a local variable.
 
 {{InteractiveExample("Wat Demo: local", "tabbed-taller")}}
 
@@ -43,3 +44,11 @@ local.set $val
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `local.set` | `0x21`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/variables/local.tee/index.md
+++ b/files/en-us/webassembly/reference/variables/local.tee/index.md
@@ -1,12 +1,13 @@
 ---
-title: "local.tee: Wasm text instruction"
+title: "local.tee: Wasm variable instruction"
 short-title: local.tee
 slug: WebAssembly/Reference/Variables/local.tee
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.local_tee
 sidebar: webassemblysidebar
 ---
 
-The **`local.tee`** instruction sets the value of a local variable and loads the value onto the stack.
+The **`local.tee`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) sets the value of a local variable and loads the value onto the stack.
 
 The instruction is named after the T-splitter used in plumbing.
 
@@ -45,3 +46,11 @@ local.tee $val
 | Instruction | Binary opcode |
 | ----------- | ------------- |
 | `local.tee` | `0x22`        |
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/webassembly/reference/variables/local/index.md
+++ b/files/en-us/webassembly/reference/variables/local/index.md
@@ -1,12 +1,13 @@
 ---
-title: "local: Wasm text instruction"
+title: "local: Wasm variable instruction"
 short-title: local
 slug: WebAssembly/Reference/Variables/local
 page-type: webassembly-instruction
+browser-compat: webassembly.instructions.local
 sidebar: webassemblysidebar
 ---
 
-The **`local`** instruction declares a new local variable.
+The **`local`** [variable instruction](/en-US/docs/WebAssembly/Reference/Variables) declares a new local variable.
 
 {{InteractiveExample("Wat Demo: local", "tabbed-taller")}}
 
@@ -36,3 +37,11 @@ await WebAssembly.instantiateStreaming(fetch(url), { console });
 ;; declare new variable named $val of type i32
 (local $val i32)
 ```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
…pecs

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR updates all the Wasm [table instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Table) and [variable instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Variables) pages so they will properly display the BCD/spec data added in https://github.com/mdn/browser-compat-data/pull/30105.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
