### PR TITLE
Fix typo in MutationRecord.addedNodes and MutationRecord.removedNodes

### DIFF
--- a/files/en-us/web/api/mutationrecord/addednodes/index.md
+++ b/files/en-us/web/api/mutationrecord/addednodes/index.md
@@ -20,7 +20,7 @@ A {{domxref("NodeList")}} containing the nodes added to the target of the mutati
 
 In the following example, there are two buttons: one to add new nodes to a target node, and one to remove them. A {{domxref("MutationObserver")}} is used to observe the target node for changes; when a change is detected, the observer calls a function, `logNewNodes()`.
 
-The `logNewNodes()` function checks that the MutationRecord's `type` is `childList`, which means that the target node's children have changed. If the type is `childlist` the function updates the total number of new nodes that have been added. However, note that clicking the "Remove a node" button will not increment the total number of new nodes, because in this case `record.addedNodes` will have a length of `0`.
+The `logNewNodes()` function checks that the MutationRecord's `type` is `childList`, which means that the target node's children have changed. If the type is `childList` the function updates the total number of new nodes that have been added. However, note that clicking the "Remove a node" button will not increment the total number of new nodes, because in this case `record.addedNodes` will have a length of `0`.
 
 #### HTML
 

--- a/files/en-us/web/api/mutationrecord/addednodes/index.md
+++ b/files/en-us/web/api/mutationrecord/addednodes/index.md
@@ -67,7 +67,7 @@ reset.addEventListener("click", () => self.location.reload());
 
 function logNewNodes(records) {
   for (const record of records) {
-    // Check if the childlist of the target node has been mutated
+    // Check if the childList of the target node has been mutated
     if (record.type === "childList") {
       totalAddedNodes += record.addedNodes.length;
       // Log the number of nodes added

--- a/files/en-us/web/api/mutationrecord/removednodes/index.md
+++ b/files/en-us/web/api/mutationrecord/removednodes/index.md
@@ -20,7 +20,7 @@ A {{domxref("NodeList")}} containing the nodes removed from the target of the mu
 
 In the following example, there are two buttons: one to add new nodes to a target node, and one to remove them. A {{domxref("MutationObserver")}} is used to observe the target node for changes; when a change is detected, the observer calls a function, `logRemovedNodes()`.
 
-The `logRemovedNodes()` function checks that the MutationRecord's `type` is `childList`, which means that the target node's children have changed. If the type is `childlist` the function updates the total number of nodes that have been removed. However, note that clicking the "Add a node" button will not increment the total number of removed nodes, because in this case `record.removedNodes` will have a length of `0`.
+The `logRemovedNodes()` function checks that the MutationRecord's `type` is `childList`, which means that the target node's children have changed. If the type is `childList` the function updates the total number of nodes that have been removed. However, note that clicking the "Add a node" button will not increment the total number of removed nodes, because in this case `record.removedNodes` will have a length of `0`.
 
 #### HTML
 

--- a/files/en-us/web/api/mutationrecord/removednodes/index.md
+++ b/files/en-us/web/api/mutationrecord/removednodes/index.md
@@ -67,7 +67,7 @@ reset.addEventListener("click", () => self.location.reload());
 
 function logRemovedNodes(records) {
   for (const record of records) {
-    // Check if the childlist of the target node has been mutated
+    // Check if the childList of the target node has been mutated
     if (record.type === "childList") {
       totalRemovedNodes += record.removedNodes.length;
       // Log the number of nodes added


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Correct `childlist` to `childList` with a large `L`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
