### PR TITLE
columns property: add value to interactive example

### DIFF
--- a/files/en-us/web/css/reference/properties/columns/index.md
+++ b/files/en-us/web/css/reference/properties/columns/index.md
@@ -24,7 +24,7 @@ columns: 12em;
 ```
 
 ```css interactive-example-choice
-columns: 3;
+columns: 2 / 5em;
 ```
 
 ```html interactive-example


### PR DESCRIPTION
we describe a syntax in the page that was not reflected in the interactive example. Added an example within the interactive example that demonstrates `column-height` included in the shorthand property.