### PR TITLE
Add a make cross-origin network requests page

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -8,6 +8,9 @@ sidebar: addonsidebar
 
 Add event listeners for the various stages of making an HTTP request, which includes websocket requests on `ws://` and `wss://`. The event listener receives detailed information about the request and can modify or cancel the request.
 
+> [!NOTE]
+> `webRequest` only lets you observe, block, or modify requests that are made elsewhere, such as by a web page or another part of the browser; it doesn't provide a way for an extension to make an HTTP request. To make a request from a background script or other extension page, use [`fetch()`](/en-US/docs/Web/API/Fetch_API) or [`XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest), as described in [Make cross-origin network requests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Cross-origin_network_requests).
+
 Each event is fired at a particular stage of the request. The sequence of events is like this:
 
 ![Order of requests is onBeforeRequest, onBeforeSendHeader, onSendHeaders, onHeadersReceived, onResponseStarted, and onCompleted. The onHeadersReceived can cause an onBeforeRedirect and an onAuthRequired. Events caused by onHeadersReceived start at the beginning onBeforeRequest. Events caused by onAuthRequired start at onBeforeSendHeader.](webrequest-flow.png)

--- a/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
@@ -40,7 +40,7 @@ Background scripts can use any [WebExtension APIs](/en-US/docs/Mozilla/Add-ons/W
 
 ### Cross-origin access
 
-Background scripts can make XHR requests to hosts they have [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) for.
+Background scripts can make `fetch()` or `XMLHttpRequest` requests to hosts they have [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) for. See [Cross-origin network requests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Cross-origin_network_requests) for details.
 
 ### Web content
 

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -81,6 +81,9 @@ Extensions cannot inject content scripts into privileged browser UI pages (such 
 
 If an extension wants to run code in an extension page dynamically, it can include a script in the page. This script contains the code to run and registers a {{WebExtAPIRef("runtime.onMessage")}} listener that implements a way to execute the code. The extension can then send a message to the listener to trigger the code's execution.
 
+> [!NOTE]
+> Content scripts run with more privilege than the page they're injected into, and can be exposed to untrusted page content. See [Security considerations](/en-US/docs/Mozilla/Add-ons/WebExtensions/Cross-origin_network_requests#security_considerations) in Cross-origin network requests for guidance.
+
 ## Content script environment
 
 ### DOM access
@@ -209,29 +212,9 @@ In addition to the standard DOM APIs, content scripts can use these WebExtension
 
 ### XHR and Fetch
 
-Content scripts can make requests using the normal [`window.XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) and [`window.fetch()`](/en-US/docs/Web/API/Fetch_API) APIs.
+Content scripts can make requests using the [`window.XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) and [`window.fetch()`](/en-US/docs/Web/API/Fetch_API) APIs.
 
-> [!NOTE]
-> In Firefox in Manifest V2, content script requests (for example, using [`fetch()`](/en-US/docs/Web/API/Fetch_API/Using_Fetch)) happen in the context of an extension, so you must provide an absolute URL to reference page content.
->
-> In Chrome and Firefox in Manifest V3, these requests happen in context of the page, so they are made to a relative URL. For example, `/api` is sent to `https://«current page URL»/api`.
-
-Content scripts get the same cross-domain privileges as the rest of the extension: so if the extension has requested cross-domain access for a domain using the [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) key in `manifest.json`, then its content scripts get access that domain as well.
-
-> [!NOTE]
-> When using Manifest V3, content scripts can perform cross-origin requests when the destination server opts in using [CORS](/en-US/docs/Web/HTTP/Guides/CORS); however, host permissions don't work in content scripts, but they still do in regular extension pages.
-
-This is accomplished by exposing more privileged XHR and fetch instances in the content script, which has the side effect of not setting the [`Origin`](/en-US/docs/Web/HTTP/Reference/Headers/Origin) and [`Referer`](/en-US/docs/Web/HTTP/Reference/Headers/Referer) headers like a request from the page itself would; this is often preferable to prevent the request from revealing its cross-origin nature.
-
-> [!NOTE]
-> In Firefox in Manifest V2, extensions that need to perform requests that behave as if they were sent by the content itself can use `content.XMLHttpRequest` and `content.fetch()` instead.
->
-> For cross-browser extensions, the presence of these methods must be feature-detected.
->
-> This is not possible in Manifest V3, as `content.XMLHttpRequest` and `content.fetch()` are not available.
-
-> [!NOTE]
-> In Chrome, starting with version 73, and Firefox, starting with version 101 when using Manifest V3, content scripts are subject to the same [CORS](/en-US/docs/Web/HTTP/Guides/CORS) policy as the page they are running within. Only backend scripts have elevated cross-domain privileges. See [Changes to Cross-Origin Requests in Chrome Extension Content Scripts](https://www.chromium.org/Home/chromium-security/extension-content-script-fetches/).
+See [Make cross-origin network requests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Cross-origin_network_requests) for details.
 
 ## Communicating with background scripts
 

--- a/files/en-us/mozilla/add-ons/webextensions/cross-origin_network_requests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/cross-origin_network_requests/index.md
@@ -1,0 +1,124 @@
+---
+title: Make cross-origin network requests
+slug: Mozilla/Add-ons/WebExtensions/Cross-origin_network_requests
+page-type: guide
+sidebar: addonsidebar
+---
+
+Extensions often need to make an HTTP request to an origin other than its own. For example, calling a REST API from a background script, or fetching data from a third-party domain in a content script. [Content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts), [background scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts), and other extension pages (such as options pages and popups) can make these requests using the [`window.XMLHttpRequest`](/en-US/docs/Web/API/XMLHttpRequest) and [`window.fetch()`](/en-US/docs/Web/API/Fetch_API) APIs.
+
+This article explains how these APIs behave when called from extension code. It also explains how these requests are "privileged" and how cookies are handled.
+
+> [!NOTE]
+> This article is about extension code making network requests. To observe, block, or modify requests made elsewhere, such as by a web page, use the {{WebExtAPIRef("declarativeNetRequest")}} or {{WebExtAPIRef("webRequest")}} API instead. See [Intercept HTTP requests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests).
+
+## Example
+
+This background script fetches JSON data from `https://example.org/` and logs it to the console:
+
+```js
+async function getData() {
+  const response = await fetch("https://example.org/data.json");
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  console.log(await response.json());
+}
+
+getData();
+```
+
+For the request to succeed, the extension must have a host permission covering `https://example.org/`:
+
+```json
+{
+  "name": "fetch-example",
+  "version": "1.0",
+  "manifest_version": 3,
+  "host_permissions": ["https://example.org/*"],
+  "background": {
+    "scripts": ["background.js"],
+    "service_worker": "background.js"
+  }
+}
+```
+
+## Privileged XHR and fetch instances
+
+Extension code doesn't use the same `XMLHttpRequest` and `fetch()` instances that a web page's scripts would. Instead, it exposes more privileged instances of these APIs, which run with the security domain of the extension itself, rather than that of the web page a content script is running in. This means:
+
+- The request isn't subject to the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) that applies to requests made by a page's scripts. Instead, whether a cross-origin request succeeds depends on the extension's host permissions (Manifest V2), or on the destination server opting in with [CORS](/en-US/docs/Web/HTTP/Guides/CORS) (Manifest V3).
+- The request doesn't automatically set the [`Origin`](/en-US/docs/Web/HTTP/Reference/Headers/Origin) and [`Referer`](/en-US/docs/Web/HTTP/Reference/Headers/Referer) headers to the requesting page's URL, as a request from the page would. This is often desirable to prevent the request from revealing its cross-origin nature.
+- Header restrictions that normally apply to page scripts are relaxed. For example, a privileged instance can set the `Origin` header explicitly, which a page script cannot, because `Origin` is a {{Glossary("Forbidden_request_header", "forbidden request header")}} for non-privileged requests.
+- Background scripts, extension pages, and popups always make requests through a privileged instance, because there's no less-privileged "page" context for them to fall back to. Content scripts get the same privileged instance and run in the page's context.
+
+### Cross-domain permissions
+
+Content scripts get the same cross-domain privileges as the rest of the extension. If the extension has requested cross-domain access for a domain using the [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) key in `manifest.json`, then its content scripts get access to that domain too. Background scripts and other extension pages likewise need [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for a host before they can make cross-origin requests to it.
+
+#### CORS needed for Manifest V3 content scripts
+
+In Manifest V3, content scripts can perform cross-origin requests when the destination server opts in using [CORS](/en-US/docs/Web/HTTP/Guides/CORS); host permissions don't work. Host permissions continue to apply to requests from regular extension pages and background scripts.
+
+In Chrome, starting with version 73, and Firefox, starting with version 101, when using Manifest V3, content scripts are subject to the same [CORS](/en-US/docs/Web/HTTP/Guides/CORS) policy as the page they run in. Only background scripts have elevated cross-domain privileges. See [Changes to Cross-Origin Requests in Chrome Extension Content Scripts](https://www.chromium.org/Home/chromium-security/extension-content-script-fetches/).
+
+### Content like requests
+
+In Manifest V2 (Firefox and Safari), extensions that need to make requests that behave as if the content itself sent them can use `content.XMLHttpRequest` and `content.fetch()` instead, from a content script.
+
+For cross-browser extensions, these methods must be detected at runtime.
+
+This isn't possible in Manifest V3 because `content.XMLHttpRequest` and `content.fetch()` aren't available.
+
+### Relative and absolute URLs in content scripts
+
+In Manifest V2 (Firefox and Safari), content script requests (for example, using [`fetch()`](/en-US/docs/Web/API/Fetch_API/Using_Fetch)) happen in the context of an extension, so your extension must provide an absolute URL to reference page content.
+
+In Manifest V3, these requests occur in the page context, so they are made to a relative URL. For example, `/api` is sent to `https://«current page URL»/api`.
+
+## Cookies
+
+Setting the `Origin` header to a specific value doesn't, by itself, cause the browser to send that domain's cookies with the request. Cookie handling is controlled separately, by the request's credentials mode: the [`credentials`](/en-US/docs/Web/API/RequestInit#credentials) option for `fetch()`, or [`XMLHttpRequest.withCredentials`](/en-US/docs/Web/API/XMLHttpRequest/withCredentials) for `XMLHttpRequest`.
+
+A privileged request is always considered cross-origin; its origin is the extension's `moz-extension://` (or `chrome-extension://`), not the target site's origin. Therefore, cookies for the destination domain are only included if the request opts in, using `credentials: "include"` (for `fetch()`) or `withCredentials = true` (for `XMLHttpRequest`). When it does, the browser attaches the cookies for the target domain from the current cookie store, subject to each cookie's `SameSite`, `Secure`, and partitioning attributes, exactly as it would for any other cross-origin request that includes credentials. The value of the `Origin` header has no bearing on this.
+
+## Cookie stores
+
+There is currently no way for an extension to specify which [`cookieStoreId`](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities#using_cookiestoreid) (for example, a particular container) a `fetch()` or `XMLHttpRequest` call made from a background script or other extension page should use. These requests always use the default cookie store, not a specific container's, so they can't be used to send or receive cookies scoped to a particular container. See [Firefox bug 1670278](https://bugzil.la/1670278) for the status of adding this capability.
+
+## Cross-browser compatibility
+
+### Chrome: no `XMLHttpRequest` in Manifest V3 service workers
+
+In Chrome, a Manifest V3 background script runs as a service worker. A web-platform restriction on service workers is that they don't implement `XMLHttpRequest`. Calling `XMLHttpRequest` from a Chrome Manifest V3 background service worker throws a `ReferenceError`, so background code must use `fetch()` instead. Content scripts and other extension pages that run in a normal DOM context, rather than a service worker, can use `XMLHttpRequest` in Chrome.
+
+Firefox doesn't use service workers for Manifest V3 background scripts, so it doesn't have this restriction, and `XMLHttpRequest` remains available.
+
+Using `fetch()` is recommended, as it works in all contexts across Firefox, Chrome, and Safari.
+
+## Security considerations
+
+Because extension code runs with more privilege than a web page, and content scripts in particular can be exposed to untrusted page content. This section outlines some considerations to avoid issues.
+
+### Avoid cross-site scripting vulnerabilities
+
+Don't insert untrusted strings into the DOM using unsafe methods such as `innerHTML`, and be careful about trusting messages received from the page. See [Safely inserting external content into a page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page) and the warning in [Communicating with the web page](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#communicating_with_the_web_page).
+
+### Limit content script access to cross-origin requests
+
+A compromised content script can make cross-origin requests to any host the extension has been granted access to. Therefore, only request the [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) your content scripts need, rather than broad or `<all_urls>` permissions. See [Cross-domain permissions](#cross-domain_permissions) above.
+
+### Prefer HTTPS over HTTP
+
+Where possible, use `https://` (and `wss://`) in match patterns and host permissions rather than `http://`. This ensures that content scripts and the requests they make aren't exposed to network-level tampering. See [Upgrade insecure network requests in Manifest V3](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#upgrade_insecure_network_requests_in_manifest_v3).
+
+### Adjust the content security policy
+
+In Manifest V3, content scripts share the extension's content security policy (CSP), which restricts capabilities such as `eval()` and inline scripts. See [Content Security Policy](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy) for the default policy and advice on adjusting it.
+
+## See also
+
+- {{WebExtAPIRef("webRequest")}}
+- [Content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)
+- [Background scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts)
+- [Intercept HTTP requests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests)

--- a/files/sidebars/addonsidebar.yaml
+++ b/files/sidebars/addonsidebar.yaml
@@ -46,6 +46,7 @@ sidebar:
     details: closed
     children:
       - /Mozilla/Add-ons/WebExtensions/Intercept_HTTP_requests
+      - /Mozilla/Add-ons/WebExtensions/Cross-origin_network_requests
       - /Mozilla/Add-ons/WebExtensions/Modify_a_web_page
       - /Mozilla/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page
       - /Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts


### PR DESCRIPTION
### Description

This change addresses #27663 by consolidating cross-origin network request information into one page. It provides a parallel page to the Chrome [Cross-origin network requests](https://developer.chrome.com/docs/extensions/develop/concepts/network-requests) page.

### Motivation

To provide readers looking to use fetch or XHR with one point of reference.

### Related issues and pull requests

Fixes #27663