### PR TITLE
Clarify object references in destructuring rest bindings

### DIFF
--- a/files/en-us/web/javascript/reference/operators/destructuring/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring/index.md
@@ -188,6 +188,18 @@ const [first, ...others2] = [1, 2, 3];
 console.log(others2); // [2, 3]
 ```
 
+Object values collected by a rest property or rest element are not cloned. The rest binding contains references to the same objects as the source, so mutations to these objects are visible through both the source and the rest binding.
+
+```js
+const source = { a: 1, nested: { value: 2 } };
+const { a, ...rest } = source;
+
+console.log(rest.nested === source.nested); // true
+
+rest.nested.value = 3;
+console.log(source.nested.value); // 3
+```
+
 The rest property must be the last in the pattern, and must not have a trailing comma.
 
 ```js-nolint example-bad

--- a/files/en-us/web/javascript/reference/operators/destructuring/index.md
+++ b/files/en-us/web/javascript/reference/operators/destructuring/index.md
@@ -188,18 +188,6 @@ const [first, ...others2] = [1, 2, 3];
 console.log(others2); // [2, 3]
 ```
 
-Object values collected by a rest property or rest element are not cloned. The rest binding contains references to the same objects as the source, so mutations to these objects are visible through both the source and the rest binding.
-
-```js
-const source = { a: 1, nested: { value: 2 } };
-const { a, ...rest } = source;
-
-console.log(rest.nested === source.nested); // true
-
-rest.nested.value = 3;
-console.log(source.nested.value); // 3
-```
-
 The rest property must be the last in the pattern, and must not have a trailing comma.
 
 ```js-nolint example-bad
@@ -208,6 +196,8 @@ const [a, ...b,] = [1, 2, 3];
 // SyntaxError: rest element may not have a trailing comma
 // Always consider using rest operator as the last element
 ```
+
+Like any other JavaScript language feature, there is no implicit deep-copying. The rest property creates a new object (or array), but all its member values, if they are object references, remain the same.
 
 ## Examples
 


### PR DESCRIPTION

### Description

Clarifies that object values collected by a rest property or rest element are not cloned. Adds an object destructuring example showing that the source and rest binding refer to the same nested object.

### Motivation

The existing section explains that rest bindings create a new array or object, but it does not clarify that collected object values retain their identity. This helps readers understand why mutating a nested object through the rest binding can also be observed through the source.

### Additional details

None

### Related issues and pull requests

None