### PR TITLE
FF154 Relnote: rtcp property get/set in RTCRtp{Receiver|Sender}.getarameters() + send.setParameters()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -60,6 +60,9 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
   ([Firefox bug 2019332](https://bugzil.la/2019332)).
 - The {{domxref("RTCDtlsTransport/error_event", "error")}} event is now fired on {{domxref("RTCDtlsTransport")}} to report DTLS and fingerprinting errors.
   ([Firefox bug 1805447](https://bugzil.la/1805447)).
+- The `rtcp` property is now included in the object returned from {{domxref("RTCRtpReceiver.getParameters()")}} and {{domxref("RTCRtpSender.getParameters()")}}, and can be set in the object passed to {{domxref("RTCRtpSender.setParameters()")}}.
+  This provides the {{glossary("RTCP")}} configuration parameters for the connection.
+  ([Firefox bug 1584318](https://bugzil.la/1584318)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
FF154 adds support for get/set the `rtcp` property in the object returned from [`RTCRtpReceiver.getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpReceiver/getParameters), [`RTCRtpSender.getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/getParameters) and set using [`RTCRtpSender.setParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters) in https://bugzilla.mozilla.org/show_bug.cgi?id=1584318

This adds a release note.

Related docs work can be tracked in #44834
