### PR TITLE
Add Firefox 154 release note for :open support on select elements

### DIFF
--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -32,7 +32,10 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### CSS -->
+### CSS
+
+- The {{cssxref(":open")}} pseudo-class now matches {{htmlelement("select")}} elements while their drop-down picker is open, allowing authors to style the control based on their open state.
+  ([Firefox bug 2048183](https://bugzil.la/2048183)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
### Description

Adds a Firefox 154 release note documenting that the `:open` pseudo-class now matches `<select>` elements while their drop-down picker is open.

### Motivation

This feature shipped in Firefox 154 but was not mentioned in the Firefox 154 release notes. This change documents the new behavior so developers can discover and use it.

### Additional details

- Firefox Bug: https://bugzil.la/2048183
- Verified that the existing `:open` documentation already covers `<select>` support.
- Verified that no update to the Firefox Experimental Features page is required.
- Investigated Browser Compatibility Data; the existing `css.selectors.open` entry already covers the original `:open` support.

### Related issues and pull requests

Related docs work can be tracked in #44847