### PR TITLE
docs: explain feGaussianBlur filter-region clipping

### DIFF
--- a/files/en-us/web/svg/reference/element/fegaussianblur/index.md
+++ b/files/en-us/web/svg/reference/element/fegaussianblur/index.md
@@ -10,7 +10,12 @@ The **`<feGaussianBlur>`** [SVG](/en-US/docs/Web/SVG) filter primitive blurs the
 
 Like other filter primitives, it handles color components in the `linearRGB` {{glossary("color space")}} by default. You can use {{svgattr("color-interpolation-filters")}} to use `sRGB` instead.
 
-A Gaussian blur can extend beyond the bounds of the input image. The {{SVGElement("filter")}} element's {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, and {{SVGAttr("height")}} attributes define the filter region within which the blurred output is rendered. Pixels outside this region are clipped. For large blur values, expand the filter region as needed, for example, with `<filter x="-30%" y="-30%" width="160%" height="160%">`.
+A Gaussian blur can extend beyond the bounds of the input image. The {{SVGElement("filter")}} element's {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, and {{SVGAttr("height")}} attributes define the filter region within which the blurred output is rendered; pixels outside this region are clipped. By default, `x` and `y` are `-10%` and `width` and `height` are `120%`, providing a margin for the blur to spread. For larger {{SVGAttr("stdDeviation")}} values, expand the filter region further.
+For example:
+
+```svg
+<filter x="-30%" y="-30%" width="160%" height="160%">
+```
 
 ## Usage context
 

--- a/files/en-us/web/svg/reference/element/fegaussianblur/index.md
+++ b/files/en-us/web/svg/reference/element/fegaussianblur/index.md
@@ -10,6 +10,8 @@ The **`<feGaussianBlur>`** [SVG](/en-US/docs/Web/SVG) filter primitive blurs the
 
 Like other filter primitives, it handles color components in the `linearRGB` {{glossary("color space")}} by default. You can use {{svgattr("color-interpolation-filters")}} to use `sRGB` instead.
 
+A Gaussian blur can extend beyond the bounds of the input image. The {{SVGElement("filter")}} element's {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, and {{SVGAttr("height")}} attributes define the filter region within which the blurred output is rendered. Pixels outside this region are clipped. For large blur values, expand the filter region as needed, for example, with `<filter x="-30%" y="-30%" width="160%" height="160%">`.
+
 ## Usage context
 
 {{svginfo}}


### PR DESCRIPTION
## Summary

Explains that a Gaussian blur can extend outside its input bounds and that the parent `<filter>` region controls where the result is rendered. Includes a concrete expanded-region example for larger blur values.

## Validation

- `git diff --check`

Fixes #24169
