### PR TITLE
fix: use .some() instead of .forEach() in WebRTC capabilities examples

### DIFF
--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities_static/index.md
@@ -133,12 +133,9 @@ The function below returns a Boolean indicating whether or not the device suppor
 function canReceiveH264() {
   let capabilities = RTCRtpReceiver.getCapabilities("video");
 
-  capabilities.codecs.forEach((codec) => {
-    if (codec.mimeType === "video/H264") {
-      return true;
-    }
+  return capabilities.codecs.some((codec) => {
+    return codec.mimeType === "video/H264";
   });
-  return false;
 }
 ```
 

--- a/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getcapabilities_static/index.md
@@ -135,12 +135,9 @@ The function below returns a `true` or `false` indicating whether or not the dev
 function canSendH264() {
   let capabilities = RTCRtpSender.getCapabilities("video");
 
-  capabilities.codecs.forEach((codec) => {
-    if (codec.mimeType === "video/H264") {
-      return true;
-    }
+  return capabilities.codecs.some((codec) => {
+    return codec.mimeType === "video/H264";
   });
-  return false;
 }
 ```
 


### PR DESCRIPTION
### Description

The commit message/title is self-explanatory

### Motivation

Fix bugs where the original code samples always return `false`.

### Additional details

N/A

### Related issues and pull requests

N/A
