### PR TITLE
Fix broken internal links to relocated pages

### DIFF
--- a/files/en-us/web/webdriver/reference/capabilities/acceptinsecurecerts/index.md
+++ b/files/en-us/web/webdriver/reference/capabilities/acceptinsecurecerts/index.md
@@ -30,4 +30,4 @@ https://self-signed.badssl.com/
 
 - [List of WebDriver capabilities](/en-US/docs/Web/WebDriver/Reference/Capabilities)
 - [Navigate To](/en-US/docs/Web/WebDriver/Reference/Commands/NavigateTo) command
-- [New Session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) command
+- [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) command

--- a/files/en-us/web/webdriver/reference/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/reference/capabilities/firefoxoptions/index.md
@@ -110,7 +110,7 @@ Profiles are created in the systems temporary folder. This is also where the enc
 `profile` is provided. By default geckodriver will create a new profile in this location.
 
 The effective profile in use by the WebDriver session is returned to the user in the `moz:profile`
-capability in the [new session response](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession).
+capability in the [new session response](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession).
 
 To have geckodriver pick up an existing profile on the filesystem, please set the `args` field to
 `{"args": ["-profile", "/path/to/your/profile"]}`. Note that if you use a remote client targeting a server
@@ -278,4 +278,4 @@ This runs the GeckoView example application as installed on the first Android em
 - [Chrome-specific WebDriver capabilities](https://developer.chrome.com/docs/chromedriver/capabilities)
   (`goog:chromeOptions)`
 - [List of WebDriver capabilities](/en-US/docs/Web/WebDriver/Reference/Capabilities)
-- [New Session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) command
+- [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) command

--- a/files/en-us/web/webdriver/reference/capabilities/index.md
+++ b/files/en-us/web/webdriver/reference/capabilities/index.md
@@ -144,5 +144,5 @@ But because there is only one `firstMatch` arm, and we know that session creatio
 
 ## See also
 
-- [New Session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) command
-- [Delete Session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) command
+- [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) command
+- [Delete Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) command

--- a/files/en-us/web/webdriver/reference/capabilities/websocketurl/index.md
+++ b/files/en-us/web/webdriver/reference/capabilities/websocketurl/index.md
@@ -6,7 +6,7 @@ sidebar: webdriver
 ---
 
 With the `webSocketUrl` capability set to `true` a WebSocket server will be started in the browser, supporting bidirectional communication by using the [WebDriver BiDi protocol](https://w3c.github.io/webdriver-bidi/).
-When the [New Session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) request has the `webSocketUrl` capability set to `true`, and the session starts successfully, the value of the `capabilities` field in the response will have a `webSocketUrl` property set to the URL of the WebSocket server.
+When the [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) request has the `webSocketUrl` capability set to `true`, and the session starts successfully, the value of the `capabilities` field in the response will have a `webSocketUrl` property set to the URL of the WebSocket server.
 
 ## Example
 
@@ -35,5 +35,5 @@ Response:
 ## See also
 
 - [List of WebDriver capabilities](/en-US/docs/Web/WebDriver/Reference/Capabilities)
-- [New Session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) command
+- [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) command
 - [Establishing a WebDriver BiDi connection](https://w3c.github.io/webdriver-bidi/#establishing)

--- a/files/en-us/web/webdriver/reference/classic/commands/gettimeouts/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/gettimeouts/index.md
@@ -28,7 +28,7 @@ The response payload is a [`Timeouts`](/en-US/docs/Web/WebDriver/Reference/Class
 - `pageLoad`
   - : Time in milliseconds to wait for the document to finish loading. By default WebDriver will wait five minutes (or 300,000 ms).
 - `script`
-  - : Scripts injected with [Execute Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteScript) or [Execute Async Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteAsyncScript) will run until they hit the script timeout duration, which is also given in milliseconds. The scripts will then be interrupted and a [`script timeout error`](/en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeoutError) will be returned. Defaults to 30 seconds (or 30,000 ms).
+  - : Scripts injected with [Execute Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteScript) or [Execute Async Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteAsyncScript) will run until they hit the script timeout duration, which is also given in milliseconds. The scripts will then be interrupted and a [`script timeout error`](/en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeout) will be returned. Defaults to 30 seconds (or 30,000 ms).
 
 ### Errors
 

--- a/files/en-us/web/webdriver/reference/classic/commands/settimeouts/index.md
+++ b/files/en-us/web/webdriver/reference/classic/commands/settimeouts/index.md
@@ -28,7 +28,7 @@ The input is a [`Timeouts`](/en-US/docs/Web/WebDriver/Reference/Classic/Timeouts
 - `pageLoad`
   - : Time in milliseconds to wait for the document to finish loading. By default, WebDriver will wait five minutes (or 300,000 ms).
 - `script`
-  - : Scripts injected with [Execute Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteScript) or [Execute Async Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteAsyncScript) will run until they hit the script timeout duration, which is also given in milliseconds. The scripts will then be interrupted and a [`script timeout error`](/en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeoutError) will be returned. Defaults to 30 seconds (or 30,000 ms).
+  - : Scripts injected with [Execute Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteScript) or [Execute Async Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteAsyncScript) will run until they hit the script timeout duration, which is also given in milliseconds. The scripts will then be interrupted and a [`script timeout error`](/en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeout) will be returned. Defaults to 30 seconds (or 30,000 ms).
 
 ### Errors
 

--- a/files/en-us/web/webdriver/reference/classic/timeouts/index.md
+++ b/files/en-us/web/webdriver/reference/classic/timeouts/index.md
@@ -8,9 +8,9 @@ sidebar: webdriver
 
 Associated with a [WebDriver](/en-US/docs/Web/WebDriver) session are various timeout definitions that control behavior for [script injection](#script), [document navigation](#pageload), and [element retrieval](#implicit).
 
-You will find the _[timeouts object](#payload)_ used in a few different contexts. It can be used as configuration when [creating a new session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) through [capabilities](/en-US/docs/Web/WebDriver/Reference/Capabilities), it is returned as part of the matched, effective capabilities after the session has been created, and it is used as input and output for the [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) and [Get Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/GetTimeouts) commands.
+You will find the _[timeouts object](#payload)_ used in a few different contexts. It can be used as configuration when [creating a new session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) through [capabilities](/en-US/docs/Web/WebDriver/Reference/Capabilities), it is returned as part of the matched, effective capabilities after the session has been created, and it is used as input and output for the [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) and [Get Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/GetTimeouts) commands.
 
-The default values can be overridden when [creating the session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession) and they will be effective until the session is closed. If you call [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) during the session's lifetime, the defaults are overridden and will take effect for the lifetime of the session or until [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) is called again.
+The default values can be overridden when [creating the session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession) and they will be effective until the session is closed. If you call [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) during the session's lifetime, the defaults are overridden and will take effect for the lifetime of the session or until [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) is called again.
 
 ## Payload
 
@@ -21,11 +21,11 @@ The **timeouts object** is a JSON Object that either describes the current sessi
 - `pageLoad`
   - : Time in milliseconds to wait for the document to finish loading. By default WebDriver will wait five minutes (or 300,000 ms).
 - `script`
-  - : Scripts injected with [Execute Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteScript) or [Execute Async Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteAsyncScript) will run until they hit the script timeout duration, which is also given in milliseconds. The scripts will then be interrupted and a [script timeout error](/en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeoutError) will be returned. Defaults to 30 seconds (or 30,000 ms).
+  - : Scripts injected with [Execute Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteScript) or [Execute Async Script](/en-US/docs/Web/WebDriver/Reference/Commands/ExecuteAsyncScript) will run until they hit the script timeout duration, which is also given in milliseconds. The scripts will then be interrupted and a [script timeout error](/en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeout) will be returned. Defaults to 30 seconds (or 30,000 ms).
 
-When the object is used as input for the [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) command or as part of the [timeouts capability](/en-US/docs/Web/WebDriver/Reference/Capabilities) when [creating a new session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession), all fields are optional. This means you can configure zero or more of the timeout duration values individually or all at once.
+When the object is used as input for the [Set Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/SetTimeouts) command or as part of the [timeouts capability](/en-US/docs/Web/WebDriver/Reference/Capabilities) when [creating a new session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession), all fields are optional. This means you can configure zero or more of the timeout duration values individually or all at once.
 
-When it is returned by the driver, either by [Get Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/GetTimeouts) or in the matched capabilities from [having created a session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession), all fields will be present.
+When it is returned by the driver, either by [Get Timeouts](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/GetTimeouts) or in the matched capabilities from [having created a session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession), all fields will be present.
 
 ## Examples
 

--- a/files/en-us/web/webdriver/reference/errors/invalidsessionid/index.md
+++ b/files/en-us/web/webdriver/reference/errors/invalidsessionid/index.md
@@ -67,5 +67,5 @@ No active session with ID 46197c16-8373-469b-bc56-4c4d9e4132b4
 - [List of WebDriver errors](/en-US/docs/Web/WebDriver/Reference/Errors)
 - [Session not created](/en-US/docs/Web/WebDriver/Reference/Errors/SessionNotCreated)
 - Related WebDriver commands:
-  - [New Session](/en-US/docs/Web/WebDriver/Reference/Commands/NewSession)
+  - [New Session](/en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession)
   - [Delete Session](/en-US/docs/Web/WebDriver/Reference/Commands/DeleteSession)

--- a/files/en-us/webassembly/reference/javascript_interface/tag/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/tag/index.md
@@ -140,4 +140,4 @@ If the tag was used to throw an exception that propagated to JavaScript, we coul
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Guides/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Guides/Using_the_JavaScript_API)
 - [`tag`](/en-US/docs/WebAssembly/Reference/Definitions/tag) definition
-- [`exnref`](/en-US/docs/WebAssembly/Reference/Types/exnref) type
+- [`exnref`](/en-US/docs/WebAssembly/Reference/Value_types/exnref) type


### PR DESCRIPTION
### Description

Fixes 16 internal links across 9 pages that point at slugs which don't exist and have no redirect, so they currently 404 for readers.

| Broken target | Corrected to | Occurrences |
| --- | --- | --- |
| `Web/WebDriver/Reference/Commands/NewSession` | `Web/WebDriver/Reference/Classic/Commands/NewSession` | 12 |
| `Web/WebDriver/Reference/Errors/ScriptTimeoutError` | `Web/WebDriver/Reference/Errors/ScriptTimeout` | 3 |
| `WebAssembly/Reference/Types/exnref` | `WebAssembly/Reference/Value_types/exnref` | 1 |

### Motivation

All three targets currently return 404 on the live site, and each corrected target returns 200:

```
404  /en-US/docs/Web/WebDriver/Reference/Commands/NewSession
200  /en-US/docs/Web/WebDriver/Reference/Classic/Commands/NewSession
404  /en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeoutError
200  /en-US/docs/Web/WebDriver/Reference/Errors/ScriptTimeout
404  /en-US/docs/WebAssembly/Reference/Types/exnref
200  /en-US/docs/WebAssembly/Reference/Value_types/exnref
```

Supporting evidence for each:

- **`NewSession`** — the WebDriver classic commands live under `Reference/Classic/Commands/`. `classic/timeouts/index.md` already links to `Reference/Classic/Commands/SetTimeouts` and `.../GetTimeouts` correctly on lines adjacent to the broken `Reference/Commands/NewSession` links, so the file is internally inconsistent.
- **`ScriptTimeoutError`** — the link text is "script timeout error" and the page documenting it is titled "`script timeout` error code" with slug `Web/WebDriver/Reference/Errors/ScriptTimeout`.
- **`exnref`** — there is no `WebAssembly/Reference/Types/` subtree at all; the value types live under `WebAssembly/Reference/Value_types/`.

### Additional details

Scope was kept deliberately narrow: **only links whose correct target provably exists** were changed. Links pointing at pages that simply haven't been written yet were left untouched — for example `Web/WebDriver/Reference/Commands/ExecuteScript`, `.../FindElement`, and `Web/WebDriver/Reference/WebElement` have no counterpart anywhere in the repo, so repairing those means writing the pages or removing the links, which is a content decision rather than a link fix.

One related cluster I deliberately left alone, in case a maintainer wants to weigh in: `Web/MathML/Reference/Global_attributes/index.md` links to `Web/MathML/Reference/Global_attributes/{autofocus,class,id,nonce,style,tabindex}`, none of which exist, while the corresponding `Web/HTML/Reference/Global_attributes/` pages do. Repointing them at the HTML pages would fix the 404s, but creating MathML-specific pages may be the preferred outcome — happy to follow up either way.

No prose, code samples, or link text was changed; only the URLs.

### Related issues and pull requests

None.
