### PR TITLE
Fix dead external links in MathML fonts guide and VisualViewport

### DIFF
--- a/files/en-us/web/api/visualviewport/index.md
+++ b/files/en-us/web/api/visualviewport/index.md
@@ -143,7 +143,7 @@ The `scrollUpdater()` function will fire on `resize` and `scroll`, while `scroll
 
 ### Hiding an overlaid box on zoom
 
-This example, taken from the [Visual Viewport README](https://github.com/WICG/visual-viewport), shows how to write a bit of code that will hide an overlaid box (which might contain an advert, say) when the user zooms in. This is a nice way to improve the user experience when zooming in on pages. A [live sample](https://wicg.github.io/visual-viewport/examples/hide-on-zoom.html) is also available.
+This example, taken from the [Visual Viewport README](https://github.com/WICG/visual-viewport), shows how to write a bit of code that will hide an overlaid box (which might contain an advert, say) when the user zooms in. This is a nice way to improve the user experience when zooming in on pages. The [full example source](https://github.com/WICG/visual-viewport/blob/gh-pages/examples/hide-on-zoom.html) is also available.
 
 ```js
 const bottomBar = document.getElementById("bottom-bar");
@@ -158,7 +158,7 @@ window.visualViewport.addEventListener("resize", resizeHandler);
 
 ### Simulating position: device-fixed
 
-This example, also taken from the [Visual Viewport README](https://github.com/WICG/visual-viewport), shows how to use this API to simulate `position: device-fixed`, which fixes elements to the visual viewport. A [live sample](https://wicg.github.io/visual-viewport/examples/fixed-to-viewport.html) is also available.
+This example, also taken from the [Visual Viewport README](https://github.com/WICG/visual-viewport), shows how to use this API to simulate `position: device-fixed`, which fixes elements to the visual viewport. The [full example source](https://github.com/WICG/visual-viewport/blob/gh-pages/examples/fixed-to-viewport.html) is also available.
 
 ```js
 const bottomBar = document.getElementById("bottom-bar");

--- a/files/en-us/web/mathml/guides/fonts/index.md
+++ b/files/en-us/web/mathml/guides/fonts/index.md
@@ -20,7 +20,7 @@ Install the _Latin Modern Math_ and _STIX Two Math_ fonts as follows:
 1. Download [latinmodern-math-1959.zip](https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip).
 2. Open the ZIP archive, move inside the `latinmodern-math-1959` directory and then inside the `otf` directory. You will find a `latinmodern-math` font file.
 3. Open the `latinmodern-math` font file and click the **Install** button.
-4. Download [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/master/zipfiles/static_otf.zip).
+4. Download [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/v2.13b171/zipfiles/static_otf.zip).
 5. Open the `static_otf.zip` ZIP archive, and then move inside the `static_otf` directory. Among the files there, you will find a `STIXTwoMath-Regular` file.
 6. Open the `STIXTwoMath-Regular` file and click the **Install** button. If desired, you may also do the same for the other font files in the directory.
 
@@ -40,7 +40,7 @@ Install the _Latin Modern Math_ font as follows:
 
 Install the _STIX Two Math_ font as follows:
 
-1. Download [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/master/zipfiles/static_otf.zip).
+1. Download [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/v2.13b171/zipfiles/static_otf.zip).
 2. Open the `static_otf.zip` ZIP archive, and then move inside the `static_otf` directory. Among the files there, you will find a `STIXTwoMath-Regular.otf` file.
 3. Open the `STIXTwoMath-Regular.otf` file and click the **Install Font** button from the window that opens. If desired, you may also do the same for the other font files in the directory.
 
@@ -110,7 +110,7 @@ fc-cache -sf
 
 If no packages are available on your Linux distributions, or if you just want to install upstream packages then try this:
 
-1. Download [latinmodern-math-1959.zip](https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip) and [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/master/zipfiles/static_otf.zip).
+1. Download [latinmodern-math-1959.zip](https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip) and [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/v2.13b171/zipfiles/static_otf.zip).
 2. Create a `~/.fonts` if it does not exist already and place `latinmodern-math.otf` and `STIXTwoMath-Regular.otf` in that directory.
 3. Run `fc-cache -f` to regenerate the fontconfig cache.
 


### PR DESCRIPTION
### Description

Fixes three external links that currently return 404, across two pages.

| Page | Dead link | Repointed to |
| --- | --- | --- |
| `Web/MathML/Guides/Fonts` (×3) | `raw.githubusercontent.com/stipub/stixfonts/master/zipfiles/static_otf.zip` | same path at the `v2.13b171` release tag |
| `Web/API/VisualViewport` (×2) | `wicg.github.io/visual-viewport/examples/{hide-on-zoom,fixed-to-viewport}.html` | the example sources on the `gh-pages` branch |

### Motivation

**STIX fonts download.** The MathML fonts guide tells readers to "Download `static_otf.zip`" in three separate install walkthroughs, but that URL 404s, so the instructions can't be completed as written. The `zipfiles/` directory was removed from `master` when the repo was restructured — it is not present in the current tree — but it still exists in the `v2.13b171` release tag, which is the latest release. Pinning to the tag keeps the existing "download this zip, install the OTF files" flow intact.

```
404  .../stixfonts/master/zipfiles/static_otf.zip
200  .../stixfonts/v2.13b171/zipfiles/static_otf.zip   (2,151,632 bytes)
```

**VisualViewport live samples.** Both linked demos 404. The repo's GitHub Pages site still serves its root (`https://wicg.github.io/visual-viewport/` → 200) but no longer serves `/examples/`, while the files themselves remain on the `gh-pages` branch:

```
200  https://wicg.github.io/visual-viewport/
404  https://wicg.github.io/visual-viewport/examples/hide-on-zoom.html
200  https://github.com/WICG/visual-viewport/blob/gh-pages/examples/hide-on-zoom.html
```

Since the target is now source rather than a running demo, the link text is changed from "A live sample is also available" to "The full example source is also available" so it doesn't promise something the link no longer delivers. Happy to drop the sentences entirely instead if you'd prefer.
