### PR TITLE
Fix JavaScript examples that throw a SyntaxError

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -130,13 +130,13 @@ The optional `pixelFormat` setting allows you to get image data in the desired p
 ```js
 const context = canvas.getContext("2d");
 
-const imageData = context.getImageData(0, 0, 1, 1);
-console.log(imageData.pixelFormat); // "rgba-unorm8"
+const defaultImageData = context.getImageData(0, 0, 1, 1);
+console.log(defaultImageData.pixelFormat); // "rgba-unorm8"
 
-const imageData = context.getImageData(0, 0, 1, 1, {
+const float16ImageData = context.getImageData(0, 0, 1, 1, {
   pixelFormat: "rgba-float16",
 });
-console.log(imageData.pixelFormat); // "rgba-float16"
+console.log(float16ImageData.pixelFormat); // "rgba-float16"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/rtcpeerconnectionstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnectionstats/index.md
@@ -44,19 +44,29 @@ The function waits for the result of a call to {{domxref("RTCPeerConnection.getS
 It then returns the total number of open channels, or `null`, using the data in the report.
 
 ```js
-async function numberOpenConnections (peerConnection) {
+async function numberOpenConnections(peerConnection) {
   const stats = await peerConnection.getStats();
   let peerConnectionStats = null;
 
-  stats.forEach((report) => {
+  for (const report of stats.values()) {
     if (report.type === "peer-connection") {
       peerConnectionStats = report;
       break;
     }
-  });
+  }
 
-result = (typeof peerConnectionStats.dataChannelsOpened === 'undefined' || typeof peerConnectionStats.dataChannelsClosed=== 'undefined') ? null : peerConnectionStats.dataChannelsOpened - peerConnectionStats.dataChannelsClosed;
-return result
+  if (
+    peerConnectionStats === null ||
+    typeof peerConnectionStats.dataChannelsOpened === "undefined" ||
+    typeof peerConnectionStats.dataChannelsClosed === "undefined"
+  ) {
+    return null;
+  }
+
+  return (
+    peerConnectionStats.dataChannelsOpened -
+    peerConnectionStats.dataChannelsClosed
+  );
 }
 ```
 

--- a/files/en-us/web/api/rtctransportstats/index.md
+++ b/files/en-us/web/api/rtctransportstats/index.md
@@ -80,18 +80,16 @@ The function waits for the result of a call to {{domxref("RTCPeerConnection.getS
 It then returns the statistics, or `null`, using the data in the report.
 
 ```js
-async function numberOpenConnections (peerConnection) {
+async function getTransportStats(peerConnection) {
   const stats = await peerConnection.getStats();
-  let transportStats = null;
 
-  stats.forEach((report) => {
+  for (const report of stats.values()) {
     if (report.type === "transport") {
-      transportStats = report;
-      break;
+      return report;
     }
-  });
+  }
 
-return transportStats
+  return null;
 }
 ```
 


### PR DESCRIPTION
### Description

Fixes three JavaScript examples that fail to parse, so they throw a `SyntaxError` and cannot run as written.

| Page | Problem |
| --- | --- |
| `RTCTransportStats` | `break` inside a `forEach()` callback |
| `RTCPeerConnectionStats` | `break` inside a `forEach()` callback, plus an undeclared `result` and an unchecked dereference |
| `CanvasRenderingContext2D.getImageData` | `const imageData` declared twice in the same scope |

### Motivation

**The two WebRTC examples.** Both iterate the stats report with `forEach()` and then use `break` to stop early:

```js
stats.forEach((report) => {
  if (report.type === "transport") {
    transportStats = report;
    break; // SyntaxError: Illegal break statement
  }
});
```

`break` is not valid inside a callback, so neither example parses. {{domxref("RTCStatsReport")}} is a read-only `Map`-like object exposing `entries()`, `forEach()`, `keys()`, `values()` and `[Symbol.iterator]`, but no `some()` or `find()`, so an array search method isn't available here. Iterating with `for...of` over `stats.values()` keeps the intended early exit and makes `break` valid.

`RTCPeerConnectionStats` has two further problems in the same block: `result` is assigned without a declaration, creating an implicit global that throws in strict mode and in modules; and `peerConnectionStats` is dereferenced without checking that a matching report was found, which throws a `TypeError` when the connection has no `peer-connection` entry. Both are addressed.

The transport example is also renamed from `numberOpenConnections` to `getTransportStats`, since it returns transport statistics rather than a count of open connections — the name looks like a copy/paste from the `RTCPeerConnectionStats` page. The surrounding prose already describes it as returning "the transport statistics, or `null`", so no prose changes were needed.

**The canvas example.** It declares `const imageData` twice in the same scope, which is a redeclaration error:

```js
const imageData = context.getImageData(0, 0, 1, 1);
console.log(imageData.pixelFormat); // "rgba-unorm8"

const imageData = context.getImageData(0, 0, 1, 1, {
  pixelFormat: "rgba-float16",
});
```

The two declarations are renamed to `defaultImageData` and `float16ImageData`, which also makes it clearer that each one demonstrates a different pixel format.
