### PR TITLE
fix: missing apostrophe in CSS Replaced Elements guide ('dont' -> 'don't')

### DIFF
--- a/files/en-us/web/css/guides/images/replaced_element_properties/index.md
+++ b/files/en-us/web/css/guides/images/replaced_element_properties/index.md
@@ -13,7 +13,7 @@ A **{{glossary("replaced elements", "replaced element")}}** is an element whose 
 
 CSS handles replaced elements specifically in some cases, like when calculating margins and some `auto` values. Only replaced elements can ever have {{glossary("intrinsic size", "intrinsic dimensions")}}. Some replaced elements, but not all, have intrinsic dimensions or a defined baseline, which is used by some CSS properties, such as {{cssxref("vertical-align")}}.
 
-While document styles can set the size and position of replaced elements, document styles dont affect the replaced elements' content, with some exceptions: The [CSS images module](/en-US/docs/Web/CSS/Guides/Images) includes properties which support controlling the positioning of the element's content within its box.
+While document styles can set the size and position of replaced elements, document styles don't affect the replaced elements' content, with some exceptions: The [CSS images module](/en-US/docs/Web/CSS/Guides/Images) includes properties which support controlling the positioning of the element's content within its box.
 
 ## Controlling object position within the content box
 


### PR DESCRIPTION
## Summary

Small typo fix in prose: **'dont'** → **'don't**' (missing apostrophe).

### File changed
- `files/en-us/web/css/guides/images/replaced_element_properties/index.md` (line 16)

### Context
Original text: *"document styles **dont** affect the replaced elements' content"*
Fixed to: *"document styles **don't** affect the replaced elements' content"*

Unambiguous spelling correction in body text (not code identifier or macro).