### PR TITLE
Clarify URL-based payment method identifiers

### DIFF
--- a/files/en-us/web/api/payment_request_api/concepts/index.md
+++ b/files/en-us/web/api/payment_request_api/concepts/index.md
@@ -49,7 +49,7 @@ These identifiers are typically provided by payment service providers during onb
 - `https://apple.com/apple-pay`
   - : Payments are handled using the [Apple Pay](https://www.apple.com/apple-pay/) service. This payment method is primarily supported in Safari on compatible Apple devices.
 - `https://google.com/pay`
-  - : Payments are processed by [Google Pay](https://pay.google.com/payments/home/). Support for this payment method is generally limited to Chromium-based browsers because only Chromium-based browsers support payment handlers that aren't built into the browser.
+  - : Payments are processed by [Google Pay](https://pay.google.com/payments/home/). Support depends on browsers that implement the Payment Handler API (currently primarily Chromium-based browsers).
 
 ## Functions of a payment handler
 

--- a/files/en-us/web/api/payment_request_api/concepts/index.md
+++ b/files/en-us/web/api/payment_request_api/concepts/index.md
@@ -44,12 +44,12 @@ Standardized payment method identifiers are those listed in the [payment method 
 
 ### URL-based payment method identifiers
 
-These may vary substantially depending on the specifics of the service, and a given processing service may have multiple URLs used, depending on the version of their API, their communication technology, and so forth.
+These identifiers are typically provided by payment service providers during onboarding or integration and may vary substantially depending on the specifics of the service, API version, and communication technology. Developers will usually obtain these identifiers directly from their chosen payment service provider's documentation rather than discovering them independently.
 
 - `https://apple.com/apple-pay`
-  - : Payments are handled using the [Apple Pay](https://www.apple.com/apple-pay/) service. Currently, Apple Pay is only supported by Safari.
+  - : Payments are handled using the [Apple Pay](https://www.apple.com/apple-pay/) service. This payment method is primarily supported in Safari on compatible Apple devices.
 - `https://google.com/pay`
-  - : Payments are processed by [Google Pay](https://pay.google.com/payments/home). This is currently supported only by Chrome and Chromium-based browsers.
+  - : Payments are processed by [Google Pay](https://pay.google.com/payments/home/). Support for this payment method is generally limited to Chromium-based browsers because only Chromium-based browsers support payment handlers that aren't built into the browser.
 
 ## Functions of a payment handler
 
@@ -87,3 +87,5 @@ Thus, it's important to note that the {{Glossary("user agent")}} never sends a {
 - [Using the Payment Request API](/en-US/docs/Web/API/Payment_Request_API/Using_the_Payment_Request_API)
 - [Introducing the Payment Request API for Apple Pay](https://webkit.org/blog/8182/introducing-the-payment-request-api-for-apple-pay/)
 - [Google Pay API PaymentRequest Tutorial](https://developers.google.com/pay/api/web/guides/paymentrequest/tutorial)
+- [Android Payment Apps Developers Guide](https://web.dev/articles/android-payment-apps-developers-guide)
+- [Samsung Internet Web Payments Integration Guide](https://developer.samsung.com/internet/android/web-payments-integration-guide.html)


### PR DESCRIPTION
### Description

This PR updates the **URL-based payment method identifiers** section of the Payment Request API concepts page by:

- Explaining how developers typically obtain URL-based payment method identifiers from payment service providers during onboarding or integration.
- Updating the Apple Pay and Google Pay examples with clearer browser support wording.
- Adding links to additional resources for developers interested in payment handler integrations.

### Motivation

The current documentation only lists Apple Pay and Google Pay as examples without explaining how developers discover URL-based payment method identifiers.

Based on the discussion in the issue, this PR focuses on providing better guidance ("breadcrumbs") for developers instead of maintaining a list of payment providers. It also clarifies that support for non-built-in payment handlers is primarily a browser capability rather than a limitation imposed by a specific payment provider.

### Additional details

The new "See also" resources point readers to official documentation for implementing payment handlers and integrating web payments, without expanding the documentation into a list of provider-specific implementations.

### Related issues and pull requests

Fixes #38581