### PR TITLE
Intro to css values

### DIFF
--- a/files/en-us/web/css/reference/properties/column-fill/index.md
+++ b/files/en-us/web/css/reference/properties/column-fill/index.md
@@ -52,14 +52,14 @@ column-fill: revert-layer;
 column-fill: unset;
 ```
 
-The `column-fill` property is specified as one of the keyword values listed below. The initial value is `balance` so the content will be balanced across the columns.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : Columns are filled sequentially. Content takes up only the room it needs, possibly resulting in some columns remaining empty.
 - `balance`
-  - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/Guides/Paged_media), only the last fragment is balanced. Therefore in paged media, only the last page would be balanced.
+  - : Content is equally divided between columns. In fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/Guides/Paged_media), only the last fragment is balanced. Therefore in paged media, only the last page would be balanced. This is the default value.
 
 The specification defines a `balance-all` value, in which content is equally divided between columns in fragmented contexts, such as [paged media](/en-US/docs/Web/CSS/Guides/Paged_media). This value is not yet supported in any browser.
 

--- a/files/en-us/web/css/reference/properties/font-size/index.md
+++ b/files/en-us/web/css/reference/properties/font-size/index.md
@@ -80,6 +80,8 @@ font-size: unset;
 
 ### Values
 
+This property is specified as a `<length>`, a `<percentage>`, or one of the following keyword values:
+
 - `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large`, `xxx-large`
   - : [Absolute-size](/en-US/docs/Web/CSS/Reference/Values/absolute-size) keywords, based on the user's default font size (which is `medium`).
 

--- a/files/en-us/web/css/reference/properties/font-size/index.md
+++ b/files/en-us/web/css/reference/properties/font-size/index.md
@@ -80,7 +80,7 @@ font-size: unset;
 
 ### Values
 
-This property is specified as a `<length>`, a `<percentage>`, or one of the following keyword values:
+This property is specified as a single value from the following list:
 
 - `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large`, `xxx-large`
   - : [Absolute-size](/en-US/docs/Web/CSS/Reference/Values/absolute-size) keywords, based on the user's default font size (which is `medium`).

--- a/files/en-us/web/css/reference/properties/font-stretch/index.md
+++ b/files/en-us/web/css/reference/properties/font-stretch/index.md
@@ -91,8 +91,6 @@ font-stretch: revert-layer;
 font-stretch: unset;
 ```
 
-
-
 ### Values
 
 This property is specified as a {{cssxref("&lt;percentage&gt;")}} value or one of the following keyword values:

--- a/files/en-us/web/css/reference/properties/font-stretch/index.md
+++ b/files/en-us/web/css/reference/properties/font-stretch/index.md
@@ -91,9 +91,11 @@ font-stretch: revert-layer;
 font-stretch: unset;
 ```
 
-This property may be specified as a single keyword or {{cssxref("&lt;percentage&gt;")}} value.
+
 
 ### Values
+
+This property is specified as a {{cssxref("&lt;percentage&gt;")}} value or one of the following keyword values:
 
 - `normal`
   - : Specifies a normally condensed font face.

--- a/files/en-us/web/css/reference/properties/font-stretch/index.md
+++ b/files/en-us/web/css/reference/properties/font-stretch/index.md
@@ -93,7 +93,7 @@ font-stretch: unset;
 
 ### Values
 
-This property is specified as a {{cssxref("&lt;percentage&gt;")}} value or one of the following keyword values:
+This property is specified as a single value from the following list:
 
 - `normal`
   - : Specifies a normally condensed font face.

--- a/files/en-us/web/css/reference/properties/font-style/index.md
+++ b/files/en-us/web/css/reference/properties/font-style/index.md
@@ -74,6 +74,8 @@ The `font-style` property is specified as a single keyword chosen from the list 
 
 ### Values
 
+This property is specified as one of the following keyword values, with `oblique` optionally followed by an `<angle>`:
+
 - `normal`
   - : Selects a font that is classified as `normal` within a {{Cssxref("font-family")}}.
 - `italic`

--- a/files/en-us/web/css/reference/properties/font-style/index.md
+++ b/files/en-us/web/css/reference/properties/font-style/index.md
@@ -74,7 +74,7 @@ The `font-style` property is specified as a single keyword chosen from the list 
 
 ### Values
 
-This property is specified as one of the following keyword values, with `oblique` optionally followed by an `<angle>`:
+This property is specified as one of the following keyword values. The `oblique` keyword can optionally be followed by an `<angle>`:
 
 - `normal`
   - : Selects a font that is classified as `normal` within a {{Cssxref("font-family")}}.

--- a/files/en-us/web/css/reference/properties/font-style/index.md
+++ b/files/en-us/web/css/reference/properties/font-style/index.md
@@ -70,8 +70,6 @@ font-style: revert-layer;
 font-style: unset;
 ```
 
-The `font-style` property is specified as a single keyword chosen from the list of values below, which can optionally include an angle if the keyword is `oblique`.
-
 ### Values
 
 This property is specified as one of the following keyword values. The `oblique` keyword can optionally be followed by an `<angle>`:

--- a/files/en-us/web/css/reference/properties/font-variant-alternates/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-alternates/index.md
@@ -37,12 +37,9 @@ font-variant-alternates: revert-layer;
 font-variant-alternates: unset;
 ```
 
-This property may take one of two forms:
-
-- either the keyword `normal`
-- or one or more of the other keywords and functions listed below, space-separated, in any order.
-
 ### Values
+
+This property is specified either as `normal` or as a space-separated list of the following values and functions:
 
 - `normal`
   - : This keyword deactivates alternate glyphs.

--- a/files/en-us/web/css/reference/properties/font-variant-alternates/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-alternates/index.md
@@ -39,7 +39,7 @@ font-variant-alternates: unset;
 
 ### Values
 
-This property is specified either as `normal` or as a space-separated list of the following values and functions:
+This property is specified as `normal` or as a space-separated list of the following values:
 
 - `normal`
   - : This keyword deactivates alternate glyphs.

--- a/files/en-us/web/css/reference/properties/font-variant-caps/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-caps/index.md
@@ -93,7 +93,7 @@ The `font-variant-caps` property controls the use of alternate glyphs used for s
 
 When a given font includes capital letter glyphs of multiple different sizes, this property selects the most appropriate ones. If petite capital glyphs are not available, they are rendered using small capital glyphs. If these are not present, the browser synthesizes them from the uppercase glyphs.
 
-The values is a single keyword. For each value, if the font doesn't support the OpenType value, then it synthesizes the glyphs. Fonts sometimes include special glyphs for various caseless characters (such as punctuation marks) to better match the capitalized characters around them. However, small capital glyphs are never synthesized for caseless characters.
+The value is a single keyword. For each value, if the font doesn't support the OpenType value, then it synthesizes the glyphs. Fonts sometimes include special glyphs for various caseless characters (such as punctuation marks) to better match the capitalized characters around them. However, small capital glyphs are never synthesized for caseless characters.
 
 ### Language-specific rules
 

--- a/files/en-us/web/css/reference/properties/font-variant-caps/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-caps/index.md
@@ -68,9 +68,9 @@ font-variant-caps: revert-layer;
 font-variant-caps: unset;
 ```
 
-The `font-variant-caps` property is specified using a single keyword value from the list below. In each case, if the font doesn't support the OpenType value, then it synthesizes the glyphs.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `normal`
   - : Deactivates of the use of alternate glyphs.
@@ -89,9 +89,11 @@ The `font-variant-caps` property is specified using a single keyword value from 
 
 ## Description
 
+The `font-variant-caps` property controls the use of alternate glyphs used for small or petite capitals or for titling.
+
 When a given font includes capital letter glyphs of multiple different sizes, this property selects the most appropriate ones. If petite capital glyphs are not available, they are rendered using small capital glyphs. If these are not present, the browser synthesizes them from the uppercase glyphs.
 
-Fonts sometimes include special glyphs for various caseless characters (such as punctuation marks) to better match the capitalized characters around them. However, small capital glyphs are never synthesized for caseless characters.
+The values is a single keyword. For each value, if the font doesn't support the OpenType value, then it synthesizes the glyphs. Fonts sometimes include special glyphs for various caseless characters (such as punctuation marks) to better match the capitalized characters around them. However, small capital glyphs are never synthesized for caseless characters.
 
 ### Language-specific rules
 

--- a/files/en-us/web/css/reference/properties/font-variant-emoji/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-emoji/index.md
@@ -28,9 +28,9 @@ font-variant-emoji: revert-layer;
 font-variant-emoji: unset;
 ```
 
-The `font-variant-emoji` property is specified using a single keyword value from the list below.
-
 ### Values
+
+This property is specified as one of the following keyword values:
 
 - `normal`
   - : Allows a browser to choose how to display the emoji. This often follows the operating system setting.

--- a/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
@@ -78,8 +78,6 @@ font-variant-ligatures: revert-layer;
 font-variant-ligatures: unset;
 ```
 
-
-
 ### Values
 
 This property is specified as `normal`, `none`, or a space-separated list of the following values:

--- a/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
@@ -80,7 +80,7 @@ font-variant-ligatures: unset;
 
 ### Values
 
-This property is specified as `normal`, `none`, or a space-separated list of the following values:
+This property is specified as a single keyword or as a space-separated list of the following values:
 
 - `normal`
   - : This keyword activates the usual ligatures and contextual forms needed for correct rendering. The ligatures and forms activated depend on the font, language, and kind of script. This is the default value.

--- a/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-ligatures/index.md
@@ -78,9 +78,11 @@ font-variant-ligatures: revert-layer;
 font-variant-ligatures: unset;
 ```
 
-The `font-variant-ligatures` property is specified as `normal`, `none`, or one or more of the other value types listed below. Spaces separate multiple values.
+
 
 ### Values
+
+This property is specified as `normal`, `none`, or a space-separated list of the following values:
 
 - `normal`
   - : This keyword activates the usual ligatures and contextual forms needed for correct rendering. The ligatures and forms activated depend on the font, language, and kind of script. This is the default value.

--- a/files/en-us/web/css/reference/properties/font-variant/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant/index.md
@@ -104,6 +104,8 @@ font-variant: unset;
 
 ### Values
 
+This property is specified as a space-separated list of keyword values:
+
 - `normal`
   - : Specifies a normal font face. Each longhand property has an initial value of `normal`.
 

--- a/files/en-us/web/css/reference/properties/font-variant/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant/index.md
@@ -104,7 +104,7 @@ font-variant: unset;
 
 ### Values
 
-This property is specified as a space-separated list of keyword values:
+This property is specified as a space-separated list of the following values:
 
 - `normal`
   - : Specifies a normal font face. Each longhand property has an initial value of `normal`.

--- a/files/en-us/web/css/reference/properties/font-variation-settings/index.md
+++ b/files/en-us/web/css/reference/properties/font-variation-settings/index.md
@@ -68,7 +68,7 @@ font-variation-settings: unset;
 
 ### Values
 
-This property's value can take one of two forms:
+This property is specified as `normal` or a comma-separated list of string-number value pairs:
 
 - `normal`
   - : Text is laid out using default settings.

--- a/files/en-us/web/css/reference/properties/font-weight/index.md
+++ b/files/en-us/web/css/reference/properties/font-weight/index.md
@@ -87,6 +87,8 @@ The `font-weight` property is specified using either a `<font-weight-absolute>` 
 
 ### Values
 
+This property is specified as one of the following keyword values or a `<number>`:
+
 - `normal`
   - : Normal font weight. Same as `400`.
 

--- a/files/en-us/web/css/reference/properties/font-weight/index.md
+++ b/files/en-us/web/css/reference/properties/font-weight/index.md
@@ -83,11 +83,9 @@ font-weight: revert-layer;
 font-weight: unset;
 ```
 
-The `font-weight` property is specified using either a `<font-weight-absolute>` value or a relative weight value, as listed below.
-
 ### Values
 
-his property is specified as a single value from the following list:
+This property is specified as a single value from the following list:
 
 - `normal`
   - : Normal font weight. Same as `400`.

--- a/files/en-us/web/css/reference/properties/font-weight/index.md
+++ b/files/en-us/web/css/reference/properties/font-weight/index.md
@@ -87,7 +87,7 @@ The `font-weight` property is specified using either a `<font-weight-absolute>` 
 
 ### Values
 
-This property is specified as one of the following keyword values or a `<number>`:
+his property is specified as a single value from the following list:
 
 - `normal`
   - : Normal font weight. Same as `400`.

--- a/files/en-us/web/css/reference/properties/font-width/index.md
+++ b/files/en-us/web/css/reference/properties/font-width/index.md
@@ -97,7 +97,7 @@ font-width: unset;
 
 ### Values
 
-This property is specified as one of the following keyword values or a `<percentage>` value:
+This property is specified as a single value from the following list:
 
 - `normal`
   - : Specifies a normally condensed font face.

--- a/files/en-us/web/css/reference/properties/font-width/index.md
+++ b/files/en-us/web/css/reference/properties/font-width/index.md
@@ -95,9 +95,9 @@ font-width: revert-layer;
 font-width: unset;
 ```
 
-This property may be specified as a single keyword or {{cssxref("&lt;percentage&gt;")}} value.
-
 ### Values
+
+This property is specified as one of the following keyword values or a `<percentage>` value:
 
 - `normal`
   - : Specifies a normally condensed font face.

--- a/files/en-us/web/css/reference/properties/frame-sizing/index.md
+++ b/files/en-us/web/css/reference/properties/frame-sizing/index.md
@@ -33,7 +33,7 @@ frame-sizing: unset;
 
 ### Values
 
-The `frame-sizing` property value is equal to one of the following keywords:
+This property is specified as one of the following keyword values:
 
 - `auto`
   - : The initial value. The `<iframe>` element's size is not affected by the layout size of its embedded document.

--- a/files/en-us/web/css/reference/properties/hyphenate-limit-chars/index.md
+++ b/files/en-us/web/css/reference/properties/hyphenate-limit-chars/index.md
@@ -37,9 +37,9 @@ hyphenate-limit-chars: revert-layer;
 hyphenate-limit-chars: unset;
 ```
 
-The `hyphenate-limit-chars` property takes 1–3 values that can be numeric or `auto`, as explained below.
-
 ### Values
+
+This property is specified as one to three values, with each being a `<number>` or the keyword `auto`:
 
 - `<number> <number> <number>`
   - : The first value is the minimum word length before words should be hyphenated. The second value is the minimum number of characters before the hyphen. The third value is the minimum number of characters after the hyphen.

--- a/files/en-us/web/css/reference/properties/hyphenate-limit-chars/index.md
+++ b/files/en-us/web/css/reference/properties/hyphenate-limit-chars/index.md
@@ -39,7 +39,7 @@ hyphenate-limit-chars: unset;
 
 ### Values
 
-This property is specified as one to three values, with each being a `<number>` or the keyword `auto`:
+This property is specified as one to three values from the following list:
 
 - `<number> <number> <number>`
   - : The first value is the minimum word length before words should be hyphenated. The second value is the minimum number of characters before the hyphen. The third value is the minimum number of characters after the hyphen.

--- a/files/en-us/web/css/reference/properties/hyphenate-limit-chars/index.md
+++ b/files/en-us/web/css/reference/properties/hyphenate-limit-chars/index.md
@@ -39,7 +39,7 @@ hyphenate-limit-chars: unset;
 
 ### Values
 
-This property is specified as one to three values from the following list:
+This property is specified as one to three numeric or `auto` values:
 
 - `<number> <number> <number>`
   - : The first value is the minimum word length before words should be hyphenated. The second value is the minimum number of characters before the hyphen. The third value is the minimum number of characters after the hyphen.

--- a/files/en-us/web/css/reference/properties/image-resolution/index.md
+++ b/files/en-us/web/css/reference/properties/image-resolution/index.md
@@ -33,6 +33,8 @@ image-resolution: unset;
 
 ### Values
 
+This property is specified as the `from-image` keyword, a `<resolution>`, or both, space-separated, optionally with the `snap` keyword:
+
 - {{cssxref("resolution")}}
   - : Specifies the intrinsic resolution explicitly.
 - `from-image`

--- a/files/en-us/web/css/reference/properties/image-resolution/index.md
+++ b/files/en-us/web/css/reference/properties/image-resolution/index.md
@@ -33,7 +33,7 @@ image-resolution: unset;
 
 ### Values
 
-This property is specified as the `from-image` keyword, a `<resolution>`, or both, space-separated, optionally with the `snap` keyword:
+This property is specified as one or more space-separated values from the following list:
 
 - {{cssxref("resolution")}}
   - : Specifies the intrinsic resolution explicitly.

--- a/files/en-us/web/css/reference/properties/initial-letter/index.md
+++ b/files/en-us/web/css/reference/properties/initial-letter/index.md
@@ -33,7 +33,7 @@ initial-letter: unset;
 
 ### Values
 
-The keyword value `normal`, or a `<number>` optionally followed by an `<integer>`.
+The keyword value `normal` or a `<number>` optionally followed by an `<integer>`:
 
 - `normal`
   - : No special initial-letter effect. Text behaves as normal.

--- a/files/en-us/web/css/reference/properties/initial-letter/index.md
+++ b/files/en-us/web/css/reference/properties/initial-letter/index.md
@@ -33,7 +33,7 @@ initial-letter: unset;
 
 ### Values
 
-The keyword value `normal` or a `<number>` optionally followed by an `<integer>`:
+This property is specified as `normal` or a `<number>` optionally followed by an `<integer>`:
 
 - `normal`
   - : No special initial-letter effect. Text behaves as normal.

--- a/files/en-us/web/css/reference/properties/letter-spacing/index.md
+++ b/files/en-us/web/css/reference/properties/letter-spacing/index.md
@@ -76,7 +76,7 @@ letter-spacing: unset;
 
 ### Values
 
-This property is specified as a `<length-percentage>` or the keyword `normal`:
+This property is specified as a single value from the following list:
 
 - `normal`
   - : The normal letter spacing for the current font. Unlike a value of `0`, this keyword allows the {{glossary("user agent")}} to alter the space between characters in order to justify text.

--- a/files/en-us/web/css/reference/properties/letter-spacing/index.md
+++ b/files/en-us/web/css/reference/properties/letter-spacing/index.md
@@ -76,6 +76,8 @@ letter-spacing: unset;
 
 ### Values
 
+This property is specified as a `<length-percentage>` or the keyword `normal`:
+
 - `normal`
   - : The normal letter spacing for the current font. Unlike a value of `0`, this keyword allows the {{glossary("user agent")}} to alter the space between characters in order to justify text.
 - {{cssxref("&lt;length-percentage&gt;")}}

--- a/files/en-us/web/css/reference/properties/line-break/index.md
+++ b/files/en-us/web/css/reference/properties/line-break/index.md
@@ -65,6 +65,8 @@ line-break: unset;
 
 ### Values
 
+This property is specified as one of the following keyword values:
+
 - `auto`
   - : Break text using the default line break rule.
 - `loose`

--- a/files/en-us/web/css/reference/properties/line-clamp/index.md
+++ b/files/en-us/web/css/reference/properties/line-clamp/index.md
@@ -36,7 +36,7 @@ line-clamp: unset;
 
 ### Values
 
-This property is specified as an `<integer>` or the keyword `none`:
+This property is specified as a single value from the following list:
 
 - `none`
   - : This value specifies that the content won't be clamped.

--- a/files/en-us/web/css/reference/properties/line-clamp/index.md
+++ b/files/en-us/web/css/reference/properties/line-clamp/index.md
@@ -36,6 +36,8 @@ line-clamp: unset;
 
 ### Values
 
+This property is specified as an `<integer>` or the keyword `none`:
+
 - `none`
   - : This value specifies that the content won't be clamped.
 - {{cssxref("integer")}}

--- a/files/en-us/web/css/reference/properties/line-height-step/index.md
+++ b/files/en-us/web/css/reference/properties/line-height-step/index.md
@@ -29,7 +29,7 @@ line-height-step: unset;
 
 ### Values
 
-This property is specified as a `<length>`:
+This property is specified as the following value:
 
 - `<length>`
   - : The specified {{cssxref("&lt;length&gt;")}} is used in the calculation of the line box height step.

--- a/files/en-us/web/css/reference/properties/line-height-step/index.md
+++ b/files/en-us/web/css/reference/properties/line-height-step/index.md
@@ -27,11 +27,9 @@ line-height-step: revert-layer;
 line-height-step: unset;
 ```
 
-The `line-height-step` property is specified as any one of the following:
-
-- a `<length>`.
-
 ### Values
+
+This property is specified as a `<length>`:
 
 - `<length>`
   - : The specified {{cssxref("&lt;length&gt;")}} is used in the calculation of the line box height step.

--- a/files/en-us/web/css/reference/properties/line-height/index.md
+++ b/files/en-us/web/css/reference/properties/line-height/index.md
@@ -71,14 +71,9 @@ line-height: revert-layer;
 line-height: unset;
 ```
 
-The `line-height` property is specified as any one of the following:
-
-- a `<number>`
-- a `<length>`
-- a `<percentage>`
-- the keyword `normal`.
-
 ### Values
+
+This property is specified as a `<number>`,`<length>`, `<percentage>`, or the keyword `normal`:
 
 - `normal`
   - : Depends on the user agent. Desktop browsers (including Firefox) use a default value of roughly **`1.2`**, depending on the element's `font-family`.

--- a/files/en-us/web/css/reference/properties/line-height/index.md
+++ b/files/en-us/web/css/reference/properties/line-height/index.md
@@ -73,7 +73,7 @@ line-height: unset;
 
 ### Values
 
-This property is specified as a `<number>`,`<length>`, `<percentage>`, or the keyword `normal`:
+This property is specified as a single value from the following list:
 
 - `normal`
   - : Depends on the user agent. Desktop browsers (including Firefox) use a default value of roughly **`1.2`**, depending on the element's `font-family`.

--- a/files/en-us/web/css/reference/properties/list-style-image/index.md
+++ b/files/en-us/web/css/reference/properties/list-style-image/index.md
@@ -97,6 +97,8 @@ list-style-image: unset;
 
 ### Values
 
+This property is specified as an `<image>` or the keyword `none`:
+
 - {{cssxref("image")}}
   - : A valid image to use as the marker.
 - `none`

--- a/files/en-us/web/css/reference/properties/list-style-image/index.md
+++ b/files/en-us/web/css/reference/properties/list-style-image/index.md
@@ -97,7 +97,7 @@ list-style-image: unset;
 
 ### Values
 
-This property is specified as an `<image>` or the keyword `none`:
+This property is specified as a single value from the following list:
 
 - {{cssxref("image")}}
   - : A valid image to use as the marker.


### PR DESCRIPTION
CSS properties include a "Values" section.
Sometimes there is an intro to the values. sometimes there isn't.
This is the third PR in an attempt to make things consistent. This PR addresses some of the properties that had no intro sentence in the values section that and didn't need a whole bunch of other work done

continuation of https://github.com/mdn/content/pull/44833