### PR TITLE
Document that String.prototype.replace() resets lastIndex for global regexes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -59,6 +59,22 @@ If the `pattern` is an empty string, the replacement is prepended to the start o
 
 A regexp with the `g` flag is the only case where `replace()` replaces more than once. For more information about how regex properties (especially the [sticky](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) flag) interact with `replace()`, see [`RegExp.prototype[Symbol.replace]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/Symbol.replace).
 
+When `pattern` is a regex with the [`g` flag](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global), `replace()` sets the regex's [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) to `0` before matching, so replacement always starts from the beginning of the string regardless of the regex's previous `lastIndex`. After the call, `lastIndex` is left at `0`.
+
+This means you don't need to manually reset `lastIndex` before calling `replace()`, even if the same regex was previously used with methods that advance `lastIndex`, such as [`test()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test):
+
+```js
+const re = /b/g;
+const str = "aAbBcC";
+
+console.log(re.test(str)); // true
+console.log(re.lastIndex); // 3; advanced by test()
+console.log(str.replace(re, "-")); // "aA-BcC"; replace() resets lastIndex itself
+console.log(re.lastIndex); // 0
+```
+
+If the regex does not have the `g` flag, `lastIndex` is not reset before matching.
+
 ### Specifying a string as the replacement
 
 The replacement string can include the following special replacement patterns:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description
Explain that when the pattern is a regex with the g flag, replace() sets the regex's lastIndex to 0 before matching and leaves it at 0 after the call, so there is no need to manually reset lastIndex after using the same regex with methods like test(). Also note that non-global regexes do not get their lastIndex reset.

Per ECMA-262:
- https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.replace
- https://tc39.es/ecma262/#sec-regexp.prototype-@@replace
<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
