### PR TITLE
Clarify why pagehide is still recommended as a fallback in Navigator.sendBeacon

### DIFF
--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -105,6 +105,8 @@ Firefox will also exclude pages from the bfcache if they contain `beforeunload` 
 To support browsers which don't implement `visibilitychange`, use the [`pagehide`](/en-US/docs/Web/API/Window/pagehide_event) event.
 Like `beforeunload` and `unload`, this event is not reliably fired, especially on mobile. However, it is compatible with the bfcache.
 
+> **Note:** The `pagehide` fallback stays useful even though all modern browsers implement `visibilitychange`. `visibilitychange` fires on _every_ transition to `hidden` (for example, when you switch tabs), so its handler can run multiple times. `pagehide`, by contrast, fires a single time as the page is unloaded, making it a reliable place for a final, fire-and-forget beacon in addition to `visibilitychange`.
+
 ## Examples
 
 The following example specifies a handler for the {{domxref("document.visibilitychange_event", "visibilitychange")}} event. The handler calls `sendBeacon()` to send analytics.

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -105,7 +105,8 @@ Firefox will also exclude pages from the bfcache if they contain `beforeunload` 
 To support browsers which don't implement `visibilitychange`, use the [`pagehide`](/en-US/docs/Web/API/Window/pagehide_event) event.
 Like `beforeunload` and `unload`, this event is not reliably fired, especially on mobile. However, it is compatible with the bfcache.
 
-> **Note:** The `pagehide` fallback stays useful even though all modern browsers implement `visibilitychange`. `visibilitychange` fires on _every_ transition to `hidden` (for example, when you switch tabs), so its handler can run multiple times. `pagehide`, by contrast, fires a single time as the page is unloaded, making it a reliable place for a final, fire-and-forget beacon in addition to `visibilitychange`.
+> [!NOTE]
+> The `pagehide` fallback stays useful even though all modern browsers implement `visibilitychange`. `visibilitychange` fires on _every_ transition to `hidden` (for example, when you switch tabs), so its handler can run multiple times. `pagehide`, by contrast, fires a single time as the page is unloaded, making it a reliable place for a final, fire-and-forget beacon in addition to `visibilitychange`.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Clarifies the "Use pagehide as a fallback" section of the `Navigator.sendBeacon` page (see issue #44942, which followed up on #44927).

The current text frames `pagehide` as needed "to support browsers which don't implement `visibilitychange`". Since all modern browsers implement `visibilitychange`, a reader reasonably wonders whether the fallback is obsolete.

This PR adds a note explaining the still-valid reason: `visibilitychange` fires on _every_ transition to `hidden` (so it can run multiple times), whereas `pagehide` fires once at unload — making it a reliable place for a final, fire-and-forget beacon in addition to `visibilitychange`.

## Motivation

- `visibilitychange` → fires every time the page becomes hidden (tab switch, minimize, etc.) → handler can run repeatedly.
- `pagehide` → fires a single time as the document is unloaded → ideal for the final beacon.

So the fallback is about reliability/idempotency, not missing `visibilitychange` support.

fixes #44942