### PR TITLE
FF154 Relnote/ExprF: CSS typed OM API

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -581,7 +581,7 @@ This simplifies CSS property manipulation by exposing CSS values as typed JavaSc
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 154           | Y                   |
+| Nightly           | 154           | Yes                 |
 | Developer Edition | 149           | No                  |
 | Beta              | 149           | No                  |
 | Release           | 149           | No                  |

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -575,13 +575,13 @@ The implementation includes:
 
 ### CSS Typed Object Model Level 1
 
-Implementation work has started on the [CSS Typed OM Level 1](https://drafts.css-houdini.org/css-typed-om/).
-For example, the {{domxref("CSSNumericValue/to","to()")}} method of the {{domxref("CSSNumericValue")}} interface is supported for converting a CSS numeric value from one unit to another.
+The [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) is implemented in Nightly.
+This simplifies CSS property manipulation by exposing CSS values as typed JavaScript objects rather than strings.
 ([Firefox bug 1278697](https://bugzil.la/1278697)).
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |
-| Nightly           | 149           | No                  |
+| Nightly           | 154           | Y                   |
 | Developer Edition | 149           | No                  |
 | Beta              | 149           | No                  |
 | Release           | 149           | No                  |

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -92,3 +92,8 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **Percentage values for `text-decoration-inset`**: `layout.css.text-decoration-inset-percentage.enabled`
 
   The {{cssxref("text-decoration-inset")}} CSS property now supports percentages as values. The percentage value specifies the size of the inset as a percentage of the {{cssxref("font-size")}}. ([Firefox bug 2044602](https://bugzil.la/2044602)).
+
+- **CSS Typed Object Model Level 1** (Nightly): `layout.css.typed-om.enabled`
+
+  The [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) (as defined in the CSS Typed Object Model Level 1 specification) is now implemented.
+  This simplifies CSS property manipulation by exposing CSS values as typed JavaScript objects rather than strings. ([Firefox bug 2051047](https://bugzil.la/2051047)).


### PR DESCRIPTION
FF154 added nightly support for the [CSS_Typed_OM_API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API) in https://bugzilla.mozilla.org/show_bug.cgi?id=2051047

This adds a release note and experimental features update. Note that these entries existed before but a lot of work has been done since then, so worth re-advertising in the release notes.

Related docs work can be tracked in #44849
