### PR TITLE
Add a note on localStorage doc about item update

### DIFF
--- a/files/en-us/web/api/window/localstorage/index.md
+++ b/files/en-us/web/api/window/localstorage/index.md
@@ -37,7 +37,7 @@ In all current browsers, `localStorage` seems to return a different object for e
 
 ## Examples
 
-The following snippet accesses the current domain's local {{DOMxRef("Storage")}} object and adds a data item to it using {{DOMxRef("Storage.setItem()")}}.
+The following snippet accesses the current domain's local {{DOMxRef("Storage")}} object and adds a data item to it using {{DOMxRef("Storage.setItem()")}}, or updates the item if one already exists for that key.
 
 ```js
 localStorage.setItem("myCat", "Tom");


### PR DESCRIPTION
Update is correctly documented on https://developer.mozilla.org/en-US/docs/Web/API/Storage/setItem but IMHO it might be good to add a note about update operation here too, for readers who might not check all subpages.