### PR TITLE
Fix broken browser-compat keys in SVG attribute reference

### DIFF
--- a/files/en-us/web/svg/reference/attribute/data-_star_/index.md
+++ b/files/en-us/web/svg/reference/attribute/data-_star_/index.md
@@ -2,7 +2,7 @@
 title: data-*
 slug: Web/SVG/Reference/Attribute/data-*
 page-type: svg-attribute
-browser-compat: svg.global_attributes.data
+browser-compat: svg.global_attributes.data_attributes
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/requiredfeatures/index.md
+++ b/files/en-us/web/svg/reference/attribute/requiredfeatures/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Reference/Attribute/requiredFeatures
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.global_attributes.requiredFeatures
+spec-urls: https://www.w3.org/TR/SVG11/struct.html#RequiredFeaturesAttribute
 sidebar: svgref
 ---
 
@@ -791,7 +791,3 @@ text {
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}

--- a/files/en-us/web/svg/reference/attribute/systemlanguage/index.md
+++ b/files/en-us/web/svg/reference/attribute/systemlanguage/index.md
@@ -2,7 +2,7 @@
 title: systemLanguage
 slug: Web/SVG/Reference/Attribute/systemLanguage
 page-type: svg-attribute
-browser-compat: svg.global_attributes.systemLanguage
+browser-compat: svg.elements.a.systemLanguage
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/xlink_colon_arcrole/index.md
+++ b/files/en-us/web/svg/reference/attribute/xlink_colon_arcrole/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Reference/Attribute/xlink:arcrole
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.global_attributes.xlink_arcrole
+spec-urls: https://www.w3.org/TR/SVG11/linking.html#XLinkArcRoleAttribute
 sidebar: svgref
 ---
 
@@ -61,10 +61,6 @@ You can use this attribute with the following SVG elements:
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/svg/reference/attribute/xlink_colon_title/index.md
+++ b/files/en-us/web/svg/reference/attribute/xlink_colon_title/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Reference/Attribute/xlink:title
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.global_attributes.xlink_title
+browser-compat: svg.elements.a.xlink_title
 sidebar: svgref
 ---
 

--- a/files/en-us/web/svg/reference/attribute/xlink_colon_type/index.md
+++ b/files/en-us/web/svg/reference/attribute/xlink_colon_type/index.md
@@ -4,7 +4,7 @@ slug: Web/SVG/Reference/Attribute/xlink:type
 page-type: svg-attribute
 status:
   - deprecated
-browser-compat: svg.global_attributes.xlink_type
+spec-urls: https://www.w3.org/TR/SVG11/linking.html#XLinkTypeAttribute
 sidebar: svgref
 ---
 
@@ -55,10 +55,6 @@ You can use this attribute with the following SVG elements:
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
### Description

- Repoints `data-*` to `svg.global_attributes.data_attributes`
- Repoints `xlink:title` and `systemLanguage` to their per-element keys
- Removes the dead `browser-compat` key and empty `{{Compat}}` section
- Adds `spec-urls` so the Specifications section still renders

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852