### PR TITLE
Fix errors in SVG filter documentation

### DIFF
--- a/files/en-us/web/svg/guides/applying_svg_effects_to_html_content/index.md
+++ b/files/en-us/web/svg/guides/applying_svg_effects_to_html_content/index.md
@@ -193,7 +193,6 @@ And some more filters:
 <svg height="0">
   <filter id="f3">
     <feConvolveMatrix
-      filterRes="100 100"
       color-interpolation-filters="sRGB"
       order="3"
       kernelMatrix="0 -1 0

--- a/files/en-us/web/svg/reference/attribute/color-interpolation-filters/index.md
+++ b/files/en-us/web/svg/reference/attribute/color-interpolation-filters/index.md
@@ -9,18 +9,17 @@ sidebar: svgref
 The **`color-interpolation-filters`** attribute specifies the color space for imaging operations performed via filter effects.
 
 > [!NOTE]
-> This property just has an affect on filter operations. Therefore, it has no effect on filter primitives like {{SVGElement("feOffset")}}, {{SVGElement("feImage")}}, {{SVGElement("feTile")}} or {{SVGElement("feFlood")}}.
+> This property just has an effect on filter operations. Therefore, it has no effect on filter primitives like {{SVGElement("feOffset")}}, {{SVGElement("feImage")}}, {{SVGElement("feTile")}} or {{SVGElement("feFlood")}}.
 >
 > `color-interpolation-filters` has a different initial value than {{SVGAttr("color-interpolation")}}. `color-interpolation-filters` has an initial value of `linearRGB`, whereas `color-interpolation` has an initial value of `sRGB`. Thus, in the default case, filter effects operations occur in the linearRGB color space, whereas all other color interpolations occur by default in the sRGB color space.
 >
-> It has no affect on filter functions, which operate in the {{Glossary("RGB", "sRGB")}} color space.
+> It has no effect on filter functions, which operate in the {{Glossary("RGB", "sRGB")}} color space.
 
 > [!NOTE]
 > As a presentation attribute, `color-interpolation-filters` also has a CSS property counterpart: {{cssxref("color-interpolation-filters")}}. When both are specified, the CSS property takes priority.
 
 You can use this attribute with the following SVG elements:
 
-- {{SVGElement("feSpotLight")}}
 - {{SVGElement("feBlend")}}
 - {{SVGElement("feColorMatrix")}}
 - {{SVGElement("feComponentTransfer")}}

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
@@ -106,7 +106,7 @@ Filters are defined by the {{SVGElement('filter')}} element, which should be put
 
 ```html
 <feSpecularLighting
-  in="offsetBlur"
+  in="blur"
   surfaceScale="5"
   specularConstant=".75"
   specularExponent="20"
@@ -116,7 +116,7 @@ Filters are defined by the {{SVGElement('filter')}} element, which should be put
 </feSpecularLighting>
 ```
 
-{{SVGelement('feSpecularLighting')}} takes `in` "offsetBlur", generates a lighting effect, and stores the `result` in the buffer "specOut".
+{{SVGElement('feSpecularLighting')}} takes `in` "blur", generates a lighting effect, and stores the `result` in the buffer "specOut".
 
 ### Step 4
 


### PR DESCRIPTION
### Description

- Corrects two affect/effect typos on color-interpolation-filters
- Drops the misplaced `feSpotLight` from that page’s element list
- Fixes the `SVGelement/SVGElement` macro-casing
- Turn `feSpecularLighting` input to `in="blur"` in the tutorial’s Step 3 to match the full example
- Removes non-supported `filterRes` attribute

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852