### PR TITLE
Fix factual errors in SVG element reference

### DIFF
--- a/files/en-us/web/svg/reference/element/feimage/index.md
+++ b/files/en-us/web/svg/reference/element/feimage/index.md
@@ -15,7 +15,7 @@ The **`<feImage>`** [SVG](/en-US/docs/Web/SVG) filter primitive fetches image da
 ## Attributes
 
 - {{SVGAttr("crossorigin")}}
-- {{SVGAttr("fetchpriority")}} {{experimental_inline}}
+- {{SVGAttr("fetchpriority")}} {{experimental_inline}} {{non-standard_inline}}
 - {{SVGAttr("preserveAspectRatio")}}
 - {{SVGAttr("href")}}
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}

--- a/files/en-us/web/svg/reference/element/mpath/index.md
+++ b/files/en-us/web/svg/reference/element/mpath/index.md
@@ -14,6 +14,7 @@ The **`<mpath>`** [SVG](/en-US/docs/Web/SVG) sub-element for the {{SVGElement("a
 
 ## Attributes
 
+- {{SVGAttr("href")}}
 - {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 
 ## DOM Interface

--- a/files/en-us/web/svg/reference/element/switch/index.md
+++ b/files/en-us/web/svg/reference/element/switch/index.md
@@ -6,7 +6,7 @@ browser-compat: svg.elements.switch
 sidebar: svgref
 ---
 
-The **`<switch>`** [SVG](/en-US/docs/Web/SVG) element evaluates any {{SVGAttr("requiredFeatures")}}, {{SVGAttr("requiredExtensions")}} and {{SVGAttr("systemLanguage")}} attributes on its direct child elements in order, and then renders the first child where these attributes evaluate to true.
+The **`<switch>`** [SVG](/en-US/docs/Web/SVG) element evaluates any {{SVGAttr("requiredExtensions")}} and {{SVGAttr("systemLanguage")}} attributes on its direct child elements in order, and then renders the first child where these attributes evaluate to true.
 
 Other direct children will be bypassed and therefore not rendered. If a child element is a container element, like {{SVGElement("g")}}, then its subtree is also processed/rendered or bypassed/not rendered.
 
@@ -63,4 +63,5 @@ This example demonstrates showing different text content depending on the browse
 
 ## See also
 
-- {{SVGAttr("requiredFeatures")}}
+- {{SVGAttr("requiredExtensions")}}
+- {{SVGAttr("systemLanguage")}}


### PR DESCRIPTION
### Description

- Marks `feImage`'s `fetchpriority` as `{{non-standard_inline}}`, matching the image and script pages
- Documents the current `href` attribute on `mpath` alongside the deprecated `xlink:href`
- Removes `requiredFeatures` from `switch` page

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852