### PR TITLE
Fix typos in SVG guides

### DIFF
--- a/files/en-us/web/svg/guides/content_type/index.md
+++ b/files/en-us/web/svg/guides/content_type/index.md
@@ -147,7 +147,7 @@ SVG makes use of a number of data types. This article lists these types along wi
     SVG makes extensive use of _IRI_ references, both absolute and relative, to other objects. For example, to fill a rectangle with a linear gradient, you first define a {{SVGElement("linearGradient")}} element and give it an ID, as in:
 
     ```html
-    <linearGradient xml:id="MyGradient">...</linearGradient>
+    <linearGradient id="MyGradient">...</linearGradient>
     ```
 
     You then reference the linear gradient as the value of the {{SVGAttr("fill")}} attribute for the rectangle, as in the following example:

--- a/files/en-us/web/svg/guides/svg_animation_with_smil/index.md
+++ b/files/en-us/web/svg/guides/svg_animation_with_smil/index.md
@@ -51,7 +51,7 @@ If you want to animate more attributes inside the same element, you can add more
 
 ## Animating the transform attributes
 
-The {{ SVGElement("animateTransform") }} element let you animate [transform](/en-US/docs/Web/SVG/Reference/Attribute/transform) attributes. This element is necessary because we are not animating a single attribute like [x](/en-US/docs/Web/SVG/Reference/Attribute/x) which is a number. Rotation attributes look like this: `rotation(theta, x, y)`, where `theta` is the angle in degrees, and `x` and `y` are absolute positions. In the example below, we animate the center of the rotation and the angle.
+The {{ SVGElement("animateTransform") }} element let you animate [transform](/en-US/docs/Web/SVG/Reference/Attribute/transform) attributes. This element is necessary because we are not animating a single attribute like [x](/en-US/docs/Web/SVG/Reference/Attribute/x) which is a number. Rotation attributes look like this: `rotate(theta, x, y)`, where `theta` is the angle in degrees, and `x` and `y` are absolute positions. In the example below, we animate the center of the rotation and the angle.
 
 ```html
 <svg width="300" height="100">

--- a/files/en-us/web/svg/guides/svg_in_html/index.md
+++ b/files/en-us/web/svg/guides/svg_in_html/index.md
@@ -71,7 +71,7 @@ If the SVG can be labeled by visible text, reference that text with an [`aria-la
     </style>
   </defs>
 
-  <rect width="36" height="60" x="13" y="18" ry="2" transform="skewy(24deg)" />
+  <rect width="36" height="60" x="13" y="18" ry="2" transform="skewY(24deg)" />
   <rect width="39" height="60" x="11" y="20" ry="2" transform="skewY(18deg)" />
   <rect width="42" height="90" x="8" y="22" ry="2" transform="skewY(12deg)" />
   <rect width="36" height="60" x="50" y="18" ry="2" transform="skewY(-24deg)" />


### PR DESCRIPTION
### Description

- Fixes an invalid `skewy(24deg)` transform
- Corrects `rotation()` → `rotate()`
- Replaces `xml:id` → `id`

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852