### PR TITLE
Remove outdated browser compatibility info about sideways-rl and sideways-lr

### DIFF
--- a/files/en-us/web/css/guides/flexible_box_layout/relationship_with_other_layout_methods/index.md
+++ b/files/en-us/web/css/guides/flexible_box_layout/relationship_with_other_layout_methods/index.md
@@ -55,8 +55,6 @@ The writing modes specification defines the following values of the {{cssxref("w
 
 {{EmbedLiveSample("writing-modes")}}
 
-The `sideways-rl` and `sideways-lr` have support only in Firefox currently.
-
 Note that you would not normally use CSS and the `writing-mode` property to change an entire document to another writing mode. This would be done via HTML, by adding a [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir) and [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute to the {{htmlelement("html")}} element to indicate the document language and default text direction. This would mean that the document would display correctly even if CSS did not load.
 
 ## Flexbox and other layout methods


### PR DESCRIPTION
### Description

Removes a paragraph about `sideways-rl` and `sideways-lr` being only supported in Firefox. Both are now compatible with all browsers per https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/writing-mode#browser_compatibility

### Motivation

Removal of outdated information