### PR TITLE
docs: add guidance for no-support banners in examples

### DIFF
--- a/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
@@ -39,6 +39,9 @@ Some more general guidelines include:
 ### Browser support
 
 When creating code examples for a technology that's not yet available in all major browsers, consider using [feature detection](/en-US/docs/Learn_web_development/Extensions/Testing/Feature_detection) to fall back to a simpler behavior or inform the user that their browser is not yet supported.
+
+When possible, keep examples visible even if they can't run in the reader's browser. For interactive examples, prefer showing a "No support" banner instead of hiding or removing them so readers can still inspect the code and learn how the feature works.
+
 Do not specify supported browsers and their versions in code comments or prose, as this information quickly becomes outdated.
 
 ## MDN code style and formatting

--- a/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
@@ -38,7 +38,7 @@ Some more general guidelines include:
 
 ### Browser support
 
-When creating code examples for a technology that's not yet available in all major browsers, consider using [feature detection](/en-US/docs/Learn_web_development/Extensions/Testing/Feature_detection) to fall back to a simpler behavior or inform the user that their browser is not yet supported.
+When creating code examples for a technology that's not yet available in all major browsers, consider using [feature detection](/en-US/docs/Learn_web_development/Extensions/Testing/Feature_detection) to provide a fallback behavior or display a message indicating that the reader's browser doesn't support the demonstrated feature.
 
 Keep the rendered output of code examples visible even when the reader's browser doesn't support the demonstrated feature. This lets readers compare the code with its result and see how the example behaves without the feature. Display a browser-support message alongside the rendered output instead of hiding or removing it to explain why the result may appear different from the intended demonstration.
 

--- a/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
@@ -42,6 +42,20 @@ When creating code examples for a technology that's not yet available in all maj
 
 When possible, keep examples visible even if they can't run in the reader's browser. For interactive examples, prefer showing a "No support" banner instead of hiding or removing them so readers can still inspect the code and learn how the feature works.
 
+For example, a CSS example can use `@supports not` to display a "No support" banner when the feature isn't supported:
+
+```css
+@supports not (animation-timeline: scroll()) {
+  body::before {
+    content: "Your browser doesn't support this feature.";
+    display: block;
+    padding: 1rem;
+    text-align: center;
+    background-color: wheat;
+  }
+}
+```
+
 Do not specify supported browsers and their versions in code comments or prose, as this information quickly becomes outdated.
 
 ## MDN code style and formatting

--- a/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
@@ -42,19 +42,61 @@ When creating code examples for a technology that's not yet available in all maj
 
 Keep the rendered output of code examples visible even when the reader's browser doesn't support the demonstrated feature. This lets readers compare the code with its result and see how the example behaves without the feature. Display a browser-support message alongside the rendered output instead of hiding or removing it to explain why the result may appear different from the intended demonstration.
 
-For example, in CSS code examples, use the [`@supports` at-rule with the `not` operator](/en-US/docs/Web/CSS/Reference/At-rules/@supports#the_not_operator) to display a browser-support message when the reader's browser doesn't support the feature being demonstrated:
+For example, in CSS code examples, use the [`@supports` at-rule with the `not` operator](/en-US/docs/Web/CSS/Reference/At-rules/@supports#the_not_operator) to display a browser-support message when the reader's browser doesn't support the feature being demonstrated.
 
-```css
-@supports not (animation-timeline: scroll()) {
+#### HTML
+
+```html live-sample___corner-shape-support
+<div>Nice scooped corners</div>
+```
+
+#### CSS
+
+```css hidden live-sample___corner-shape-support
+body {
+  font-family: "Helvetica", "Arial", sans-serif;
+  width: 240px;
+  margin: 20px auto;
+}
+
+div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 180px;
+  background-color: cyan;
+  border-radius: 30px;
+  box-shadow: 1px 1px 3px gray;
+}
+
+@supports not (corner-shape: scoop) {
+  body {
+    all: unset !important;
+  }
+
   body::before {
-    content: "Your browser doesn't support this feature.";
-    display: block;
-    padding: 1rem;
-    text-align: center;
+    content: "Your browser does not support the 'corner-shape' property.";
+    color: black;
     background-color: wheat;
+    display: block;
+    width: 100%;
+    text-align: center;
+    padding: 1rem 0;
   }
 }
 ```
+
+```css live-sample___corner-shape-support
+div {
+  corner-shape: scoop;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("corner-shape-support", "100%", "240")}}
+
+Compare the rendered output in different browsers to see how the example behaves when `corner-shape` is supported and when it isn't.
 
 Do not specify supported browsers and their versions in code comments or prose, as this information quickly becomes outdated.
 

--- a/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
@@ -40,7 +40,7 @@ Some more general guidelines include:
 
 When creating code examples for a technology that's not yet available in all major browsers, consider using [feature detection](/en-US/docs/Learn_web_development/Extensions/Testing/Feature_detection) to fall back to a simpler behavior or inform the user that their browser is not yet supported.
 
-When possible, keep examples visible even if they can't run in the reader's browser. For interactive examples, prefer showing a "No support" banner instead of hiding or removing them so readers can still inspect the code and learn how the feature works.
+Keep the rendered output of code examples visible even when the reader's browser doesn't support the demonstrated feature. This lets readers compare the code with its result and see how the example behaves without the feature. Display a browser-support message alongside the rendered output instead of hiding or removing it to explain why the result may appear different from the intended demonstration.
 
 For example, a CSS example can use `@supports not` to display a "No support" banner when the feature isn't supported:
 

--- a/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/code_style_guide/index.md
@@ -42,7 +42,7 @@ When creating code examples for a technology that's not yet available in all maj
 
 Keep the rendered output of code examples visible even when the reader's browser doesn't support the demonstrated feature. This lets readers compare the code with its result and see how the example behaves without the feature. Display a browser-support message alongside the rendered output instead of hiding or removing it to explain why the result may appear different from the intended demonstration.
 
-For example, a CSS example can use `@supports not` to display a "No support" banner when the feature isn't supported:
+For example, in CSS code examples, use the [`@supports` at-rule with the `not` operator](/en-US/docs/Web/CSS/Reference/At-rules/@supports#the_not_operator) to display a browser-support message when the reader's browser doesn't support the feature being demonstrated:
 
 ```css
 @supports not (animation-timeline: scroll()) {


### PR DESCRIPTION
### Description

Add guidance to the Code Style Guide recommending that interactive examples remain visible when a feature is unsupported, using a "No support" banner instead of hiding or removing the example.

### Motivation

This documents the principle established in PR #43857 that hiding interactive examples is not a good learning experience. Keeping examples visible allows readers to inspect the code and understand how a feature works, even if it cannot run in their current browser.

### Additional details

This change updates the **Browser support** section of the Code Style Guide by adding guidance for interactive examples. It is a documentation-only change.

### Related issues and pull requests

Fixes #43896

Relates to #43857