### PR TITLE
Editorial review: Add doc for getSecurePaymentConfirmationCapabilities() static method

### DIFF
--- a/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
+++ b/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
@@ -26,7 +26,7 @@ None.
 
 A {{jsxref("Promise")}} that resolves with a [map-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis). Each key is a string representing the name of a secure payment confirmation feature, and each value is a boolean representing whether the feature is available (`true`) or not (`false`).
 
-Available features are as follows:
+Known features are as follows:
 
 - `browserBoundKeyHardware`
   - : The Secure Payment Confirmation API is capable of using browser bound keys that are stored in hardware secure elements on the device. A browser-bound key is a public-private key pair that signs over the transaction details in addition to the [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) credential and is tied to a single device by the user agent.

--- a/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
+++ b/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
@@ -15,7 +15,7 @@ The **`getSecurePaymentConfirmationCapabilities()`** static method of the {{domx
 ## Syntax
 
 ```js-nolint
-getSecurePaymentConfirmationCapabilities()
+PaymentRequest.getSecurePaymentConfirmationCapabilities()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
+++ b/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
@@ -24,7 +24,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with a map-like object. Each key is a string representing the name of a secure payment confirmation feature, and each value is a boolean representing whether the feature is available (`true`) or not (`false`).
+A {{jsxref("Promise")}} that resolves with a [map-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis). Each key is a string representing the name of a secure payment confirmation feature, and each value is a boolean representing whether the feature is available (`true`) or not (`false`).
 
 Available features are as follows:
 

--- a/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
+++ b/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
@@ -1,0 +1,56 @@
+---
+title: "PaymentRequest: getSecurePaymentConfirmationCapabilities() static method"
+short-title: getSecurePaymentConfirmationCapabilities()
+slug: Web/API/PaymentRequest/getSecurePaymentConfirmationCapabilities_static
+page-type: web-api-static-method
+status:
+  - experimental
+browser-compat: api.PaymentRequest.getSecurePaymentConfirmationCapabilities_static
+---
+
+{{securecontext_header}}{{APIRef("Payment Request API")}}{{SeeCompatTable}}
+
+The **`getSecurePaymentConfirmationCapabilities()`** static method of the {{domxref("PaymentRequest")}} interface returns a [map-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis) indicating which capabilities of the [Secure payment confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation) feature are supported by the current browser.
+
+## Syntax
+
+```js-nolint
+getSecurePaymentConfirmationCapabilities()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with a map-like object. Each key is a string representing the name of a secure payment confirmation feature, and each value is a boolean representing whether the feature is available (`true`) or not (`false`).
+
+Available features are as follows:
+
+- `browserBoundKeyHardware`
+  - : The Secure Payment Confirmation API is capable of using browser bound keys that are stored in hardware secure elements on the device. A browser-bound key is a public-private key pair that signs over the transaction details in addition to the [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) credential and is tied to a single device by the user agent.
+
+## Examples
+
+```js
+async function spcFeatures() {
+  const features =
+    await PaymentRequest.getSecurePaymentConfirmationCapabilities();
+  for (const [key, value] of Object.entries(features)) {
+    console.log(`${key}: ${value}`);
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Using Secure Payment Confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation)

--- a/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
+++ b/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
@@ -31,6 +31,9 @@ Available features are as follows:
 - `browserBoundKeyHardware`
   - : The Secure Payment Confirmation API is capable of using browser bound keys that are stored in hardware secure elements on the device. A browser-bound key is a public-private key pair that signs over the transaction details in addition to the [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) credential and is tied to a single device by the user agent.
 
+> [!NOTE]
+> The browser may choose to omit some or all capabilities from the map regardless if it is supported or not, for example to protect user privacy if abuse of the API is suspected.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
+++ b/files/en-us/web/api/paymentrequest/getsecurepaymentconfirmationcapabilities_static/index.md
@@ -10,7 +10,7 @@ browser-compat: api.PaymentRequest.getSecurePaymentConfirmationCapabilities_stat
 
 {{securecontext_header}}{{APIRef("Payment Request API")}}{{SeeCompatTable}}
 
-The **`getSecurePaymentConfirmationCapabilities()`** static method of the {{domxref("PaymentRequest")}} interface returns a [map-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis) indicating which capabilities of the [Secure payment confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation) feature are supported by the current browser.
+The **`getSecurePaymentConfirmationCapabilities()`** static method of the {{domxref("PaymentRequest")}} interface returns an object indicating which capabilities of the [Secure payment confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation) feature are supported by the current browser.
 
 ## Syntax
 
@@ -24,7 +24,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with a [map-like object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#map-like_browser_apis). Each key is a string representing the name of a secure payment confirmation feature, and each value is a boolean representing whether the feature is available (`true`) or not (`false`).
+A {{jsxref("Promise")}} that resolves with an object where the property names are strings representing secure payment confirmation feature names, and the values are booleans representing whether the feature is available (`true`) or not (`false`).
 
 Known features are as follows:
 
@@ -32,9 +32,11 @@ Known features are as follows:
   - : The Secure Payment Confirmation API is capable of using browser bound keys that are stored in hardware secure elements on the device. A browser-bound key is a public-private key pair that signs over the transaction details in addition to the [WebAuthn](/en-US/docs/Web/API/Web_Authentication_API) credential and is tied to a single device by the user agent.
 
 > [!NOTE]
-> The browser may choose to omit some or all capabilities from the map regardless if it is supported or not, for example to protect user privacy if abuse of the API is suspected.
+> The browser may choose to omit some or all capabilities from the object regardless if it is supported or not, for example to protect user privacy if abuse of the API is suspected.
 
 ## Examples
+
+### Basic usage
 
 ```js
 async function spcFeatures() {

--- a/files/en-us/web/api/paymentrequest/index.md
+++ b/files/en-us/web/api/paymentrequest/index.md
@@ -30,7 +30,7 @@ The [Payment Request API's](/en-US/docs/Web/API/Payment_Request_API) **`PaymentR
 ## Static methods
 
 - {{domxref('PaymentRequest.getSecurePaymentConfirmationCapabilities_static', 'PaymentRequest.getSecurePaymentConfirmationCapabilities()')}} {{experimental_inline}}
-  - : Returns a map-like object indicating which capabilities of the [Secure payment confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation) feature are supported by the current browser.
+  - : Returns an object indicating which capabilities of the [Secure payment confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation) feature are supported by the current browser.
 - {{domxref('PaymentRequest.securePaymentConfirmationAvailability_static', 'PaymentRequest.securePaymentConfirmationAvailability()')}} {{experimental_inline}}
   - : Indicates whether the Secure payment confirmation feature is available in the current browser.
 

--- a/files/en-us/web/api/paymentrequest/index.md
+++ b/files/en-us/web/api/paymentrequest/index.md
@@ -29,8 +29,10 @@ The [Payment Request API's](/en-US/docs/Web/API/Payment_Request_API) **`PaymentR
 
 ## Static methods
 
+- {{domxref('PaymentRequest.getSecurePaymentConfirmationCapabilities_static', 'PaymentRequest.getSecurePaymentConfirmationCapabilities()')}} {{experimental_inline}}
+  - : Returns a map-like object indicating which capabilities of the [Secure payment confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation) feature are supported by the current browser.
 - {{domxref('PaymentRequest.securePaymentConfirmationAvailability_static', 'PaymentRequest.securePaymentConfirmationAvailability()')}} {{experimental_inline}}
-  - : Indicates whether the [Secure payment confirmation](/en-US/docs/Web/API/Payment_Request_API/Using_secure_payment_confirmation) feature is available.
+  - : Indicates whether the Secure payment confirmation feature is available in the current browser.
 
 ## Instance methods
 

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -301,7 +301,7 @@ interface RTCStatsReport {
 
 `Map`-like objects are either read-only or read-writable (see the `readonly` keyword in the IDL above).
 
-- Read-only `Map`-like objects have the property {{jsxref("Map/size", "size")}}, and the methods: {{jsxref("Map/entries", "entries()")}}, {{jsxref("Map/forEach", "forEach()")}}, {{jsxref("Map/get", "get()")}}, {{jsxref("Map/has", "has()")}}, {{jsxref("Map/keys", "keys()")}}, {{jsxref("Map/values", "values()")}}, and [`Symbol.iterator()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/Symbol.iterator).
+- Read-only `Map`-like objects have the property {{jsxref("Map/size", "size")}}, and the methods: {{jsxref("Map/entries", "entries()")}}, {{jsxref("Map/forEach", "forEach()")}}, {{jsxref("Map/get", "get()")}}, {{jsxref("Map/has", "has()")}}, {{jsxref("Map/keys", "keys()")}}, {{jsxref("Map/values", "values()")}}, and [`[Symbol.iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/Symbol.iterator).
 - Writeable `Map`-like objects additionally have the methods: {{jsxref("Map/clear", "clear()")}}, {{jsxref("Map/delete", "delete()")}}, and {{jsxref("Map/set", "set()")}}.
 
 The methods and properties have the same behavior as the equivalent entities in `Map`, except for the restriction on the types of the keys and values.

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -315,6 +315,7 @@ The following are examples of read-only `Map`-like browser objects:
 - {{domxref("MIDIInputMap")}}
 - {{domxref("MIDIOutputMap")}}
 - {{domxref("RTCStatsReport")}}
+- The return value of {{domxref("PaymentRequest.getSecurePaymentConfirmationCapabilities()")}}
 
 ## Constructor
 

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -315,7 +315,6 @@ The following are examples of read-only `Map`-like browser objects:
 - {{domxref("MIDIInputMap")}}
 - {{domxref("MIDIOutputMap")}}
 - {{domxref("RTCStatsReport")}}
-- The return value of {{domxref("PaymentRequest.getSecurePaymentConfirmationCapabilities()")}}
 
 ## Constructor
 

--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -142,7 +142,7 @@ interface GPUSupportedFeatures {
 
 `Set`-like objects are either read-only or read-writable (see the `readonly` keyword in the IDL above).
 
-- Read-only `Set`-like objects have the property {{jsxref("Set/size", "size")}}, and the methods: {{jsxref("Set/entries", "entries()")}}, {{jsxref("Set/forEach", "forEach()")}}, {{jsxref("Set/has", "has()")}}, {{jsxref("Set/keys", "keys()")}}, {{jsxref("Set/values", "values()")}}, and [`Symbol.iterator()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/Symbol.iterator).
+- Read-only `Set`-like objects have the property {{jsxref("Set/size", "size")}}, and the methods: {{jsxref("Set/entries", "entries()")}}, {{jsxref("Set/forEach", "forEach()")}}, {{jsxref("Set/has", "has()")}}, {{jsxref("Set/keys", "keys()")}}, {{jsxref("Set/values", "values()")}}, and [`[Symbol.iterator]()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/Symbol.iterator).
 - Writeable `Set`-like objects additionally have the methods: {{jsxref("Set/clear", "clear()")}}, {{jsxref("Set/delete", "delete()")}}, and {{jsxref("Set/add", "add()")}}.
 
 The methods and properties have the same behavior as the equivalent entities in `Set`, except for the restriction on the types of the entry.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Chrome 148 adds support for the [`PaymentRequest.getSecurePaymentConfirmationCapabilities()`](https://w3c.github.io/secure-payment-confirmation/#sctn-secure-payment-confirmation-capabilities) static method. See https://chromestatus.com/feature/4727235745546240.

This PR adds docs for the new method.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
