### PR TITLE
Update customized built-in element example to match its source

### DIFF
--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -593,7 +593,7 @@ class ExpandingList extends HTMLUListElement {
 
 Note that this time we extend {{domxref("HTMLUListElement")}}, rather than {{domxref("HTMLElement")}}. This means that we get the default behavior of a list, and only have to implement our own customizations.
 
-As before, all of the code is in the `connectedCallback()` lifecycle callback. The class does not declare a constructor at all: there is no initial state to set up here, so the implicit constructor that just calls `super()` is enough. Inside the callback, `this` refers to the custom element instance, which is how the code reaches the list's own children.
+As before, most of the code is in the `connectedCallback()` lifecycle callback.
 
 Next, we register the element using the `define()` method as before, except that this time it also includes an options object that details what element our custom element inherits from:
 

--- a/files/en-us/web/api/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/api/web_components/using_custom_elements/index.md
@@ -536,28 +536,23 @@ First of all, we define our element's class:
 ```js
 // Create a class for the element
 class ExpandingList extends HTMLUListElement {
-  constructor() {
-    // Always call super first in constructor
-    // Return value from super() is a reference to this element
-    self = super();
-  }
-
   connectedCallback() {
     // Get ul and li elements that are a child of this custom ul element
     // li elements can be containers if they have uls within them
-    const uls = Array.from(self.querySelectorAll("ul"));
-    const lis = Array.from(self.querySelectorAll("li"));
+    const uls = this.querySelectorAll("ul");
+    const lis = this.querySelectorAll("li");
+
     // Hide all child uls
     // These lists will be shown when the user clicks a higher level container
-    uls.forEach((ul) => {
+    for (const ul of uls) {
       ul.style.display = "none";
-    });
+    }
 
     // Look through each li element in the ul
-    lis.forEach((li) => {
+    for (const li of lis) {
       // If this li has a ul as a child, decorate it and add a click handler
       if (li.querySelectorAll("ul").length > 0) {
-        // Add an attribute which can be used  by the style
+        // Add an attribute which can be used by the style
         // to show an open or closed icon
         li.setAttribute("class", "closed");
 
@@ -571,7 +566,7 @@ class ExpandingList extends HTMLUListElement {
         newSpan.style.cursor = "pointer";
 
         // Add click handler to this span
-        newSpan.addEventListener("click", (e) => {
+        const onClick = (e) => {
           // next sibling to the span should be the ul
           const nextUl = e.target.nextElementSibling;
 
@@ -583,19 +578,22 @@ class ExpandingList extends HTMLUListElement {
             nextUl.style.display = "block";
             nextUl.parentNode.setAttribute("class", "open");
           }
-        });
+        };
+
+        newSpan.addEventListener("click", onClick);
+
         // Add the span and remove the bare text node from the li
-        childText.parentNode.insertBefore(newSpan, childText);
-        childText.parentNode.removeChild(childText);
+        childText.parentNode?.insertBefore(newSpan, childText);
+        childText.parentNode?.removeChild(childText);
       }
-    });
+    }
   }
 }
 ```
 
 Note that this time we extend {{domxref("HTMLUListElement")}}, rather than {{domxref("HTMLElement")}}. This means that we get the default behavior of a list, and only have to implement our own customizations.
 
-As before, most of the code is in the `connectedCallback()` lifecycle callback.
+As before, all of the code is in the `connectedCallback()` lifecycle callback. The class does not declare a constructor at all: there is no initial state to set up here, so the implicit constructor that just calls `super()` is enough. Inside the callback, `this` refers to the custom element instance, which is how the code reaches the list's own children.
 
 Next, we register the element using the `define()` method as before, except that this time it also includes an options object that details what element our custom element inherits from:
 


### PR DESCRIPTION
Fixes #44952

The `ExpandingList` snippet in the "Customized built-in elements" section was still the pre-mdn/web-components-examples#81 version, which:

- assigns to `self` in the constructor (`self = super()`), clobbering the global {{domxref("Window.self")}}. Even scoped to a module variable this would be wrong, since it only ever points at the most recently constructed instance, so a page with more than one expanding list would have every callback operate on the last one.
- declares a constructor that only calls `super()`, which the implicit constructor already does.

This syncs the snippet with the [current source](https://github.com/mdn/web-components-examples/blob/main/expanding-list-web-component/main.js): no constructor, `this` instead of `self`, `for…of` over the live NodeLists instead of `Array.from(...).forEach(...)`, and optional chaining on `childText.parentNode`.

The surrounding prose is updated to match — it no longer says "most of the code" is in `connectedCallback()` (now all of it is), and briefly explains why there's no constructor and what `this` refers to, which is the explanation the issue asked for.