### PR TITLE
Note the SVG rotate() center-of-rotation syntax

### DIFF
--- a/files/en-us/web/css/reference/values/transform-function/rotate/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/rotate/index.md
@@ -43,6 +43,9 @@ The fixed point that the element rotates around — mentioned above — is also 
 origin**. This defaults to the center of the element, but you can set your own custom transform origin using
 the {{ cssxref("transform-origin") }} property.
 
+> [!NOTE]
+> The SVG [`transform`](/en-US/docs/Web/SVG/Reference/Attribute/transform) attribute has its own grammar, in which `rotate()` accepts two optional extra values giving the center of rotation, as in `rotate(45, 50, 50)`. That form is only valid in the attribute, not in CSS: the CSS `rotate()` function takes an angle alone, and the center is set with {{cssxref("transform-origin")}}.
+
 ## Syntax
 
 ```css


### PR DESCRIPTION
Fixes #44922

The reporter hit `transform="rotate(45, 50, 50)"` in SVG files, found it working in browsers, and couldn't find it documented on the CSS `rotate()` page.

The three-argument form is real but belongs to the SVG [`transform` attribute](/en-US/docs/Web/SVG/Reference/Attribute/transform) grammar, which is already documented there (`rotate(<a> [<x> <y>])`). It is *not* part of the CSS `<transform-function>` grammar, so the CSS page's formal syntax is correct as it stands — what was missing is a pointer explaining why the same-looking function behaves differently in the two places.

This adds a short note to the CSS `rotate()` page saying the attribute accepts the optional center-of-rotation arguments, that the form is attribute-only, and that the CSS equivalent is `transform-origin`.

I deliberately did not change the formal syntax block or the compat data, since documenting an attribute-only form as CSS syntax would be inaccurate. If maintainers would rather see the same note on {{cssxref("transform")}} as well (the issue mentions its syntax summary too), happy to add it.