### PR TITLE
Explain why col backgrounds can be hidden by cell backgrounds

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/html_table_basics/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/html_table_basics/index.md
@@ -668,6 +668,9 @@ td {
 - The `<col>` elements with a `column-fixed-width` class have a narrow fixed width set on them.
 - The `<col>` element with a `column-background-border` class has a solid background color and a thick border set on it.
 
+> [!NOTE]
+> A cell's own background is painted on top of the column's, so any background set on `<td>` or `<th>` hides the one coming from `<col>`. If you try this in the template from the start of this article, the column colors will not show up, because `minimal-table.css` gives `<th>` and alternating rows their own background colors. Remove those rules from your copy of the stylesheet to see the column backgrounds.
+
 You don't need to worry about how the CSS works for now; you'll learn about it in detail later on in our [CSS styling basics](/en-US/docs/Learn_web_development/Core/Styling_basics) module.
 
 Let's look at how the above code renders:


### PR DESCRIPTION
Fixes #44816

The reporter followed the article's own instructions — copy `blank-template.html` + `minimal-table.css`, then try the `<colgroup>`/`<col>` shading — and the column colors never appeared.

That's expected once you know the painting order: per [CSS tables](https://drafts.csswg.org/css-tables/#table-painting-algorithm), backgrounds are painted table → column group → column → row group → row → cell, so a cell's own background covers the column's. `minimal-table.css` sets one on `th` and on alternating rows:

```css
th { background-color: rgb(235,235,235); }
tr:nth-child(even) td { background-color: rgb(250,250,250); }
tr:nth-child(odd) td { background-color: rgb(245,245,245); }
```

so every cell in the table already has a background and nothing from `<col>` shows through.

The live sample on the page is unaffected — its hidden CSS only sets `border`/`padding` on `td, th`, no background — which is why the example renders correctly on MDN while the reader's copy does not.

Added a note explaining the painting order and pointing out which rules to remove from the stylesheet copy. I kept it to a note rather than changing `minimal-table.css` in the learning-area repo, since those backgrounds are deliberate elsewhere in the module.