### PR TITLE
Referrer-Policy: document effect on the Origin header

### DIFF
--- a/files/en-us/web/http/reference/headers/origin/index.md
+++ b/files/en-us/web/http/reference/headers/origin/index.md
@@ -65,7 +65,8 @@ The `Origin` header value may be `null` in a number of cases, including (non-exh
 - Documents served with the {{HTTPHeader("Content-Security-Policy")}} `sandbox` directive whose value doesn't include `allow-same-origin`.
 - {{HTMLElement("iframe", "iframes")}} with a sandbox attribute whose value doesn't include `allow-same-origin`.
 - Responses that are network errors.
-- {{HTTPHeader("Referrer-Policy")}} set to `no-referrer` for non-`cors` request modes (e.g., basic form posts).
+- Certain {{HTTPHeader("Referrer-Policy")}} values, for requests that use neither `GET` nor `HEAD` and aren't made in `cors` mode (e.g., basic form posts).
+  See [Effect on the `Origin` header](/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy#effect_on_the_origin_header) for the policy values that trigger this.
 
 > [!NOTE]
 > There is a more detailed listing of cases that may return `null` on Stack Overflow: [When do browsers send the Origin header? When do browsers set the origin to null?](https://stackoverflow.com/questions/42239643/when-do-browsers-send-the-origin-header-when-do-browsers-set-the-origin-to-null/42242802)

--- a/files/en-us/web/http/reference/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/reference/headers/referrer-policy/index.md
@@ -62,6 +62,19 @@ Referrer-Policy: unsafe-url
     > [!WARNING]
     > This policy will leak potentially-private information from HTTPS resource URLs to insecure origins. Carefully consider the impact of this setting.
 
+## Effect on the `Origin` header
+
+The referrer policy also decides what the browser puts in the {{HTTPHeader("Origin")}} header, not just the {{HTTPHeader("Referer")}} header.
+This only applies to requests that don't use [CORS](/en-US/docs/Web/HTTP/Guides/CORS) and whose method is neither `GET` nor `HEAD`.
+For those requests the browser sends `Origin: null` in place of the serialized origin in these cases:
+
+- The policy is `no-referrer`.
+- The policy is `no-referrer-when-downgrade`, `strict-origin`, or `strict-origin-when-cross-origin`, and the request goes from an `https` origin to a URL that isn't `https`.
+- The policy is `same-origin` and the request is cross-origin.
+
+Any other policy value leaves the `Origin` header set to the request's origin.
+CORS requests, WebSocket requests, and WebTransport requests always send the serialized origin, whatever the referrer policy, because they already opt into sharing the origin with the server.
+
 ## Integration with HTML
 
 You can also set referrer policies inside HTML. For example, you can set the referrer policy for the entire document with a {{HTMLElement("meta")}} element with a [name](/en-US/docs/Web/HTML/Reference/Elements/meta/name) of `referrer`:

--- a/files/en-us/web/http/reference/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/reference/headers/referrer-policy/index.md
@@ -64,16 +64,20 @@ Referrer-Policy: unsafe-url
 
 ## Effect on the `Origin` header
 
-The referrer policy also decides what the browser puts in the {{HTTPHeader("Origin")}} header, not just the {{HTTPHeader("Referer")}} header.
-This only applies to requests that don't use [CORS](/en-US/docs/Web/HTTP/Guides/CORS) and whose method is neither `GET` nor `HEAD`.
-For those requests the browser sends `Origin: null` in place of the serialized origin in these cases:
+The referrer policy also affects whether the user agent sets the {{HTTPHeader("Origin")}} header with the request's origin or as `null` (not just the {{HTTPHeader("Referer")}} header).
 
-- The policy is `no-referrer`.
-- The policy is `no-referrer-when-downgrade`, `strict-origin`, or `strict-origin-when-cross-origin`, and the request goes from an `https` origin to a URL that isn't `https`.
-- The policy is `same-origin` and the request is cross-origin.
+Requests using `GET` or `HEAD`, or made in `cors`, `websocket`, or `webtransport` [mode](/en-US/docs/Web/API/Request/mode), are never affected: if the user agent sends an `Origin` header for them at all, it sends the request's origin, regardless of the referrer policy.
+
+For other requests — such as HTML form submissions or `fetch()` calls using `mode: "same-origin"` or `"no-cors"` — the user agent sets `Origin` to `null` when the referrer policy is:
+
+- `no-referrer`.
+- `no-referrer-when-downgrade`, `strict-origin`, or `strict-origin-when-cross-origin`, and the request goes from an `https` origin to a URL that isn't `https`.
+- `same-origin`, and the request is cross-origin.
 
 Any other policy value leaves the `Origin` header set to the request's origin.
-CORS requests, WebSocket requests, and WebTransport requests always send the serialized origin, whatever the referrer policy, because they already opt into sharing the origin with the server.
+
+> [!NOTE]
+> Because `fetch()` defaults to `mode: "cors"`, a same-origin `fetch()` `POST` always sends its real `Origin`, even under `Referrer-Policy: no-referrer`. This behavior mainly shows up for non-`fetch()` requests, like HTML form submissions.
 
 ## Integration with HTML
 

--- a/files/en-us/web/http/reference/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/reference/headers/referrer-policy/index.md
@@ -64,7 +64,7 @@ Referrer-Policy: unsafe-url
 
 ## Effect on the `Origin` header
 
-The referrer policy also affects whether the user agent sets the {{HTTPHeader("Origin")}} header with the request's origin or as `null` (not just the {{HTTPHeader("Referer")}} header).
+The referrer policy also affects whether the user agent sets the {{HTTPHeader("Origin")}} header with the request's origin or as `null` (as well as the {{HTTPHeader("Referer")}} header).
 
 Requests using `GET` or `HEAD`, or made in `cors`, `websocket`, or `webtransport` [mode](/en-US/docs/Web/API/Request/mode), are never affected: if the user agent sends an `Origin` header for them at all, it sends the request's origin, regardless of the referrer policy.
 
@@ -77,7 +77,7 @@ For other requests — such as HTML form submissions or `fetch()` calls using `m
 Any other policy value leaves the `Origin` header set to the request's origin.
 
 > [!NOTE]
-> Because `fetch()` defaults to `mode: "cors"`, a same-origin `fetch()` `POST` always sends its real `Origin`, even under `Referrer-Policy: no-referrer`. This behavior mainly shows up for non-`fetch()` requests, like HTML form submissions.
+> Because `fetch()` defaults to `mode: "cors"`, a same-origin `fetch()` `POST` always sends its real `Origin`, even under `Referrer-Policy: no-referrer`. The null-`Origin` behavior above therefore mainly applies to `navigate`-mode requests, like HTML form submissions, rather than to `fetch()` calls.
 
 ## Integration with HTML
 


### PR DESCRIPTION
### Description

Adds an "Effect on the `Origin` header" section to the `Referrer-Policy` reference page, documenting that the referrer policy also decides whether the `Origin` header is sent as the request's origin or as `null`, and cross-links {{HTTPHeader("Origin")}}.

### Motivation

Fixes #36543. The `Origin` page already notes that its value may be `null` with "Referrer-Policy set to `no-referrer` for non-`cors` request modes", but the `Referrer-Policy` page did not mention the `Origin` header at all, so the side effect was invisible when choosing a policy value. The issue also asked whether values other than `no-referrer` are affected — per the spec, three more are.

### Additional details

Content verified against the Fetch Standard's [append a request `Origin` header](https://fetch.spec.whatwg.org/#append-a-request-origin-header) algorithm. For a request whose response tainting is not "cors" and whose mode is not "websocket"/"webtransport", if the method is neither `GET` nor `HEAD` and the mode is not "cors", the spec switches on the referrer policy:

- `no-referrer` → `serializedOrigin` is set to `null`;
- `no-referrer-when-downgrade` / `strict-origin` / `strict-origin-when-cross-origin` → `null` when the origin is a tuple origin with scheme `https` and the current URL's scheme is not `https`;
- `same-origin` → `null` when the origin is not same origin with the current URL's origin;
- otherwise → unchanged.

The spec's own note is reflected in the closing sentence: "A request's referrer policy is taken into account for all fetches where the fetcher did not explicitly opt into sharing their origin with the server, e.g., via using the CORS protocol."

### Related issues and pull requests

Fixes #36543
