### PR TITLE
<kbd>: fix multiple details in the first paragraph

### DIFF
--- a/files/en-us/web/html/reference/elements/kbd/index.md
+++ b/files/en-us/web/html/reference/elements/kbd/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`<kbd>`** [HTML](/en-US/docs/Web/HTML) element represents user input (typically keyboard input). By default, the content text is displayed using the {{Glossary("user agent", "user agent's")}} default monospace font.
 
+`<kbd>` may be nested in various combinations with the {{HTMLElement("samp")}} (Sample Output) element to represent various forms of input or output based on visual cues.
+
 {{InteractiveExample("HTML Demo: &lt;kbd&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -35,8 +37,6 @@ kbd {
   white-space: nowrap;
 }
 ```
-
-`<kbd>` may be nested in various combinations with the {{HTMLElement("samp")}} (Sample Output) element to represent various forms of input or output based on visual cues.
 
 ## Attributes
 

--- a/files/en-us/web/html/reference/elements/kbd/index.md
+++ b/files/en-us/web/html/reference/elements/kbd/index.md
@@ -7,7 +7,7 @@ browser-compat: html.elements.kbd
 sidebar: htmlsidebar
 ---
 
-The **`<kbd>`** [HTML](/en-US/docs/Web/HTML) element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the {{Glossary("user agent")}} defaults to rendering the contents of a `<kbd>` element using its default monospace font, although this is not mandated by the HTML standard.
+The **`<kbd>`** [HTML](/en-US/docs/Web/HTML) element represents user input (typically keyboard input). By default, the content text is displayed using the {{Glossary("user agent", "user agent's")}} default monospace font.
 
 {{InteractiveExample("HTML Demo: &lt;kbd&gt;", "tabbed-shorter")}}
 


### PR DESCRIPTION
I didn’t dig into the history, but I think it fell out of sync with HTML spec changes, and even the rest of the page.

- The user input is not necessarily *textual*. See the “Representing onscreen input options” subsection, where it’s activation of a command based on an on-screen label.

- monospace *is* part of the expected user-agent stylesheet for kbd, so I adopted the wording from the \<code> page about monospaceness.