### PR TITLE
Ff154 CSS Typed OM API follow up 1

### DIFF
--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -5,11 +5,11 @@ page-type: web-api-interface
 browser-compat: api.CSSImageValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSImageValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values for properties that take an image, for example {{cssxref('background-image')}}, {{cssxref('list-style-image')}}, or {{cssxref('border-image-source')}}.
 
-The CSSImageValue object represents an {{cssxref("image")}} that involves a URL, such as {{cssxref("url_function", "url()")}} or {{cssxref("image()")}}, but not {{cssxref("gradient/linear-gradient", "linear-gradient()")}} or {{cssxref("element()")}}.
+The `CSSImageValue` object represents an {{cssxref("image")}} that involves a URL, such as {{cssxref("url_function", "url()")}} or {{cssxref("image()")}}, but not {{cssxref("gradient/linear-gradient", "linear-gradient()")}} or {{cssxref("element()")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -7,9 +7,8 @@ browser-compat: api.CSSImageValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSImageValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values for properties that take an image, for example {{cssxref('background-image')}}, {{cssxref('list-style-image')}}, or {{cssxref('border-image-source')}}.
-
-The `CSSImageValue` object represents an {{cssxref("image")}} that involves a URL, such as {{cssxref("url_function", "url()")}} or {{cssxref("image()")}}, but not {{cssxref("gradient/linear-gradient", "linear-gradient()")}} or {{cssxref("element()")}}.
+The **`CSSImageValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values for CSS properties that take an {{cssxref("image")}} value, such as
+{{cssxref("background-image")}}, {{cssxref("list-style-image")}}, or {{cssxref("border-image-source")}}.
 
 {{InheritanceDiagram}}
 
@@ -19,15 +18,47 @@ None.
 
 ## Instance methods
 
-_Inherits methods from {{domxref('CSSStyleValue')}}._
+_Inherits methods from {{domxref("CSSStyleValue")}}._
+
+## Description
+
+`CSSImageValue` can contain every kind of value the {{cssxref("image")}} data type accepts, including URL-based images specified using {{cssxref("url_function", "url()")}},
+{{cssxref("gradient")}}s such as {{cssxref("gradient/linear-gradient", "linear-gradient()")}}, {{cssxref("image/image", "image()")}}, {{cssxref("image/image-set", "image-set()")}}, {{cssxref("cross-fade", "cross-fade()")}}, and {{cssxref("element()")}}.
+
+For image values that involve a URL, such as `url()` or `image()`, relative and fragment URLs are resolved the same way as in CSS.
+That is, relative to the style sheet's URL, or the document's URL for inline styles.
+
+This resolution happens during value computation rather than at parse time, which means that the value of a `CSSImageValue` depends on whether you're working with the specified value or the computed value:
+
+- A **specified** value carries an unresolved relative URL.
+  If the unresolved value is copied to an element in a different document, it resolves against the destination document's own base URL and can point to a different resource.
+- A **computed** value has already been resolved to an absolute URL, so it behaves consistently no matter which document it's later applied to.
+- A **fragment-only** URL value is always resolved against the current document.
+
+Note that `CSSImageValue` objects are intentionally opaque: they don't expose any information about the image they represent.
 
 ## Examples
 
-We create an element
+### Basic usage
+
+This example sets the `background-image` of a {{htmlelement("button")}} using `url()`, specifying a relative URL for the file.
+We then demonstrate getting the stringified computed and specified values.
+
+Note that there is hidden logging code that is not shown, as it is not relevant to the example.
+
+#### HTML
+
+First we define the button element:
 
 ```html
 <button>Magic Wand</button>
 ```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
 
 We add some CSS, including a background image requesting a binary file:
 
@@ -40,19 +71,62 @@ button {
 }
 ```
 
-We get the element's style map. We then get() the background-image from the style map and stringify it:
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+Next we get the `<button>` element so that we can query its specified and computed styles.
 
 ```js
 // get the element
 const button = document.querySelector("button");
-
-// Retrieve all computed styles with computedStyleMap()
-const allComputedStyles = button.computedStyleMap();
-
-// Return the CSSImageValue Example
-console.log(allComputedStyles.get("background-image"));
-console.log(allComputedStyles.get("background-image").toString());
 ```
+
+To get the computed value of the `background-image` we first get the element's style map.
+Then we `get()` the `background-image` from the style map and stringify it.
+We also print the name of the constructor to demonstrate the returned object is a `CSSImageValue`.
+
+```js
+// Get all computed styles with computedStyleMap()
+const allComputedStyles = button.computedStyleMap();
+const computedImageCSS = allComputedStyles.get("background-image");
+log(computedImageCSS.toString());
+log(computedImageCSS.constructor.name); // CSSImageValue
+```
+
+Next we get the specified value of the `background-image`.
+To do this we first get the set of CSS rules associated with the `css-output` element — this is where MDN writes CSS for the playground.
+We then filter the rule to find the CSS rule matched purely on its name "button" (note, this is fragile code in a real application).
+Once we have the associated rule we can get the image from its style map, and log the value.
+
+```js
+// Get the specified value
+const sheet = document.getElementById("css-output").sheet;
+const rule = [...sheet.cssRules].find((r) => r.selectorText === "button");
+const specifiedImageCSS = rule.styleMap.get("background-image");
+log(specifiedImageCSS.toString());
+log(specifiedImageCSS.constructor.name); // CSSImageValue
+```
+
+#### Result
+
+The results are shown below.
+Note that the computed value displayed first has a fully resolved URL, while the specified value is a relative URL.
 
 {{EmbedLiveSample("Examples", 120, 300)}}
 
@@ -66,8 +140,8 @@ console.log(allComputedStyles.get("background-image").toString());
 
 ## See also
 
-- {{domxref('CSSKeywordValue')}}
-- {{domxref('CSSNumericValue')}}
-- {{domxref('CSSPositionValue')}}
-- {{domxref('CSSTransformValue')}}
-- {{domxref('CSSUnparsedValue')}}
+- {{domxref("CSSKeywordValue")}}
+- {{domxref("CSSNumericValue")}}
+- {{domxref("CSSPositionValue")}}
+- {{domxref("CSSTransformValue")}}
+- {{domxref("CSSUnparsedValue")}}

--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSImageValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSImageValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values for CSS properties that take an {{cssxref("image")}} value, such as
+The **`CSSImageValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents values for CSS properties that take an {{cssxref("image")}} value, such as
 {{cssxref("background-image")}}, {{cssxref("list-style-image")}}, or {{cssxref("border-image-source")}}.
 
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSKeywordValue.CSSKeywordValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSKeywordValue()`** constructor
 creates a new {{domxref("CSSKeywordValue")}} object which represents CSS keywords and

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
@@ -8,56 +8,92 @@ browser-compat: api.CSSKeywordValue.CSSKeywordValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSKeywordValue()`** constructor
-creates a new {{domxref("CSSKeywordValue")}} object which represents CSS keywords and
-other identifiers.
+The **`CSSKeywordValue()`** constructor creates a new {{domxref("CSSKeywordValue")}} object which represents a CSS keyword or other identifier.
 
 ## Syntax
 
 ```js-nolint
-new CSSKeywordValue(val)
+new CSSKeywordValue(value)
 ```
 
 ### Parameters
 
 - `value`
-  - : Sets or returns the value of the new `CSSKeywordValue`.
+  - : A {{jsxref('String')}} that will be used to set {{domxref("CSSKeywordValue.value")}}.
 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the `value` parameter is not specified or it is not of type {{jsxref('String')}}.
+  - : Thrown if the `value` parameter is not specified, or if it is an empty string.
 
 ## Examples
 
-The following example resets the CSS {{cssxref('display')}} property to its defaults,
-setting the inline
-[`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute
-to `style="display: initial"` if viewed in the [developer tools inspector](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/select_an_element/index.html).
+### Basic usage
 
-```css hidden
+This example sets the CSS {{cssxref('display')}} property to `initial`, constructing a `CSSKeywordValue` for the keyword.
+
+#### HTML
+
+The HTML defines an element on which we'll set the value of the `display` keyword, an {{htmlelement("hr")}} element, a button that will be used to set the value of the `display` keyword, and a "Reset" button to reset the example.
+
+```html
+<div id="myElement">
+  Check the developer tools to see the log in the console and to inspect this
+  div's style attributes.
+</div>
+<hr />
+<button id="set-initial" type="button">Set initial</button>
+<button id="reset" type="button">Reset</button>
+```
+
+#### CSS
+
+The CSS initially sets the element to `flex`, which forces it to display full-width, and gives it a solid border with padding and margins.
+
+```css
 #myElement {
   display: flex;
+  border: solid;
+  padding: 10px;
+  margin: 5px;
 }
 ```
 
-```html hidden
-<div id="myElement">
-  Check the developer tools to see the log in the console and to inspect the
-  style attribute on this div.
-</div>
-```
+#### JavaScript
+
+The code first gets a handle to the "Set initial" button and adds a listener to handle the click event when it is pressed.
+
+The listener then gets the element's inline styles using {{domxref(Element.attributeStyleMap)}}, and sets the `display` attribute with a newly constructed `CSSKeywordValue`.
+It then logs the value of that keyword to the console.
 
 ```js
-const keyword = new CSSKeywordValue("initial");
-const myElement = document.getElementById("myElement").attributeStyleMap;
-myElement.set("display", keyword);
+const setInitialButton = document.querySelector("#set-initial");
 
-console.log(myElement.get("display").value); // 'initial'
-console.dir(keyword);
+setInitialButton.addEventListener("click", () => {
+  const myElementInlineStyles =
+    document.getElementById("myElement").attributeStyleMap;
+  myElementInlineStyles.set("display", new CSSKeywordValue("initial"));
+  console.log(`display: ${myElementInlineStyles.get("display").value}`);
+});
 ```
 
-{{EmbedLiveSample("Examples", 120, 120)}}
+Note that we can't log the value of the inline styles before pressing the button, because there aren't any.
+
+```js hidden
+const resetButton = document.querySelector("#reset");
+resetButton.addEventListener("click", () => {
+  window.location.reload(true);
+});
+```
+
+#### Result
+
+Right click on the element and open the [developer tools inspector](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/select_an_element/index.html) to inspect its styles.
+You should see that `display: flex` is set on `#myElement`.
+Press "Set initial" to make set the inline style of `display` to `"initial"`.
+You should see the styles change in the inspector, and the element will also shrink slightly as the `flex` is disabled.
+
+{{EmbedLiveSample("Basic usage", 120, 150)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSKeywordValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSKeywordValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) creates an object to represent CSS keywords and other identifiers.
 

--- a/files/en-us/web/api/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/index.md
@@ -7,9 +7,9 @@ browser-compat: api.CSSKeywordValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSKeywordValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) creates an object to represent CSS keywords and other identifiers.
+The **`CSSKeywordValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents the value of a CSS keyword or other identifier.
 
-The interface instance name is a {{Glossary("stringifier")}} meaning that when used anywhere a string is expected it will return the value of `CSSKeyword.value`.
+The interface instance name is a {{Glossary("stringifier")}}, so when used anywhere a string is expected it will return the value of `CSSKeyword.value`.
 
 {{InheritanceDiagram}}
 
@@ -21,7 +21,7 @@ The interface instance name is a {{Glossary("stringifier")}} meaning that when u
 ## Instance properties
 
 - {{domxref('CSSKeywordValue.value')}}
-  - : Returns or sets the value of the `CSSKeywordValue`.
+  - : A string that represents the value of the `CSSKeywordValue`.
 
 ## Instance methods
 
@@ -29,29 +29,72 @@ _Inherits methods from {{domxref('CSSStyleValue')}}._
 
 ## Examples
 
-The following example resets the CSS {{cssxref('display')}} property to its defaults, setting the inline [`style`](/en-US/docs/Web/HTML/Reference/Global_attributes/style) attribute to `style="display: initial"` if viewed in the [developer tools inspector](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/select_an_element/index.html).
+### Basic usage
 
-```css hidden
+This example sets the CSS {{cssxref('display')}} property to `initial`, using `CSSKeywordValue` to define the value.
+
+#### HTML
+
+The HTML defines an element on which we'll set the value of the `display` keyword, an {{htmlelement("hr")}} element, a button that will be used to set the value of the `display` keyword, and a "Reset" button to reset the example.
+
+```html
+<div id="myElement">
+  Check the developer tools to see the log in the console and to inspect this
+  div's style attributes.
+</div>
+<hr />
+<button id="set-initial" type="button">Set initial</button>
+<button id="reset" type="button">Reset</button>
+```
+
+#### CSS
+
+The CSS initially sets the element to `flex`, which forces it to display full-width, and gives it a solid border with padding and margins.
+
+```css
 #myElement {
   display: flex;
+  border: solid;
+  padding: 10px;
+  margin: 5px;
 }
 ```
 
-```html hidden
-<div id="myElement">
-  Check the developer tools to see the log in the console and to inspect the
-  style attribute on this div.
-</div>
-```
+#### JavaScript
+
+The code first gets a handle to the "Set initial" button and adds a listener to handle the click event when it is pressed.
+
+The listener then gets the element's inline styles using {{domxref(Element.attributeStyleMap)}}, and sets the `display` attribute with a newly constructed `CSSKeywordValue`.
+It then logs the value of that keyword to the console.
 
 ```js
-let myElement = document.getElementById("myElement").attributeStyleMap;
-myElement.set("display", new CSSKeywordValue("initial"));
+const setInitialButton = document.querySelector("#set-initial");
 
-console.log(myElement.get("display").value); // 'initial'
+setInitialButton.addEventListener("click", () => {
+  const myElementInlineStyles =
+    document.getElementById("myElement").attributeStyleMap;
+  myElementInlineStyles.set("display", new CSSKeywordValue("initial"));
+  console.log(`display: ${myElementInlineStyles.get("display").value}`);
+});
 ```
 
-{{EmbedLiveSample("Examples", 120, 120)}}
+Note that we can't log the value of the inline styles before pressing the button, because there aren't any.
+
+```js hidden
+const resetButton = document.querySelector("#reset");
+resetButton.addEventListener("click", () => {
+  window.location.reload(true);
+});
+```
+
+#### Result
+
+Right click on the element and open the [developer tools inspector](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/select_an_element/index.html) to inspect its styles.
+You should see that `display: flex` is set on `#myElement`.
+Press "Set initial" to make set the inline style of `display` to `"initial"`.
+You should see the styles change in the inspector, and the element will also shrink slightly as the `flex` is disabled.
+
+{{EmbedLiveSample("Basic usage", 120, 150)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSKeywordValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSKeywordValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) creates an object to represent CSS keywords and other identifiers.
+The **`CSSKeywordValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) creates an object to represent CSS keywords and other identifiers.
 
 The interface instance name is a {{Glossary("stringifier")}} meaning that when used anywhere a string is expected it will return the value of `CSSKeyword.value`.
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.md
+++ b/files/en-us/web/api/csskeywordvalue/value/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSKeywordValue.value
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`value`** property of the {{domxref("CSSKeywordValue")}} interface returns or sets the value of the `CSSKeywordValue`.
+The **`value`** property of the {{domxref("CSSKeywordValue")}} interface represents the value of the `CSSKeywordValue`.
 
 ## Value
 
@@ -17,7 +17,7 @@ A string.
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the `value` property is an empty {{jsxref('String')}} when being set.
+  - : Thrown if the `value` property is set to an empty {{jsxref('String')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.md
+++ b/files/en-us/web/api/csskeywordvalue/value/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSKeywordValue.value
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`value`** property of the {{domxref("CSSKeywordValue")}} interface returns or sets the value of the `CSSKeywordValue`.
 

--- a/files/en-us/web/api/cssmathclamp/cssmathclamp/index.md
+++ b/files/en-us/web/api/cssmathclamp/cssmathclamp/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSMathClamp.CSSMathClamp
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathClamp()`** constructor creates a new {{domxref("CSSMathClamp")}} object representing a CSS {{CSSXref("clamp", "clamp()")}} function.
 

--- a/files/en-us/web/api/cssmathclamp/index.md
+++ b/files/en-us/web/api/cssmathclamp/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathClamp
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathClamp`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the CSS {{CSSXref("clamp","clamp()")}} function. It inherits properties and methods from its parent {{domxref("CSSNumericValue")}}.
 

--- a/files/en-us/web/api/cssmathclamp/lower/index.md
+++ b/files/en-us/web/api/cssmathclamp/lower/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathClamp.lower
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`lower`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object containing the minimum value of a {{domxref("CSSMathClamp")}} object.
 

--- a/files/en-us/web/api/cssmathclamp/upper/index.md
+++ b/files/en-us/web/api/cssmathclamp/upper/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathClamp.upper
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`upper`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object containing the maximum value of a {{domxref("CSSMathClamp")}} object.
 

--- a/files/en-us/web/api/cssmathclamp/value/index.md
+++ b/files/en-us/web/api/cssmathclamp/value/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathClamp.value
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`value`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object containing the preferred value of a {{domxref("CSSMathClamp")}} object.
 

--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSMathInvert.CSSMathInvert
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathInvert()`** constructor creates a new {{domxref("CSSMathInvert")}} object which represents a CSS {{CSSXref('calc','calc()')}} used as `calc(1 / value)`
 

--- a/files/en-us/web/api/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathInvert
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathInvert`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents a CSS {{CSSXref('calc','calc()')}} used as `calc(1 / <value>)`.
 It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.

--- a/files/en-us/web/api/cssmathinvert/value/index.md
+++ b/files/en-us/web/api/cssmathinvert/value/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathInvert.value
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The CSSMathInvert.value read-only property of the {{domxref("CSSMathInvert")}} interface returns a {{domxref('CSSNumericValue')}} object.
 

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CSSMathMax.CSSMathMax
 ---
 
-{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
+{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathMax()`** constructor creates a new {{domxref("CSSMathMax")}} object which represents the CSS {{CSSXref('max', 'max()')}} function.
 

--- a/files/en-us/web/api/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathMax
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathMax`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the CSS {{CSSXref('max','max()')}} function.
 It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.

--- a/files/en-us/web/api/cssmathmax/values/index.md
+++ b/files/en-us/web/api/cssmathmax/values/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathMax.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The CSSMathMax.values read-only property of the {{domxref("CSSMathMax")}} interface returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CSSMathMin.CSSMathMin
 ---
 
-{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}}
+{{SeeCompatTable}}{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathMin()`** constructor creates a new {{domxref("CSSMathMin")}} object that represents the CSS {{CSSXref('min','min()')}} function.
 

--- a/files/en-us/web/api/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathMin
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathMin`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the CSS {{CSSXref('min','min()')}} function.
 It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.

--- a/files/en-us/web/api/cssmathmin/values/index.md
+++ b/files/en-us/web/api/cssmathmin/values/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathMin.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The CSSMathMin.values read-only property of the {{domxref("CSSMathMin")}} interface returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 

--- a/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSMathNegate.CSSMathNegate
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathNegate()`** constructor creates a new {{domxref("CSSMathNegate")}} object which negates the value passed into it.
 

--- a/files/en-us/web/api/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathNegate
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathNegate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) negates the value passed into it. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/cssmathnegate/value/index.md
+++ b/files/en-us/web/api/cssmathnegate/value/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathNegate.value
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathNegate.value`** read-only property of the {{domxref("CSSMathNegate")}} interface returns a {{domxref('CSSNumericValue')}} object.
 

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CSSMathProduct.CSSMathProduct
 ---
 
-{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}{{SeeCompatTable}}
 
 The **`CSSMathProduct()`** constructor creates a {{domxref("CSSMathProduct")}} object that multiplies the arguments passed into it.
 

--- a/files/en-us/web/api/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathProduct
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/cssmathproduct/values/index.md
+++ b/files/en-us/web/api/cssmathproduct/values/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathProduct.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathProduct.values`** read-only property of the {{domxref("CSSMathProduct")}} interface returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.CSSMathSum.CSSMathSum
 ---
 
-{{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}{{SeeCompatTable}}
 
 The **`CSSMathSum()`** constructor creates a new {{domxref("CSSMathSum")}} object that represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathSum
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathSum`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
 

--- a/files/en-us/web/api/cssmathsum/values/index.md
+++ b/files/en-us/web/api/cssmathsum/values/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathSum.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathSum.values`** read-only property of the {{domxref("CSSMathSum")}} interface returns a {{domxref('CSSNumericArray')}} object that contains one or more {{domxref('CSSNumericValue')}} objects.
 

--- a/files/en-us/web/api/cssmathvalue/index.md
+++ b/files/en-us/web/api/cssmathvalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMathValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) a base class for classes representing complex numeric values.
 

--- a/files/en-us/web/api/cssmathvalue/operator/index.md
+++ b/files/en-us/web/api/cssmathvalue/operator/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathValue.operator
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathValue.operator`** read-only property of the {{domxref("CSSMathValue")}} interface indicates the operator that the current subtype represents.
 For example, if the current `CSSMathValue` subtype is `CSSMathSum`, this property will return the string `"sum"`.

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSMatrixComponent.CSSMatrixComponent
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMatrixComponent()`** constructor creates a new {{domxref("CSSMatrixComponent")}} object representing the {{cssxref("transform-function/matrix", "matrix()")}} and {{cssxref("transform-function/matrix3d", "matrix3d()")}} values of the individual {{CSSXRef('transform')}} property in CSS.
 

--- a/files/en-us/web/api/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSMatrixComponent
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMatrixComponent`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/matrix", "matrix()")}} and {{cssxref("transform-function/matrix3d", "matrix3d()")}} values of the individual {{CSSXRef('transform')}} property in CSS.
 It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMatrixComponent.matrix
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`matrix`** property of the {{domxref("CSSMatrixComponent")}} interface gets and sets a 2D or 3D matrix.
 

--- a/files/en-us/web/api/cssnumericarray/index.md
+++ b/files/en-us/web/api/cssnumericarray/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSNumericArray
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSNumericArray`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) contains a list of {{domxref("CSSNumericValue")}} objects.
 

--- a/files/en-us/web/api/cssnumericarray/length/index.md
+++ b/files/en-us/web/api/cssnumericarray/length/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSNumericArray.length
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The read-only **`length`** property of the {{domxref("CSSNumericArray")}} interface returns the number of {{domxref("CSSNumericValue")}} objects in the list.
 

--- a/files/en-us/web/api/cssnumericvalue/add/index.md
+++ b/files/en-us/web/api/cssnumericvalue/add/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.add
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`add()`** method of the {{domxref("CSSNumericValue")}} interface adds a supplied number to the `CSSNumericValue`.
 

--- a/files/en-us/web/api/cssnumericvalue/div/index.md
+++ b/files/en-us/web/api/cssnumericvalue/div/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.div
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`div()`** method of the {{domxref("CSSNumericValue")}} interface divides the `CSSNumericValue` by the supplied value.
 

--- a/files/en-us/web/api/cssnumericvalue/equals/index.md
+++ b/files/en-us/web/api/cssnumericvalue/equals/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.equals
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`equals()`** method of the {{domxref("CSSNumericValue")}} interface returns a boolean indicating whether the passed values are strictly equal.
 To return a value of `true`, all passed values must be of the same type and value and must be in the same order.

--- a/files/en-us/web/api/cssnumericvalue/index.md
+++ b/files/en-us/web/api/cssnumericvalue/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSNumericValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSNumericValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents operations that all numeric values can perform.
+The **`CSSNumericValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents operations that all numeric values can perform.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssnumericvalue/index.md
+++ b/files/en-us/web/api/cssnumericvalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSNumericValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSNumericValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents operations that all numeric values can perform.
 

--- a/files/en-us/web/api/cssnumericvalue/max/index.md
+++ b/files/en-us/web/api/cssnumericvalue/max/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.max
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`max()`** method of the {{domxref("CSSNumericValue")}} interface returns the highest value from among the values passed.
 The passed values must be of the same type.

--- a/files/en-us/web/api/cssnumericvalue/min/index.md
+++ b/files/en-us/web/api/cssnumericvalue/min/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.min
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`min()`** method of the {{domxref("CSSNumericValue")}} interface returns the lowest value from among those values passed.
 The passed values must be of the same type.

--- a/files/en-us/web/api/cssnumericvalue/mul/index.md
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.mul
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`mul()`** method of the {{domxref("CSSNumericValue")}} interface multiplies the `CSSNumericValue` by the supplied value.
 

--- a/files/en-us/web/api/cssnumericvalue/parse_static/index.md
+++ b/files/en-us/web/api/cssnumericvalue/parse_static/index.md
@@ -10,6 +10,10 @@ browser-compat: api.CSSNumericValue.parse_static
 
 The **`parse()`** static method of the {{domxref("CSSNumericValue")}} interface converts a value string into an object whose members are value and the units.
 
+> [!NOTE]
+> This method cannot be called in {{domxref("Worker")}} or {{domxref("Worklet")}} contexts — parsing CSS text is restricted to the main thread.
+> All other methods in the `CSSNumericValue` interface are available in workers and worklets.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/cssnumericvalue/sub/index.md
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.sub
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`sub()`** method of the {{domxref("CSSNumericValue")}} interface subtracts a supplied number from the `CSSNumericValue`.
 

--- a/files/en-us/web/api/cssnumericvalue/to/index.md
+++ b/files/en-us/web/api/cssnumericvalue/to/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.to
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`to()`** method of the {{domxref("CSSNumericValue")}} interface converts a numeric value from one unit to another.
 

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.md
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.toSum
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`toSum()`** method of the {{domxref("CSSNumericValue")}} interface converts the object's value to a {{domxref("CSSMathSum")}} object to values of the specified unit.
 

--- a/files/en-us/web/api/cssnumericvalue/type/index.md
+++ b/files/en-us/web/api/cssnumericvalue/type/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSNumericValue.type
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`type()`** method of the {{domxref("CSSNumericValue")}} interface returns the type of `CSSNumericValue`, one of `angle`, `flex`, `frequency`, `length`, `resolution`, `percent`, `percentHint`, or `time`.
 

--- a/files/en-us/web/api/cssperspective/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/cssperspective/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSPerspective.CSSPerspective
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSPerspective()`** constructor creates a new {{domxref("CSSPerspective")}} object representing the {{cssxref("transform-function/perspective", "perspective()")}} value of the individual {{CSSXref('transform')}} property in CSS.
 

--- a/files/en-us/web/api/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSPerspective
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSPerspective`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/perspective", "perspective()")}} value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.
 

--- a/files/en-us/web/api/cssperspective/length/index.md
+++ b/files/en-us/web/api/cssperspective/length/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSPerspective.length
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`length`** property of the {{domxref("CSSPerspective")}} interface sets the distance from z=0.
 

--- a/files/en-us/web/api/cssrotate/angle/index.md
+++ b/files/en-us/web/api/cssrotate/angle/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSRotate.angle
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`angle`** property of the {{domxref("CSSRotate")}} interface gets and sets the angle of rotation.
 A positive angle denotes a clockwise rotation, a negative angle a counter-clockwise one.

--- a/files/en-us/web/api/cssrotate/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSRotate.CSSRotate
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSRotate()`** constructor creates a new
 {{domxref("CSSRotate")}} object representing the {{cssxref("transform-function/rotate", "rotate()")}} value of the

--- a/files/en-us/web/api/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSRotate
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSRotate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the rotate value of the individual {{CSSXRef('transform')}} property in CSS.
 It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.

--- a/files/en-us/web/api/cssrotate/x/index.md
+++ b/files/en-us/web/api/cssrotate/x/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSRotate.x
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`x`** property of the {{domxref("CSSRotate")}} interface gets and sets the abscissa or x-axis of the translating vector.
 

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSRotate.y
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`y`** property of the {{domxref("CSSRotate")}} interface gets and sets the ordinate or y-axis of the translating vector.
 

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSRotate.z
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`z`** property of the {{domxref("CSSRotate")}} interface representing the z-component of the translating vector.
 A positive value moves the element towards the viewer and a negative value farther away.

--- a/files/en-us/web/api/cssscale/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/cssscale/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSScale.CSSScale
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSScale()`** constructor creates a new {{domxref("CSSScale")}} object representing the {{cssxref("transform-function/scale", "scale()")}} and {{cssxref("transform-function/scale3d", "scale3d()")}} values of the individual {{CSSXref('transform')}} property in CSS.
 

--- a/files/en-us/web/api/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSScale
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSScale`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/scale", "scale()")}} and {{cssxref("transform-function/scale3d", "scale3d()")}} values of the individual {{CSSXRef('transform')}} property in CSS.
 It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.

--- a/files/en-us/web/api/cssscale/x/index.md
+++ b/files/en-us/web/api/cssscale/x/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSScale.x
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`x`** property of the {{domxref("CSSScale")}} interface gets and sets the abscissa or x-axis of the translating vector.
 

--- a/files/en-us/web/api/cssscale/y/index.md
+++ b/files/en-us/web/api/cssscale/y/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSScale.y
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`y`** property of the {{domxref("CSSScale")}} interface gets and sets the ordinate or y-axis of the translating vector.
 

--- a/files/en-us/web/api/cssscale/z/index.md
+++ b/files/en-us/web/api/cssscale/z/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSScale.z
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`z`** property of the {{domxref("CSSScale")}} interface representing the z-component of the translating vector.
 A positive value moves the element towards the viewer, and a negative value farther away.

--- a/files/en-us/web/api/cssskew/ax/index.md
+++ b/files/en-us/web/api/cssskew/ax/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSSkew.ax
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`ax`** property of the {{domxref("CSSSkew")}} interface gets and sets the angle used to distort the element along the x-axis (or abscissa).
 

--- a/files/en-us/web/api/cssskew/ay/index.md
+++ b/files/en-us/web/api/cssskew/ay/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSSkew.ay
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`ay`** property of the {{domxref("CSSSkew")}} interface gets and sets the angle used to distort the element along the y-axis (or ordinate).
 

--- a/files/en-us/web/api/cssskew/cssskew/index.md
+++ b/files/en-us/web/api/cssskew/cssskew/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSSkew.CSSSkew
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSSkew()`** constructor creates a new {{domxref("CSSSkew")}} object which represents the {{cssxref("transform-function/skew", "skew()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
 

--- a/files/en-us/web/api/cssskew/index.md
+++ b/files/en-us/web/api/cssskew/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSSkew
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSSkew`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is part of the {{domxref('CSSTransformValue')}} interface.
 It represents the {{cssxref("transform-function/skew", "skew()")}} value of the individual {{CSSXRef('transform')}} property in CSS.

--- a/files/en-us/web/api/cssstylevalue/index.md
+++ b/files/en-us/web/api/cssstylevalue/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSStyleValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSStyleValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) is the base class of all CSS values accessible through the Typed OM API.
+The **`CSSStyleValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) is the base class of all CSS values accessible through the Typed OM API.
 An instance of this class may be used anywhere a string is expected.
 
 ## Interfaces based on CSSStyleValue

--- a/files/en-us/web/api/cssstylevalue/index.md
+++ b/files/en-us/web/api/cssstylevalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSStyleValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSStyleValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) is the base class of all CSS values accessible through the Typed OM API.
 An instance of this class may be used anywhere a string is expected.

--- a/files/en-us/web/api/cssstylevalue/parse_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parse_static/index.md
@@ -10,6 +10,10 @@ browser-compat: api.CSSStyleValue.parse_static
 
 The **`parse()`** static method of the {{domxref("CSSStyleValue")}} interface sets a specific CSS property to the specified values and returns the first value as a {{domxref('CSSStyleValue')}} object.
 
+> [!NOTE]
+> This method cannot be called in {{domxref("Worker")}} or {{domxref("Worklet")}} contexts.
+> The rest of the `CSSStyleValue` interface remains available in workers and worklets.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/cssstylevalue/parseall_static/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall_static/index.md
@@ -10,6 +10,10 @@ browser-compat: api.CSSStyleValue.parseAll_static
 
 The **`parseAll()`** static method of the {{domxref("CSSStyleValue")}} interface sets all occurrences of a specific CSS property to the specified value and returns an array of {{domxref('CSSStyleValue')}} objects, each containing one of the supplied values.
 
+> [!NOTE]
+> This method cannot be called in {{domxref("Worker")}} or {{domxref("Worklet")}} contexts.
+> The rest of the `CSSStyleValue` interface remains available in workers and worklets.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/cssstylevalue/tostring/index.md
+++ b/files/en-us/web/api/cssstylevalue/tostring/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSStyleValue.toString
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`toString()`** method of the {{domxref("CSSStyleValue")}} interface is a {{Glossary("stringifier")}} that returns the value formatted as a string of standard CSS text.
 

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSTransformComponent
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTransformComponent`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is part of the {{domxref('CSSTransformValue')}} interface.
 

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.md
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSTransformComponent.is2D
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`is2D`** read-only property of the {{domxref("CSSTransformComponent")}} interface indicates where the transform is 2D or 3D.
 

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSTransformComponent.toMatrix
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`toMatrix()`** method of the {{domxref("CSSTransformComponent")}} interface returns a {{domxref('DOMMatrix')}} object.
 

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSTransformComponent.toString
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`toString()`** method of the {{domxref("CSSTransformComponent")}} interface is a {{Glossary("stringifier")}} returning a [CSS Transforms](/en-US/docs/Web/CSS/Guides/Transforms) function.
 

--- a/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSTransformValue.CSSTransformValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTransformValue()`** constructor creates a new {{domxref("CSSTransformValue")}} object which represents a list of individual transform objects.
 

--- a/files/en-us/web/api/csstransformvalue/entries/index.md
+++ b/files/en-us/web/api/csstransformvalue/entries/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSTransformValue.entries
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTransformValue.entries()`** method
 returns an array of a given object's own enumerable

--- a/files/en-us/web/api/csstransformvalue/foreach/index.md
+++ b/files/en-us/web/api/csstransformvalue/foreach/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSTransformValue.forEach
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTransformValue.forEach()`** method executes a provided function once for each element of the `CSSTransformValue`.
 

--- a/files/en-us/web/api/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSTransformValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTransformValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents `transform-list` values as used by the CSS {{CSSxref('transform')}} property.
 

--- a/files/en-us/web/api/csstransformvalue/is2d/index.md
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSTransformValue.is2D
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The read-only **`is2D`** property of the {{domxref("CSSTransformValue")}} interface returns whether the transform is 2D or 3D.
 

--- a/files/en-us/web/api/csstransformvalue/keys/index.md
+++ b/files/en-us/web/api/csstransformvalue/keys/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSTransformValue.keys
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTransformValue.keys()`** method returns a new _array iterator_ object that contains the keys for each index in the array.
 

--- a/files/en-us/web/api/csstransformvalue/length/index.md
+++ b/files/en-us/web/api/csstransformvalue/length/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSTransformValue.length
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The read-only **`length`** property of the {{domxref("CSSTransformValue")}} interface returns the number of transform components in the list.
 

--- a/files/en-us/web/api/csstransformvalue/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformvalue/tomatrix/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSTransformValue.toMatrix
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`toMatrix()`** method of the {{domxref("CSSTransformValue")}} interface returns a {{domxref('DOMMatrix')}} object.
 

--- a/files/en-us/web/api/csstransformvalue/values/index.md
+++ b/files/en-us/web/api/csstransformvalue/values/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSTransformValue.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTransformValue.values()`** returns a new _array iterator_ object that contains the values for each index in the `CSSTransformValue` object.
 

--- a/files/en-us/web/api/csstranslate/csstranslate/index.md
+++ b/files/en-us/web/api/csstranslate/csstranslate/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSTranslate.CSSTranslate
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTranslate()`** constructor creates a new {{domxref("CSSTranslate")}} object representing the {{cssxref("transform-function/translate", "translate()")}} value of the individual {{CSSXref('transform')}} property in CSS.
 

--- a/files/en-us/web/api/csstranslate/index.md
+++ b/files/en-us/web/api/csstranslate/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSTranslate
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTranslate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/translate", "translate()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
 It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.

--- a/files/en-us/web/api/csstranslate/x/index.md
+++ b/files/en-us/web/api/csstranslate/x/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSTranslate.x
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`x`** property of the {{domxref("CSSTranslate")}} interface gets and sets the abscissa or x-axis of the translating vector.
 

--- a/files/en-us/web/api/csstranslate/y/index.md
+++ b/files/en-us/web/api/csstranslate/y/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSTranslate.y
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`y`** property of the {{domxref("CSSTranslate")}} interface gets and sets the ordinate or y-axis of the translating vector.
 

--- a/files/en-us/web/api/csstranslate/z/index.md
+++ b/files/en-us/web/api/csstranslate/z/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSTranslate.z
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`z`** property of the {{domxref("CSSTranslate")}} interface representing the z-component of the translating vector.
 A positive value moves the element towards the viewer, and a negative value farther away.

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSUnitValue.CSSUnitValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnitValue()`** constructor creates a new {{domxref("CSSUnitValue")}} object which returns a new {{domxref('CSSUnitValue')}} object which represents values that contain a single unit type.
 For example, "42px" would be represented by a `CSSNumericValue`.

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSUnitValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnitValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values that contain a single [unit type](/en-US/docs/Web/CSS/Guides/Values_and_units#units).
 

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSUnitValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSUnitValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values that contain a single [unit type](/en-US/docs/Web/CSS/Guides/Values_and_units#units).
+The **`CSSUnitValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents values that contain a single [unit type](/en-US/docs/Web/CSS/Guides/Values_and_units#units).
 
 For example, the value `42px` (a {{cssxref("&lt;dimension&gt;")}}) would be represented by a `CSSNumericValue`.
 

--- a/files/en-us/web/api/cssunitvalue/unit/index.md
+++ b/files/en-us/web/api/cssunitvalue/unit/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSUnitValue.unit
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnitValue.unit`** read-only property of the {{domxref("CSSUnitValue")}} interface returns a string indicating the [unit type](/en-US/docs/Web/CSS/Guides/Values_and_units#units).
 

--- a/files/en-us/web/api/cssunitvalue/value/index.md
+++ b/files/en-us/web/api/cssunitvalue/value/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSUnitValue.value
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnitValue.value`** property of the {{domxref("CSSUnitValue")}} interface returns a double indicating the number of units.
 

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSUnparsedValue.CSSUnparsedValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnparsedValue()`** constructor creates a new {{domxref("CSSUnparsedValue")}} object which represents property values that reference custom properties.
 

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSUnparsedValue.entries
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnparsedValue.entries()`** method returns an array of a given object's own enumerable property `[key, value]` pairs in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
 

--- a/files/en-us/web/api/cssunparsedvalue/foreach/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/foreach/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSUnparsedValue.forEach
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnparsedValue.forEach()`** method executes a provided function once for each element of the {{domxref('CSSUnparsedValue')}}.
 

--- a/files/en-us/web/api/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSUnparsedValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnparsedValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents property values that reference [custom properties](/en-US/docs/Web/CSS/Guides/Cascading_variables).
 It consists of a list of string fragments and variable references.

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSUnparsedValue.keys
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnparsedValue.keys()`** method returns a new _array iterator_ object that contains the keys for each index in the array.
 

--- a/files/en-us/web/api/cssunparsedvalue/length/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSUnparsedValue.length
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`length`** read-only property of the {{domxref("CSSUnparsedValue")}} interface returns the number of items in the object.
 

--- a/files/en-us/web/api/cssunparsedvalue/values/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.CSSUnparsedValue.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSUnparsedValue.values()`** method returns a new _array iterator_ object that contains the values for each index in the CSSUnparsedValue object.
 

--- a/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.CSSVariableReferenceValue.CSSVariableReferenceValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 Creates a new {{domxref('CSSVariableReferenceValue')}}.
 

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSVariableReferenceValue.fallback
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`fallback`** read-only property of the
 {{domxref("CSSVariableReferenceValue")}} interface returns the [custom property fallback value](/en-US/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties#custom_property_fallback_values) of the {{domxref("CSSVariableReferenceValue")}}.

--- a/files/en-us/web/api/cssvariablereferencevalue/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.CSSVariableReferenceValue
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSVariableReferenceValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) allows you to create a custom name for a built-in CSS value. This object functionality is sometimes called a "CSS variable" and serves the same purpose as the {{cssxref("var", "var()")}} function. The custom name must begin with two dashes.
 

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.CSSVariableReferenceValue.variable
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`variable`** property of the
 {{domxref("CSSVariableReferenceValue")}} interface returns the [custom property name](/en-US/docs/Web/CSS/Reference/Properties/--*) of the

--- a/files/en-us/web/api/stylepropertymap/index.md
+++ b/files/en-us/web/api/stylepropertymap/index.md
@@ -11,6 +11,10 @@ The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/
 
 {{InheritanceDiagram}}
 
+> [!NOTE]
+> This interface is only available on the window thread; unlike other interfaces in this API it cannot be accessed in {{domxref("Worker")}} or {{domxref("Worklet")}} contexts.
+> Worklets receive a read-only snapshot of an element's style through {{domxref("StylePropertyMapReadOnly")}}.
+
 ## Instance properties
 
 _Inherits properties from its parent, {{DOMxRef("StylePropertyMapReadOnly")}}._

--- a/files/en-us/web/api/stylepropertymap/index.md
+++ b/files/en-us/web/api/stylepropertymap/index.md
@@ -7,7 +7,7 @@ browser-compat: api.StylePropertyMap
 
 {{APIRef("CSS Typed Object Model API")}}
 
-The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) provides a representation of a CSS declaration block that is an alternative to {{DOMxRef("CSSStyleDeclaration")}}.
+The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) provides a representation of a CSS declaration block that is an alternative to {{DOMxRef("CSSStyleDeclaration")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/stylepropertymapreadonly/entries/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/entries/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.StylePropertyMapReadOnly.entries
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`StylePropertyMapReadOnly.entries()`** method returns an array of a given object's own enumerable property `[key, value]` pairs, in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
 

--- a/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.StylePropertyMapReadOnly.forEach
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`StylePropertyMapReadOnly.forEach()`** method executes a provided function once for each element of {{domxref('StylePropertyMapReadOnly')}}.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/get/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/get/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.StylePropertyMapReadOnly.get
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`get()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface returns a {{domxref("CSSStyleValue")}} object for the first value of the specified property.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/getall/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/getall/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.StylePropertyMapReadOnly.getAll
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`getAll()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface returns an array of {{domxref("CSSStyleValue")}} objects containing the values for the provided property.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/has/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/has/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.StylePropertyMapReadOnly.has
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`has()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface indicates whether the specified property is in the `StylePropertyMapReadOnly` object.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.md
@@ -7,7 +7,7 @@ browser-compat: api.StylePropertyMapReadOnly
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`StylePropertyMapReadOnly`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) provides a read-only representation of a CSS declaration block that is an alternative to {{domxref("CSSStyleDeclaration")}}.
+The **`StylePropertyMapReadOnly`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) provides a read-only representation of a CSS declaration block that is an alternative to {{domxref("CSSStyleDeclaration")}}.
 Retrieve an instance of this interface using {{domxref('Element.computedStyleMap','Element.computedStyleMap()')}}.
 
 ## Instance properties

--- a/files/en-us/web/api/stylepropertymapreadonly/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.StylePropertyMapReadOnly
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`StylePropertyMapReadOnly`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) provides a read-only representation of a CSS declaration block that is an alternative to {{domxref("CSSStyleDeclaration")}}.
 Retrieve an instance of this interface using {{domxref('Element.computedStyleMap','Element.computedStyleMap()')}}.

--- a/files/en-us/web/api/stylepropertymapreadonly/keys/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/keys/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.StylePropertyMapReadOnly.keys
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`StylePropertyMapReadOnly.keys()`** method returns a new _array iterator_ containing the keys for each item in `StylePropertyMapReadOnly`.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/size/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/size/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.StylePropertyMapReadOnly.size
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`size`** read-only property of the {{domxref("StylePropertyMapReadOnly")}} interface returns a positive integer containing the size of the `StylePropertyMapReadOnly` object.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/values/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/values/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.StylePropertyMapReadOnly.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}}
+{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`StylePropertyMapReadOnly.values()`** method returns a new _array iterator_ containing the values for each index in the `StylePropertyMapReadOnly` object.
 

--- a/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -51,6 +51,7 @@ The following Web APIs are available to workers:
 - {{domxref("Content Index API", "", "", "nocode")}}
 - {{domxref("Cookie Store API", "", "", "nocode")}} (service workers only)
 - {{domxref("CSS Font Loading API", "", "", "nocode")}}
+- {{domxref("CSS Typed Object Model API", "", "", "nocode")}} (excluding {{domxref("StylePropertyMap")}})
 - {{domxref("Encoding API", "", "", "nocode")}}
 - {{domxref("Fetch API", "", "", "nocode")}}
 - {{domxref("File API", "", "", "nocode")}}


### PR DESCRIPTION
FF154 adds preview support for the [CSS Typed OM API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API). This is following fixes to the docs.

1. All the interfaces bar a couple are AvailableInWorkers. Added macro for most cases. Then added a few notes for the few cases that are not, because they are unexpected.
2. Many interfaces were pointing to the wrong API overview (CSSOM rather than the typed OM docs)
3. CSSImageValue contained a number of incorrect statements. Fixed those and also tidied the example.
4. CSSKeywordValue - fixes and improved example
5. Removed redirect from Typed OM page to CSSOM page. It is arguably OK to say this should all be under CSSOM but then cleanup should have removed that Typed OM overview. At this point given their different implementation stories, definitely better as separate APIs.

Related docs can be tracked in #44849