### PR TITLE
CSSOM updates to match web API templates

### DIFF
--- a/files/en-us/web/api/caretposition/index.md
+++ b/files/en-us/web/api/caretposition/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CaretPosition
 
 {{APIRef("CSSOM view API")}}
 
-The `CaretPosition` interface represents the caret position, an indicator for the text insertion point.
+The `CaretPosition` interface of the [CSSOM view API](/en-US/docs/Web/API/CSSOM_view_API) represents the caret position, an indicator for the text insertion point.
 You can get a `CaretPosition` using the {{domxref("Document.caretPositionFromPoint()")}} method.
 
 ## Instance properties

--- a/files/en-us/web/api/css/index.md
+++ b/files/en-us/web/api/css/index.md
@@ -7,7 +7,9 @@ browser-compat: api.CSS
 
 {{APIRef("CSSOM")}}
 
-The **`CSS`** interface holds useful CSS-related methods. No objects with this interface are implemented: it contains only static methods and is therefore a utilitarian interface.
+The **`CSS`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) groups useful CSS-related static methods.
+
+No objects with this interface are implemented: it contains only static methods and is therefore a utilitarian interface.
 
 ## Static properties
 

--- a/files/en-us/web/api/css_object_model/index.md
+++ b/files/en-us/web/api/css_object_model/index.md
@@ -10,14 +10,24 @@ spec-urls:
 
 {{DefaultAPISidebar("CSSOM")}}
 
-The **CSS Object Model** is a set of APIs allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify CSS style dynamically.
+The **CSS Object Model** is a set of APIs and interfaces allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify CSS style dynamically.
 
-The values of CSS are represented untyped, that is using {{JSxRef("String")}} objects.
+The values of CSS are represented untyped, that is using {{JSxRef("String")}} objects (except when using the [CSS Typed Object Model API](#css_typed_object_model_api)).
 
-## Reference
+## Guides
+
+- [CSS Declaration](/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration)
+- [CSS Declaration Block](/en-US/docs/Web/API/CSS_Object_Model/CSS_Declaration_Block)
+- [Determining the dimensions of elements](/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements)
+- [Managing screen orientation](/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation)
+- [Using dynamic styling information](/en-US/docs/Web/API/CSS_Object_Model/Using_dynamic_styling_information)
+- [CSS value serialization](/en-US/docs/Web/API/CSS_Object_Model/CSS_value_serialization)
+
+## Interfaces
+
+These interfaces are defined in the CSSOM specification:
 
 - {{DOMxRef("AnimationEvent")}}
-- {{DOMxRef("CaretPosition")}}
 - {{DOMxRef("CSS")}}
 - {{DOMxRef("CSSConditionRule")}}
 - {{DOMxRef("CSSCounterStyleRule")}}
@@ -46,51 +56,12 @@ The values of CSS are represented untyped, that is using {{JSxRef("String")}} ob
 - {{DOMxRef("CSSStyleRule")}}
 - {{DOMxRef("CSSSupportsRule")}}
 - {{DOMXRef("CSSNestedDeclarations")}}
-- {{DOMxRef("FontFace")}}
-- {{DOMxRef("FontFaceSet")}}
-- {{DOMxRef("FontFaceSetLoadEvent")}}
 - {{DOMxRef("MediaList")}}
-- {{DOMxRef("MediaQueryList")}}
-- {{DOMxRef("MediaQueryListEvent")}}
-- {{DOMxRef("Screen")}}
 - {{DOMxRef("StyleSheet")}}
 - {{DOMxRef("StyleSheetList")}}
 - {{DOMxRef("TransitionEvent")}}
-- {{DOMxRef("VisualViewport")}}
 
 Several other interfaces are also extended by the CSSOM-related specifications: {{DOMxRef("Document")}}, {{DOMxRef("Window")}}, {{DOMxRef("Element")}}, {{DOMxRef("HTMLElement")}}, {{DOMxRef("HTMLImageElement")}}, {{DOMxRef("Range")}}, {{DOMxRef("MouseEvent")}}, and {{DOMxRef("SVGElement")}}.
-
-### CSS Typed Object Model
-
-- {{DOMxRef("CSSImageValue")}}
-- {{DOMxRef("CSSKeywordValue")}}
-- {{DOMxRef("CSSMathClamp")}}
-- {{DOMxRef("CSSMathInvert")}}
-- {{DOMxRef("CSSMathMax")}}
-- {{DOMxRef("CSSMathMin")}}
-- {{DOMxRef("CSSMathNegate")}}
-- {{DOMxRef("CSSMathProduct")}}
-- {{DOMxRef("CSSMathSum")}}
-- {{DOMxRef("CSSMathValue")}}
-- {{DOMxRef("CSSMatrixComponent")}}
-- {{DOMxRef("CSSNumericArray")}}
-- {{DOMxRef("CSSNumericValue")}}
-- {{DOMxRef("CSSPerspective")}}
-- {{DOMxRef("CSSPositionValue")}}
-- {{DOMxRef("CSSRotate")}}
-- {{DOMxRef("CSSScale")}}
-- {{DOMxRef("CSSSkew")}}
-- {{DOMxRef("CSSSkewX")}}
-- {{DOMxRef("CSSSkewY")}}
-- {{DOMxRef("CSSStyleValue")}}
-- {{DOMxRef("CSSTransformComponent")}}
-- {{DOMxRef("CSSTransformValue")}}
-- {{DOMxRef("CSSTranslate")}}
-- {{DOMxRef("CSSUnitValue")}}
-- {{DOMxRef("CSSUnparsedValue")}}
-- {{DOMxRef("CSSVariableReferenceValue")}}
-- {{DOMxRef("StylePropertyMap")}}
-- {{DOMxRef("StylePropertyMapReadOnly")}}
 
 ### Obsolete CSSOM interfaces {{deprecated_inline}}
 
@@ -100,10 +71,16 @@ Several other interfaces are also extended by the CSSOM-related specifications: 
 - {{DOMxRef("CSSValue")}} {{deprecated_inline}}
 - {{DOMxRef("CSSValueList")}} {{deprecated_inline}}
 
-## Tutorials
+### CSSOM APIs
 
-- [Determining the dimensions of elements](/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements)
-- [Managing screen orientation](/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation)
+- [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API)
+  - : Provides mechanisms for dynamically loading font resources.
+
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)
+  - : simplifies CSS property manipulation by exposing CSS values as typed JavaScript objects rather than strings.
+
+- [CSSOM view API](/en-US/docs/Web/API/CSSOM_view_API)
+  - : Enables manipulation of the visual view of a document, including getting the position of element layout boxes, obtaining the width or height of the viewport through script, and also scrolling an element.
 
 ## Specifications
 

--- a/files/en-us/web/api/css_object_model/index.md
+++ b/files/en-us/web/api/css_object_model/index.md
@@ -12,7 +12,7 @@ spec-urls:
 
 The **CSS Object Model** is a set of APIs and interfaces allowing the manipulation of CSS from JavaScript. It is much like the DOM, but for the CSS rather than the HTML. It allows users to read and modify CSS style dynamically.
 
-The values of CSS are represented untyped, that is using {{JSxRef("String")}} objects (except when using the [CSS Typed Object Model API](#css_typed_object_model_api)).
+The values of CSS are represented untyped, that is using {{JSxRef("String")}} objects (except when using the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)).
 
 ## Guides
 

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -240,7 +240,7 @@ You can use a `CSSUnitValue` or `CSSKeywordValue` to create other objects.
 
 ## CSSStyleValue
 
-The `CSSStyleValue` interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) is the base class of all CSS values accessible through the Typed OM API, including {{domxref('CSSImageValue')}}, {{domxref('CSSKeywordValue')}}, {{domxref('CSSNumericValue')}}, {{domxref('CSSPositionValue')}}, {{domxref('CSSTransformValue')}}, and {{domxref('CSSUnparsedValue')}}.
+The `CSSStyleValue` interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) is the base class of all CSS values accessible through the Typed OM API, including {{domxref('CSSImageValue')}}, {{domxref('CSSKeywordValue')}}, {{domxref('CSSNumericValue')}}, {{domxref('CSSPositionValue')}}, {{domxref('CSSTransformValue')}}, and {{domxref('CSSUnparsedValue')}}.
 
 It has two methods:
 

--- a/files/en-us/web/api/css_typed_om_api/index.md
+++ b/files/en-us/web/api/css_typed_om_api/index.md
@@ -13,96 +13,79 @@ browser-compat:
 
 The CSS Typed Object Model API simplifies CSS property manipulation by exposing CSS values as typed JavaScript objects rather than strings. This not only simplifies CSS manipulation, but also lessens the negative impact on performance as compared to {{domxref('HTMLElement.style')}}.
 
+## Concepts and usage
+
 Generally, CSS values can be read and written in JavaScript as strings, which can be slow and cumbersome. CSS Typed Object Model API provides interfaces to interact with underlying values, by representing them with specialized JS objects that can be manipulated and understood more easily and more reliably than string parsing and concatenation. This is easier for authors (for example, numeric values are reflected with actual JS numbers, and have unit-aware mathematical operations defined for them). It is also generally faster, as values can be directly manipulated and then cheaply translated back into underlying values without having to both build and parse strings of CSS.
 
 CSS Typed OM both allows for the performant manipulation of values assigned to CSS properties while enabling maintainable code that is both more understandable and easier to write.
 
+## Guides
+
+- [Using the CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+  - : An introduction to the main features of the typed object model.
+
 ## Interfaces
 
-### `CSSStyleValue`
-
-The {{domxref('CSSStyleValue')}} interface of the CSS Typed Object Model API is the base class of all CSS values accessible through the Typed OM API. An instance of this class may be used anywhere a string is expected.
-
-- {{domxref('CSSStyleValue/parse_static', 'CSSStyleValue.parse()')}}
-  - : Method that allows `CSSNumericValue` to be constructed from a CSS string. It sets a specific CSS property to the specified values and returns the first value as a `CSSStyleValue` object.
-- {{domxref('CSSStyleValue.parseAll_static', 'CSSStyleValue.parseAll()')}}
-  - : Method that sets all occurrences of a specific CSS property to the specified value and returns an array of `CSSStyleValue` objects, each containing one of the supplied values.
-
-### `StylePropertyMap`
-
-The {{domxref('StylePropertyMap')}} interface of the CSS Typed Object Model API provides a representation of a CSS declaration block that is an alternative to `CSSStyleDeclaration`.
-
-- {{domxref('StylePropertyMap.set()')}}
-  - : Method that changes the CSS declaration with the given property to the value given.
-- {{domxref('StylePropertyMap.append()')}}
-  - : Method that adds a new CSS declaration to the `StylePropertyMap` with the given property and value.
-- {{domxref('StylePropertyMap.delete()')}}
-  - : Method that removes the CSS declaration with the given property from the `StylePropertyMap`.
-- {{domxref('StylePropertyMap.clear()')}}
-  - : Method that removes all declarations in the `StylePropertyMap`.
-
-### `CSSUnparsedValue`
-
-The {{domxref('CSSUnparsedValue')}} interface of the CSS Typed Object Model API represents property values that reference custom properties. It consists of a list of string fragments and variable references.
-
-- {{domxref("CSSUnparsedValue.CSSUnparsedValue", "CSSUnparsedValue()")}} constructor
-  - : Creates a new `CSSUnparsedValue` object which represents property values that reference custom properties.
-- {{domxref('CSSUnparsedValue.entries()')}}
-  - : Method returning an array of a given object's own enumerable property `[key, value]` pairs in the same order as that provided by a `for...in` loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
-- {{domxref('CSSUnparsedValue.forEach()')}}
-  - : Method executing a provided function once for each element of the `CSSUnparsedValue`.
-- {{domxref('CSSUnparsedValue.keys()')}}
-  - : Method returning a new _array iterator_ object that contains the keys for each index in the array.
-
-### `CSSKeywordValue` Serialization
-
-The {{domxref('CSSKeywordValue')}} interface of the CSS Typed Object Model API creates an object to represent CSS keywords and other identifiers.
-
-- {{domxref("CSSKeywordValue.CSSKeywordValue", "CSSKeywordValue()")}} constructor
-  - : Constructor creates a new {{domxref("CSSKeywordValue.CSSKeywordValue", "CSSKeywordValue()")}} object which represents CSS keywords and other identifiers.
-- {{domxref('CSSKeywordValue.value()')}}
-  - : Property of the `CSSKeywordValue` interface returning or setting the value of the `CSSKeywordValue`.
-
-## CSSStyleValue Interfaces
-
-{{domxref('CSSStyleValue')}} is the base class through which all CSS values are expressed. Subclasses include:
-
 - {{domxref('CSSImageValue')}}
-  - : An interface representing values for properties that take an image, for example {{cssxref("background-image")}}, {{cssxref("list-style-image")}}, or {{cssxref("border-image-source")}}.
+  - : Represents values for properties that take an image, such as {{cssxref("background-image")}}, {{cssxref("list-style-image")}}, or {{cssxref("border-image-source")}}.
 - {{domxref('CSSKeywordValue')}}
-  - : An interface which creates an object to represent CSS keywords and other identifiers. When used where a string is expected, it will return the value of `CSSKeyword.value`.
+  - : Represent the value of a CSS keyword or other identifier, such as `initial`, or `auto`.
+    When used where a string is expected, it will return the value of `CSSKeyword.value`.
+- {{domxref('CSSMathClamp')}}
+  - : Represents the CSS {{cssxref("clamp","clamp()")}} function.
+- {{domxref('CSSMathInvert')}}
+  - : represents a CSS {{cssxref("calc","calc()")}} value used as `calc(1 / <value>)`. This type is used internally by {{domxref('CSSNumericValue.div','div()')}}, to create an appropriate {{domxref('CSSMathProduct')}}.
+- {{domxref('CSSMathMax')}}
+  - : represents the CSS {{cssxref("max","max()")}} function.
+- {{domxref('CSSMathMin')}}
+  - : represents the CSS {{cssxref("min","min()")}} function.
+- {{domxref('CSSMathNegate')}}
+  - : negates the value passed into it.
+- {{domxref('CSSMathProduct')}}
+  - : represents the result obtained by calling {{domxref('CSSNumericValue.mul','mul()')}} or {{domxref('CSSNumericValue.div','div()')}} on {{domxref('CSSNumericValue')}}.
+- {{domxref('CSSMathSum')}}
+  - : represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
 - {{domxref('CSSMathValue')}}
-  - : A tree of subclasses representing numeric values that are more complicated than a single value and unit, including:
-    - {{domxref('CSSMathMax')}} - represents the CSS {{cssxref("max","max()")}} function.
-    - {{domxref('CSSMathMin')}} - represents the CSS {{cssxref("min","min()")}} function.
-    - {{domxref('CSSMathClamp')}} - represents the CSS {{cssxref("clamp","clamp()")}} function.
-    - {{domxref('CSSMathNegate')}} - negates the value passed into it.
-    - {{domxref('CSSMathInvert')}} - represents a CSS {{cssxref("calc","calc()")}} value used as `calc(1 / <value>)`. This type is used internally by {{domxref('CSSNumericValue.div','div()')}}, to create an appropriate {{domxref('CSSMathProduct')}}.
-    - {{domxref('CSSMathProduct')}} - represents the result obtained by calling {{domxref('CSSNumericValue.mul','mul()')}} or {{domxref('CSSNumericValue.div','div()')}} on {{domxref('CSSNumericValue')}}.
-    - {{domxref('CSSMathSum')}} - represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
-
+  - : The base class for numeric values that are more complicated than a single value and unit, such as `CSSMathMax` and `CSSMathSum`
+- {{domxref('CSSMatrixComponent')}}
+  - : TBD
+- {{domxref('CSSNumericArray')}}
+  - : TBD
 - {{domxref('CSSNumericValue')}}
-  - : An interface representing operations that all numeric values can perform, including:
-    - {{domxref('CSSNumericValue.add')}} - Adds supplied numbers to the `CSSNumericValue`.
-    - {{domxref('CSSNumericValue.sub')}} - Subtracts supplied numbers to the `CSSNumericValue`.
-    - {{domxref('CSSNumericValue.mul')}} - Multiplies supplied numbers to the `CSSNumericValue`.
-    - {{domxref('CSSNumericValue.div')}} - Divides the `CSSNumericValue` by the supplied value, throwing an error if `0`.
-    - {{domxref('CSSNumericValue.min')}} - Returns the minimum value passed
-    - {{domxref('CSSNumericValue.max')}} - Returns the maximum value passed
-    - {{domxref('CSSNumericValue.equals')}} - Returns true if all the values are the exact same type and value, in the same order. Otherwise, false
-    - {{domxref('CSSNumericValue.to')}} - Converts `value` into another one with the specified _unit._
-    - {{domxref('CSSNumericValue.toSum')}}
-    - {{domxref('CSSNumericValue.type')}}
-    - {{domxref('CSSNumericValue/parse_static', 'CSSNumericValue.parse')}} - Returns a number parsed from a CSS string
-
+  - : An interface representing operations that all numeric values can perform, such as addition, multiplication, and so on.
+- {{domxref('CSSPerspective')}}
+  - : TBD
 - {{domxref('CSSPositionValue')}}
   - : Represents values for properties that take a position, for example object-position.
+- {{domxref('CSSRotate')}}
+  - : TBD
+- {{domxref('CSSScale')}}
+  - : TBD
+- {{domxref('CSSSkew')}}
+  - : TBD
+- {{domxref('CSSSkewX')}}
+  - : TBD
+- {{domxref('CSSSkewY')}}
+  - : TBD
+- {{domxref('CSSStyleValue')}}
+  - : Base class of all CSS values accessible through the Typed OM API.
+    An instance of this class may be used anywhere a string is expected.
+- {{domxref('CSSTransformComponent')}}
+  - : TBD
 - {{domxref('CSSTransformValue')}}
   - : An interface representing a list of {{cssxref("transform")}} list values. They "contain" one or more {{domxref('CSSTransformComponent')}}s, which represent individual `transform` function values.
+- {{domxref('CSSTranslate')}}
+  - : TBD
 - {{domxref('CSSUnitValue')}}
   - : An interface representing numeric values that can be represented as a single unit, or a named number and percentage.
 - {{domxref('CSSUnparsedValue')}}
-  - : Represents property values that reference [custom properties](/en-US/docs/Web/CSS/Reference/Properties/--*). It consists of a list of string fragments and variable references.
+  - : Represents property values that reference [custom properties](/en-US/docs/Web/CSS/Reference/Properties/--*). It consists of a list of string fragments and variable references. Represents property values that reference custom properties. It consists of a list of string fragments and variable references.
+- {{domxref('CSSVariableReferenceValue')}}
+  - : TBD
+- {{domxref('StylePropertyMap')}}
+  - : The {{domxref('StylePropertyMap')}} interface of the CSS Typed Object Model API provides a representation of a CSS declaration block that is an alternative to `CSSStyleDeclaration`.
+- {{domxref('StylePropertyMapReadOnly')}}
+  - : TBD
 
 ## Specifications
 

--- a/files/en-us/web/api/cssconditionrule/index.md
+++ b/files/en-us/web/api/cssconditionrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSConditionRule
 
 {{ APIRef("CSSOM") }}
 
-An object implementing the **`CSSConditionRule`** interface represents a single condition CSS [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules), which consists of a condition and a statement block.
+The **`CSSConditionRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single condition CSS [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules), which consists of a condition and a statement block.
 
 Three objects derive from `CSSConditionRule`: {{domxref("CSSMediaRule")}}, {{domxref("CSSContainerRule")}} and {{domxref("CSSSupportsRule")}}.
 

--- a/files/en-us/web/api/csscounterstylerule/index.md
+++ b/files/en-us/web/api/csscounterstylerule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSCounterStyleRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSCounterStyleRule`** interface represents an {{CSSxRef("@counter-style")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSCounterStyleRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents an {{CSSxRef("@counter-style")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssfontfacedescriptors/index.md
+++ b/files/en-us/web/api/cssfontfacedescriptors/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSFontFaceDescriptors
 
 {{APIRef("CSSOM")}}
 
-The **`CSSFontFaceDescriptors`** interface represents a CSS declaration block for an {{cssxref("@font-face")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSFontFaceDescriptors`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a CSS declaration block for an {{cssxref("@font-face")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 Each descriptor in the body of the corresponding {{cssxref("@font-face")}} at-rule can be accessed using either its kebab-case property name in [bracket notation](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics#bracket_notation) or the camel-case version of the property name in [dot notation](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics#dot_notation).
 For example, you can access the `font-family` CSS descriptor as `style["font-family"]` or `style.fontFamily`, where `style` is a `CSSFontFaceDescriptors` instance.

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSFontFaceRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSFontFaceRule`** interface represents an {{cssxref("@font-face")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSFontFaceRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents an {{cssxref("@font-face")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
+++ b/files/en-us/web/api/cssfontfeaturevaluesrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSFontFeatureValuesRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSFontFeatureValuesRule`** interface represents an {{cssxref("@font-feature-values")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules). The values of its instance properties can be accessed with the [`CSSFontFeatureValuesMap`](/en-US/docs/Web/API/CSSFontFeatureValuesMap) interface.
+The **`CSSFontFeatureValuesRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents an {{cssxref("@font-feature-values")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules). The values of its instance properties can be accessed with the [`CSSFontFeatureValuesMap`](/en-US/docs/Web/API/CSSFontFeatureValuesMap) interface.
 
 `@font-feature-values` allows developers to associate, for a given font face, a human-readable name with a numeric index that controls a particular [OpenType font feature](/en-US/docs/Web/CSS/Guides/Fonts/OpenType_fonts).
 For features that select alternative glyphs (stylistic, styleset, character-variant, swash, ornament or annotation), the {{cssxref("font-variant-alternates")}} property can then reference the human-readable name in order to apply the associated feature.

--- a/files/en-us/web/api/cssfunctiondeclarations/index.md
+++ b/files/en-us/web/api/cssfunctiondeclarations/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSSFunctionDeclarations
 
 {{ APIRef("CSSOM") }}{{SeeCompatTable}}
 
-The **`CSSFunctionDeclarations`** interface of the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) represents a consecutive run of CSS declarations included within a {{cssxref("@function")}} body.
+The **`CSSFunctionDeclarations`** interface of the of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a consecutive run of CSS declarations included within a {{cssxref("@function")}} body.
 
 This can include [CSS custom properties](/en-US/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties), and the value of the `results` descriptor inside the `@function` body, but it doesn't include blocks such as {{cssxref("@media")}} at-rules that may be included. Such a block, included in the middle of a set of declarations, would cause the body contents to be broken up into separate `CSSFunctionDeclarations` objects, as seen in our [Multiple `CSSFunctionDeclarations`](#multiple_cssfunctiondeclarations) demo.
 

--- a/files/en-us/web/api/cssfunctiondescriptors/index.md
+++ b/files/en-us/web/api/cssfunctiondescriptors/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSSFunctionDescriptors
 
 {{ APIRef("CSSOM") }}{{SeeCompatTable}}
 
-The **`CSSFunctionDescriptors`** interface of the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) represents the descriptors contained within a set of CSS declarations represented by a {{domxref("CSSFunctionDeclarations")}} object.
+The **`CSSFunctionDescriptors`** interface of the of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents the descriptors contained within a set of CSS declarations represented by a {{domxref("CSSFunctionDeclarations")}} object.
 
 A `CSSFunctionDescriptors` object is accessed via the {{domxref("CSSFunctionDeclarations.style")}} property.
 

--- a/files/en-us/web/api/cssfunctionrule/index.md
+++ b/files/en-us/web/api/cssfunctionrule/index.md
@@ -9,7 +9,7 @@ browser-compat: api.CSSFunctionRule
 
 {{ APIRef("CSSOM") }}{{SeeCompatTable}}
 
-The **`CSSFunctionRule`** interface of the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) represents CSS {{cssxref("@function")}} (custom function) [at-rules](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSFunctionRule`** interface of the of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents CSS {{cssxref("@function")}} (custom function) [at-rules](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssgroupingrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSGroupingRule
 
 {{ APIRef("CSSOM") }}
 
-The **`CSSGroupingRule`** interface of the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) represents any CSS [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules) that contains other rules nested within it.
+The **`CSSGroupingRule`** interface of the of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents any CSS [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules) that contains other rules nested within it.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -7,8 +7,7 @@ browser-compat: api.CSSImageValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSImageValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents values for CSS properties that take an {{cssxref("image")}} value, such as
-{{cssxref("background-image")}}, {{cssxref("list-style-image")}}, or {{cssxref("border-image-source")}}.
+The **`CSSImageValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents values for CSS properties that take an {{cssxref("image")}} value, such as {{cssxref("background-image")}}, {{cssxref("list-style-image")}}, or {{cssxref("border-image-source")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSImportRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSImportRule`** interface represents an {{cssxref("@import")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSImportRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents an {{cssxref("@import")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/csskeyframerule/index.md
+++ b/files/en-us/web/api/csskeyframerule/index.md
@@ -7,7 +7,8 @@ browser-compat: api.CSSKeyframeRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSKeyframeRule`** interface describes an object representing a set of styles for a given keyframe. It corresponds to the contents of a single keyframe of a {{cssxref("@keyframes")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSKeyframeRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a set of styles for a given keyframe.
+It corresponds to the contents of a single keyframe of a {{cssxref("@keyframes")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/csskeyframesrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSKeyframesRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSKeyframesRule`** interface describes an object representing a complete set of keyframes for a CSS animation. It corresponds to the contents of a whole {{cssxref("@keyframes")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSKeyframesRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) describes an object representing a complete set of keyframes for a CSS animation. It corresponds to the contents of a whole {{cssxref("@keyframes")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssmediarule/index.md
+++ b/files/en-us/web/api/cssmediarule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSMediaRule
 
 {{ APIRef("CSSOM") }}
 
-The **`CSSMediaRule`** interface represents a single CSS {{cssxref("@media")}} rule.
+The **`CSSMediaRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single CSS {{cssxref("@media")}} rule.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssnamespacerule/index.md
+++ b/files/en-us/web/api/cssnamespacerule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSNamespaceRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSNamespaceRule`** interface describes an object representing a single CSS {{ cssxref("@namespace") }} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSNamespaceRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) describes an object representing a single CSS {{ cssxref("@namespace") }} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssnesteddeclarations/index.md
+++ b/files/en-us/web/api/cssnesteddeclarations/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSNestedDeclarations
 
 {{APIRef("CSSOM")}}
 
-The **`CSSNestedDeclarations`** interface of the [CSS Rule API](/en-US/docs/Web/API/CSSRule) is used to group nested {{domxref("CSSRule")}}s.
+The **`CSSNestedDeclarations`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) is used to group nested {{domxref("CSSRule")}}s.
 
 The interface allows the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) to mirror the structure of CSS documents with nested CSS rules, and ensure that rules are parsed and evaluated in the order that they are declared.
 

--- a/files/en-us/web/api/cssnesteddeclarations/index.md
+++ b/files/en-us/web/api/cssnesteddeclarations/index.md
@@ -7,9 +7,9 @@ browser-compat: api.CSSNestedDeclarations
 
 {{APIRef("CSSOM")}}
 
-The **`CSSNestedDeclarations`** interface of the [CSS Rule API](/en-US/docs/Web/API/CSSRule) is used to group nested {{domxref("CSSRule")}}s.
+The **`CSSNestedDeclarations`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) is used to group nested {{domxref("CSSRule")}}s.
 
-The interface allows the [CSS Object Model (CSSOM](/en-US/docs/Web/API/CSS_Object_Model) to mirror the structure of CSS documents with nested CSS rules, and ensure that rules are parsed and evaluated in the order that they are declared.
+The interface allows the CSSOM to mirror the structure of CSS documents with nested CSS rules, and ensure that rules are parsed and evaluated in the order that they are declared.
 
 > [!NOTE]
 > Implementations that do not support this interface may parse nested rules in the wrong order.

--- a/files/en-us/web/api/csspagerule/index.md
+++ b/files/en-us/web/api/csspagerule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSPageRule
 
 {{APIRef("CSSOM")}}
 
-**`CSSPageRule`** represents a single CSS {{cssxref("@page")}} rule.
+The **`CSSPageRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single CSS {{cssxref("@page")}} rule.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/csspositiontrydescriptors/index.md
+++ b/files/en-us/web/api/csspositiontrydescriptors/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSPositionTryDescriptors
 
 {{APIRef("CSSOM")}}
 
-The **`CSSPositionTryDescriptors`** interface defines properties that represent the list of CSS descriptors that can be set in the body of a {{cssxref("@position-try")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSPositionTryDescriptors`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) defines properties that represent the list of CSS descriptors that can be set in the body of a {{cssxref("@position-try")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 Each descriptor in the body of the corresponding {{cssxref("@position-try")}} at-rule can be accessed using either its property name in [bracket notation](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics#bracket_notation) or the camel-case version of the property name "propertyName" in [dot notation](/en-US/docs/Learn_web_development/Core/Scripting/Object_basics#dot_notation).
 For example, you can access the CSS property "property-name" as `style["property-name"]` or `style.propertyName`, where `style` is a `CSSPositionTryDescriptors` instance.

--- a/files/en-us/web/api/csspositiontryrule/index.md
+++ b/files/en-us/web/api/csspositiontryrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSPositionTryRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSPositionTryRule`** interface describes an object representing a {{cssxref("@position-try")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSPositionTryRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) describes an object representing a {{cssxref("@position-try")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSSPositionValue
 
 {{APIRef("CSS Typed Object Model API")}}{{Non-standard_header}}
 
-The **`CSSPositionValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values for properties that take a position, for example {{cssxref('object-position')}}.
+The **`CSSPositionValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents values for properties that take a position, for example {{cssxref('object-position')}}.
 
 ## Constructor
 

--- a/files/en-us/web/api/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSSPositionValue
 
 {{deprecated_header}}{{APIRef("CSS Typed Object Model API")}}{{Non-standard_header}}
 
-The **`CSSPositionValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) represents values for properties that take a position, for example {{cssxref('object-position')}}.
+The **`CSSPositionValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) represents values for properties that take a position, for example {{cssxref('object-position')}}.
 
 ## Constructor
 

--- a/files/en-us/web/api/cssrule/index.md
+++ b/files/en-us/web/api/cssrule/index.md
@@ -7,7 +7,9 @@ browser-compat: api.CSSRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSRule`** interface represents a single CSS rule. There are several types of rules which inherit properties from `CSSRule`.
+The **`CSSRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single CSS rule.
+
+There are several types of rules which inherit properties from `CSSRule`.
 
 - {{DOMXRef("CSSGroupingRule")}}
 - {{DOMXRef("CSSStyleRule")}}

--- a/files/en-us/web/api/cssrulelist/index.md
+++ b/files/en-us/web/api/cssrulelist/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSRuleList
 
 {{ APIRef("CSSOM") }}
 
-A `CSSRuleList` represents an ordered collection of read-only {{domxref("CSSRule")}} objects.
+A `CSSRuleList` of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents an ordered collection of read-only {{domxref("CSSRule")}} objects.
 
 While the `CSSRuleList` object is read-only, and cannot be directly modified, it is considered a `live` object, as the content can change over time.
 

--- a/files/en-us/web/api/cssstartingstylerule/index.md
+++ b/files/en-us/web/api/cssstartingstylerule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSStartingStyleRule
 
 {{ APIRef("CSSOM") }}
 
-The **`CSSStartingStyleRule`** interface of the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) represents a CSS {{CSSxRef("@starting-style")}} at-rule.
+The **`CSSStartingStyleRule`** interface of the of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a CSS {{CSSxRef("@starting-style")}} at-rule.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssstyledeclaration/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSStyleDeclaration
 
 {{APIRef("CSSOM")}}
 
-The **`CSSStyleDeclaration`** interface is the base class for objects that represent CSS declaration blocks with different supported sets of CSS style information:
+The **`CSSStyleDeclaration`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) is the base class for objects that represent CSS declaration blocks with different supported sets of CSS style information:
 
 - {{domxref("CSSStyleProperties")}} — CSS styles declared in stylesheet ({{domxref("CSSStyleRule.style")}}), inline styles for an element such as {{DOMxRef("HTMLElement/style","HTMLElement")}}, {{domxref("SVGElement/style","SVGElement")}}, and {{domxref("MathMLElement/style","MathMLElement")}}, or the computed style for an element returned by {{DOMxRef("Window.getComputedStyle()")}}.
 - {{domxref("CSSPageDescriptors")}} — Styles for CSS [at-rules](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).

--- a/files/en-us/web/api/cssstylerule/index.md
+++ b/files/en-us/web/api/cssstylerule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSStyleRule
 
 {{ APIRef("CSSOM") }}
 
-The **`CSSStyleRule`** interface represents a single CSS style rule.
+The **`CSSStyleRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single CSS style rule.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/index.md
@@ -7,26 +7,11 @@ browser-compat: api.CSSStyleSheet
 
 {{APIRef("CSSOM")}}
 
-The **`CSSStyleSheet`** interface represents a single [CSS](/en-US/docs/Web/CSS) stylesheet, and lets you inspect and modify the list of rules contained in the stylesheet. It inherits properties and methods from its parent, {{domxref("StyleSheet")}}.
+The **`CSSStyleSheet`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single [CSS](/en-US/docs/Web/CSS) stylesheet.
+
+It can be used to inspect and modify the list of rules contained in the stylesheet.
 
 {{InheritanceDiagram}}
-
-A stylesheet consists of a collection of {{domxref("CSSRule")}} objects representing each of the rules in the stylesheet. The rules are contained in a {{domxref("CSSRuleList")}}, which can be obtained from the stylesheet's {{domxref("CSSStyleSheet.cssRules", "cssRules")}} property.
-
-For example, one rule might be a {{domxref("CSSStyleRule")}} object containing a style such as:
-
-```css
-h1,
-h2 {
-  font-size: 16pt;
-}
-```
-
-Another rule might be an _at-rule_ such as {{cssxref("@import")}} or {{cssxref("@media")}}, and so forth.
-
-See the [Obtaining a StyleSheet](#obtaining_a_stylesheet) section for the various ways a `CSSStyleSheet` object can be obtained. A `CSSStyleSheet` object can also be directly constructed. The constructor, and the {{domxref("CSSStyleSheet.replace()")}}, and {{domxref("CSSStyleSheet.replaceSync()")}} methods are newer additions to the specification, enabling _Constructable Stylesheets_.
-
-To apply a `CSSStyleSheet` to a document or shadow root, assign it to the {{domxref("Document.adoptedStyleSheets")}} or {{domxref("ShadowRoot.adoptedStyleSheets")}} property, respectively.
 
 ## Constructor
 
@@ -78,7 +63,26 @@ _These methods are legacy methods as introduced by Microsoft; these are maintain
 - {{domxref("CSSStyleSheet.removeRule", "removeRule()")}} {{Deprecated_Inline}}
   - : Functionally identical to {{domxref("CSSStyleSheet.deleteRule", "deleteRule()")}}; removes the rule at the specified index from the stylesheet's rule list.
 
-## Obtaining a StyleSheet
+## Description
+
+A stylesheet consists of a collection of {{domxref("CSSRule")}} objects representing each of the rules in the stylesheet. The rules are contained in a {{domxref("CSSRuleList")}}, which can be obtained from the stylesheet's {{domxref("CSSStyleSheet.cssRules", "cssRules")}} property.
+
+For example, one rule might be a {{domxref("CSSStyleRule")}} object containing a style such as:
+
+```css
+h1,
+h2 {
+  font-size: 16pt;
+}
+```
+
+Another rule might be an _at-rule_ such as {{cssxref("@import")}} or {{cssxref("@media")}}, and so forth.
+
+See the [Obtaining a StyleSheet](#obtaining_a_stylesheet) section for the various ways a `CSSStyleSheet` object can be obtained. A `CSSStyleSheet` object can also be directly constructed. The constructor, and the {{domxref("CSSStyleSheet.replace()")}}, and {{domxref("CSSStyleSheet.replaceSync()")}} methods are newer additions to the specification, enabling _Constructable Stylesheets_.
+
+To apply a `CSSStyleSheet` to a document or shadow root, assign it to the {{domxref("Document.adoptedStyleSheets")}} or {{domxref("ShadowRoot.adoptedStyleSheets")}} property, respectively.
+
+### Obtaining a StyleSheet
 
 A stylesheet is associated with at most one {{domxref("Document")}}, which it applies to (unless {{domxref("StyleSheet.disabled", "disabled", "", 1)}}). A list of `CSSStyleSheet` objects for a given document can be obtained using the {{domxref("Document.styleSheets")}} property. A specific style sheet can also be accessed from its _owner_ object (`Node` or `CSSImportRule`), if any.
 

--- a/files/en-us/web/api/csssupportsrule/index.md
+++ b/files/en-us/web/api/csssupportsrule/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSSupportsRule
 
 {{APIRef("CSSOM")}}
 
-The **`CSSSupportsRule`** interface represents a single CSS {{cssxref("@supports")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
+The **`CSSSupportsRule`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single CSS {{cssxref("@supports")}} [at-rule](/en-US/docs/Web/CSS/Guides/Syntax/At-rules).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/medialist/index.md
+++ b/files/en-us/web/api/medialist/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaList
 
 {{APIRef("CSSOM")}}
 
-The **`MediaList`** interface represents the media queries of a stylesheet, e.g., those set using a {{htmlelement("link")}} element's `media` attribute.
+The **`MediaList`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents the media queries of a stylesheet, e.g., those set using a {{htmlelement("link")}} element's `media` attribute.
 
 > [!NOTE]
 > `MediaList` is a live list; updating the list using properties or methods listed below will immediately update the behavior of the document.

--- a/files/en-us/web/api/mediaquerylist/index.md
+++ b/files/en-us/web/api/mediaquerylist/index.md
@@ -7,9 +7,10 @@ browser-compat: api.MediaQueryList
 
 {{APIRef("CSSOM view API")}}
 
-A **`MediaQueryList`** object stores information on a [media query](/en-US/docs/Web/CSS/Guides/Media_queries) applied to a document, with support for both immediate and event-driven matching against the state of the document.
+The **`MediaQueryList`** interface of the [CSSOM view API](/en-US/docs/Web/API/CSSOM_view_API) represents a [media query](/en-US/docs/Web/CSS/Guides/Media_queries) applied to a document.
 
-You can create a `MediaQueryList` by calling {{DOMxRef("Window.matchMedia", "matchMedia()")}} on the {{DOMxRef("window")}} object. The resulting object handles sending notifications to listeners when the media query state changes (i.e., when the media query test starts or stops evaluating to `true`).
+You can create a `MediaQueryList` by calling {{DOMxRef("Window.matchMedia", "matchMedia()")}} on the {{DOMxRef("window")}} object.
+The resulting object handles sending notifications to listeners when the media query state changes (i.e., when the media query test starts or stops evaluating to `true`).
 
 This is very useful for adaptive design, since this makes it possible to observe a document to detect when its media queries change, instead of polling the values periodically, and allows you to programmatically make changes to a document based on media query status.
 

--- a/files/en-us/web/api/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.MediaQueryListEvent
 
 {{APIRef("CSSOM view API")}}
 
-The `MediaQueryListEvent` object stores information on the changes that have happened to a {{DOMxRef("MediaQueryList")}} object — instances are available as the event object on a function referenced by a {{DOMxRef("MediaQueryList.change_event", "change")}} event.
+The `MediaQueryListEvent` interface of the [CSSOM view API](/en-US/docs/Web/API/CSSOM_view_API) represents the event object for the {{DOMxRef("MediaQueryList.change_event", "change")}} event fired on a {{DOMxRef("MediaQueryList")}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/screen/index.md
+++ b/files/en-us/web/api/screen/index.md
@@ -7,7 +7,7 @@ browser-compat: api.Screen
 
 {{APIRef("CSSOM view API")}}
 
-The `Screen` interface represents a screen, usually the one on which the current window is being rendered, and is obtained using {{DOMxRef("window.screen")}}.
+The `Screen` interface of the [CSSOM view API](/en-US/docs/Web/API/CSSOM_view_API) represents a screen, usually the one on which the current window is being rendered, and is obtained using {{DOMxRef("window.screen")}}.
 
 Note that browsers determine which screen to report as current by detecting which screen has the center of the browser window.
 

--- a/files/en-us/web/api/stylesheet/index.md
+++ b/files/en-us/web/api/stylesheet/index.md
@@ -7,7 +7,9 @@ browser-compat: api.StyleSheet
 
 {{APIRef("CSSOM")}}
 
-An object implementing the `StyleSheet` interface represents a single style sheet. CSS style sheets will further implement the more specialized {{domxref("CSSStyleSheet")}} interface.
+The **`StyleSheet`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a single style sheet.
+
+CSS style sheets will further implement the more specialized {{domxref("CSSStyleSheet")}} interface.
 
 ## Instance properties
 

--- a/files/en-us/web/api/stylesheetlist/index.md
+++ b/files/en-us/web/api/stylesheetlist/index.md
@@ -7,9 +7,11 @@ browser-compat: api.StyleSheetList
 
 {{APIRef("CSSOM")}}
 
-The `StyleSheetList` interface represents a list of {{domxref("CSSStyleSheet")}} objects. An instance of this object can be returned by {{domxref("Document.styleSheets")}}.
+The `StyleSheetList` interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents a list of {{domxref("CSSStyleSheet")}} objects.
 
-It is an array-like object but can't be iterated over using {{jsxref("Array")}} methods. However it can be iterated over in a standard {{jsxref("Statements/for", "for")}} loop over its indices, or converted to an {{jsxref("Array")}}.
+An instance of this object can be returned by {{domxref("Document.styleSheets")}}.
+It is an array-like object but can't be iterated over using {{jsxref("Array")}} methods.
+However it can be iterated over in a standard {{jsxref("Statements/for", "for")}} loop over its indices, or converted to an {{jsxref("Array")}}.
 
 > [!NOTE]
 > Typically list interfaces like `StyleSheetList` wrap around {{jsxref("Array")}} types, so you can use `Array` methods on them.

--- a/files/en-us/web/api/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.TransitionEvent
 
 {{APIRef("CSSOM")}}
 
-The **`TransitionEvent`** interface represents events providing information related to [transitions](/en-US/docs/Web/CSS/Guides/Transitions/Using).
+The **`TransitionEvent`** interface of the [CSS Object Model (CSSOM)](/en-US/docs/Web/API/CSS_Object_Model) represents events providing information related to [transitions](/en-US/docs/Web/CSS/Guides/Transitions/Using).
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
FF154 adds preview support for the [CSS Typed OM API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API). As part of that noticed a bunch of inconsistencies in the CSSOM "parent interface".

Changes made here:
- Adds "interface of the [CSSOM API] ..." style boilerplate for the different interfaces, where missing
- For the CSSOM page, this had a huge list of interfaces that contained interfaces mixed from different related APIs, and also a big list of Typed OM interfaces. 
  - I've tried to move towards the normal structure - adding "RElated APIs" sections and removing interfaces in their APIs from the big list.
  - This is a little non-standard because we don't normally cross link interfaces in this way, but CSSOM is messy.

This is not exhaustive - its just better.

Related docs can be tracked in #44849