### PR TITLE
Remove unused xmlns:xlink declarations from SVG tutorials

### DIFF
--- a/files/en-us/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
@@ -18,10 +18,7 @@ Erasing part of what you have created might seem contradictory at first. But whe
 We create the above-mentioned semicircle based on a `circle` element:
 
 ```html
-<svg
-  version="1.1"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="cut-off-bottom">
       <rect x="0" y="0" width="200" height="100" />
@@ -45,12 +42,7 @@ We now have a semicircle without having to deal with arcs in path elements. For 
 The effect of masking is most impressively presented with a gradient. If you want an element to fade out, you can achieve this effect quite quickly with masks.
 
 ```html
-<svg
-  width="200"
-  height="200"
-  version="1.1"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="Gradient">
       <stop offset="0" stop-color="black" />
@@ -81,12 +73,7 @@ The `opacity` attribute lets you set the transparency for a whole element:
 The above rectangle will be painted half-transparent. For the fill and stroke, there are two separate attributes, `fill-opacity` and `stroke-opacity`, that control each of those property opacities separately. Note, that the stroke will be painted on top of the filling. Hence, if you set a stroke opacity on an element, which also has a fill, the fill will shine through on half of the stroke while on the other half, the background will appear:
 
 ```html
-<svg
-  width="200"
-  height="200"
-  version="1.1"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0" width="200" height="200" fill="blue" />
   <circle
     cx="100"

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
@@ -98,11 +98,8 @@ The `<linearGradient>` element also takes several other attributes, which specif
 >   x2="0"
 >   y1="0"
 >   y2="1"
->   xmlns:xlink="http://www.w3.org/1999/xlink"
 >   href="#Gradient1" />
 > ```
->
-> We've included the xlink namespace here directly on the node, although usually you would define it at the top of your document. More on that when we [talk about images](/en-US/docs/Web/SVG/Tutorials/SVG_from_scratch/Other_content_in_SVG).
 
 ## Radial Gradient
 

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/image_element/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/image_element/index.md
@@ -16,7 +16,7 @@ In this basic example, a .jpg image referenced by an {{ SVGAttr("href") }} attri
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg width="5cm" height="4cm" version="1.1"
-     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+     xmlns="http://www.w3.org/2000/svg">
   <image href="firefox.jpg" x="0" y="0" height="50px" width="50px"/>
 </svg>
 ```

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
@@ -16,12 +16,7 @@ Much like the img element in HTML SVG has an `image` element to serve the same p
 The embedded picture becomes a normal SVG element. This means, that you can use clips, masks, filters, rotations and all other tools of SVG on the content:
 
 ```html
-<svg
-  version="1.1"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink"
-  width="200"
-  height="200">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="200" height="200">
   <image
     x="90"
     y="-65"

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/svg_and_css/index.md
@@ -23,8 +23,7 @@ Make a new SVG document as a plain text file, `doc8.svg`. Copy and paste the con
   width="600px"
   height="600px"
   viewBox="-300 -300 600 600"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+  xmlns="http://www.w3.org/2000/svg">
   <link
     xmlns="http://www.w3.org/1999/xhtml"
     rel="stylesheet"
@@ -442,8 +441,7 @@ See below how the structure then looks like.
   width="600px"
   height="600px"
   viewBox="-300 -300 600 600"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
+  xmlns="http://www.w3.org/2000/svg">
   <link
     xmlns="http://www.w3.org/1999/xhtml"
     rel="stylesheet"

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/texts/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/texts/index.md
@@ -73,9 +73,7 @@ This element fetches via its `href` attribute an arbitrary path and aligns the c
 <svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
   <path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="transparent" />
   <text>
-    <textPath xmlns:xlink="http://www.w3.org/1999/xlink" href="#my_path">
-      A curve.
-    </textPath>
+    <textPath href="#my_path">A curve.</textPath>
   </text>
 
   <style>


### PR DESCRIPTION
### Description

Dropped never used `xmlns:xlink` from tutorials.

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852