### PR TITLE
Strip legacy XML boilerplate from SVG examples

### DIFF
--- a/files/en-us/web/svg/reference/attribute/begin/index.md
+++ b/files/en-us/web/svg/reference/attribute/begin/index.md
@@ -115,8 +115,7 @@ The `<begin-value-list>` is a semicolon-separated list of values. Each value can
   width="120"
   height="120"
   viewBox="0 0 120 120"
-  xmlns="http://www.w3.org/2000/svg"
-  version="1.1">
+  xmlns="http://www.w3.org/2000/svg">
   <!-- animated rectangles -->
   <rect x="10" y="35" height="15" width="0">
     <animate
@@ -175,7 +174,6 @@ The `<begin-value-list>` is a semicolon-separated list of values. Each value can
   height="120"
   viewBox="0 0 120 120"
   xmlns="http://www.w3.org/2000/svg"
-  version="1.1"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <!-- animated rectangles -->
   <rect x="10" y="35" height="15" width="0">
@@ -235,7 +233,6 @@ The `<begin-value-list>` is a semicolon-separated list of values. Each value can
   height="120"
   viewBox="0 0 120 120"
   xmlns="http://www.w3.org/2000/svg"
-  version="1.1"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <!-- animated rectangle -->
   <rect x="10" y="35" height="15" width="0">
@@ -293,7 +290,6 @@ The `<begin-value-list>` is a semicolon-separated list of values. Each value can
   height="120"
   viewBox="0 0 120 120"
   xmlns="http://www.w3.org/2000/svg"
-  version="1.1"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <!-- animated rectangle -->
   <rect x="10" y="35" height="15" width="0">
@@ -353,7 +349,6 @@ The `<begin-value-list>` is a semicolon-separated list of values. Each value can
   height="120"
   viewBox="0 0 120 120"
   xmlns="http://www.w3.org/2000/svg"
-  version="1.1"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <!-- animated rectangles -->
   <rect x="10" y="35" height="15" width="0">

--- a/files/en-us/web/svg/reference/attribute/class/index.md
+++ b/files/en-us/web/svg/reference/attribute/class/index.md
@@ -47,7 +47,6 @@ You can use this class to style SVG content using CSS.
       width="120"
       height="220"
       viewPort="0 0 120 120"
-      version="1.1"
       xmlns="http://www.w3.org/2000/svg">
       <style>
         <![CDATA[

--- a/files/en-us/web/svg/reference/attribute/clip-rule/index.md
+++ b/files/en-us/web/svg/reference/attribute/clip-rule/index.md
@@ -60,11 +60,7 @@ whereas the following fragment of code will not cause an evenodd clipping rule t
 ## Example
 
 ```html
-<svg
-  width="100"
-  viewBox="0 0 100 90"
-  xmlns="http://www.w3.org/2000/svg"
-  version="1.1">
+<svg width="100" viewBox="0 0 100 90" xmlns="http://www.w3.org/2000/svg">
   <!-- Define star path -->
   <defs>
     <path d="M50,0 21,90 98,35 2,35 79,90z" id="star" />

--- a/files/en-us/web/svg/reference/attribute/end/index.md
+++ b/files/en-us/web/svg/reference/attribute/end/index.md
@@ -110,8 +110,7 @@ The `<end-value-list>` is a semicolon-separated list of values. Each value can b
   width="120"
   height="120"
   viewBox="0 0 120 120"
-  xmlns="http://www.w3.org/2000/svg"
-  version="1.1">
+  xmlns="http://www.w3.org/2000/svg">
   <!-- animated rectangles -->
   <rect x="10" y="35" height="15" width="0">
     <animate
@@ -170,7 +169,6 @@ The `<end-value-list>` is a semicolon-separated list of values. Each value can b
   height="120"
   viewBox="0 0 120 120"
   xmlns="http://www.w3.org/2000/svg"
-  version="1.1"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <!-- animated rectangle -->
   <rect x="10" y="35" height="15" width="0">
@@ -230,7 +228,6 @@ The `<end-value-list>` is a semicolon-separated list of values. Each value can b
   height="120"
   viewBox="0 0 120 120"
   xmlns="http://www.w3.org/2000/svg"
-  version="1.1"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <!-- animated rectangles -->
   <rect x="10" y="35" height="15" width="0">

--- a/files/en-us/web/svg/reference/attribute/slope/index.md
+++ b/files/en-us/web/svg/reference/attribute/slope/index.md
@@ -58,8 +58,7 @@ In this example, a gradient box has two text elements with linear filters applie
   width="8cm"
   height="4cm"
   viewBox="0 0 800 400"
-  xmlns="http://www.w3.org/2000/svg"
-  version="1.1">
+  xmlns="http://www.w3.org/2000/svg">
   <title>Examples of feComponentTransfer operations</title>
   <desc>
     Text strings showing the effects of the slope attribute of the

--- a/files/en-us/web/svg/reference/attribute/tabindex/index.md
+++ b/files/en-us/web/svg/reference/attribute/tabindex/index.md
@@ -21,7 +21,6 @@ svg {
 ```
 
 ```html
-<?xml version="1.0"?>
 <svg viewBox="0 0 260 260" xmlns="http://www.w3.org/2000/svg">
   <circle r="10" tabindex="0" fill="green" cx="60" cy="60" />
   <circle r="40" tabindex="0" fill="red" cx="60" cy="160" />

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/basic_shapes/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/basic_shapes/index.md
@@ -16,8 +16,7 @@ To insert a shape, you create an element in the document. Different elements cor
 The code to generate that image looks something like this:
 
 ```xml
-<?xml version="1.0" standalone="no"?>
-<svg width="200" height="250" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="200" height="250" xmlns="http://www.w3.org/2000/svg">
 
   <rect x="10" y="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>
   <rect x="60" y="10" rx="10" ry="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/basic_transformations/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/basic_transformations/index.md
@@ -125,7 +125,7 @@ The resulting rectangular in the above example will be 100x100px. The more intri
 In contrast to HTML, SVG allows you to embed other `svg` elements seamlessly. This way you can also create new coordinate systems by utilizing the `viewBox`, `width` and `height` of the inner `svg` element.
 
 ```html
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="100" height="100">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
   <svg width="100" height="100" viewBox="0 0 50 50">
     <rect width="50" height="50" />
   </svg>

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
@@ -18,7 +18,7 @@ Erasing part of what you have created might seem contradictory at first. But whe
 We create the above-mentioned semicircle based on a `circle` element:
 
 ```html
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="cut-off-bottom">
       <rect x="0" y="0" width="200" height="100" />
@@ -42,7 +42,7 @@ We now have a semicircle without having to deal with arcs in path elements. For 
 The effect of masking is most impressively presented with a gradient. If you want an element to fade out, you can achieve this effect quite quickly with masks.
 
 ```html
-<svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="Gradient">
       <stop offset="0" stop-color="black" />
@@ -73,7 +73,7 @@ The `opacity` attribute lets you set the transparency for a whole element:
 The above rectangle will be painted half-transparent. For the fill and stroke, there are two separate attributes, `fill-opacity` and `stroke-opacity`, that control each of those property opacities separately. Note, that the stroke will be painted on top of the filling. Hence, if you set a stroke opacity on an element, which also has a fill, the fill will shine through on half of the stroke while on the other half, the background will appear:
 
 ```html
-<svg width="200" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0" width="200" height="200" fill="blue" />
   <circle
     cx="100"

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/fills_and_strokes/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/fills_and_strokes/index.md
@@ -16,8 +16,7 @@ There are several ways to color shapes (including specifying attributes on the o
 Basic coloring can be done by setting two attributes on the node: `fill` and `stroke`. Using `fill` sets the color inside the object and `stroke` sets the color of the line drawn around the object. You can use the same CSS color naming schemes that you use in HTML, whether that's color names (like `red`), rgb values (like `rgb(255 0 0)`), hex values, etc.
 
 ```html
-<?xml version="1.0" standalone="no"?>
-<svg width="160" height="140" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="160" height="140" xmlns="http://www.w3.org/2000/svg">
   <rect
     x="10"
     y="10"
@@ -42,8 +41,7 @@ In addition to its color properties, there are a few other attributes available 
 ![The stroke-linecap attribute changes the look of these stroke's ends: square adds a square cap, round provides a rounded cap, and butt removes capping](svg_stroke_linecap_example.png)
 
 ```xml
-<?xml version="1.0" standalone="no"?>
-<svg width="160" height="140" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="160" height="140" xmlns="http://www.w3.org/2000/svg">
   <line x1="40" x2="120" y1="20" y2="20" stroke="black" stroke-width="20" stroke-linecap="butt"/>
   <line x1="40" x2="120" y1="60" y2="60" stroke="black" stroke-width="20" stroke-linecap="square"/>
   <line x1="40" x2="120" y1="100" y2="100" stroke="black" stroke-width="20" stroke-linecap="round"/>
@@ -65,8 +63,7 @@ Use `stroke-linejoin` to control how the joint between two line segments is draw
 ![The stroke-linejoin attribute changes the look at the point where two lines join, with miter created an angled join, round rounding the corner, and bevel creating a beveled edge, flattening the corner.](svg_stroke_linejoin_example.png)
 
 ```xml
-<?xml version="1.0" standalone="no"?>
-<svg width="160" height="280" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="160" height="280" xmlns="http://www.w3.org/2000/svg">
   <polyline points="40 60 80 20 120 60" stroke="black" stroke-width="20"
       stroke-linecap="butt" fill="none" stroke-linejoin="miter"/>
 
@@ -85,8 +82,7 @@ Finally, you can also use dashed line types on a stroke by specifying the `strok
 ![Two custom dashed lines, one with evenly spaced dashes and the other using a long-dash short dash using a stroke-dasharray attribute value.](svg_stroke_dasharray_example.png)
 
 ```xml
-<?xml version="1.0" standalone="no"?>
-<svg width="200" height="150" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="200" height="150" xmlns="http://www.w3.org/2000/svg">
   <path d="M 10 75 Q 50 10 100 75 T 190 75" stroke="black"
     stroke-linecap="round" stroke-dasharray="5,10,5" fill="none"/>
   <path d="M 10 75 L 190 75" stroke="red"
@@ -105,8 +101,7 @@ There are additional `stroke` and `fill` properties available, including `fill-r
 The order in which fill and stroke are painted can be controlled using the [`paint-order`](/en-US/docs/Web/SVG/Reference/Attribute/paint-order) attribute.
 
 ```html
-<?xml version="1.0" standalone="no"?>
-<svg width="400" height="180" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="400" height="180" xmlns="http://www.w3.org/2000/svg">
   <polyline
     points="40 80 80 40 120 80"
     stroke-width="15"
@@ -146,8 +141,7 @@ Or it can be moved to a special style section that you include. Instead of shovi
 {{SVGElement("defs")}} stands for definitions, and it is here that you can create elements that don't appear in the SVG directly, but are used by other elements.
 
 ```xml
-<?xml version="1.0" standalone="no"?>
-<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <style><![CDATA[
        #MyRect {
@@ -173,10 +167,9 @@ Moving styles to an area like this can make it easier to adjust properties on la
 You can also specify an external stylesheet for your CSS rules through [normal XML-stylesheet syntax](https://www.w3.org/TR/xml-stylesheet/):
 
 ```xml
-<?xml version="1.0" standalone="no"?>
 <?xml-stylesheet type="text/css" href="style.css"?>
 
-<svg width="200" height="150" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg width="200" height="150" xmlns="http://www.w3.org/2000/svg">
   <rect height="10" width="10" id="MyRect"/>
 </svg>
 ```

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/filter_effects/index.md
@@ -16,11 +16,7 @@ A basic example is to add a blur effect to SVG content. While basic blurs can be
 Filters are defined by the {{SVGElement('filter')}} element, which should be put in the `<defs>` section of your SVG file. Between the filter tags goes a list of _primitives_: basic operations that build on top of the previous operations (like blurring, adding a lighting effect, etc.). To apply your created filter on a graphic element, you set the {{SVGAttr('filter')}} attribute.
 
 ```html
-<svg
-  width="250"
-  viewBox="0 0 200 85"
-  xmlns="http://www.w3.org/2000/svg"
-  version="1.1">
+<svg width="250" viewBox="0 0 200 85" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <!-- Filter declaration -->
     <filter

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/getting_started/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/getting_started/index.md
@@ -12,8 +12,7 @@ sidebar: svgref
 Let us dive straight in with an example. Take a look at the following code.
 
 ```xml
-<svg version="1.1"
-     width="300" height="200"
+<svg width="300" height="200"
      xmlns="http://www.w3.org/2000/svg">
 
   <rect width="100%" height="100%" fill="red" />

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
@@ -18,7 +18,7 @@ Linear gradients change along a straight line. To insert one, you create a {{SVG
 ### Basic example
 
 ```html
-<svg width="120" height="240" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="120" height="240" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="Gradient1">
       <stop class="stop1" offset="0%" />
@@ -108,8 +108,7 @@ Radial gradients are similar to linear ones but draw a gradient that radiates ou
 ### Basic example
 
 ```html
-<?xml version="1.0" standalone="no"?>
-<svg width="120" height="240" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="120" height="240" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <radialGradient id="RadialGradient1">
       <stop offset="0%" stop-color="red" />
@@ -149,9 +148,7 @@ The second point is called the focal point and is defined by the `fx` and `fy` a
 ### Center and focal point
 
 ```html
-<?xml version="1.0" standalone="no"?>
-
-<svg width="120" height="120" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="120" height="120" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <radialGradient id="Gradient" cx="0.5" cy="0.5" r="0.5" fx="0.25" fy="0.25">
       <stop offset="0%" stop-color="red" />
@@ -197,9 +194,7 @@ Both linear and radial gradients also take a few other attributes to describe tr
 ### spreadMethod
 
 ```html
-<?xml version="1.0" standalone="no"?>
-
-<svg width="220" height="220" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="220" height="220" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <radialGradient
       id="GradientPad"

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/image_element/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/image_element/index.md
@@ -12,10 +12,7 @@ The SVG {{ SVGElement("image") }} element allows for raster images to be rendere
 In this basic example, a .jpg image referenced by an {{ SVGAttr("href") }} attribute will be rendered inside an SVG object:
 
 ```xml
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="5cm" height="4cm" version="1.1"
+<svg width="5cm" height="4cm"
      xmlns="http://www.w3.org/2000/svg">
   <image href="firefox.jpg" x="0" y="0" height="50px" width="50px"/>
 </svg>

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/other_content_in_svg/index.md
@@ -16,7 +16,7 @@ Much like the img element in HTML SVG has an `image` element to serve the same p
 The embedded picture becomes a normal SVG element. This means, that you can use clips, masks, filters, rotations and all other tools of SVG on the content:
 
 ```html
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
   <image
     x="90"
     y="-65"


### PR DESCRIPTION
### Description

Removed `version="1.1"`, `<?xml … standalone?>`, etc. Kept only ones that make sense in context.

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852