### PR TITLE
Ff154 CSS Typed OM API follow up (3)

### DIFF
--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -18,7 +18,7 @@ None.
 
 ## Instance methods
 
-_Inherits methods from {{domxref("CSSStyleValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSStyleValue")}}._
 
 ## Description
 

--- a/files/en-us/web/api/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/index.md
@@ -25,7 +25,7 @@ The interface instance name is a {{Glossary("stringifier")}}, so when used anywh
 
 ## Instance methods
 
-_Inherits methods from {{domxref('CSSStyleValue')}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSStyleValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.md
+++ b/files/en-us/web/api/csskeywordvalue/value/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSKeywordValue.value
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`value`** property of the {{domxref("CSSKeywordValue")}} interface represents the value of the `CSSKeywordValue`.
+The **`value`** property of the {{domxref("CSSKeywordValue")}} interface represents the keyword as a string.
 
 ## Value
 

--- a/files/en-us/web/api/cssmathclamp/cssmathclamp/index.md
+++ b/files/en-us/web/api/cssmathclamp/cssmathclamp/index.md
@@ -19,20 +19,47 @@ new CSSMathClamp(lower, value, upper)
 ### Parameters
 
 - `lower`
-  - : A {{domxref("CSSNumericValue")}} object – either a number or {{domxref("CSSUnitValue")}} – representing the minimum value.
+  - : A number or {{domxref("CSSNumericValue")}} that represents the minimum value.
 - `value`
-  - : A {{domxref("CSSNumericValue")}} object – either a number or {{domxref("CSSUnitValue")}} – representing the preferred value.
+  - : A number or {{domxref("CSSNumericValue")}} that represents the preferred value.
 - `upper`
-  - : A {{domxref("CSSNumericValue")}} object – either a number or {{domxref("CSSUnitValue")}} – representing the maximum value.
+  - : A number or {{domxref("CSSNumericValue")}} that represents the maximum value.
 
 ### Exceptions
 
 - [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
-  - : Thrown if there is a _failure_ when adding the three arguments.
+  - : Thrown if the parameters have conflicting unit types.
+    For example, specifying parameters that specify length and time bounds.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathClamp` instance from three lengths, then reads back its `lower`, `value`, and `upper` properties.
+
+```js
+const clamp = new CSSMathClamp(CSS.px(10), CSS.percent(50), CSS.px(500));
+
+console.log(clamp.constructor.name); // "CSSMathClamp"
+console.log(clamp.lower); // CSSUnitValue {value: 10, unit: "px"}
+console.log(clamp.value); // CSSUnitValue {value: 50, unit: "percent"}
+console.log(clamp.upper); // CSSUnitValue {value: 500, unit: "px"}
+```
+
+### Handling incompatible types
+
+The constructor throws a `TypeError` if the three arguments don't resolve to a compatible type
+In the following code we mix a length with a time, and log the error.
+
+```js
+try {
+  // Mixes a length (px) with a time (s): incompatible types
+  new CSSMathClamp(CSS.px(10), CSS.s(2), CSS.px(500));
+} catch (e) {
+  console.log(e instanceof TypeError); // true
+  console.log(e.message);
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathclamp/index.md
+++ b/files/en-us/web/api/cssmathclamp/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSMathClamp
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathClamp`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the CSS {{CSSXref("clamp","clamp()")}} function. It inherits properties and methods from its parent {{domxref("CSSNumericValue")}}.
+The **`CSSMathClamp`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the CSS {{CSSXref("clamp","clamp()")}} function.
 
 {{InheritanceDiagram}}
 
@@ -18,24 +18,166 @@ The **`CSSMathClamp`** interface of the [CSS Typed Object Model API](/en-US/docs
 
 ## Instance properties
 
-- {{domxref("CSSMathClamp.lower")}}
+_Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
+
+- {{domxref("CSSMathClamp.lower")}} {{readonlyinline}}
   - : Returns a {{domxref("CSSNumericValue")}} object containing the minimum value.
-- {{domxref("CSSMathClamp.value")}}
+- {{domxref("CSSMathClamp.value")}} {{readonlyinline}}
   - : Returns a {{domxref("CSSNumericValue")}} object containing the preferred value.
-- {{domxref("CSSMathClamp.upper")}}
+- {{domxref("CSSMathClamp.upper")}} {{readonlyinline}}
   - : Returns a {{domxref("CSSNumericValue")}} object containing the upper value.
 
 ## Static methods
 
-_The interface also inherits methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Instance methods
 
-_The interface also inherits methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Examples
 
-To do
+### Inspecting a clamped value
+
+This example uses three range sliders to set the `lower`, `preferred`, and `upper` values of a `CSSMathClamp`, then applies it to the width of a box using {{domxref("StylePropertyMap.set", "attributeStyleMap.set()")}}.
+This allows you to see the effect of changing the range on the clamped value of the `width`.
+
+Dragging a slider changes what `lower`, `value`, and `upper` report, because they always mirror the three operands passed to the `CSSMathClamp` — note that `value` is reported in `vw`, not the pixels shown on its slider. The output next to the preferred slider shows both its pixel value and the `vw` equivalent actually passed to the constructor, so the conversion stays visible. The box's actual rendered width, by contrast, is the result of clamping that `vw` value between the two pixel bounds, and can differ substantially from `value` itself — for example, when the preferred slider is dragged below the lower slider or above the upper slider.
+
+#### HTML
+
+First we define a {{htmlelement("div")}} element for the resizable box, three sliders to set the minimum, preferred, and upper values of its width, and {{htmlelement("output")}} elements to display the slider values numerically.
+All three sliders share the same 0 to 400 pixel range, so their positions are directly comparable.
+We set the initial values so that `lower < pref < upper`.
+
+```html
+<div id="box"></div>
+<div class="controls">
+  <label for="lower">Lower (px)</label>
+  <input id="lower" type="range" min="0" max="400" value="50" />
+  <output for="lower" id="lowerOut"></output>
+
+  <label for="pref">Preferred (px)</label>
+  <input id="pref" type="range" min="0" max="400" value="180" />
+  <output for="pref" id="prefOut"></output>
+
+  <label for="upper">Upper (px)</label>
+  <input id="upper" type="range" min="0" max="400" value="350" />
+  <output for="upper" id="upperOut"></output>
+</div>
+<pre id="log"></pre>
+```
+
+At the end we define a `#log` element to output information returned about the box width.
+
+#### CSS
+
+The CSS sets the visual properties and alignment of the box, sliders, and other elements.
+
+```css
+#box {
+  height: 50px;
+  background: rebeccapurple;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  max-width: 400px;
+}
+
+.controls output {
+  font-family: monospace;
+  text-align: right;
+}
+```
+
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+First we create variables to reference the box, the sliders, and the output elements.
+
+```js
+const box = document.querySelector("#box");
+const lowerInput = document.querySelector("#lower");
+const prefInput = document.querySelector("#pref");
+const upperInput = document.querySelector("#upper");
+const lowerOut = document.querySelector("#lowerOut");
+const prefOut = document.querySelector("#prefOut");
+const upperOut = document.querySelector("#upperOut");
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+Then we call the `update()` function to update the box and output elements based on the slider value.
+We set up a listener so that the function is called whenever the slider positions are changed.
+
+```js
+[lowerInput, prefInput, upperInput].forEach((el) =>
+  el.addEventListener("input", update),
+);
+update();
+```
+
+The `update()` function is shown below.
+This logs the values of the sliders and uses them when creating a `CSSMathClamp` that is then set on the `width` attribute of the box.
+The attribute styles of the box are then read using {{domxref("HTMLElement.attributeStyleMap")}} and the retrieved values of `width` are also logged, along with the rendered width of the box.
+
+One complexity in the code is that while `lower` and `upper` are passed to the `CSSMathClamp()` constructor as pixels, exactly matching their sliders, the pixel value of `preferred` is first converted to `vw` (viewport width) units.
+This has been done because if all three operands were absolute lengths (for example, all in pixels), the browser could resolve `clamp()` down to a single fixed number, which would be read back as a {{domxref("CSSUnitValue")}} instead of a `CSSMathClamp`.
+Converting `preferred` to a relative unit like `vw` means the browser can't resolve the expression until layout, so it keeps the value as a live `CSSMathClamp` with all three operands intact.
+
+```js
+function update() {
+  logElement.innerText = "";
+
+  // The preferred slider uses the same 0-400px scale as lower and upper,
+  // so its value is converted to vw before being passed to CSSMathClamp.
+  const prefVw = (prefInput.value / window.innerWidth) * 100;
+  lowerOut.textContent = `${lowerInput.value}px`;
+  prefOut.textContent = `${prefInput.value}px (~${prefVw.toFixed(1)}vw)`;
+  upperOut.textContent = `${upperInput.value}px`;
+
+  try {
+    const clampValue = new CSSMathClamp(
+      CSS.px(lowerInput.value),
+      CSS.vw(prefVw),
+      CSS.px(upperInput.value),
+    );
+    box.attributeStyleMap.set("width", clampValue);
+    const widthClamp = box.attributeStyleMap.get("width");
+    const valuePx = (widthClamp.value.value / 100) * window.innerWidth;
+    log(`type: ${widthClamp.constructor.name}`);
+    log(`lower: ${widthClamp.lower}`);
+    log(`value: ${widthClamp.value} (~${valuePx.toFixed(1)}px)`);
+    log(`upper: ${widthClamp.upper}`);
+    log(`rendered width: ${getComputedStyle(box).width}`);
+  } catch (e) {
+    log(`Error: ${e.message}`);
+  }
+}
+```
+
+#### Result
+
+Drag the sliders to see how `lower`, `value`, and `upper` always match the slider positions, while the rendered width is clamped between `lower` and `upper`.
+
+{{EmbedLiveSample("Inspecting a clamped value", 300, 350)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathclamp/lower/index.md
+++ b/files/en-us/web/api/cssmathclamp/lower/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathClamp.lower
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`lower`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object containing the minimum value of a {{domxref("CSSMathClamp")}} object.
+The **`lower`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object representing its minimum value.
 
 ## Value
 
@@ -16,7 +16,20 @@ A {{domxref("CSSNumericValue")}}.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathClamp` object, then reads its `lower` value.
+
+```js
+const clamp = new CSSMathClamp(CSS.px(10), CSS.percent(50), CSS.px(500));
+
+console.log(clamp.lower); // CSSUnitValue {value: 10, unit: "px"}
+console.log(clamp.lower.value); // 10
+console.log(clamp.lower.unit); // "px"
+```
+
+`lower` simply returns whatever {{domxref("CSSNumericValue")}} was passed into the constructor — here that's a {{domxref("CSSUnitValue")}}, since `CSS.px(10)` is a `CSSUnitValue`.
+Passing a more complex expression, such as `CSS.px(10).add(CSS.em(2))` (a {{domxref("CSSMathSum")}}), means `lower` would return that `CSSMathSum` instead.
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathclamp/upper/index.md
+++ b/files/en-us/web/api/cssmathclamp/upper/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathClamp.upper
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`upper`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object containing the maximum value of a {{domxref("CSSMathClamp")}} object.
+The **`upper`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object representing its maximum value.
 
 ## Value
 
@@ -16,7 +16,20 @@ A {{domxref("CSSNumericValue")}}.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathClamp` object, then reads its `upper` value.
+
+```js
+const clamp = new CSSMathClamp(CSS.px(10), CSS.percent(50), CSS.px(500));
+
+console.log(clamp.upper); // CSSUnitValue {value: 500, unit: "px"}
+console.log(clamp.upper.value); // 500
+console.log(clamp.upper.unit); // "px"
+```
+
+`upper` simply returns whatever {{domxref("CSSNumericValue")}} was passed into the constructor — here that's a {{domxref("CSSUnitValue")}}, since `CSS.px(500)` is a `CSSUnitValue`.
+Passing a more complex expression, such as `CSS.px(500).add(CSS.em(2))` (a {{domxref("CSSMathSum")}}), means `upper` would return that `CSSMathSum` instead.
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathclamp/value/index.md
+++ b/files/en-us/web/api/cssmathclamp/value/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathClamp.value
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`value`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} object containing the preferred value of a {{domxref("CSSMathClamp")}} object.
+The **`value`** read-only property of the {{domxref("CSSMathClamp")}} interface returns a {{domxref("CSSNumericValue")}} instance representing its preferred value.
 
 ## Value
 
@@ -16,7 +16,20 @@ A {{domxref("CSSNumericValue")}}.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathClamp` object, then reads its `value`.
+
+```js
+const clamp = new CSSMathClamp(CSS.px(10), CSS.percent(50), CSS.px(500));
+
+console.log(clamp.value); // CSSUnitValue {value: 50, unit: "percent"}
+console.log(clamp.value.value); // 50
+console.log(clamp.value.unit); // "percent"
+```
+
+`value` simply returns whatever {{domxref("CSSNumericValue")}} was passed into the constructor — here that's a {{domxref("CSSUnitValue")}}, since `CSS.percent(50)` is a `CSSUnitValue`.
+Passing a more complex expression, such as `CSS.percent(50).add(CSS.em(2))` (a {{domxref("CSSMathSum")}}), means `value` would return that `CSSMathSum` instead.
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSMathInvert
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathInvert`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents a CSS {{CSSXref('calc','calc()')}} used as `calc(1 / <value>)`.
-It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -19,16 +18,18 @@ It inherits properties and methods from its parent {{domxref('CSSNumericValue')}
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
+
 - {{domxref('CSSMathInvert.value')}} {{ReadOnlyInline}}
   - : Returns a {{domxref('CSSNumericValue')}} object.
 
 ## Static methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Instance methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathinvert/value/index.md
+++ b/files/en-us/web/api/cssmathinvert/value/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathInvert.value
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The CSSMathInvert.value read-only property of the {{domxref("CSSMathInvert")}} interface returns a {{domxref('CSSNumericValue')}} object.
+The **`value`** read-only property of the {{domxref("CSSMathInvert")}} interface returns the {{domxref("CSSNumericValue")}} that is being inverted.
 
 ## Value
 

--- a/files/en-us/web/api/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSMathMax
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathMax`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the CSS {{CSSXref('max','max()')}} function.
-It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -19,16 +18,18 @@ It inherits properties and methods from its parent {{domxref('CSSNumericValue')}
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
+
 - {{domxref('CSSMathMax.values')}} {{ReadOnlyInline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
 ## Static methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Instance methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathmax/values/index.md
+++ b/files/en-us/web/api/cssmathmax/values/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathMax.values
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The CSSMathMax.values read-only property of the {{domxref("CSSMathMax")}} interface returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
+The **`values`** read-only property of the {{domxref("CSSMathMax")}} interface returns a {{domxref("CSSNumericArray")}} containing the {{domxref("CSSNumericValue")}} objects being compared to find the maximum.
 
 ## Value
 

--- a/files/en-us/web/api/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSMathMin
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMathMin`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the CSS {{CSSXref('min','min()')}} function.
-It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -19,16 +18,18 @@ It inherits properties and methods from its parent {{domxref('CSSNumericValue')}
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
+
 - {{domxref('CSSMathMin.values')}} {{ReadOnlyInline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
 ## Static methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Instance methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathmin/values/index.md
+++ b/files/en-us/web/api/cssmathmin/values/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathMin.values
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The CSSMathMin.values read-only property of the {{domxref("CSSMathMin")}} interface returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
+The **`values`** read-only property of the {{domxref("CSSMathMin")}} interface returns a {{domxref("CSSNumericArray")}} containing the {{domxref("CSSNumericValue")}} objects being compared to find the minimum.
 
 ## Value
 

--- a/files/en-us/web/api/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSMathNegate
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathNegate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) negates the value passed into it. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
+The **`CSSMathNegate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) negates the value passed into it.
 
 {{InheritanceDiagram}}
 
@@ -18,16 +18,18 @@ The **`CSSMathNegate`** interface of the [CSS Typed Object Model API](/en-US/doc
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
+
 - {{domxref('CSSMathNegate.value')}} {{ReadOnlyInline}}
   - : Returns a {{domxref('CSSNumericValue')}} object.
 
 ## Static methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Instance methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathnegate/value/index.md
+++ b/files/en-us/web/api/cssmathnegate/value/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathNegate.value
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathNegate.value`** read-only property of the {{domxref("CSSMathNegate")}} interface returns a {{domxref('CSSNumericValue')}} object.
+The **`value`** read-only property of the {{domxref("CSSMathNegate")}} interface returns the {{domxref("CSSNumericValue")}} that is being negated.
 
 ## Value
 

--- a/files/en-us/web/api/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSMathProduct
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}. It inherits properties and methods from its parent {{domxref('CSSNumericValue')}}.
+The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -18,16 +18,18 @@ The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/do
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
+
 - {{domxref('CSSMathProduct.values')}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
 ## Static methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Instance methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSMathProduct
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
+The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.mul','mul()')}} or {{domxref('CSSNumericValue.div','div()')}} on a {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssmathproduct/values/index.md
+++ b/files/en-us/web/api/cssmathproduct/values/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathProduct.values
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathProduct.values`** read-only property of the {{domxref("CSSMathProduct")}} interface returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
+The **`values`** read-only property of the {{domxref("CSSMathProduct")}} interface returns a {{domxref("CSSNumericArray")}} containing the {{domxref("CSSNumericValue")}} objects being multiplied together.
 
 ## Value
 

--- a/files/en-us/web/api/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/index.md
@@ -20,16 +20,18 @@ A CSSMathSum is the object type returned when the [`StylePropertyMapReadOnly.get
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
+
 - {{domxref('CSSMathSum.values')}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
 ## Static methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Instance methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSMathValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathsum/values/index.md
+++ b/files/en-us/web/api/cssmathsum/values/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathSum.values
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathSum.values`** read-only property of the {{domxref("CSSMathSum")}} interface returns a {{domxref('CSSNumericArray')}} object that contains one or more {{domxref('CSSNumericValue')}} objects.
+The **`values`** read-only property of the {{domxref("CSSMathSum")}} interface returns a {{domxref("CSSNumericArray")}} containing the {{domxref("CSSNumericValue")}} objects being summed together.
 
 ## Value
 

--- a/files/en-us/web/api/cssmathvalue/index.md
+++ b/files/en-us/web/api/cssmathvalue/index.md
@@ -11,9 +11,20 @@ The **`CSSMathValue`** interface of the [CSS Typed Object Model API](/en-US/docs
 
 {{InheritanceDiagram}}
 
-## Interfaces based on CSSMathValue
+## Instance properties
 
-Below is a list of interfaces based on the CSSMathValue interface.
+- {{domxref('CSSMathValue.operator')}}
+  - : Indicates the operator that the current subtype represents.
+
+## Static methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSNumericValue")}}._
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSNumericValue")}}._
+
+## Interfaces based on CSSMathValue
 
 - {{DOMxRef('CSSMathClamp')}}
 - {{domxref('CSSMathInvert')}}
@@ -22,19 +33,6 @@ Below is a list of interfaces based on the CSSMathValue interface.
 - {{domxref('CSSMathNegate')}}
 - {{domxref('CSSMathProduct')}}
 - {{domxref('CSSMathSum')}}
-
-## Instance properties
-
-- {{domxref('CSSMathValue.operator')}}
-  - : Indicates the operator that the current subtype represents.
-
-## Static methods
-
-_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
-
-## Instance methods
-
-_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmathvalue/operator/index.md
+++ b/files/en-us/web/api/cssmathvalue/operator/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathValue.operator
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathValue.operator`** read-only property of the {{domxref("CSSMathValue")}} interface indicates the operator that the current subtype represents.
+The **`operator`** read-only property of the {{domxref("CSSMathValue")}} interface indicates the operator that the current subtype represents.
 For example, if the current `CSSMathValue` subtype is `CSSMathSum`, this property will return the string `"sum"`.
 
 ## Value

--- a/files/en-us/web/api/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSMatrixComponent
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSMatrixComponent`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/matrix", "matrix()")}} and {{cssxref("transform-function/matrix3d", "matrix3d()")}} values of the individual {{CSSXRef('transform')}} property in CSS.
-It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -19,8 +18,14 @@ It inherits properties and methods from its parent {{domxref('CSSTransformValue'
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+
 - {{domxref('CSSMatrixComponent.matrix','matrix')}}
   - : A {{domxref("DOMMatrix")}} object.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
@@ -8,13 +8,13 @@ browser-compat: api.CSSMatrixComponent.matrix
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`matrix`** property of the {{domxref("CSSMatrixComponent")}} interface gets and sets a 2D or 3D matrix.
+The **`matrix`** property of the {{domxref("CSSMatrixComponent")}} interface represents a {{domxref("DOMMatrix")}} object containing a 2D or 3D matrix.
 
 See the {{cssxref("transform-function/matrix", "matrix()")}} and {{cssxref("transform-function/matrix3d", "matrix3d()")}} pages for examples.
 
 ## Value
 
-a matrix.
+A {{domxref("DOMMatrix")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericarray/length/index.md
+++ b/files/en-us/web/api/cssnumericarray/length/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSNumericArray.length
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The read-only **`length`** property of the {{domxref("CSSNumericArray")}} interface returns the number of {{domxref("CSSNumericValue")}} objects in the list.
+The **`length`** read-only property of the {{domxref("CSSNumericArray")}} interface returns the number of {{domxref("CSSNumericValue")}} objects in the list.
 
 ## Value
 

--- a/files/en-us/web/api/cssnumericvalue/index.md
+++ b/files/en-us/web/api/cssnumericvalue/index.md
@@ -11,21 +11,6 @@ The **`CSSNumericValue`** interface of the [CSS Typed Object Model API](/en-US/d
 
 {{InheritanceDiagram}}
 
-## Interfaces based on CSSNumericValue
-
-Below is a list of interfaces based on the CSSNumericValue interface.
-
-- {{domxref('CSSMathClamp')}}
-- {{domxref('CSSMathInvert')}}
-- {{domxref('CSSMathMax')}}
-- {{domxref('CSSMathMin')}}
-- {{domxref('CSSMathNegate')}}
-- {{domxref('CSSMathProduct')}}
-- {{domxref('CSSMathSum')}}
-- {{domxref('CSSMathValue')}}
-- {{domxref('CSSNumericArray')}}
-- {{domxref('CSSUnitValue')}}
-
 ## Instance properties
 
 None.
@@ -57,6 +42,19 @@ None.
   - : Converts an existing `CSSNumericValue` into a {{domxref("CSSMathSum")}} object with values of a specified unit.
 - {{domxref('CSSNumericValue.type')}}
   - : Returns the type of `CSSNumericValue`, one of `angle`, `flex`, `frequency`, `length`, `resolution`, `percent`, `percentHint`, or `time`.
+
+## Interfaces based on CSSNumericValue
+
+- {{domxref('CSSMathClamp')}}
+- {{domxref('CSSMathInvert')}}
+- {{domxref('CSSMathMax')}}
+- {{domxref('CSSMathMin')}}
+- {{domxref('CSSMathNegate')}}
+- {{domxref('CSSMathProduct')}}
+- {{domxref('CSSMathSum')}}
+- {{domxref('CSSMathValue')}}
+- {{domxref('CSSNumericArray')}}
+- {{domxref('CSSUnitValue')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSPerspective
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSPerspective`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/perspective", "perspective()")}} value of the individual {{CSSXRef('transform')}} property in CSS. It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.
+The **`CSSPerspective`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/perspective", "perspective()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
 
 {{InheritanceDiagram}}
 
@@ -18,8 +18,14 @@ The **`CSSPerspective`** interface of the [CSS Typed Object Model API](/en-US/do
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+
 - {{domxref('CSSPerspective.length','length')}}
   - : Returns or sets the distance from z=0.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssperspective/length/index.md
+++ b/files/en-us/web/api/cssperspective/length/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSPerspective.length
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`length`** property of the {{domxref("CSSPerspective")}} interface sets the distance from z=0.
+The **`length`** property of the {{domxref("CSSPerspective")}} interface represents the distance from z=0.
 
 It is used to apply a perspective transform to the element and its content.
 If the value is 0 or a negative number, no perspective transform is applied.

--- a/files/en-us/web/api/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSRotate
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSRotate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the rotate value of the individual {{CSSXRef('transform')}} property in CSS.
-It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -19,6 +18,8 @@ It inherits properties and methods from its parent {{domxref('CSSTransformValue'
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+
 - {{domxref('CSSRotate.x','x')}}
   - : Returns or sets the x-axis value.
 - {{domxref('CSSRotate.y','y')}}
@@ -27,6 +28,10 @@ It inherits properties and methods from its parent {{domxref('CSSTransformValue'
   - : Returns or sets the z-axis value.
 - {{domxref('CSSRotate.angle','angle')}}
   - : Returns or sets the angle value.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSRotate.z
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`z`** property of the {{domxref("CSSRotate")}} interface representing the z-component of the translating vector.
+The **`z`** property of the {{domxref("CSSRotate")}} interface represents the z-component of the translating vector.
 A positive value moves the element towards the viewer and a negative value farther away.
 
 ## Value

--- a/files/en-us/web/api/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSScale
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSScale`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/scale", "scale()")}} and {{cssxref("transform-function/scale3d", "scale3d()")}} values of the individual {{CSSXRef('transform')}} property in CSS.
-It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -19,12 +18,18 @@ It inherits properties and methods from its parent {{domxref('CSSTransformValue'
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+
 - {{domxref('CSSScale.x','x')}}
   - : Returns or sets the x-axis value.
 - {{domxref('CSSScale.y','y')}}
   - : Returns or sets the y-axis value.
 - {{domxref('CSSScale.z','z')}}
   - : Returns or sets the z-axis value.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssscale/z/index.md
+++ b/files/en-us/web/api/cssscale/z/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSScale.z
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`z`** property of the {{domxref("CSSScale")}} interface representing the z-component of the translating vector.
+The **`z`** property of the {{domxref("CSSScale")}} interface represents the z-component of the translating vector.
 A positive value moves the element towards the viewer, and a negative value farther away.
 
 If this value is present, then the transform is a 3D transform and the `is2D` property will be set to false.

--- a/files/en-us/web/api/cssskew/index.md
+++ b/files/en-us/web/api/cssskew/index.md
@@ -7,8 +7,7 @@ browser-compat: api.CSSSkew
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSSkew`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is part of the {{domxref('CSSTransformValue')}} interface.
-It represents the {{cssxref("transform-function/skew", "skew()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
+The **`CSSSkew`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/skew", "skew()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
 
 {{InheritanceDiagram}}
 
@@ -19,10 +18,16 @@ It represents the {{cssxref("transform-function/skew", "skew()")}} value of the 
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+
 - {{domxref('CSSSkew.ax','ax')}}
   - : Returns or sets the x-axis value.
 - {{domxref('CSSSkew.ay','ay')}}
   - : Returns or sets the y-axis value.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssskewx/index.md
+++ b/files/en-us/web/api/cssskewx/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSSkewX
 {{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}
 
 The **`CSSSkewX`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/skewX", "skewX()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
-It inherits properties and methods from its parent {{domxref("CSSTransformValue")}}.
 
 {{InheritanceDiagram}}
 
@@ -19,8 +18,14 @@ It inherits properties and methods from its parent {{domxref("CSSTransformValue"
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+
 - {{domxref('CSSSkewX.ax','ax')}}
   - : Returns or sets the x-axis value.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssskewy/index.md
+++ b/files/en-us/web/api/cssskewy/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSSkewY
 {{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}
 
 The **`CSSSkewY`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/skewY", "skewY()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
-It inherits properties and methods from its parent {{domxref("CSSTransformValue")}}.
 
 {{InheritanceDiagram}}
 
@@ -19,14 +18,14 @@ It inherits properties and methods from its parent {{domxref("CSSTransformValue"
 
 ## Instance properties
 
-_Inherits properties from its ancestor_ {{domxref("CSSTransformValue")}}.
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 - {{domxref('CSSSkewY.ay','ay')}}
   - : Returns or sets the y-axis value.
 
 ## Instance methods
 
-_Inherits methods from its ancestor_ {{domxref("CSSTransformValue")}}.
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssstylevalue/index.md
+++ b/files/en-us/web/api/cssstylevalue/index.md
@@ -10,17 +10,6 @@ browser-compat: api.CSSStyleValue
 The **`CSSStyleValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) is the base class of all CSS values accessible through the Typed OM API.
 An instance of this class may be used anywhere a string is expected.
 
-## Interfaces based on CSSStyleValue
-
-Below is a list of interfaces based on the `CSSStyleValue` interface.
-
-- {{domxref('CSSImageValue')}}
-- {{domxref('CSSKeywordValue')}}
-- {{domxref('CSSNumericValue')}}
-- {{domxref('CSSPositionValue')}}
-- {{domxref('CSSTransformValue')}}
-- {{domxref('CSSUnparsedValue')}}
-
 ## Static methods
 
 - [`CSSStyleValue.parse()`](/en-US/docs/Web/API/CSSStyleValue/parse_static)
@@ -32,6 +21,15 @@ Below is a list of interfaces based on the `CSSStyleValue` interface.
 
 - {{domxref("CSSStyleValue.toString()")}}
   - : A {{Glossary("stringifier")}} that returns the value formatted as a string of standard CSS text.
+
+## Interfaces based on CSSStyleValue
+
+- {{domxref('CSSImageValue')}}
+- {{domxref('CSSKeywordValue')}}
+- {{domxref('CSSNumericValue')}}
+- {{domxref('CSSPositionValue')}}
+- {{domxref('CSSTransformValue')}}
+- {{domxref('CSSUnparsedValue')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -23,6 +23,17 @@ The **`CSSTransformComponent`** interface of the [CSS Typed Object Model API](/e
 
     This will use the value of `is2D` to return either a 2D or 3D transform. For example if the component represents {{domxref("CSSRotate")}} and `is2D` is false then the string returned will be in the form of the CSS transformation {{cssxref("transform-function/rotate3d", "rotate3d()")}} function. If true the string returned will be in the form of the 2-dimensional {{cssxref("transform-function/rotate", "rotate()")}} function.
 
+## Interfaces based on CSSTransformComponent
+
+- {{domxref('CSSTranslate')}}
+- {{domxref('CSSRotate')}}
+- {{domxref('CSSScale')}}
+- {{domxref('CSSSkew')}}
+- {{domxref('CSSSkewX')}}
+- {{domxref('CSSSkewY')}}
+- {{domxref('CSSPerspective')}}
+- {{domxref('CSSMatrixComponent')}}
+
 ## Examples
 
 To do

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.md
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformComponent.is2D
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`is2D`** read-only property of the {{domxref("CSSTransformComponent")}} interface indicates where the transform is 2D or 3D.
+The **`is2D`** read-only property of the {{domxref("CSSTransformComponent")}} interface indicates whether the transform is 2D or 3D.
 
 ## Value
 

--- a/files/en-us/web/api/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/index.md
@@ -11,19 +11,6 @@ The **`CSSTransformValue`** interface of the [CSS Typed Object Model API](/en-US
 
 {{InheritanceDiagram}}
 
-## Interfaces based on CSSTransformValue
-
-Below is a list of interfaces based on the `CSSTransformValue` interface.
-
-- {{domxref('CSSTranslate')}}
-- {{domxref('CSSRotate')}}
-- {{domxref('CSSScale')}}
-- {{domxref('CSSSkew')}}
-- {{domxref('CSSSkewX')}}
-- {{domxref('CSSSkewY')}}
-- {{domxref('CSSPerspective')}}
-- {{domxref('CSSMatrixComponent')}}
-
 ## Constructor
 
 - {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
@@ -38,7 +25,7 @@ Below is a list of interfaces based on the `CSSTransformValue` interface.
 
 ## Instance methods
 
-_Inherits methods from its ancestor {{domxref('CSSStyleValue')}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSStyleValue")}}._
 
 - {{domxref("CSSTransformValue.toMatrix()")}}
   - : Returns a new {{domxref('DOMMatrix')}} object.
@@ -50,6 +37,17 @@ _Inherits methods from its ancestor {{domxref('CSSStyleValue')}}._
   - : Returns a new _array iterator_ object that contains the keys for each index in the `CSSTransformValue` object.
 - {{domxref('CSSTransformValue.values()')}}
   - : Returns a new _array iterator_ object that contains the values for each index in the `CSSTransformValue` object.
+
+## Interfaces based on CSSTransformValue
+
+- {{domxref('CSSTranslate')}}
+- {{domxref('CSSRotate')}}
+- {{domxref('CSSScale')}}
+- {{domxref('CSSSkew')}}
+- {{domxref('CSSSkewX')}}
+- {{domxref('CSSSkewY')}}
+- {{domxref('CSSPerspective')}}
+- {{domxref('CSSMatrixComponent')}}
 
 ## Examples
 

--- a/files/en-us/web/api/csstransformvalue/is2d/index.md
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformValue.is2D
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The read-only **`is2D`** property of the {{domxref("CSSTransformValue")}} interface returns whether the transform is 2D or 3D.
+The **`is2D`** read-only property of the {{domxref("CSSTransformValue")}} interface returns whether the transform is 2D or 3D.
 
 In the case of the `CSSTransformValue`, this property returns true unless any of the individual functions return false for `Is2D`, in which case, it returns false.
 

--- a/files/en-us/web/api/csstransformvalue/length/index.md
+++ b/files/en-us/web/api/csstransformvalue/length/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformValue.length
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The read-only **`length`** property of the {{domxref("CSSTransformValue")}} interface returns the number of transform components in the list.
+The **`length`** read-only property of the {{domxref("CSSTransformValue")}} interface returns the number of transform components in the list.
 
 ## Value
 

--- a/files/en-us/web/api/csstranslate/index.md
+++ b/files/en-us/web/api/csstranslate/index.md
@@ -8,7 +8,6 @@ browser-compat: api.CSSTranslate
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
 The **`CSSTranslate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the {{cssxref("transform-function/translate", "translate()")}} value of the individual {{CSSXRef('transform')}} property in CSS.
-It inherits properties and methods from its parent {{domxref('CSSTransformValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -19,12 +18,18 @@ It inherits properties and methods from its parent {{domxref('CSSTransformValue'
 
 ## Instance properties
 
+_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+
 - {{domxref('CSSTranslate.x','x')}}
   - : Returns or sets the x-axis value.
 - {{domxref('CSSTranslate.y','y')}}
   - : Returns or sets the y-axis value.
 - {{domxref('CSSTranslate.z','z')}}
   - : Returns or sets the z-axis value.
+
+## Instance methods
+
+_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/csstranslate/z/index.md
+++ b/files/en-us/web/api/csstranslate/z/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTranslate.z
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`z`** property of the {{domxref("CSSTranslate")}} interface representing the z-component of the translating vector.
+The **`z`** property of the {{domxref("CSSTranslate")}} interface represents the z-component of the translating vector.
 A positive value moves the element towards the viewer, and a negative value farther away.
 
 If this value is present then the transform is a 3D transform and the `is2D` property will be set to false.

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
@@ -20,7 +20,7 @@ new CSSUnitValue(value, unit)
 ### Parameters
 
 - `value`
-  - : A double indicating the number of units.
+  - : A number indicating the number of units.
 - `unit`
   - : A string indicating the type of unit.
 

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -28,11 +28,11 @@ For example, the value `42px` (a {{cssxref("&lt;dimension&gt;")}}) would be repr
 
 ## Static methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSNumericValue")}}._
 
 ## Instance methods
 
-_The interface may also inherit methods from its parent interface, {{domxref("CSSNumericValue")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("CSSNumericValue")}}._
 
 ## Examples
 

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -21,7 +21,7 @@ For example, the value `42px` (a {{cssxref("&lt;dimension&gt;")}}) would be repr
 ## Instance properties
 
 - {{domxref('CSSUnitValue.value')}}
-  - : Returns a double indicating the number of units.
+  - : A number representing the number of units.
     For a `CSSNumericValue` representing `42px`, this would be `42`.
 - {{domxref('CSSUnitValue.unit')}}
   - : Returns a string indicating the type of unit. For a `CSSNumericValue` representing `42px`, this would be `"px"`.

--- a/files/en-us/web/api/cssunitvalue/unit/index.md
+++ b/files/en-us/web/api/cssunitvalue/unit/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSUnitValue.unit
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSUnitValue.unit`** read-only property of the {{domxref("CSSUnitValue")}} interface returns a string indicating the [unit type](/en-US/docs/Web/CSS/Guides/Values_and_units#units).
+The **`unit`** read-only property of the {{domxref("CSSUnitValue")}} interface returns a string indicating the [unit type](/en-US/docs/Web/CSS/Guides/Values_and_units#units).
 
 ## Value
 

--- a/files/en-us/web/api/cssunitvalue/value/index.md
+++ b/files/en-us/web/api/cssunitvalue/value/index.md
@@ -8,11 +8,11 @@ browser-compat: api.CSSUnitValue.value
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSUnitValue.value`** property of the {{domxref("CSSUnitValue")}} interface returns a double indicating the number of units.
+The **`value`** property of the {{domxref("CSSUnitValue")}} interface represents the number of units.
 
 ## Value
 
-A double.
+A number.
 
 ## Examples
 

--- a/files/en-us/web/api/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/index.md
@@ -26,6 +26,8 @@ Custom properties are represented by `CSSUnparsedValue` and {{cssxref("var", "va
 
 ## Instance methods
 
+_Also inherits methods from its parent interface, {{DOMxRef("CSSStyleValue")}}._
+
 - {{domxref('CSSUnparsedValue.entries()')}}
   - : Returns an array of a given object's own enumerable property `[key, value]` pairs in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
 - {{domxref('CSSUnparsedValue.forEach()')}}

--- a/files/en-us/web/api/stylepropertymap/index.md
+++ b/files/en-us/web/api/stylepropertymap/index.md
@@ -17,11 +17,11 @@ The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/
 
 ## Instance properties
 
-_Inherits properties from its parent, {{DOMxRef("StylePropertyMapReadOnly")}}._
+_Also inherits properties from its parent interface, {{DOMxRef("StylePropertyMapReadOnly")}}._
 
 ## Instance methods
 
-_Inherits methods from its parent, {{DOMxRef("StylePropertyMapReadOnly")}}._
+_Also inherits methods from its parent interface, {{DOMxRef("StylePropertyMapReadOnly")}}._
 
 - {{DOMxRef("StylePropertyMap.append()")}}
   - : Adds a new CSS declaration to the `StylePropertyMap` with the given property and value.


### PR DESCRIPTION
FF154 adds preview support for the [CSS Typed OM API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API). This is part of a set of PRs to tidy the docs as I go through them.

1. Commit https://github.com/mdn/content/commit/00fd99d865b847c4510580d0bceda494a3a30e84 
   - updates all the inheritence info to match the Web API template (i.e. the sentences about inheritence on properties/methods). 
   - Moves the lists of classes that inherit from an interface towards the end not after the inherited-from macro. The template doesn't suggest we document inherited classes at all. I think it is useful, but it shouldn't be more important than the class definition itself.
2. Commit https://github.com/mdn/content/commit/70caae6941e2440a7649d28ebda8f97787d02289 Fixes up the docs for `CSSMathClamp`. 
   - Some of the properties were incorrecly documented. 
   - Added examples. Note I have chosen a pattern of a life exmaple if possible for the interface page, and "copy me console examples" for the methods/properties.
3. Commit https://github.com/mdn/content/pull/45004/changes/68f08f7b479a610c3dc0ab8f78fed82828450688
   - Property initial sentence template fixes. Nothing controversial.

Related docs can be tracked in #44849