### PR TITLE
Correct information related to HTML table manipulation methods

### DIFF
--- a/files/en-us/web/api/htmltableelement/caption/index.md
+++ b/files/en-us/web/api/htmltableelement/caption/index.md
@@ -14,7 +14,7 @@ The **`caption`** property of the {{domxref("HTMLTableElement")}} interface repr
 
 An {{domxref("HTMLTableCaptionElement")}} or `null`.
 
-This property can be assigned, which causes the existing first {{HTMLElement("caption")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the first child. If the assigned value is not an {{domxref("HTMLTableCaptionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown.
+This property can be assigned, which causes the existing first {{HTMLElement("caption")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the first child. Therefore, setting `null` has the same effect as calling {{domxref("HTMLTableElement.deleteCaption", "deleteCaption()")}}. If the assigned value is not an {{domxref("HTMLTableCaptionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltableelement/caption/index.md
+++ b/files/en-us/web/api/htmltableelement/caption/index.md
@@ -8,13 +8,13 @@ browser-compat: api.HTMLTableElement.caption
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.caption`** property represents the
-table caption. If no caption element is associated with the table, this property is
-`null`.
+The **`caption`** property of the {{domxref("HTMLTableElement")}} interface represents the first {{HTMLElement("caption")}} element child of the given {{HTMLElement("table")}}, or `null` if no such element exists.
 
 ## Value
 
-A string.
+An {{domxref("HTMLTableCaptionElement")}} or `null`.
+
+This property can be assigned, which causes the existing first {{HTMLElement("caption")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the first child. If the assigned value is not an {{domxref("HTMLTableCaptionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown.
 
 ## Examples
 
@@ -34,4 +34,8 @@ if (table.caption) {
 
 ## See also
 
-- The interface implementing this property: {{domxref("HTMLTableElement")}}.
+- {{domxref("HTMLTableElement.tBodies")}}
+- {{domxref("HTMLTableElement.tFoot")}}
+- {{domxref("HTMLTableElement.tHead")}}
+- {{domxref("HTMLTableElement.createCaption()")}}
+- {{domxref("HTMLTableElement.deleteCaption()")}}

--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -8,16 +8,9 @@ browser-compat: api.HTMLTableElement.createCaption
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.createCaption()`** method returns the
-{{HtmlElement("caption")}} element associated with a given {{HtmlElement("table")}}.
-If no `<caption>` element exists on the table, this method creates
-it, and then returns it.
+The **`createCaption()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("caption")}} element, inserts it as the first child of the given {{HTMLElement("table")}}, and returns it. If the table already has a `<caption>` element child, this method returns the first such child without creating one.
 
-> [!NOTE]
-> If no caption exists, `createCaption()` inserts a
-> new caption directly into the table. The caption does not need to be added
-> separately as would be the case if {{domxref("Document.createElement()")}} had
-> been used to create the new `<caption>` element.
+This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
 
 ## Syntax
 
@@ -31,7 +24,7 @@ None.
 
 ### Return value
 
-{{domxref("HTMLTableCaptionElement")}}
+An {{domxref("HTMLTableCaptionElement")}}.
 
 ## Examples
 
@@ -59,8 +52,8 @@ This example uses JavaScript to add a caption to a table that initially lacks on
 ### JavaScript
 
 ```js
-let table = document.querySelector("table");
-let caption = table.createCaption();
+const table = document.querySelector("table");
+const caption = table.createCaption();
 caption.textContent = "This caption was created by JavaScript!";
 ```
 
@@ -75,3 +68,10 @@ caption.textContent = "This caption was created by JavaScript!";
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.createTBody()")}}
+- {{domxref("HTMLTableElement.createTFoot()")}}
+- {{domxref("HTMLTableElement.createTHead()")}}
+- {{domxref("HTMLTableElement.deleteCaption()")}}

--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableElement.createCaption
 
 The **`createCaption()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("caption")}} element, inserts it as the first child of the given {{HTMLElement("table")}}, and returns it. If the table already has a `<caption>` element child, this method returns the first such child without creating one.
 
-This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
+When creation is needed, this method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}} and {{domxref("Node.insertBefore()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -8,16 +8,12 @@ browser-compat: api.HTMLTableElement.createTBody
 
 {{APIRef("HTML DOM")}}
 
-The **`createTBody()`** method of
-{{domxref("HTMLTableElement")}} objects creates and returns a new
-{{HTMLElement("tbody")}} element associated with a given {{HtmlElement("table")}}.
+The **`createTBody()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("tbody")}} element, inserts it immediately after the last {{HTMLElement("tbody")}} element child of the given {{HTMLElement("table")}}, or as the last child if there is no such element, and returns it.
+
+This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
 
 > [!NOTE]
-> Unlike {{domxref("HTMLTableElement.createTHead()")}} and
-> {{domxref("HTMLTableElement.createTFoot()")}}, `createTBody()`
-> systematically creates a new `<tbody>` element, even if the table
-> already contains one or more bodies. If so, the new one is inserted after the existing
-> ones.
+> Unlike {{domxref("HTMLTableElement.createTHead()")}} and {{domxref("HTMLTableElement.createTFoot()")}}, `createTBody()` always creates a new `<tbody>` element, even if the table already contains one or more bodies.
 
 ## Syntax
 
@@ -31,12 +27,12 @@ None.
 
 ### Return value
 
-{{domxref("HTMLTableSectionElement")}}
+An {{domxref("HTMLTableSectionElement")}} (which is always a `tbody`).
 
 ## Examples
 
 ```js
-let myBody = myTable.createTBody();
+const myBody = myTable.createTBody();
 // Now this should be true: myBody === myTable.tBodies.item(myTable.tBodies.length - 1)
 ```
 
@@ -47,3 +43,9 @@ let myBody = myTable.createTBody();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.createCaption()")}}
+- {{domxref("HTMLTableElement.createTFoot()")}}
+- {{domxref("HTMLTableElement.createTHead()")}}

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableElement.createTBody
 
 The **`createTBody()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("tbody")}} element, inserts it immediately after the last {{HTMLElement("tbody")}} element child of the given {{HTMLElement("table")}}, or as the last child if there is no such element, and returns it.
 
-This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
+This method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}}, {{domxref("Node.insertBefore()")}}, and {{domxref("Node.appendChild()")}}.
 
 > [!NOTE]
 > Unlike {{domxref("HTMLTableElement.createTHead()")}} and {{domxref("HTMLTableElement.createTFoot()")}}, `createTBody()` always creates a new `<tbody>` element, even if the table already contains one or more bodies.

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableElement.createTFoot
 
 The **`createTFoot()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("tfoot")}} element, inserts it as the last child of the given {{HTMLElement("table")}}, and returns it. If the table already has a `<tfoot>` element child, this method returns the first such child without creating one.
 
-This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
+When creation is needed, this method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}} and {{domxref("Node.appendChild()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -8,16 +8,9 @@ browser-compat: api.HTMLTableElement.createTFoot
 
 {{APIRef("HTML DOM")}}
 
-The **`createTFoot()`** method of
-{{domxref("HTMLTableElement")}} objects returns the {{HTMLElement("tfoot")}} element
-associated with a given {{HtmlElement("table")}}. If no footer exists in the table, this
-method creates it, and then returns it.
+The **`createTFoot()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("tfoot")}} element, inserts it as the last child of the given {{HTMLElement("table")}}, and returns it. If the table already has a `<tfoot>` element child, this method returns the first such child without creating one.
 
-> [!NOTE]
-> If no footer exists, `createTFoot()` inserts a new
-> footer directly into the table. The footer does not need to be added separately as
-> would be the case if {{domxref("Document.createElement()")}} had been used to create
-> the new `<tfoot>` element.
+This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
 
 ## Syntax
 
@@ -31,12 +24,12 @@ None.
 
 ### Return value
 
-{{domxref("HTMLTableSectionElement")}}
+An {{domxref("HTMLTableSectionElement")}} (which is always a `tfoot`).
 
 ## Examples
 
 ```js
-let myFoot = myTable.createTFoot();
+const myFoot = myTable.createTFoot();
 // Now this should be true: myFoot === myTable.tFoot
 ```
 
@@ -47,3 +40,10 @@ let myFoot = myTable.createTFoot();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.createCaption()")}}
+- {{domxref("HTMLTableElement.createTBody()")}}
+- {{domxref("HTMLTableElement.createTHead()")}}
+- {{domxref("HTMLTableElement.deleteTFoot()")}}

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -8,9 +8,9 @@ browser-compat: api.HTMLTableElement.createTHead
 
 {{APIRef("HTML DOM")}}
 
-The **`createTHead()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("thead")}} element, inserts it before the first element child of the given {{HTMLElement("table")}} that's neither a {{HTMLElement("caption")}} or {{HTMLElement("colgroup")}}, or as the last child if no such insertion location is found, and returns it. If the table already has a `<thead>` element child, this method returns the first such child without creating one.
+The **`createTHead()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("thead")}} element, inserts it before the first element child of the given {{HTMLElement("table")}} that's neither a {{HTMLElement("caption")}} nor a {{HTMLElement("colgroup")}}, or as the last child if no such insertion location is found, and returns it. If the table already has a `<thead>` element child, this method returns the first such child without creating one.
 
-This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
+When creation is needed, this method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}} and {{domxref("Node.insertBefore()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -8,16 +8,9 @@ browser-compat: api.HTMLTableElement.createTHead
 
 {{APIRef("HTML DOM")}}
 
-The **`createTHead()`** method of
-{{domxref("HTMLTableElement")}} objects returns the {{HTMLElement("thead")}} element
-associated with a given {{HtmlElement("table")}}. If no header exists in the table, this
-method creates it, and then returns it.
+The **`createTHead()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("thead")}} element, inserts it before the first element child of the given {{HTMLElement("table")}} that's neither a {{HTMLElement("caption")}} or {{HTMLElement("colgroup")}}, or as the last child if no such insertion location is found, and returns it. If the table already has a `<thead>` element child, this method returns the first such child without creating one.
 
-> [!NOTE]
-> If no header exists, `createTHead()` inserts a new
-> header directly into the table. The header does not need to be added separately as
-> would be the case if {{domxref("Document.createElement()")}} had been used to create
-> the new `<thead>` element.
+This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
 
 ## Syntax
 
@@ -31,12 +24,12 @@ None.
 
 ### Return value
 
-{{domxref("HTMLTableSectionElement")}}
+An {{domxref("HTMLTableSectionElement")}} (which is always a `thead`).
 
 ## Examples
 
 ```js
-let myHead = myTable.createTHead();
+const myHead = myTable.createTHead();
 // Now this should be true: myHead === myTable.tHead
 ```
 
@@ -47,3 +40,10 @@ let myHead = myTable.createTHead();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.createCaption()")}}
+- {{domxref("HTMLTableElement.createTBody()")}}
+- {{domxref("HTMLTableElement.createTFoot()")}}
+- {{domxref("HTMLTableElement.deleteTHead()")}}

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.md
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.md
@@ -8,10 +8,7 @@ browser-compat: api.HTMLTableElement.deleteCaption
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.deleteCaption()`** method removes the
-{{HtmlElement("caption")}} element from a given {{HtmlElement("table")}}. If there is no
-`<caption>` element associated with the table, this method does
-nothing.
+The **`deleteCaption()`** method of the {{domxref("HTMLTableElement")}} interface removes the first {{HTMLElement("caption")}} element child from a given {{HTMLElement("table")}}, if any.
 
 ## Syntax
 
@@ -54,7 +51,7 @@ This example uses JavaScript to delete a table's caption.
 ### JavaScript
 
 ```js
-let table = document.querySelector("table");
+const table = document.querySelector("table");
 table.deleteCaption();
 ```
 
@@ -69,3 +66,9 @@ table.deleteCaption();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.createCaption()")}}
+- {{domxref("HTMLTableElement.deleteTFoot()")}}
+- {{domxref("HTMLTableElement.deleteTHead()")}}

--- a/files/en-us/web/api/htmltableelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableElement.deleteRow
 
 {{APIRef("HTML DOM")}}
 
-The **`deleteRow()`** method of the {{domxref("HTMLTableElement")}} interface removes a specific row ({{HTMLElement("tr")}}) from a given {{HtmlElement("table")}}.
+The **`deleteRow()`** method of the {{domxref("HTMLTableElement")}} interface removes a specific row ({{HTMLElement("tr")}}) from a given {{HTMLElement("table")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmltableelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.md
@@ -8,8 +8,7 @@ browser-compat: api.HTMLTableElement.deleteRow
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.deleteRow()`** method removes a
-specific row ({{HtmlElement("tr")}}) from a given {{HtmlElement("table")}}.
+The **`deleteRow()`** method of the {{domxref("HTMLTableElement")}} interface removes a specific row ({{HTMLElement("tr")}}) from a given {{HtmlElement("table")}}.
 
 ## Syntax
 
@@ -20,9 +19,7 @@ deleteRow(index)
 ### Parameters
 
 - `index`
-  - : `index` is an integer representing the row that should be deleted.
-    However, the special index `-1` can be used to remove the very last row of
-    a table.
+  - : The index of the row to remove in the {{domxref("HTMLTableElement.rows", "rows")}} collection. If `index` is `-1`, the last row is removed.
 
 ### Return value
 
@@ -31,7 +28,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than or equal to the number of available rows or is a negative value other than `-1`.
+  - : Thrown if `index` is greater than or equal to the number of rows or smaller than `-1`.
 
 ## Examples
 
@@ -64,7 +61,7 @@ This example uses JavaScript to delete a table's second row.
 ### JavaScript
 
 ```js
-let table = document.querySelector("table");
+const table = document.querySelector("table");
 
 // Delete second row
 table.deleteRow(1);
@@ -84,4 +81,5 @@ table.deleteRow(1);
 
 ## See also
 
+- {{domxref("HTMLTableRowElement.deleteCell()")}}
 - {{domxref("HTMLTableSectionElement.deleteRow()")}}

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.md
@@ -8,8 +8,7 @@ browser-compat: api.HTMLTableElement.deleteTFoot
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.deleteTFoot()`** method removes the
-{{HTMLElement("tfoot")}} element from a given {{HtmlElement("table")}}.
+The **`deleteTFoot()`** method of the {{domxref("HTMLTableElement")}} interface removes the first {{HTMLElement("tfoot")}} element child from a given {{HTMLElement("table")}}, if any.
 
 ## Syntax
 
@@ -61,7 +60,7 @@ This example uses JavaScript to delete a table's footer.
 ### JavaScript
 
 ```js
-let table = document.querySelector("table");
+const table = document.querySelector("table");
 table.deleteTFoot();
 ```
 
@@ -76,3 +75,9 @@ table.deleteTFoot();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.createTFoot()")}}
+- {{domxref("HTMLTableElement.deleteCaption()")}}
+- {{domxref("HTMLTableElement.deleteTHead()")}}

--- a/files/en-us/web/api/htmltableelement/deletethead/index.md
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.md
@@ -8,8 +8,7 @@ browser-compat: api.HTMLTableElement.deleteTHead
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.deleteTHead()`** removes the
-{{HTMLElement("thead")}} element from a given {{HtmlElement("table")}}.
+The **`deleteTHead()`** method of the {{domxref("HTMLTableElement")}} interface removes the first {{HTMLElement("thead")}} element child from a given {{HTMLElement("table")}}, if any.
 
 ## Syntax
 
@@ -70,3 +69,9 @@ table.deleteTHead();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.createTHead()")}}
+- {{domxref("HTMLTableElement.deleteCaption()")}}
+- {{domxref("HTMLTableElement.deleteTFoot()")}}

--- a/files/en-us/web/api/htmltableelement/deletethead/index.md
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.md
@@ -54,7 +54,7 @@ This example uses JavaScript to delete a table's header.
 ### JavaScript
 
 ```js
-let table = document.querySelector("table");
+const table = document.querySelector("table");
 table.deleteTHead();
 ```
 

--- a/files/en-us/web/api/htmltableelement/index.md
+++ b/files/en-us/web/api/htmltableelement/index.md
@@ -16,15 +16,15 @@ The **`HTMLTableElement`** interface provides special properties and methods (be
 _Inherits properties from its parent, {{DOMxRef("HTMLElement")}}._
 
 - {{DOMxRef("HTMLTableElement.caption")}}
-  - : A {{DOMxRef("HTMLTableCaptionElement")}} representing the first {{HTMLElement("caption")}} that is a child of the element, or `null` if none is found. When set, if the object doesn't represent a `<caption>`, a {{DOMxRef("DOMException")}} with the `HierarchyRequestError` name is thrown. If a correct object is given, it is inserted in the tree as the first child of this element and the first `<caption>` that is a child of this element is removed from the tree, if any.
+  - : An {{domxref("HTMLTableCaptionElement")}} representing the first {{HTMLElement("caption")}} element child of the given {{HTMLElement("table")}}, or `null` if no such element exists. This property can be assigned, which causes the existing first `<caption>` element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the first child. If the assigned value is not an {{domxref("HTMLTableCaptionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown.
 - {{DOMxRef("HTMLTableElement.tHead")}}
-  - : A {{DOMxRef("HTMLTableSectionElement")}} representing the first {{HTMLElement("thead")}} that is a child of the element, or `null` if none is found. When set, if the object doesn't represent a `<thead>`, a {{DOMxRef("DOMException")}} with the `HierarchyRequestError` name is thrown. If a correct object is given, it is inserted in the tree immediately before the first element that is neither a {{HTMLElement("caption")}}, nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element, and the first `<thead>` that is a child of this element is removed from the tree, if any.
+  - : An {{domxref("HTMLTableSectionElement")}} representing the first {{HTMLElement("thead")}} element child of the given {{HTMLElement("table")}}, or `null` if no such element exists. This property can be assigned, which causes the existing first `<thead>` element child, if any, to be removed, and the given value, if it is not `null`, to be inserted immediately before the first element child that's neither a {{HTMLElement("caption")}} nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("thead")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
 - {{DOMxRef("HTMLTableElement.tFoot")}}
-  - : A {{DOMxRef("HTMLTableSectionElement")}} representing the first {{HTMLElement("tfoot")}} that is a child of the element, or `null` if none is found. When set, if the object doesn't represent a `<tfoot>`, a {{DOMxRef("DOMException")}} with the `HierarchyRequestError` name is thrown. If a correct object is given, it is inserted in the tree immediately before the first element that is neither a {{HTMLElement("caption")}}, a {{HTMLElement("colgroup")}}, nor a {{HTMLElement("thead")}}, or as the last child if there is no such element, and the first `<tfoot>` that is a child of this element is removed from the tree, if any.
+  - : An {{domxref("HTMLTableSectionElement")}} representing the first {{HTMLElement("tfoot")}} element child of the given {{HTMLElement("table")}}, or `null` if no such element exists. This property can be assigned, which causes the existing first `<tfoot>` element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the last child. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("tfoot")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
 - {{DOMxRef("HTMLTableElement.rows")}} {{ReadOnlyInline}}
-  - : Returns a live {{DOMxRef("HTMLCollection")}} containing all the rows of the element, that is all {{HTMLElement("tr")}} that are a child of the element, or a child of one of its {{HTMLElement("thead")}}, {{HTMLElement("tbody")}} and {{HTMLElement("tfoot")}} children. The rows members of a `<thead>` appear first, in tree order, and those members of a `<tbody>` last, also in tree order. The `HTMLCollection` is live and is automatically updated when the `HTMLTableElement` changes.
+  - : Returns a live {{domxref("HTMLCollection")}} of all {{HTMLElement("tr")}} elements that are a child of the given {{HTMLElement("table")}} element, or a child of one of the table's {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, and {{HTMLElement("tfoot")}} children. The members of the `<thead>` appear first, followed by members of the `<tbody>` and the table itself, and members of the `<tfoot>` come last, sorted by tree order within each group. The returned object is automatically updated when the `HTMLTableElement` changes.
 - {{DOMxRef("HTMLTableElement.tBodies")}} {{ReadOnlyInline}}
-  - : Returns a live {{DOMxRef("HTMLCollection")}} containing all the {{HTMLElement("tbody")}} of the element. The `HTMLCollection` is live and is automatically updated when the `HTMLTableElement` changes.
+  - : Returns a live {{domxref("HTMLCollection")}} of all {{HTMLElement("tbody")}} element children of the given {{HTMLElement("table")}}. The returned object is automatically updated when the `HTMLTableElement` changes.
 
 ### Obsolete Properties
 
@@ -55,23 +55,23 @@ _Inherits properties from its parent, {{DOMxRef("HTMLElement")}}._
 _Inherits methods from its parent, {{DOMxRef("HTMLElement")}}_.
 
 - {{DOMxRef("HTMLTableElement.createTHead()")}}
-  - : Returns an {{DOMxRef("HTMLTableSectionElement")}} representing the first {{HTMLElement("thead")}} that is a child of the element. If none is found, a new one is created and inserted in the tree immediately before the first element that is neither a {{HTMLElement("caption")}}, nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element.
+  - : Creates a {{HTMLElement("thead")}} element, inserts it before the first element child of the given {{HTMLElement("table")}} that's neither a {{HTMLElement("caption")}} nor a {{HTMLElement("colgroup")}}, or as the last child if no such insertion location is found, and returns it. If the table already has a `<thead>` element child, this method returns the first such child without creating one.
 - {{DOMxRef("HTMLTableElement.deleteTHead()")}}
-  - : Removes the first {{HTMLElement("thead")}} that is a child of the element.
+  - : Removes the first {{HTMLElement("thead")}} element child from a given {{HTMLElement("table")}}, if any.
 - {{DOMxRef("HTMLTableElement.createTFoot()")}}
-  - : Returns an {{DOMxRef("HTMLTableSectionElement")}} representing the first {{HTMLElement("tfoot")}} that is a child of the element. If none is found, a new one is created and inserted in the tree as the last child.
+  - : Creates a {{HTMLElement("tfoot")}} element, inserts it as the last child of the given {{HTMLElement("table")}}, and returns it. If the table already has a `<tfoot>` element child, this method returns the first such child without creating one.
 - {{DOMxRef("HTMLTableElement.deleteTFoot()")}}
-  - : Removes the first {{HTMLElement("tfoot")}} that is a child of the element.
+  - : Removes the first {{HTMLElement("tfoot")}} element child from a given {{HTMLElement("table")}}, if any.
 - {{DOMxRef("HTMLTableElement.createTBody()")}}
-  - : Returns a {{DOMxRef("HTMLTableSectionElement")}} representing a new {{HTMLElement("tbody")}} that is a child of the element. It is inserted in the tree after the last element that is a {{HTMLElement("tbody")}}, or as the last child if there is no such element.
+  - : Creates a {{HTMLElement("tbody")}} element, inserts it immediately after the last `<tbody>` element child of the given {{HTMLElement("table")}}, or as the last child if there is no such element, and returns it.
 - {{DOMxRef("HTMLTableElement.createCaption()")}}
-  - : Returns an {{DOMxRef("HTMLElement")}} representing the first {{HTMLElement("caption")}} that is a child of the element. If none is found, a new one is created and inserted in the tree as the first child of the {{HTMLElement("table")}} element.
+  - : Creates a {{HTMLElement("caption")}} element, inserts it as the first child of the given {{HTMLElement("table")}}, and returns it. If the table already has a `<caption>` element child, this method returns the first such child without creating one.
 - {{DOMxRef("HTMLTableElement.deleteCaption()")}}
-  - : Removes the first {{HTMLElement("caption")}} that is a child of the element.
+  - : Removes the first {{HTMLElement("caption")}} element child from a given {{HTMLElement("table")}}, if any.
 - {{DOMxRef("HTMLTableElement.insertRow()")}}
-  - : Returns an {{DOMxRef("HTMLTableRowElement")}} representing a new row of the table. It inserts it in the rows collection immediately before the {{HTMLElement("tr")}} element at the given `index` position. If necessary a {{HTMLElement("tbody")}} is created. If the `index` is `-1`, the new row is appended to the collection. If the `index` is smaller than `-1` or greater than the number of rows in the collection, a {{DOMxRef("DOMException")}} with the value `IndexSizeError` is raised.
+  - : Creates a {{HTMLElement("tr")}} element, inserts it at the specified position in the {{domxref("HTMLTableElement.rows", "rows")}} collection, and returns it. If the `rows` collection is empty and the table also has no {{HTMLElement("tbody")}} elements, a `<tbody>` element is first created and inserted.
 - {{DOMxRef("HTMLTableElement.deleteRow()")}}
-  - : Removes the row corresponding to the `index` given in parameter. If the `index` value is `-1` the last row is removed; if it is smaller than `-1` or greater than the amount of rows in the collection, a {{DOMxRef("DOMException")}} with the value `IndexSizeError` is raised.
+  - : Removes a specific row ({{HTMLElement("tr")}}) from a given {{HTMLElement("table")}}. If `index` is `-1`, the last row is removed.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -12,8 +12,9 @@ The **`insertRow()`** method of the {{domxref("HTMLTableElement")}} interface in
 ({{HtmlElement("tr")}}) in a given {{HtmlElement("table")}}, and returns a reference to
 the new row.
 
-If a table has multiple {{HtmlElement("tbody")}} elements, by default, the new row is
-inserted into the last `<tbody>`.
+The section into which the new row is inserted depends on the insertion position.
+When appending a row (using `insertRow()` or `insertRow(-1)`), it is inserted
+into the parent section of the table's last row.
 To insert the row into a specific section, use {{domxref("HTMLTableSectionElement.insertRow()")}}
 
 > [!NOTE]

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -12,10 +12,11 @@ The **`insertRow()`** method of the {{domxref("HTMLTableElement")}} interface in
 ({{HtmlElement("tr")}}) in a given {{HtmlElement("table")}}, and returns a reference to
 the new row.
 
-The section into which the new row is inserted depends on the insertion position.
-When appending a row (using `insertRow()` or `insertRow(-1)`), it is inserted
-into the parent section of the table's last row.
-To insert the row into a specific section, use {{domxref("HTMLTableSectionElement.insertRow()")}}
+If a specific `index` is provided, the new row is inserted immediately before the row at that index, within the same table section (such as a `<tbody>`, `<thead>`, or `<tfoot>`).
+
+If the `index` is `-1` or omitted, the new row is appended to the table. When appending, the new row is added to the same section as the existing last row. Note that if the table's last row is in a `<tfoot>`, the new row will be appended to the `<tfoot>`. If the table is completely empty, a new `<tbody>` is automatically created and appended to the table to contain the new row.
+
+To explicitly insert a row into a specific section, use {{domxref("HTMLTableSectionElement.insertRow()")}}
 
 > [!NOTE]
 > `insertRow()` inserts the row directly into the

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableElement.insertRow
 
 The **`insertRow()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("tr")}} element, inserts it at the specified position in the {{domxref("HTMLTableElement.rows", "rows")}} collection, and returns it. If the `rows` collection is empty and the table also has no {{HTMLElement("tbody")}} elements, a `<tbody>` element is first created and inserted.
 
-This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
+This method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}}, {{domxref("Node.insertBefore()")}}, and {{domxref("Node.appendChild()")}}.
 
 To explicitly insert a row into a specific section, use {{domxref("HTMLTableSectionElement.insertRow()")}}.
 
@@ -26,7 +26,7 @@ insertRow(index)
 - `index` {{optional_inline}}
   - : The index of the new row in the {{domxref("HTMLTableElement.rows", "rows")}} collection. If `index` is `-1` or equal to the number of rows, the row is appended as the last row. If `index` is omitted, it defaults to `-1`.
 
-    If `rows` is empty, the new row is appended to the last `<tbody>` element (one is created if there's none). Otherwise, the new row is inserted immediately before the row at `index`, or immediately after the last row if it's to become the last row. The new row is inserted to the same parent as the reference row, so it could be inserted to any table sectioning element (`<thead>`, `<tbody>`, `<tfoot>`).
+    If `rows` is empty, the new row is appended to the last `<tbody>` element (one is created if there's none). Otherwise, the new row is inserted immediately before the row at `index`, or appended to the parent of the last row if the new row is to become the last row. The new row is inserted into the same parent as the reference row, so it can be inserted directly into the `<table>` or into any table sectioning element (`<thead>`, `<tbody>`, or `<tfoot>`).
 
 ### Return value
 

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -8,21 +8,11 @@ browser-compat: api.HTMLTableElement.insertRow
 
 {{APIRef("HTML DOM")}}
 
-The **`insertRow()`** method of the {{domxref("HTMLTableElement")}} interface inserts a new row
-({{HtmlElement("tr")}}) in a given {{HtmlElement("table")}}, and returns a reference to
-the new row.
+The **`insertRow()`** method of the {{domxref("HTMLTableElement")}} interface creates a {{HTMLElement("tr")}} element, inserts it at the specified position in the {{domxref("HTMLTableElement.rows", "rows")}} collection, and returns it. If the `rows` collection is empty and the table also has no {{HTMLElement("tbody")}} elements, a `<tbody>` element is first created and inserted.
 
-If a specific `index` is provided, the new row is inserted immediately before the row at that index, within the same table section (such as a `<tbody>`, `<thead>`, or `<tfoot>`).
+This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
 
-If the `index` is `-1` or omitted, the new row is appended to the table. When appending, the new row is added to the same section as the existing last row. Note that if the table's last row is in a `<tfoot>`, the new row will be appended to the `<tfoot>`. If the table is completely empty, a new `<tbody>` is automatically created and appended to the table to contain the new row.
-
-To explicitly insert a row into a specific section, use {{domxref("HTMLTableSectionElement.insertRow()")}}
-
-> [!NOTE]
-> `insertRow()` inserts the row directly into the
-> table. The row does not need to be appended separately as would be the case if
-> {{domxref("Document.createElement()")}} had been used to create the new
-> `<tr>` element.
+To explicitly insert a row into a specific section, use {{domxref("HTMLTableSectionElement.insertRow()")}}.
 
 ## Syntax
 
@@ -31,34 +21,27 @@ insertRow()
 insertRow(index)
 ```
 
-{{domxref("HTMLTableElement")}} is a reference to an HTML {{HtmlElement("table")}}
-element.
-
 ### Parameters
 
 - `index` {{optional_inline}}
-  - : The row index of the new row. If `index` is `-1` or equal to
-    the number of rows, the row is appended as the last row.
-    If `index` is omitted it defaults to `-1`.
+  - : The index of the new row in the {{domxref("HTMLTableElement.rows", "rows")}} collection. If `index` is `-1` or equal to the number of rows, the row is appended as the last row. If `index` is omitted, it defaults to `-1`.
+
+    If `rows` is empty, the new row is appended to the last `<tbody>` element (one is created if there's none). Otherwise, the new row is inserted immediately before the row at `index`, or immediately after the last row if it's to become the last row. The new row is inserted to the same parent as the reference row, so it could be inserted to any table sectioning element (`<thead>`, `<tbody>`, `<tfoot>`).
 
 ### Return value
 
-An {{domxref("HTMLTableRowElement")}} that references the new
-row.
+An {{domxref("HTMLTableRowElement")}} that references the new row.
 
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than the number of rows.
+  - : Thrown if `index` is greater than the number of rows or smaller than `-1`.
 
 ## Examples
 
 This example uses `insertRow(-1)` to append a new row to a table.
 
-We then use {{domxref("HTMLTableRowElement.insertCell()")}} to insert a new cell in the
-new row. (To be valid HTML, a `<tr>` must have at least one
-`<td>` element.) Finally, we add some text to the cell using
-{{domxref("Document.createTextNode()")}} and {{domxref("Node.appendChild()")}}.
+We then use {{domxref("HTMLTableRowElement.insertCell()")}} to insert a new cell in the new row. Finally, we add some text to the cell using {{domxref("Document.createTextNode()")}} and {{domxref("Node.appendChild()")}}.
 
 ### HTML
 
@@ -83,16 +66,16 @@ new row. (To be valid HTML, a `<tr>` must have at least one
 ```js
 function addRow(tableID) {
   // Get a reference to the table
-  let tableRef = document.getElementById(tableID);
+  const tableRef = document.getElementById(tableID);
 
   // Insert a row at the end of the table
-  let newRow = tableRef.insertRow(-1);
+  const newRow = tableRef.insertRow(-1);
 
   // Insert a cell in the row at index 0
-  let newCell = newRow.insertCell(0);
+  const newCell = newRow.insertCell(0);
 
   // Append a text node to the cell
-  let newText = document.createTextNode("New bottom row");
+  const newText = document.createTextNode("New bottom row");
   newCell.appendChild(newText);
 }
 

--- a/files/en-us/web/api/htmltableelement/rows/index.md
+++ b/files/en-us/web/api/htmltableelement/rows/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableElement.rows
 
 {{APIRef("HTML DOM")}}
 
-The **`rows`** read-only property of the {{domxref("HTMLTableElement")}} interface returns a live {{domxref("HTMLCollection")}} of all {{HTMLElement("tr")}} elements that are a child of the given {{HTMLElement("table")}} element, or a child of one of the table's {{HTMLElement("thead")}}, {{HTMLElement("tbody")}} and {{HTMLElement("tfoot")}} children. The members of the `<thead>` appear first, followed by members of the `<tbody>` and the table itself, and members of the `<tfoot>` come last, sorted by tree order within each group.
+The **`rows`** read-only property of the {{domxref("HTMLTableElement")}} interface returns a live {{domxref("HTMLCollection")}} of all {{HTMLElement("tr")}} elements that are a child of the given {{HTMLElement("table")}} element, or a child of one of the table's {{HTMLElement("thead")}}, {{HTMLElement("tbody")}}, and {{HTMLElement("tfoot")}} children. The members of the `<thead>` appear first, followed by members of the `<tbody>` and the table itself, and members of the `<tfoot>` come last, sorted by tree order within each group.
 
 Although the property is read-only, the returned object is live and is automatically updated when the `HTMLTableElement` changes.
 

--- a/files/en-us/web/api/htmltableelement/rows/index.md
+++ b/files/en-us/web/api/htmltableelement/rows/index.md
@@ -8,33 +8,23 @@ browser-compat: api.HTMLTableElement.rows
 
 {{APIRef("HTML DOM")}}
 
-The read-only {{domxref("HTMLTableElement")}}
-property **`rows`** returns a live
-{{domxref("HTMLCollection")}} of all the rows in the table, including the rows
-contained within any {{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, and
-{{HTMLElement("tbody")}} elements.
+The **`rows`** read-only property of the {{domxref("HTMLTableElement")}} interface returns a live {{domxref("HTMLCollection")}} of all {{HTMLElement("tr")}} elements that are a child of the given {{HTMLElement("table")}} element, or a child of one of the table's {{HTMLElement("thead")}}, {{HTMLElement("tbody")}} and {{HTMLElement("tfoot")}} children. The members of the `<thead>` appear first, followed by members of the `<tbody>` and the table itself, and members of the `<tfoot>` come last, sorted by tree order within each group.
 
-Although the property itself is read-only, the returned object is live and allows the
-modification of its content.
+Although the property is read-only, the returned object is live and is automatically updated when the `HTMLTableElement` changes.
 
 ## Value
 
-An {{domxref("HTMLCollection")}} providing a live-updating list of the
-{{domxref("HTMLTableRowElement")}} objects representing all of the {{HTMLElement("tr")}}
-elements contained in the table. This provides quick access to all of the table rows,
-without having to manually search for them.
+A live {{domxref("HTMLCollection")}} of {{domxref("HTMLTableRowElement")}} objects.
 
 ## Examples
 
 ```js
-myRows = myTable.rows;
-firstRow = myTable.rows[0];
-lastRow = myTable.rows.item(myTable.rows.length - 1);
+const myRows = myTable.rows;
+const firstRow = myTable.rows[0];
+const lastRow = myTable.rows.item(myTable.rows.length - 1);
 ```
 
-This demonstrates how you can use both indexed access and the
-{{domxref("HTMLCollection.item()")}} method to obtain individual rows in the
-table.
+This demonstrates how you can use both indexed access and the {{domxref("HTMLCollection.item()")}} method to obtain individual rows in the table.
 
 ## Specifications
 
@@ -43,3 +33,8 @@ table.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLTableElement.insertRow()")}}
+- {{domxref("HTMLTableElement.deleteRow()")}}

--- a/files/en-us/web/api/htmltableelement/tbodies/index.md
+++ b/files/en-us/web/api/htmltableelement/tbodies/index.md
@@ -8,14 +8,11 @@ browser-compat: api.HTMLTableElement.tBodies
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.tBodies`** read-only property returns a
-live {{domxref("HTMLCollection")}} of the bodies in a {{htmlElement("table")}}.
+The **`tBodies`** read-only property of the {{domxref("HTMLTableElement")}} interface returns a live {{domxref("HTMLCollection")}} of all {{HTMLElement("tbody")}} element children of the given {{HTMLElement("table")}}.
 
-Although the property is read-only, the returned object is live and allows the
-modification of its content.
+Although the property is read-only, the returned object is live and is automatically updated when the `HTMLTableElement` changes.
 
-The collection returned includes implicit {{HTMLElement("tbody")}} elements. For
-example:
+The collection returned includes implicit {{HTMLElement("tbody")}} elements. For example:
 
 ```html
 <table>
@@ -25,12 +22,11 @@ example:
 </table>
 ```
 
-The HTML DOM generated from the above HTML will have a {{HTMLElement("tbody")}} element
-even though the tags are not included in the source HTML.
+The HTML DOM generated from the above HTML will have a {{HTMLElement("tbody")}} element even though the tags are not included in the source HTML.
 
 ## Value
 
-A live {{domxref("HTMLCollection")}}.
+A live {{domxref("HTMLCollection")}} of {{domxref("HTMLTableSectionElement")}} (which are all `tbody`) objects.
 
 ## Examples
 
@@ -50,5 +46,7 @@ myTable.tBodies.length;
 
 ## See also
 
-- {{domxref("HTMLCollection")}}
-- {{HTMLElement("tbody")}}
+- {{domxref("HTMLTableElement.caption")}}
+- {{domxref("HTMLTableElement.tFoot")}}
+- {{domxref("HTMLTableElement.tHead")}}
+- {{domxref("HTMLTableElement.createTBody()")}}

--- a/files/en-us/web/api/htmltableelement/tfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/tfoot/index.md
@@ -8,19 +8,19 @@ browser-compat: api.HTMLTableElement.tFoot
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.tFoot`** property represents the
-{{HTMLElement("tfoot")}} element of a {{HTMLElement("table")}}. Its value will be
-`null` if there is no such element.
+The **`tFoot`** property of the {{domxref("HTMLTableElement")}} interface represents the first {{HTMLElement("tfoot")}} element child of the given {{HTMLElement("table")}}, or `null` if no such element exists.
 
 ## Value
 
-A {{HTMLElement("tfoot")}} element or `null`.
+An {{domxref("HTMLTableSectionElement")}} (which is always a `tfoot`) or `null`.
+
+This property can be assigned, which causes the existing first {{HTMLElement("tfoot")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the last child. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("tfoot")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
 
 ## Examples
 
 ```js
-if (table.tFoot === myFoot) {
-  // …
+if (table.tFoot) {
+  // Do something with the tfoot
 }
 ```
 
@@ -34,4 +34,8 @@ if (table.tFoot === myFoot) {
 
 ## See also
 
-- The interface implementing this property: {{domxref("HTMLTableElement")}}.
+- {{domxref("HTMLTableElement.caption")}}
+- {{domxref("HTMLTableElement.tBodies")}}
+- {{domxref("HTMLTableElement.tHead")}}
+- {{domxref("HTMLTableElement.createTFoot()")}}
+- {{domxref("HTMLTableElement.deleteTFoot()")}}

--- a/files/en-us/web/api/htmltableelement/tfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/tfoot/index.md
@@ -14,7 +14,7 @@ The **`tFoot`** property of the {{domxref("HTMLTableElement")}} interface repres
 
 An {{domxref("HTMLTableSectionElement")}} (which is always a `tfoot`) or `null`.
 
-This property can be assigned, which causes the existing first {{HTMLElement("tfoot")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the last child. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("tfoot")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
+This property can be assigned, which causes the existing first {{HTMLElement("tfoot")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted as the last child. Therefore, setting `null` has the same effect as calling {{domxref("HTMLTableElement.deleteTFoot", "deleteTFoot()")}}. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("tfoot")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltableelement/thead/index.md
+++ b/files/en-us/web/api/htmltableelement/thead/index.md
@@ -14,7 +14,7 @@ The **`tHead`** property of the {{domxref("HTMLTableElement")}} interface repres
 
 An {{domxref("HTMLTableSectionElement")}} (which is always a `thead`) or `null`.
 
-This property can be assigned, which causes the existing first {{HTMLElement("thead")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted immediately before the first element child that's neither a {{HTMLElement("caption")}} nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("thead")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
+This property can be assigned, which causes the existing first {{HTMLElement("thead")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted immediately before the first element child that's neither a {{HTMLElement("caption")}} nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element. Therefore, setting `null` has the same effect as calling {{domxref("HTMLTableElement.deleteTHead", "deleteTHead()")}}. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("thead")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
 
 ## Examples
 

--- a/files/en-us/web/api/htmltableelement/thead/index.md
+++ b/files/en-us/web/api/htmltableelement/thead/index.md
@@ -8,19 +8,19 @@ browser-compat: api.HTMLTableElement.tHead
 
 {{APIRef("HTML DOM")}}
 
-The **`HTMLTableElement.tHead`** represents the
-{{HTMLElement("thead")}} element of a {{HTMLElement("table")}}. Its value will be
-`null` if there is no such element.
+The **`tHead`** property of the {{domxref("HTMLTableElement")}} interface represents the first {{HTMLElement("thead")}} element child of the given {{HTMLElement("table")}}, or `null` if no such element exists.
 
 ## Value
 
-A {{domxref("HTMLTableSectionElement")}}.
+An {{domxref("HTMLTableSectionElement")}} (which is always a `thead`) or `null`.
+
+This property can be assigned, which causes the existing first {{HTMLElement("thead")}} element child, if any, to be removed, and the given value, if it is not `null`, to be inserted immediately before the first element child that's neither a {{HTMLElement("caption")}} nor a {{HTMLElement("colgroup")}}, or as the last child if there is no such element. If the assigned value is not an {{domxref("HTMLTableSectionElement")}} or `null`, a {{jsxref("TypeError")}} is thrown; otherwise, if it is not a {{HTMLElement("thead")}} element or `null`, a `HierarchyRequestError` {{domxref("DOMException")}} is thrown.
 
 ## Examples
 
 ```js
-if (table.tHead === myHeadEl) {
-  // …
+if (table.tHead) {
+  // Do something with the thead
 }
 ```
 
@@ -34,4 +34,8 @@ if (table.tHead === myHeadEl) {
 
 ## See also
 
-- The interface implementing this property: {{domxref("HTMLTableElement")}}.
+- {{domxref("HTMLTableElement.caption")}}
+- {{domxref("HTMLTableElement.tBodies")}}
+- {{domxref("HTMLTableElement.tFoot")}}
+- {{domxref("HTMLTableElement.createTHead()")}}
+- {{domxref("HTMLTableElement.deleteTHead()")}}

--- a/files/en-us/web/api/htmltablerowelement/deletecell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/deletecell/index.md
@@ -19,7 +19,7 @@ deleteCell(index)
 ### Parameters
 
 - `index`
-  - : The index of the cell to remove. If `index` is `-1`, the last cell of the row is removed.
+  - : The index of the cell to remove in the {{domxref("HTMLTableRowElement.cells", "cells")}} collection. If `index` is `-1`, the last cell of the row is removed.
 
 ### Return value
 

--- a/files/en-us/web/api/htmltablerowelement/deletecell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/deletecell/index.md
@@ -8,8 +8,7 @@ browser-compat: api.HTMLTableRowElement.deleteCell
 
 {{APIRef("HTML DOM")}}
 
-The **`deleteCell()`** method of the {{domxref("HTMLTableRowElement")}} interface removes a
-specific row cell from a given {{htmlelement("tr")}}.
+The **`deleteCell()`** method of the {{domxref("HTMLTableRowElement")}} interface removes a specific row cell from a given {{htmlelement("tr")}}.
 
 ## Syntax
 
@@ -20,7 +19,7 @@ deleteCell(index)
 ### Parameters
 
 - `index`
-  - : The cell index of the cell to remove. If `index` is `-1` or equal to the number of cells, the last cell of the row is removed.
+  - : The index of the cell to remove. If `index` is `-1`, the last cell of the row is removed.
 
 ### Return value
 
@@ -29,12 +28,11 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than the number of cells or if it is smaller than `-1`.
+  - : Thrown if `index` is greater than or equal to the number of cells or smaller than `-1`.
 
 ## Examples
 
-This example uses {{domxref("HTMLTableRowElement.insertCell()")}} to append a new cell to a
-row.
+This example uses {{domxref("HTMLTableRowElement.insertCell()")}} to append a new cell to a row.
 
 ### HTML
 
@@ -127,4 +125,5 @@ removeButton.addEventListener("click", () => {
 ## See also
 
 - {{domxref("HTMLTableElement.insertRow()")}}
+- {{domxref("HTMLTableRowElement.insertCell()")}}
 - The HTML element representing cells: {{domxref("HTMLTableCellElement")}}

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -8,19 +8,9 @@ browser-compat: api.HTMLTableRowElement.insertCell
 
 {{APIRef("HTML DOM")}}
 
-The **`insertCell()`** method of the {{domxref("HTMLTableRowElement")}} interface inserts a new
-cell ({{HtmlElement("td")}}) into a table row ({{HtmlElement("tr")}}) and returns a
-reference to the cell.
+The **`insertCell()`** method of the {{domxref("HTMLTableRowElement")}} interface creates a {{HTMLElement("td")}} element, inserts it at the specified child position in the given {{HTMLElement("tr")}} element, and returns it.
 
-> [!NOTE]
-> `insertCell()` inserts the cell directly into the
-> row. The cell does not need to be appended separately
-> with {{domxref("Node.appendChild()")}} as would be the case if
-> {{domxref("Document.createElement()")}} had been used to create the new
-> `<td>` element.
->
-> You can not use `insertCell()` to create a new `<th>`
-> element though.
+This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}. However, you cannot use `insertCell()` to create a new `<th>` element.
 
 ## Syntax
 
@@ -32,22 +22,20 @@ insertCell(index)
 ### Parameters
 
 - `index` {{optional_inline}}
-  - : The cell index of the new cell. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted it defaults to `-1`.
+  - : The index of the new cell. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted it defaults to `-1`.
 
 ### Return value
 
-An {{domxref("HTMLTableCellElement")}} that references the new
-cell.
+An {{domxref("HTMLTableCellElement")}} that references the new cell.
 
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than the number of cells.
+  - : Thrown if `index` is greater than the number of cells or smaller than `-1`.
 
 ## Examples
 
-This example uses `HTMLTableRowElement.insertCell()` to append a new cell to a
-row.
+This example uses `HTMLTableRowElement.insertCell()` to append a new cell to a row.
 
 ### HTML
 
@@ -140,4 +128,5 @@ removeButton.addEventListener("click", () => {
 ## See also
 
 - {{domxref("HTMLTableElement.insertRow()")}}
+- {{domxref("HTMLTableRowElement.deleteCell()")}}
 - The HTML element representing cells: {{domxref("HTMLTableCellElement")}}

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableRowElement.insertCell
 
 {{APIRef("HTML DOM")}}
 
-The **`insertCell()`** method of the {{domxref("HTMLTableRowElement")}} interface creates a {{HTMLElement("td")}} element, inserts it at the specified child position in the given {{HTMLElement("tr")}} element, and returns it.
+The **`insertCell()`** method of the {{domxref("HTMLTableRowElement")}} interface creates a {{HTMLElement("td")}} element, inserts it at the specified position in the given {{HTMLElement("tr")}} element, and returns it.
 
 This method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}}, {{domxref("Node.insertBefore()")}}, and {{domxref("Node.appendChild()")}}. However, you cannot use `insertCell()` to create a new `<th>` element.
 
@@ -22,7 +22,7 @@ insertCell(index)
 ### Parameters
 
 - `index` {{optional_inline}}
-  - : The index of the new cell. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted, it defaults to `-1`.
+  - : The index of the new cell in the {{domxref("HTMLTableRowElement.cells", "cells")}} collection. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted, it defaults to `-1`.
 
 ### Return value
 

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableRowElement.insertCell
 
 The **`insertCell()`** method of the {{domxref("HTMLTableRowElement")}} interface creates a {{HTMLElement("td")}} element, inserts it at the specified child position in the given {{HTMLElement("tr")}} element, and returns it.
 
-This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}. However, you cannot use `insertCell()` to create a new `<th>` element.
+This method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}}, {{domxref("Node.insertBefore()")}}, and {{domxref("Node.appendChild()")}}. However, you cannot use `insertCell()` to create a new `<th>` element.
 
 ## Syntax
 
@@ -22,7 +22,7 @@ insertCell(index)
 ### Parameters
 
 - `index` {{optional_inline}}
-  - : The index of the new cell. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted it defaults to `-1`.
+  - : The index of the new cell. If `index` is `-1` or equal to the number of cells, the cell is appended as the last cell in the row. If `index` is omitted, it defaults to `-1`.
 
 ### Return value
 

--- a/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableSectionElement.deleteRow
 
 {{APIRef("HTML DOM")}}
 
-The **`deleteRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface removes a specific row ({{HtmlElement("tr")}}) from the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or {{HTMLElement("tbody")}}).
+The **`deleteRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface removes a specific row ({{HTMLElement("tr")}}) from the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or {{HTMLElement("tbody")}}).
 
 ## Syntax
 

--- a/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
@@ -19,7 +19,7 @@ deleteRow(index)
 ### Parameters
 
 - `index`
-  - : The index of the row to remove. If `index` is `-1`, the last row is removed.
+  - : The index of the row to remove in the {{domxref("HTMLTableSectionElement.rows", "rows")}} collection. If `index` is `-1`, the last row is removed.
 
 ### Return value
 

--- a/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/deleterow/index.md
@@ -8,8 +8,7 @@ browser-compat: api.HTMLTableSectionElement.deleteRow
 
 {{APIRef("HTML DOM")}}
 
-The **`deleteRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface removes a
-specific row ({{HtmlElement("tr")}}) from a given {{HtmlElement("section")}}.
+The **`deleteRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface removes a specific row ({{HtmlElement("tr")}}) from the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or {{HTMLElement("tbody")}}).
 
 ## Syntax
 
@@ -20,9 +19,7 @@ deleteRow(index)
 ### Parameters
 
 - `index`
-  - : `index` is an integer representing the row that should be deleted.
-    However, the special index `-1` can be used to remove the very last row of
-    the section.
+  - : The index of the row to remove. If `index` is `-1`, the last row is removed.
 
 ### Return value
 
@@ -31,7 +28,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than or equal to the number of available rows or is a negative value other than `-1`.
+  - : Thrown if `index` is greater than or equal to the number of rows or smaller than `-1`.
 
 ## Examples
 
@@ -127,4 +124,6 @@ removeButton.addEventListener("click", () => {
 
 ## See also
 
+- {{domxref("HTMLTableRowElement.deleteCell()")}}
 - {{domxref("HTMLTableElement.deleteRow()")}}
+- {{domxref("HTMLTableSectionElement.insertRow()")}}

--- a/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
@@ -8,15 +8,9 @@ browser-compat: api.HTMLTableSectionElement.insertRow
 
 {{APIRef("HTML DOM")}}
 
-The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface inserts a new row
-({{HtmlElement("tr")}}) in the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or
-{{HTMLElement("tbody")}}), then returns a reference to this new row.
+The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface creates a {{HTMLElement("tr")}} element, inserts it at the specified child position in the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or {{HTMLElement("tbody")}}), and returns it.
 
-> [!NOTE]
-> `insertRow()` inserts the row directly into the
-> section. The row does not need to be appended separately as would be the case if
-> {{domxref("Document.createElement()")}} had been used to create the new
-> `<tr>` element.
+This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
 
 ## Syntax
 
@@ -28,9 +22,7 @@ insertRow(index)
 ### Parameters
 
 - `index` {{optional_inline}}
-  - : The row index of the new row. If `index` is `-1` or equal to
-    the number of rows, the row is appended as the last row.
-    If `index` is omitted it defaults to `-1`.
+  - : The index of the new row. If `index` is `-1` or equal to the number of rows, the row is appended as the last row. If `index` is omitted, it defaults to `-1`.
 
 ### Return value
 
@@ -39,7 +31,7 @@ An {{domxref("HTMLTableRowElement")}} that references the new row.
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if `index` is greater than the number of rows, or smaller than `-1`.
+  - : Thrown if `index` is greater than the number of rows or smaller than `-1`.
 
 ## Examples
 
@@ -137,3 +129,4 @@ removeButton.addEventListener("click", () => {
 
 - {{domxref("HTMLTableRowElement.insertCell()")}}
 - {{domxref("HTMLTableElement.insertRow()")}}
+- {{domxref("HTMLTableSectionElement.deleteRow()")}}

--- a/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLTableSectionElement.insertRow
 
 The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface creates a {{HTMLElement("tr")}} element, inserts it at the specified child position in the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or {{HTMLElement("tbody")}}), and returns it.
 
-This method is a convenience method for DOM methods such as {{domxref("Document.createElement()")}} followed by {{domxref("Node.appendChild()")}}.
+This method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}}, {{domxref("Node.insertBefore()")}}, and {{domxref("Node.appendChild()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/insertrow/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLTableSectionElement.insertRow
 
 {{APIRef("HTML DOM")}}
 
-The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface creates a {{HTMLElement("tr")}} element, inserts it at the specified child position in the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or {{HTMLElement("tbody")}}), and returns it.
+The **`insertRow()`** method of the {{domxref("HTMLTableSectionElement")}} interface creates a {{HTMLElement("tr")}} element, inserts it at the specified position in the given table sectioning element ({{HTMLElement("thead")}}, {{HTMLElement("tfoot")}}, or {{HTMLElement("tbody")}}), and returns it.
 
 This method creates and inserts the element directly, without requiring separate calls to methods such as {{domxref("Document.createElement()")}}, {{domxref("Node.insertBefore()")}}, and {{domxref("Node.appendChild()")}}.
 
@@ -22,7 +22,7 @@ insertRow(index)
 ### Parameters
 
 - `index` {{optional_inline}}
-  - : The index of the new row. If `index` is `-1` or equal to the number of rows, the row is appended as the last row. If `index` is omitted, it defaults to `-1`.
+  - : The index of the new row in the {{domxref("HTMLTableSectionElement.rows", "rows")}} collection. If `index` is `-1` or equal to the number of rows, the row is appended as the last row. If `index` is omitted, it defaults to `-1`.
 
 ### Return value
 


### PR DESCRIPTION
## 🚀 Summary

This pull request improves the accuracy of the `HTMLTableElement.insertRow()` documentation by aligning it with the HTML specification.

### ✨ Changes
- Corrected the misleading statement that rows are always inserted into the last `<tbody>`.
- Clarified that the insertion target depends on the insertion position.
- Explained that when appending (`insertRow()` or `insertRow(-1)`), the row is inserted into the parent section of the table's last row.
- Kept the update minimal and focused to preserve the existing documentation structure.

### 🎯 Impact
This change provides developers with more accurate guidance, reduces potential confusion when working with tables containing multiple `<tbody>` elements, and ensures the documentation reflects the behavior defined by the HTML specification.

Fixes #44987.