### PR TITLE
Document `headingoffset` and `headingreset` HTML global attributes

### DIFF
--- a/.vscode/dictionaries/code-entities.txt
+++ b/.vscode/dictionaries/code-entities.txt
@@ -188,6 +188,7 @@ dom.abortablepromise
 dom.closewatcher
 dom.documentpip
 dom.element.customstateset
+dom.headingoffset
 dom.input.dirpicker
 dom.media.webcodecs
 dom.performance.event_timing.enable_interactionid
@@ -287,6 +288,8 @@ hanidays
 hanidec
 hansfin
 hantfin
+headingoffset
+headingreset
 hebr
 highp
 hiliteColor

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -77,6 +77,20 @@ The HTML [`<input type="color">`](/en-US/docs/Web/HTML/Reference/Elements/input/
 - `dom.forms.html_color_picker.enabled`
   - : Set to `true` to enable.
 
+### `headingoffset` and `headingreset` attributes
+
+The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside an element, so that a component can use the same heading markup wherever it appears in a page. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside it. ([Firefox bug 1974383](https://bugzil.la/1974383)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 153           | No                  |
+| Developer Edition | 153           | No                  |
+| Beta              | 153           | No                  |
+| Release           | 153           | No                  |
+
+- `dom.headingoffset.enabled`
+  - : Set to `true` to enable.
+
 ## CSS
 
 ### `circle()` and `ellipse()` allow `farthest-corner` and `closest-corner` keywords

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -79,7 +79,7 @@ The HTML [`<input type="color">`](/en-US/docs/Web/HTML/Reference/Elements/input/
 
 ### `headingoffset` and `headingreset` attributes
 
-The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside an element, so that a component can use the same heading markup wherever it appears in a page. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside it. ([Firefox bug 1974383](https://bugzil.la/1974383)).
+The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element it is set on, so that a component can use the same heading markup wherever it appears in a page. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside the element it is set on. ([Firefox bug 1974383](https://bugzil.la/1974383)).
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -120,6 +120,10 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
   The Rust-based [JPEG XL](https://jpeg.org/jpegxl/) image decoder is now enabled by default in Nightly. ([Firefox bug 2040074](https://bugzil.la/2040074)).
 
+- **`headingoffset` and `headingreset` HTML attributes**: `dom.headingoffset.enabled`
+
+  The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside an element, so that a component can use the same heading markup wherever it appears in a page. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside it. ([Firefox bug 1974383](https://bugzil.la/1974383)).
+
 - **Tree counting CSS functions**: `layout.css.tree-counting-functions.enabled`
 
   The {{cssxref("sibling-count")}} and {{cssxref("sibling-index")}} function are now supported. The `sibling-count()` function returns the number sibling elements as well as the element itself. The `sibling-index()` function returns the index number of the element in relation to its siblings, this starts from `1` and not `0`.

--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -122,7 +122,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **`headingoffset` and `headingreset` HTML attributes**: `dom.headingoffset.enabled`
 
-  The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside an element, so that a component can use the same heading markup wherever it appears in a page. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside it. ([Firefox bug 1974383](https://bugzil.la/1974383)).
+  The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element it is set on, so that a component can use the same heading markup wherever it appears in a page. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside the element it is set on. ([Firefox bug 1974383](https://bugzil.la/1974383)).
 
 - **Tree counting CSS functions**: `layout.css.tree-counting-functions.enabled`
 

--- a/files/en-us/web/html/reference/elements/heading_elements/index.md
+++ b/files/en-us/web/html/reference/elements/heading_elements/index.md
@@ -60,12 +60,13 @@ h4 {
 
 These elements only include the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 
+The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) and [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) global attributes can be used to adjust the computed heading level of these elements.
+
 ## Usage notes
 
 - Heading information can be used by user agents to construct a table of contents for a document automatically.
 - Do not use heading elements to resize text. Instead, use the {{glossary("CSS")}} {{cssxref("font-size")}} property.
 - Do not skip heading levels: always start from `<h1>`, followed by `<h2>` and so on.
-- The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute {{experimental_inline}} increases the computed heading level of the headings inside the element it is set on, so a component can keep the same heading markup wherever it is used. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside it.
 
 ### Avoid using multiple `<h1>` elements on one page
 

--- a/files/en-us/web/html/reference/elements/heading_elements/index.md
+++ b/files/en-us/web/html/reference/elements/heading_elements/index.md
@@ -65,7 +65,7 @@ These elements only include the [global attributes](/en-US/docs/Web/HTML/Referen
 - Heading information can be used by user agents to construct a table of contents for a document automatically.
 - Do not use heading elements to resize text. Instead, use the {{glossary("CSS")}} {{cssxref("font-size")}} property.
 - Do not skip heading levels: always start from `<h1>`, followed by `<h2>` and so on.
-- The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute {{experimental_inline}} increases the computed heading level of the headings inside an element, so a component can keep the same heading markup wherever it is used. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops those offsets from applying further down the tree.
+- The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute {{experimental_inline}} increases the computed heading level of the headings inside the element it is set on, so a component can keep the same heading markup wherever it is used. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of ancestor elements from applying to the headings inside it.
 
 ### Avoid using multiple `<h1>` elements on one page
 

--- a/files/en-us/web/html/reference/elements/heading_elements/index.md
+++ b/files/en-us/web/html/reference/elements/heading_elements/index.md
@@ -65,6 +65,7 @@ These elements only include the [global attributes](/en-US/docs/Web/HTML/Referen
 - Heading information can be used by user agents to construct a table of contents for a document automatically.
 - Do not use heading elements to resize text. Instead, use the {{glossary("CSS")}} {{cssxref("font-size")}} property.
 - Do not skip heading levels: always start from `<h1>`, followed by `<h2>` and so on.
+- The [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute {{experimental_inline}} increases the computed heading level of the headings inside an element, so a component can keep the same heading markup wherever it is used. The [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops those offsets from applying further down the tree.
 
 ### Avoid using multiple `<h1>` elements on one page
 

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -21,7 +21,7 @@ A valid non-negative integer between `0` and `8`, inclusive. A value that cannot
 
 Each heading element has a **computed heading level**, which is the level assistive technologies expose to users. Without `headingoffset`, that level is the number in the element's name: `1` for [`<h1>`](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements), `2` for `<h2>`, and so on.
 
-The `headingoffset` attribute adds to that number. To find the offset for a heading, the browser starts at the heading element itself and walks up through its ancestors, adding up every `headingoffset` value it finds. The offsets accumulate: an `<h1>` inside an element with `headingoffset="1"` that is itself inside an element with `headingoffset="2"` has a computed heading level of 4.
+The `headingoffset` attribute adds to that number. To find the offset for a heading, the browser starts at the heading element itself, walks up through its ancestors – crossing shadow boundaries into the shadow host – and adds up every `headingoffset` value it finds. The offsets accumulate: an `<h1>` inside an element with `headingoffset="1"` that is itself inside an element with `headingoffset="2"` has a computed heading level of 4.
 
 Because the walk starts at the heading element, an offset on the heading itself also counts: `<h1 headingoffset="2">` has a computed heading level of 3.
 

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -41,7 +41,7 @@ Because the offset comes from the heading and its ancestors, a reusable componen
 
 Screen reader users navigate by headings and rely on heading levels to understand how a page is structured. Use `headingoffset` to make those levels match the visual structure of the page, and check the result with a screen reader or the browser's accessibility inspector.
 
-In browsers that do not support this attribute, headings keep the level of their element name, so the markup must still make sense without the offset. Alternatively, you can set [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) as a fallback.
+In browsers that do not support this attribute, headings keep the level of their element name, so the markup must still make sense without the offset.
 
 ## Examples
 

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -94,7 +94,7 @@ An element with the [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attri
 
 Screen reader users navigate by headings and rely on heading levels to understand how a page is structured. Use `headingoffset` to make those levels match the visual structure of the page, and check the result with a screen reader or the browser's accessibility inspector.
 
-In browsers that do not support this attribute, headings keep the level of their element name, so the markup must still make sense without the offset. Alternatively, you can set [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) as a fallback.
+In browsers that do not support this attribute, headings keep the level of their element name, so the markup must still make sense without the offset.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -3,7 +3,6 @@ title: "`headingoffset` HTML global attribute"
 short-title: headingoffset
 slug: Web/HTML/Reference/Global_attributes/headingoffset
 page-type: html-attribute
-sidebar: htmlsidebar
 status:
   - experimental
 browser-compat:

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -34,6 +34,12 @@ This attribute affects only the computed heading level. It does not change the f
 - The element's [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role), which stays `heading`.
 - An explicit `aria-level` attribute on the heading, which takes precedence over the computed heading level.
 
+## Accessibility
+
+Screen reader users navigate by headings and rely on heading levels to understand how a page is structured. Use `headingoffset` to make those levels match the visual structure of the page, and check the result with a screen reader or the browser's accessibility inspector.
+
+In browsers that do not support this attribute, headings keep the level of their element name, so the markup must still make sense without the offset. Alternatively, you can set [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) as a fallback.
+
 ## Examples
 
 ### Offsetting headings in a component
@@ -89,12 +95,6 @@ An element with the [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attri
   </dialog>
 </section>
 ```
-
-## Accessibility
-
-Screen reader users navigate by headings and rely on heading levels to understand how a page is structured. Use `headingoffset` to make those levels match the visual structure of the page, and check the result with a screen reader or the browser's accessibility inspector.
-
-In browsers that do not support this attribute, headings keep the level of their element name, so the markup must still make sense without the offset.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -4,13 +4,15 @@ short-title: headingoffset
 slug: Web/HTML/Reference/Global_attributes/headingoffset
 page-type: html-attribute
 sidebar: htmlsidebar
+status:
+  - experimental
+browser-compat:
+  - html.global_attributes.headingoffset
 ---
 
 {{SeeCompatTable}}
 
 The **`headingoffset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element it is set on, without changing the elements used to write them.
-
-Because the offset comes from the heading and its ancestors, a reusable component can always use the same heading markup, such as an `<h1>` for its title. You can then use the same markup at any depth of a page without editing its headings. This also avoids the accessibility problem caused by picking a heading element for its font size.
 
 ## Values
 
@@ -33,6 +35,8 @@ This attribute affects only the computed heading level. It does not change the f
 - The element's name, so CSS selectors such as `h1` still match, and the default styling of the heading is unchanged.
 - The element's [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role), which stays `heading`.
 - An explicit `aria-level` attribute on the heading, which takes precedence over the computed heading level.
+
+Because the offset comes from the heading and its ancestors, a reusable component can always use the same heading markup, such as an `<h1>` for its title. You can then use the same markup at any depth of a page without editing its headings. This also avoids the accessibility problem caused by picking a heading element for its font size.
 
 ## Accessibility
 

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -5,8 +5,8 @@ slug: Web/HTML/Reference/Global_attributes/headingoffset
 page-type: html-attribute
 status:
   - experimental
-browser-compat:
-  - html.global_attributes.headingoffset
+browser-compat: html.global_attributes.headingoffset
+sidebar: htmlsidebar
 ---
 
 {{SeeCompatTable}}

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -3,51 +3,42 @@ title: "`headingoffset` HTML global attribute"
 short-title: headingoffset
 slug: Web/HTML/Reference/Global_attributes/headingoffset
 page-type: html-attribute
-status:
-  - experimental
-browser-compat: html.global_attributes.headingoffset
 sidebar: htmlsidebar
 ---
 
 {{SeeCompatTable}}
 
-The **`headingoffset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) increases the heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element it is set on, without changing the tags used to write them.
+The **`headingoffset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element it is set on, without changing the elements used to write them.
 
-This lets you write a component that always uses the same heading markup, such as an `<h1>` for its title, and have that heading take the level that fits the place where the component is used.
+Because the offset comes from the heading and its ancestors, a reusable component can always use the same heading markup, such as an `<h1>` for its title. You can then use the same markup at any depth of a page without editing its headings. This also avoids the accessibility problem caused by picking a heading element for its font size.
 
-## Syntax
+## Values
 
-```html
-<article headingoffset="1">
-  <h1>This heading has a computed heading level of 2</h1>
-</article>
-```
-
-### Value
-
-A non-negative integer between `0` and `8`, inclusive. Values outside that range, and values that are not valid non-negative integers, are ignored, which is the same as an offset of `0`.
+A valid non-negative integer between `0` and `8`, inclusive. A value that cannot be parsed as a non-negative integer is treated as an offset of `0`.
 
 ## Description
 
-Each heading element has a **computed heading level**, which is the level assistive technologies expose to users. Without `headingoffset`, that level is the number in the element's tag name: `1` for [`<h1>`](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements), `2` for `<h2>`, and so on.
+Each heading element has a **computed heading level**, which is the level assistive technologies expose to users. Without `headingoffset`, that level is the number in the element's name: `1` for [`<h1>`](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements), `2` for `<h2>`, and so on.
 
-The `headingoffset` attribute adds to that number. The browser walks up from the heading element through its ancestors — crossing shadow boundaries into the shadow host — and adds up the `headingoffset` values it finds. It stops at the first ancestor that has the [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute. The offsets therefore accumulate: an `<h1>` inside an element with `headingoffset="1"` that is itself inside an element with `headingoffset="2"` has a computed heading level of 4.
+The `headingoffset` attribute adds to that number. To find the offset for a heading, the browser starts at the heading element itself and walks up through its ancestors, adding up every `headingoffset` value it finds. The offsets accumulate: an `<h1>` inside an element with `headingoffset="1"` that is itself inside an element with `headingoffset="2"` has a computed heading level of 4.
 
-The computed heading level is clamped to a maximum of `9`. Levels above 6 cannot be written with a tag name, so they can only be produced by `headingoffset` or by the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) attribute.
+Because the walk starts at the heading element, an offset on the heading itself also counts: `<h1 headingoffset="2">` has a computed heading level of 3.
 
-The attribute affects the computed heading level only. It does not change:
+The walk stops at the first element that has the [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute, after adding that element's own `headingoffset`.
 
-- The element's tag name, so CSS selectors such as `h1` still match, and the default styling of the heading is unchanged.
+The computed heading level never exceeds `9`, even in cases where offsets add up to more. Because HTML has no heading element above `<h6>`, heading levels of 7, 8, and 9 can be produced only by the `headingoffset` attribute or by the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) attribute.
+
+This attribute affects only the computed heading level. It does not change the following:
+
+- The element's name, so CSS selectors such as `h1` still match, and the default styling of the heading is unchanged.
 - The element's [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role), which stays `heading`.
 - An explicit `aria-level` attribute on the heading, which takes precedence over the computed heading level.
-
-Because the offset comes from ancestors, the same component markup can be reused at different depths of a page without editing its headings, and without the accessibility problems caused by picking a heading tag for its font size.
 
 ## Examples
 
 ### Offsetting headings in a component
 
-In this example, the same article markup is used twice. Both copies use an `<h1>` for their title, but the second one is nested in a `<section>` that offsets its headings by one level.
+In this example, the markup uses the same component structure twice – an `<article>` with an `<h1>` title. The second one is nested in a `<section>` that offsets its headings by one level.
 
 ```html
 <h1>Insect guide</h1>
@@ -101,9 +92,9 @@ An element with the [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attri
 
 ## Accessibility
 
-Screen reader users navigate by headings and rely on heading levels to understand how a page is structured. Use `headingoffset` to make those levels match the visual structure of the page, and check the result with a screen reader or with the browser's accessibility inspector.
+Screen reader users navigate by headings and rely on heading levels to understand how a page is structured. Use `headingoffset` to make those levels match the visual structure of the page, and check the result with a screen reader or the browser's accessibility inspector.
 
-At the time of writing, `headingoffset` is not enabled by default in any browser. In browsers that do not support it, headings keep the level of their tag name, so the markup must still make sense without the offset — or you can set [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) as a fallback.
+In browsers that do not support this attribute, headings keep the level of their element name, so the markup must still make sense without the offset. Alternatively, you can set [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) as a fallback.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingoffset/index.md
@@ -1,0 +1,121 @@
+---
+title: "`headingoffset` HTML global attribute"
+short-title: headingoffset
+slug: Web/HTML/Reference/Global_attributes/headingoffset
+page-type: html-attribute
+status:
+  - experimental
+browser-compat: html.global_attributes.headingoffset
+sidebar: htmlsidebar
+---
+
+{{SeeCompatTable}}
+
+The **`headingoffset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) increases the heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element it is set on, without changing the tags used to write them.
+
+This lets you write a component that always uses the same heading markup, such as an `<h1>` for its title, and have that heading take the level that fits the place where the component is used.
+
+## Syntax
+
+```html
+<article headingoffset="1">
+  <h1>This heading has a computed heading level of 2</h1>
+</article>
+```
+
+### Value
+
+A non-negative integer between `0` and `8`, inclusive. Values outside that range, and values that are not valid non-negative integers, are ignored, which is the same as an offset of `0`.
+
+## Description
+
+Each heading element has a **computed heading level**, which is the level assistive technologies expose to users. Without `headingoffset`, that level is the number in the element's tag name: `1` for [`<h1>`](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements), `2` for `<h2>`, and so on.
+
+The `headingoffset` attribute adds to that number. The browser walks up from the heading element through its ancestors — crossing shadow boundaries into the shadow host — and adds up the `headingoffset` values it finds. It stops at the first ancestor that has the [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute. The offsets therefore accumulate: an `<h1>` inside an element with `headingoffset="1"` that is itself inside an element with `headingoffset="2"` has a computed heading level of 4.
+
+The computed heading level is clamped to a maximum of `9`. Levels above 6 cannot be written with a tag name, so they can only be produced by `headingoffset` or by the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) attribute.
+
+The attribute affects the computed heading level only. It does not change:
+
+- The element's tag name, so CSS selectors such as `h1` still match, and the default styling of the heading is unchanged.
+- The element's [ARIA role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role), which stays `heading`.
+- An explicit `aria-level` attribute on the heading, which takes precedence over the computed heading level.
+
+Because the offset comes from ancestors, the same component markup can be reused at different depths of a page without editing its headings, and without the accessibility problems caused by picking a heading tag for its font size.
+
+## Examples
+
+### Offsetting headings in a component
+
+In this example, the same article markup is used twice. Both copies use an `<h1>` for their title, but the second one is nested in a `<section>` that offsets its headings by one level.
+
+```html
+<h1>Insect guide</h1>
+
+<article>
+  <h1>Beetles</h1>
+  <p>A beetle has a hardened forewing.</p>
+</article>
+
+<section headingoffset="1">
+  <h1>Appendix</h1>
+  <article>
+    <h1>Beetles, revisited</h1>
+    <p>The same component, one level deeper.</p>
+  </article>
+</section>
+```
+
+The computed heading levels are:
+
+- `Insect guide`: level 1
+- `Beetles`: level 1
+- `Appendix`: level 2
+- `Beetles, revisited`: level 2
+
+### Accumulating offsets
+
+Offsets from nested elements are added together, so this `<h2>` has a computed heading level of 5:
+
+```html
+<article headingoffset="1">
+  <section headingoffset="2">
+    <h2>Level 5</h2>
+  </section>
+</article>
+```
+
+### Stopping the offset
+
+An element with the [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) attribute stops the offsets of its ancestors from applying to its descendants. This is useful for content that is not part of the surrounding document structure, such as a dialog:
+
+```html
+<section headingoffset="2">
+  <h1>Level 3</h1>
+
+  <dialog headingreset>
+    <h1>Level 1</h1>
+  </dialog>
+</section>
+```
+
+## Accessibility
+
+Screen reader users navigate by headings and rely on heading levels to understand how a page is structured. Use `headingoffset` to make those levels match the visual structure of the page, and check the result with a screen reader or with the browser's accessibility inspector.
+
+At the time of writing, `headingoffset` is not enabled by default in any browser. In browsers that do not support it, headings keep the level of their tag name, so the markup must still make sense without the offset — or you can set [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) as a fallback.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) global attribute
+- [`<h1>`–`<h6>`](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) elements
+- [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) attribute
+- [ARIA: heading role](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role)

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -26,7 +26,7 @@ If the element carries both `headingoffset` and `headingreset`, its own offset a
 
 ### Resetting heading levels in a dialog
 
-The `<section>` offsets its headings by 2, so its own heading is at level 3. The dialog has `headingreset`, so the heading inside it is back at level 1:
+In this example, the `<section>` offsets its headings by `2`, so the heading directly inside it is at level 3. The `<dialog>` element has `headingreset`, so the section's offset never reaches the heading inside the dialog, which stays at level 1:
 
 ```html
 <section headingoffset="2">

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -18,7 +18,7 @@ This is a [boolean attribute](/en-US/docs/Glossary/Boolean/HTML); it takes effec
 
 When a browser computes the [heading level](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset#description) of a heading element, it walks up the ancestor chain and adds up the [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) values it finds. The `headingreset` attribute stops that walk: offsets set on the element itself still count, but no ancestor above it contributes an offset.
 
-Use it for content that is not part of the structure of the surrounding document, such as a {{htmlelement("dialog")}}, a popover, or content inserted from another source, where headings should start again at level 1.
+Use this attribute for content that is not part of the structure of the surrounding document, such as a {{htmlelement("dialog")}}, a popover, or markup inserted from another source. Their headings then start again at level 1.
 
 If the element carries both `headingoffset` and `headingreset`, its own offset applies and everything above it is discarded.
 

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -39,7 +39,7 @@ The `<section>` offsets its headings by 2, so its own heading is at level 3. The
 </section>
 ```
 
-### Combining `headingreset` with `headingoffset`
+### Using `headingreset` and `headingoffset` on the same element
 
 Here the outer offset of 3 is discarded, and only the offset on the element with `headingreset` is applied:
 

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -4,6 +4,10 @@ short-title: headingreset
 slug: Web/HTML/Reference/Global_attributes/headingreset
 page-type: html-attribute
 sidebar: htmlsidebar
+status:
+  - experimental
+browser-compat:
+  - html.global_attributes.headingreset
 ---
 
 {{SeeCompatTable}}

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -6,8 +6,8 @@ page-type: html-attribute
 sidebar: htmlsidebar
 status:
   - experimental
-browser-compat:
-  - html.global_attributes.headingreset
+browser-compat: html.global_attributes.headingreset
+sidebar: htmlsidebar
 ---
 
 {{SeeCompatTable}}

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -21,7 +21,7 @@ This is a [boolean attribute](/en-US/docs/Glossary/Boolean/HTML); it takes effec
 
 When a browser computes the [heading level](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset#description) of a heading element, it walks up the ancestor chain and adds up the [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) values it finds. The `headingreset` attribute stops that walk: offsets set on the element itself still count, but no ancestor above it contributes an offset.
 
-Use this attribute for content that is not part of the structure of the surrounding document, such as a {{htmlelement("dialog")}}, a popover, or markup inserted from another source. Their headings then start again at level 1.
+Use this attribute for content that is not part of the structure of the surrounding document, such as a {{htmlelement("dialog")}}, a popover, or markup inserted from another source. Their headings then take the level of their element name.
 
 If the element carries both `headingoffset` and `headingreset`, its own offset applies and everything above it is discarded.
 

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -12,7 +12,7 @@ The **`headingreset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_
 
 ## Values
 
-This is a [boolean attribute](/en-US/docs/Glossary/Boolean/HTML). Its presence enables it. The value is ignored, so `headingreset`, `headingreset=""`, and `headingreset="false"` all have the same effect.
+This is a [boolean attribute](/en-US/docs/Glossary/Boolean/HTML); it takes effect when it is present. A value for it is ignored, so `headingreset`, `headingreset=""`, and `headingreset="false"` all have the same effect.
 
 ## Description
 

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -3,7 +3,6 @@ title: "`headingreset` HTML global attribute"
 short-title: headingreset
 slug: Web/HTML/Reference/Global_attributes/headingreset
 page-type: html-attribute
-sidebar: htmlsidebar
 status:
   - experimental
 browser-compat: html.global_attributes.headingreset

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -41,7 +41,7 @@ In this example, the `<section>` offsets its headings by `2`, so the heading dir
 
 ### Using `headingreset` and `headingoffset` on the same element
 
-Here the outer offset of 3 is discarded, and only the offset on the element with `headingreset` is applied:
+In this example, the outer offset of `3` never reaches the heading. Only the offset on the element with `headingreset` applies, so the heading is at level 2:
 
 ```html
 <div headingoffset="3">

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -1,0 +1,75 @@
+---
+title: "`headingreset` HTML global attribute"
+short-title: headingreset
+slug: Web/HTML/Reference/Global_attributes/headingreset
+page-type: html-attribute
+status:
+  - experimental
+browser-compat: html.global_attributes.headingreset
+sidebar: htmlsidebar
+---
+
+{{SeeCompatTable}}
+
+The **`headingreset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a [boolean attribute](/en-US/docs/Glossary/Boolean/HTML) that stops the [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) values of ancestor elements from applying to the [headings](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside it.
+
+## Syntax
+
+```html
+<dialog headingreset>
+  <h1>This heading has a computed heading level of 1</h1>
+</dialog>
+```
+
+Like other boolean attributes, its presence enables it. The value is ignored, so `headingreset`, `headingreset=""`, and `headingreset="false"` all have the same effect.
+
+## Description
+
+When a browser computes the [heading level](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset#description) of a heading element, it walks up the ancestor chain and adds up the [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) values it finds. The `headingreset` attribute stops that walk: offsets set on the element itself still count, but no ancestor above it contributes an offset.
+
+Use it for content that is not part of the structure of the surrounding document, such as a {{htmlelement("dialog")}}, a popover, or content inserted from another source, where headings should start again at level 1.
+
+If the element carries both `headingoffset` and `headingreset`, its own offset applies and everything above it is discarded.
+
+## Examples
+
+### Resetting heading levels in a dialog
+
+The `<section>` offsets its headings by 2, so its own heading is at level 3. The dialog has `headingreset`, so the heading inside it is back at level 1:
+
+```html
+<section headingoffset="2">
+  <h1>Level 3</h1>
+
+  <dialog headingreset>
+    <h1>Level 1</h1>
+    <p>The offset of the section does not apply here.</p>
+  </dialog>
+</section>
+```
+
+### Combining `headingreset` with `headingoffset`
+
+Here the outer offset of 3 is discarded, and only the offset on the element with `headingreset` is applied:
+
+```html
+<div headingoffset="3">
+  <div headingreset headingoffset="1">
+    <h1>Level 2</h1>
+  </div>
+</div>
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) global attribute
+- [`<h1>`–`<h6>`](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) elements
+- [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-level) attribute

--- a/files/en-us/web/html/reference/global_attributes/headingreset/index.md
+++ b/files/en-us/web/html/reference/global_attributes/headingreset/index.md
@@ -3,25 +3,16 @@ title: "`headingreset` HTML global attribute"
 short-title: headingreset
 slug: Web/HTML/Reference/Global_attributes/headingreset
 page-type: html-attribute
-status:
-  - experimental
-browser-compat: html.global_attributes.headingreset
 sidebar: htmlsidebar
 ---
 
 {{SeeCompatTable}}
 
-The **`headingreset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is a [boolean attribute](/en-US/docs/Glossary/Boolean/HTML) that stops the [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) values of ancestor elements from applying to the [headings](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside it.
+The **`headingreset`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) stops the [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) values of ancestor elements from applying to the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element it is set on.
 
-## Syntax
+## Values
 
-```html
-<dialog headingreset>
-  <h1>This heading has a computed heading level of 1</h1>
-</dialog>
-```
-
-Like other boolean attributes, its presence enables it. The value is ignored, so `headingreset`, `headingreset=""`, and `headingreset="false"` all have the same effect.
+This is a [boolean attribute](/en-US/docs/Glossary/Boolean/HTML). Its presence enables it. The value is ignored, so `headingreset`, `headingreset=""`, and `headingreset="false"` all have the same effect.
 
 ## Description
 

--- a/files/en-us/web/html/reference/global_attributes/index.md
+++ b/files/en-us/web/html/reference/global_attributes/index.md
@@ -55,7 +55,7 @@ In addition to the basic HTML global attributes, the following global attributes
 - [`exportparts`](/en-US/docs/Web/HTML/Reference/Global_attributes/exportparts)
   - : Used to transitively export shadow parts from a nested shadow tree into a containing light tree.
 - [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) {{experimental_inline}}
-  - : Increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element, without changing the tags used to write them.
+  - : Increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element, without changing the elements used to write them.
 - [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) {{experimental_inline}}
   - : A boolean attribute that stops the `headingoffset` values of ancestor elements from applying to the headings inside the element.
 - [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden)

--- a/files/en-us/web/html/reference/global_attributes/index.md
+++ b/files/en-us/web/html/reference/global_attributes/index.md
@@ -54,6 +54,10 @@ In addition to the basic HTML global attributes, the following global attributes
   - : Hints what action label (or icon) to present for the enter key on virtual keyboards.
 - [`exportparts`](/en-US/docs/Web/HTML/Reference/Global_attributes/exportparts)
   - : Used to transitively export shadow parts from a nested shadow tree into a containing light tree.
+- [`headingoffset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingoffset) {{experimental_inline}}
+  - : Increases the computed heading level of the [heading elements](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) inside the element, without changing the tags used to write them.
+- [`headingreset`](/en-US/docs/Web/HTML/Reference/Global_attributes/headingreset) {{experimental_inline}}
+  - : A boolean attribute that stops the `headingoffset` values of ancestor elements from applying to the headings inside the element.
 - [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden)
   - : An enumerated attribute indicating that the element is not yet, or is no longer, _relevant_. For example, it can be used to hide elements of the page that can't be used until the login process has been completed. The browser won't render such elements. This attribute must not be used to hide content that could legitimately be shown.
 - [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id)


### PR DESCRIPTION
Adds reference pages for the `headingoffset` and `headingreset` HTML global attributes, which change the computed heading level of `<h1>`–`<h6>` elements without changing the tags used to write them. Also links them from the global attributes index and the `<h1>`–`<h6>` page, and records the feature in the Firefox 153 release notes and the Firefox experimental features page.

### Motivation

The attributes are specified in the HTML Standard and are now implemented in Chrome 151 and Firefox 153 (both behind a flag), but MDN had no documentation for them at all. They solve a common authoring problem: a component that always uses the same heading markup can be reused at any depth of a page, so authors no longer have to pick heading tags for the level they happen to need, a frequent source of skipped levels and inaccessible outlines.

### Additional details

- Spec: [HTML Standard: Heading levels & offsets](https://html.spec.whatwg.org/multipage/sections.html#heading-levels-&-offsets)
- Firefox implementation: [Firefox bug 1974383](https://bugzil.la/1974383), landed in Firefox 153 behind the `dom.headingoffset.enabled` preference (default `false` on all channels, per `StaticPrefList.yaml`)
- Chrome implementation: [crbug.com/333628468](https://crbug.com/333628468), Chrome 151 behind `#enable-experimental-web-platform-features`
- BCD already contains `html.global_attributes.headingoffset` and `html.global_attributes.headingreset`, so no BCD change is needed.

Pages changed:

- New: `Web/HTML/Reference/Global_attributes/headingoffset`: value range 0–8, how offsets accumulate up the ancestor chain (crossing shadow boundaries), clamping of the computed level at 9, what the attribute does *not* affect (tag name, `heading` role, an explicit `aria-level`), plus accessibility notes and examples.
- New: `Web/HTML/Reference/Global_attributes/headingreset`: boolean attribute that stops the ancestor traversal, including the case where an element carries both attributes.
- `Web/HTML/Reference/Global_attributes`: index entries, marked experimental.
- `Web/HTML/Reference/Elements/Heading_Elements`: usage note pointing at both attributes.
- `Mozilla/Firefox/Releases/153`: entry under "Experimental web features".
- `Mozilla/Firefox/Experimental_features`: HTML entry with the channel table and preference.
- `.vscode/dictionaries/code-entities.txt`: adds `headingoffset`, `headingreset`, and `dom.headingoffset` for cspell.

Not covered here, as they live outside this repo: updating the interactive examples repo, and setting the Gecko bug to `dev-doc-complete`.

### Related issues and pull requests

Fixes #44451

Relates to mdn/mdn#839 (Firefox 153 release tracking project)
