### PR TITLE
[Editorial review] BiDi - New pages for browsingContext events: downloadEnd, downloadWillBegin, userPromptClosed, userPromptOpened

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadend/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadend/index.md
@@ -1,0 +1,98 @@
+---
+title: "`browsingContext.downloadEnd` event"
+short-title: downloadEnd
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.downloadEnd_event
+sidebar: webdriver
+---
+
+The `browsingContext.downloadEnd` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a file download finishes, either because it completed or because it was canceled.
+
+## Event data
+
+The `params` field in the event notification is an object that includes a `status` field.
+The value of `status` determines which additional fields are present.
+
+- `context`
+  - : A string that contains the ID of the context in which the download occurred.
+- `download`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this download.
+    The same ID is included in the corresponding [`browsingContext.downloadWillBegin`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin) event, so you can correlate the two.
+- `filepath` {{optional_inline}}
+  - : A string that contains the path where the browser saved the downloaded file, or `null` if the path is not available.
+    This field is included only when the [`status`](#status) field value is `"complete"`.
+- `navigation`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies the associated navigation, or `null` if the download is not associated with a navigation.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by other events that fire for this navigation, such as [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module events.
+- `status`
+  - : A string that indicates the result of the download.
+    It has one of the following values:
+    - `"canceled"`: The download was canceled before it completed.
+    - `"complete"`: The download completed successfully.
+- `timestamp`
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL of the download.
+
+## Examples
+
+### Receiving an event when a download completes
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.downloadEnd` active.
+
+Suppose a download finishes saving to disk.
+The browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.downloadEnd",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "download": "6bfa8781-e33c-4f2c-8e63-4d0f6dc5d1a1",
+    "navigation": "0e2f4d20-8f0a-4de7-9749-1b12a0d6c8b0",
+    "status": "complete",
+    "timestamp": 1737033601500,
+    "url": "https://example.com/files/report.pdf",
+    "filepath": "/home/user/Downloads/report.pdf"
+  }
+}
+```
+
+### Receiving an event when a download is canceled
+
+Consider the same connection, session, and subscription as in the previous example.
+
+However, suppose the `type` field in the [`browser.setDownloadBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setDownloadBehavior) configuration is set to `"denied"`, causing the browser to reject the download rather than save it.
+In this case, the browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.downloadEnd",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "download": "6bfa8781-e33c-4f2c-8e63-4d0f6dc5d1a1",
+    "navigation": "0e2f4d20-8f0a-4de7-9749-1b12a0d6c8b0",
+    "status": "canceled",
+    "timestamp": 1737033601500,
+    "url": "https://example.com/files/report.pdf"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.downloadWillBegin`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin) event
+- [`browser.setDownloadBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setDownloadBehavior) command
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadend/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadend/index.md
@@ -15,7 +15,7 @@ The `params` field in the event notification is an object that includes a `statu
 The value of `status` determines which additional fields are present.
 
 - `context`
-  - : A string that contains the ID of the context in which the download occurred.
+  - : A string that contains the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) in which the download occurred.
 - `download`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this download.
     The same ID is included in the corresponding [`browsingContext.downloadWillBegin`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin) event, so you can correlate the two.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadwillbegin/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadwillbegin/index.md
@@ -14,7 +14,7 @@ The `browsingContext.downloadWillBegin` [event](/en-US/docs/Web/WebDriver/Refere
 The `params` field in the event notification is an object with the following fields:
 
 - `context`
-  - : A string that contains the ID of the context in which the download was triggered.
+  - : A string that contains the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) in which the download was triggered.
 - `download`
   - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this download.
     The same ID is included in the corresponding [`browsingContext.downloadEnd`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd) event, so you can correlate the two.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadwillbegin/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/downloadwillbegin/index.md
@@ -1,0 +1,74 @@
+---
+title: "`browsingContext.downloadWillBegin` event"
+short-title: downloadWillBegin
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.downloadWillBegin_event
+sidebar: webdriver
+---
+
+The `browsingContext.downloadWillBegin` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when the browser is about to start a file download.
+
+## Event data
+
+The `params` field in the event notification is an object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context in which the download was triggered.
+- `download`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies this download.
+    The same ID is included in the corresponding [`browsingContext.downloadEnd`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd) event, so you can correlate the two.
+- `navigation`
+  - : A string that contains the [UUID](/en-US/docs/Glossary/UUID) that uniquely identifies the associated navigation, or `null` if the download is not associated with a navigation.
+    If the navigation was started using the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) or [`browsingContext.reload`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/reload) command, this ID matches the `navigation` value in the command's response.
+    The same ID is shared by other events that fire for this navigation, such as [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted) and [`network`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/network) module events.
+- `suggestedFilename`
+  - : A string that contains the filename that the browser suggests for the download.
+- `timestamp`
+  - : A non-negative integer that represents the time when the event was fired, as milliseconds elapsed since the [epoch](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date).
+- `url`
+  - : A string that contains the URL of the download.
+
+## Description
+
+A download is initiated either by activating a link that has the [`download`](/en-US/docs/Web/HTML/Reference/Elements/a#download) attribute or by a response to a network request with a [`Content-Disposition`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition) header that indicates the resource as an attachment.
+
+After this event fires, the browser determines whether to allow the download and where to save it, based on the download behavior configured using [`browser.setDownloadBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setDownloadBehavior).
+
+## Examples
+
+### Receiving an event when a download starts
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.downloadWillBegin` active.
+
+Suppose a link on the page points to `https://example.com/files/report.pdf`.
+Before starting the download, the browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.downloadWillBegin",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "download": "6bfa8781-e33c-4f2c-8e63-4d0f6dc5d1a1",
+    "navigation": "0e2f4d20-8f0a-4de7-9749-1b12a0d6c8b0",
+    "suggestedFilename": "report.pdf",
+    "timestamp": 1737033600000,
+    "url": "https://example.com/files/report.pdf"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.downloadEnd`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd) event
+- [`browser.setDownloadBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/setDownloadBehavior) command
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -48,12 +48,16 @@ Calling [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Mod
 - [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated)
 - [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed)
 - [`browsingContext.domContentLoaded`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded)
+- [`browsingContext.downloadEnd`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd)
+- [`browsingContext.downloadWillBegin`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin)
 - [`browsingContext.fragmentNavigated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated)
 - [`browsingContext.historyUpdated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated)
 - [`browsingContext.load`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/load)
 - [`browsingContext.navigationCommitted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationCommitted)
 - [`browsingContext.navigationFailed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed)
 - [`browsingContext.navigationStarted`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted)
+- [`browsingContext.userPromptClosed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptClosed)
+- [`browsingContext.userPromptOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptOpened)
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/index.md
@@ -39,6 +39,10 @@ Calling [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Mod
 
 - [`browsingContext.contextCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextCreated)
 - [`browsingContext.contextDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed)
+- [`browsingContext.downloadEnd`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd)
+- [`browsingContext.downloadWillBegin`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin)
+- [`browsingContext.userPromptClosed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptClosed)
+- [`browsingContext.userPromptOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptOpened)
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptclosed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptclosed/index.md
@@ -1,0 +1,104 @@
+---
+title: "`browsingContext.userPromptClosed` event"
+short-title: userPromptClosed
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptClosed
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.userPromptClosed_event
+sidebar: webdriver
+---
+
+The `browsingContext.userPromptClosed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a user prompt closes in the browser.
+
+## Event data
+
+The `params` field in the event notification is an object with the following fields:
+
+- `accepted`
+  - : A boolean that indicates whether the user prompt was accepted.
+    - `true`: The prompt was accepted, for example, by clicking "OK" or by a [`browsingContext.handleUserPrompt`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/handleUserPrompt) command with `accept` set to `true`.
+    - `false`: The prompt was dismissed, for example, by clicking "Cancel" or by a [`browsingContext.handleUserPrompt`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/handleUserPrompt) command with `accept` set to `false`.
+
+    The browser can also close the prompt on its own, without an explicit `handleUserPrompt` command, based on the [`unhandledPromptBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#unhandledpromptbehavior) capability defined for the session, or overridden per user context with [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext).
+- `context`
+  - : A string that contains the ID of the context that had the user prompt.
+- `type`
+  - : A string that indicates the kind of user prompt that closed.
+    It has one of the following values:
+    - `"alert"`: An {{domxref("Window.alert", "alert()")}} dialog.
+    - `"beforeunload"`: A dialog shown by the {{domxref("Window.beforeunload_event", "beforeunload")}} event.
+    - `"confirm"`: A {{domxref("Window.confirm", "confirm()")}} dialog.
+    - `"prompt"`: A {{domxref("Window.prompt", "prompt()")}} dialog.
+- `userText` {{optional_inline}}
+  - : A string that contains the text entered by the user before the prompt was closed.
+    This field is included only when the `type` field value is `"prompt"`.
+
+## Examples
+
+### Receiving an event when an alert is accepted
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.userPromptClosed` active.
+
+Suppose an `alert()` dialog is accepted.
+The browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.userPromptClosed",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "accepted": true,
+    "type": "alert"
+  }
+}
+```
+
+### Receiving an event when a prompt is closed with entered text
+
+Using the same connection and session, suppose a `prompt()` dialog is accepted after text is typed into it.
+The browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.userPromptClosed",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "accepted": true,
+    "type": "prompt",
+    "userText": "Jane Doe"
+  }
+}
+```
+
+### Receiving an event when a beforeunload dialog is accepted
+
+Using the same connection and session, suppose the client uses the [`browsingContext.handleUserPrompt`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/handleUserPrompt) command with `accept` set to `true` to close a `beforeunload` dialog.
+
+When the dialog closes, the browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.userPromptClosed",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "accepted": true,
+    "type": "beforeunload"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.userPromptOpened`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptOpened) event
+- [`browsingContext.handleUserPrompt`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/handleUserPrompt) command
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptclosed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptclosed/index.md
@@ -20,7 +20,7 @@ The `params` field in the event notification is an object with the following fie
 
     The browser can also close the prompt on its own, without an explicit `handleUserPrompt` command, based on the [`unhandledPromptBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#unhandledpromptbehavior) capability defined for the session, or overridden per user context with [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext).
 - `context`
-  - : A string that contains the ID of the context that had the user prompt.
+  - : A string that contains the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) that had the user prompt.
 - `type`
   - : A string that indicates the kind of user prompt that closed.
     It has one of the following values:

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptopened/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptopened/index.md
@@ -14,7 +14,7 @@ The `browsingContext.userPromptOpened` [event](/en-US/docs/Web/WebDriver/Referen
 The `params` field in the event notification is an object with the following fields:
 
 - `context`
-  - : A string that contains the ID of the context that has the user prompt.
+  - : A string that contains the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) that has the user prompt.
 - `defaultValue` {{optional_inline}}
   - : A string that contains the default value of the {{domxref("Window.prompt", "prompt()")}} dialog.
     This field is included only when the [`type`](#type) field value is `"prompt"` and the page provided a default value that is not an empty string.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptopened/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/userpromptopened/index.md
@@ -1,0 +1,115 @@
+---
+title: "`browsingContext.userPromptOpened` event"
+short-title: userPromptOpened
+slug: Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptOpened
+page-type: webdriver-event
+browser-compat: webdriver.bidi.browsingContext.userPromptOpened_event
+sidebar: webdriver
+---
+
+The `browsingContext.userPromptOpened` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a user prompt opens in the browser.
+
+## Event data
+
+The `params` field in the event notification is an object with the following fields:
+
+- `context`
+  - : A string that contains the ID of the context that has the user prompt.
+- `defaultValue` {{optional_inline}}
+  - : A string that contains the default value of the {{domxref("Window.prompt", "prompt()")}} dialog.
+    This field is included only when the [`type`](#type) field value is `"prompt"` and the page provided a default value that is not an empty string.
+- `handler`
+  - : A string that indicates how the prompt will be handled.
+    The behavior is set by the [`unhandledPromptBehavior`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new#unhandledpromptbehavior) capability for the session, or overridden per user context with [`browser.createUserContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser/createUserContext).
+    It has one of the following values:
+    - `"accept"`: The browser will accept the prompt.
+    - `"dismiss"`: The browser will dismiss the prompt.
+    - `"ignore"`: The browser will leave the prompt open for the client to handle.
+
+    If the value is `"ignore"`, the prompt stays open until the client closes it with [`browsingContext.handleUserPrompt`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/handleUserPrompt).
+- `message`
+  - : A string that contains the message displayed in the prompt.
+- `type`
+  - : A string that indicates the kind of user prompt that opened.
+    It has one of the following values:
+    - `"alert"`: An {{domxref("Window.alert", "alert()")}} dialog.
+    - `"beforeunload"`: A dialog shown by the {{domxref("Window.beforeunload_event", "beforeunload")}} event.
+    - `"confirm"`: A {{domxref("Window.confirm", "confirm()")}} dialog.
+    - `"prompt"`: A {{domxref("Window.prompt", "prompt()")}} dialog.
+
+## Examples
+
+### Receiving an event when an alert opens
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection), an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new), and a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `browsingContext.userPromptOpened` active.
+
+Suppose a page calls `alert("Are you sure?")`.
+The browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.userPromptOpened",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "handler": "ignore",
+    "message": "Are you sure?",
+    "type": "alert"
+  }
+}
+```
+
+### Receiving an event when a prompt with a default value opens
+
+Using the same connection and session as in the previous example, suppose a page calls `prompt("Enter your name:", "Jane Doe")`.
+
+The browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.userPromptOpened",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "handler": "ignore",
+    "message": "Enter your name:",
+    "type": "prompt",
+    "defaultValue": "Jane Doe"
+  }
+}
+```
+
+### Receiving an event when a beforeunload dialog opens
+
+Using the same connection and session as in the first example, suppose the client uses the [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) command to navigate away from a page that listens for the `beforeunload` event.
+
+When the dialog opens, before the navigation completes, the browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "browsingContext.userPromptOpened",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "handler": "ignore",
+    "message": "This page is asking you to confirm that you want to leave — information you've entered may not be saved.",
+    "type": "beforeunload"
+  }
+}
+```
+
+Because the `handler` value is `"ignore"`, the dialog stays open until you close it with the [`browsingContext.handleUserPrompt`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/handleUserPrompt) command.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`browsingContext.userPromptClosed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptClosed) event
+- [`browsingContext.handleUserPrompt`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/handleUserPrompt) command
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -74,6 +74,10 @@ sidebar:
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/domContentLoaded
             code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin
+            code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/fragmentNavigated
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/historyUpdated
@@ -85,6 +89,10 @@ sidebar:
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationFailed
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigationStarted
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptClosed
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptOpened
             code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -62,6 +62,14 @@ sidebar:
             code: true
           - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/contextDestroyed
             code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadEnd
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/downloadWillBegin
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptClosed
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/browsingContext/userPromptOpened
+            code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/emulation
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/input


### PR DESCRIPTION
### Description

This PR adds pages for the following events of the [`browsingContext`](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module:
  - `browsingContext.downloadEnd`
  - `browsingContext.downloadWillBegin`
  - `browsingContext.userPromptClosed`
  - `browsingContext.userPromptOpened`

### Spec links

- https://w3c.github.io/webdriver-bidi/#event-browsingContext-downloadEnd
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-downloadWillBegin
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptClosed
- https://w3c.github.io/webdriver-bidi/#event-browsingContext-userPromptOpened

### Related issue

Doc issue: mdn/mdn#851