### PR TITLE
fix(learn): correct `git status` output in Django setup tutorial

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/development_environment/index.md
@@ -525,11 +525,13 @@ This is a useful change to make, but mostly we're doing it to show you how to pu
    It should look a bit like the listing below.
 
    ```bash
-   > git status
-   On branch main
-   Your branch is up-to-date with 'origin/update_gitignore'.
+   git status
+   ```
+
+   ```plain
+   On branch update_gitignore
    Changes to be committed:
-     (use "git reset HEAD <file>..." to unstage)
+     (use "git restore --staged <file>..." to unstage)
 
            modified:   .gitignore
    ```


### PR DESCRIPTION
Corrects the sample `git status` output in the "Modify and sync changes" step of the Django development environment tutorial: it showed the wrong branch, a tracking line for a remote branch that does not exist yet, and an unstage hint that git no longer prints.

### Motivation

Readers following the steps in order get output that contradicts what they just did. Step 2 runs `git checkout -b update_gitignore`, but the listing in step 5 says `On branch main`, so anyone new to git is left wondering whether the checkout worked or whether they were supposed to switch back.

The tracking line is also impossible at that point in the tutorial. The branch is not pushed until step 7, so it has no upstream when `git status` runs in step 5, and git prints no "Your branch is up-to-date with ..." line at all.

Finally, the hint `(use "git reset HEAD <file>..." to unstage)` is pre-2.23 output. Git has printed `(use "git restore --staged <file>..." to unstage)` since August 2019, so readers comparing their terminal against the page see a mismatch there too.

### Additional details

Before:

````
```bash
> git status
On branch main
Your branch is up-to-date with 'origin/update_gitignore'.
Changes to be committed:
  (use "git reset HEAD <file>..." to unstage)

        modified:   .gitignore
```
````

After:

````
```bash
git status
```

```plain
On branch update_gitignore
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)

        modified:   .gitignore
```
````

The command and its output are now in separate `bash` and `plain` blocks, which matches the equivalent step in the Express deployment tutorial (`learn_web_development/extensions/server-side/express_nodejs/deployment`) and removes the `>` prompt character that readers could otherwise copy.

The branch-and-pull-request workflow of the surrounding steps is left as it is: steps 7 and 8 deliberately teach pushing the branch and merging it through a pull request on GitHub, consistent with the rest of the Django series, so only the pasted output needed correcting.

Note that the same outdated `git reset HEAD` hint appears once more, in the Express deployment tutorial. That listing is otherwise correct (it really is on `main`, tracking `origin/main`), so it is outside the scope of this issue and left for a separate change.

### Related issues and pull requests

Fixes #45003
