### PR TITLE
added release note for percentage values of `text-decoration-inset`

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -449,6 +449,20 @@ The {{cssxref("line-clamp")}} CSS property now works without the `-webkit-` vend
 - `layout.css.line-clamp.enabled`
   - : Set to `true` to enable.
 
+### Percentage values for `text-decoration-inset`
+
+The {{cssxref("text-decoration-inset")}} CSS property now supports percentages as values. The percentage value specifies the size of the inset as a percentage of the {{cssxref("font-size")}}. ([Firefox bug 2044602](https://bugzil.la/2044602)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 154           | No                  |
+| Developer Edition | 154           | No                  |
+| Beta              | 154           | No                  |
+| Release           | 154           | No                  |
+
+- `layout.css.text-decoration-inset-percentage.enabled`
+  - : Set to `true` to enable.
+
 ## SVG
 
 **No experimental features in this release cycle.**

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -90,3 +90,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **Truncating content with `line-clamp`**: `layout.css.line-clamp.enabled`
 
   The {{cssxref("line-clamp")}} CSS property now works without the `-webkit-` vendor prefix, though at this stage it does not support the `no-ellipsis` and `<string>` values. ([Firefox bug 2042986](https://bugzil.la/2042986)).
+
+- **Percentage values for `text-decoration-inset`**: `layout.css.text-decoration-inset-percentage.enabled`
+
+  The {{cssxref("text-decoration-inset")}} CSS property now supports percentages as values. The percentage value specifies the size of the inset as a percentage of the {{cssxref("font-size")}}. ([Firefox bug 2044602](https://bugzil.la/2044602)).


### PR DESCRIPTION
### Description

- Added Firefox experimental feature release note for `text-decoration-inset` for percentage values
- Added Firefox 154 release note for `text-decoration-inset` for percentage values

### Motivation

- Working on [MDN issue #44840](https://github.com/mdn/content/issues/44840)

### Related issues and pull requests

- [Content PR](https://github.com/mdn/content/pull/45028)
- [Data PR](https://github.com/mdn/data/pull/1087)