### PR TITLE
Technical review: Document text-overflow ellipsis behaving as clip behavior

### DIFF
--- a/files/en-us/web/css/reference/properties/text-overflow/index.md
+++ b/files/en-us/web/css/reference/properties/text-overflow/index.md
@@ -91,7 +91,44 @@ white-space: nowrap;
 
 The `text-overflow` property only affects content that is overflowing a block container element in its _inline_ progression direction (not text overflowing at the bottom of a box, for example).
 
-The `text-overflow` property may be specified using one or two values. If one value is given, it specifies overflow behavior for the end of the line (the right end for left-to-right text, the left end for right-to-left text). If two values are given, the first specifies overflow behavior for the left end of the line, and the second specifies it for the right end of the line. The property accepts either a keyword value (`clip` or `ellipsis`) or a `<string>` value.
+The `text-overflow` property may be specified using one or two values. If one value is given, it specifies overflow behavior for the end of the line (the right end for left-to-right text, the left end for right-to-left text). If two values are given, the first specifies overflow behavior for the left end of the line, and the second specifies it for the right end of the line.
+
+### `ellipsis` behaving as `clip` for editable elements
+
+When `text-overflow: ellipsis` is applied to editable elements such as textual {{htmlelement("input")}}, {{htmlelement("textarea")}}, and [`contenteditable`](/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable) elements, browsers generally treat it as `text-overflow: clip`, either all the time or when the element is focused. The exact behavior differs across browsers; see [Browser compatibility](#browser_compatibility).
+
+This behavior is to ensure that the text can be moved through and edited, even when overflowing. If the overflowing text remained covered by an ellipsis, it would not be visible or editable.
+
+You can see the behavior in the following live example, which has this CSS applied:
+
+```css live-sample___ellipsis-as-clip
+p[contenteditable],
+input,
+textarea {
+  width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+```
+
+```html hidden live-sample___ellipsis-as-clip
+<p contenteditable="">
+  contenteditable paragraph. The text in here is overflowing.
+</p>
+
+<hr />
+
+<input type="text" value="Text input. The text in here is overflowing." />
+
+<hr />
+
+<textarea>Textarea. The text in here is overflowing.</textarea>
+```
+
+{{embedlivesample("ellipsis-as-clip", "100%", "200")}}
+
+Focus the different elements and try editing their text content.
 
 ## Formal definition
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

As of Chrome 149, the behavior of [`text-overflow: ellipsis`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-overflow#ellipsis) when applied to `contenteditable` elements has changed — it now behaves as `text-overflow: clip` while the elements are focused, to make it so that the text can be scanned and edited. See https://chromestatus.com/feature/5146265241387008.

While I was doing this, I fell down a bit of a rabbit hole and also tested the behavior of other browsers for `ellipsis` and also for string values of `text-overflow`. The notes I've added here describe what I found in my tests.

See https://codepen.io/editor/Chris-Mills/pen/019fd2ca-c668-7925-a7c0-dbce3a12bcfb for my test.

This PR documents this behavior.

See also the related compat data PR: https://github.com/mdn/browser-compat-data/pull/30178.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
