### PR TITLE
Editorial review: Document new Chrome bfcache websocket behavior - doesnt block pages

### DIFF
--- a/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
+++ b/files/en-us/web/api/performance_api/monitoring_bfcache_blocking_reasons/index.md
@@ -160,7 +160,9 @@ The values listed in [the specification](https://html.spec.whatwg.org/multipage/
 - `"parser-aborted"`
   - : The current document never finished its initial HTML parsing, and storing the unfinished document in the bfcache was prevented.
 - `"websocket"`
-  - : While unloading, an open [WebSocket](/en-US/docs/Web/API/WebSockets_API) connect was shut down, so the page was not in a stable state that could be stored in the bfcache.
+  - : While unloading, an open [WebSocket](/en-US/docs/Web/API/WebSockets_API) connection was shut down, so the page was not in a stable state that could be stored in the bfcache.
+
+    In [some browsers](#browser_compatibility), active WebSockets do not block pages from entering the bfcache. In such cases, the WebSocket connections are disconnected upon entry, and can be reconnected when the page is restored. In Chrome, for example, when a page is restored from the bfcache, the browser fires the [`error`](/en-US/docs/Web/API/WebSocket/error_event) and [`close`](/en-US/docs/Web/API/WebSocket/close_event) events, enabling an application to trigger its existing logic to reconnect to the WebSocket.
 
 ### User-agent specific blocking reasons
 

--- a/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/notrestoredreasons/index.md
@@ -10,7 +10,7 @@ browser-compat: api.PerformanceNavigationTiming.notRestoredReasons
 
 {{APIRef("Performance API")}}{{SeeCompatTable}}
 
-The **`notRestoredReasons`** read-only property of the {{domxref("PerformanceNavigationTiming")}} interface returns a {{domxref("NotRestoredReasons")}} object providing report data on reasons why the current document was blocked from using the back/forward cache ({{Glossary("bfcache")}}) on navigation.
+The **`notRestoredReasons`** read-only property of the {{domxref("PerformanceNavigationTiming")}} interface returns a {{domxref("NotRestoredReasons")}} object providing report data on [the reasons](/en-US/docs/Web/API/Performance_API/Monitoring_bfcache_blocking_reasons#blocking_reasons) why the current document was blocked from using the back/forward cache ({{Glossary("bfcache")}}) on navigation.
 
 ## Value
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

From version 149, Chrome no longer allows active WebSocket connections to block pages from entering the [bfcache](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Monitoring_bfcache_blocking_reasons). The WebSocket connections are disconnected upon the page entering the cache, and can be reconnected when the page is navigated to again.

See https://chromestatus.com/feature/5068439115923456.

This PR documents the new behavior.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
