### PR TITLE
GPUCommandEncoder.copyTextureToTexture(): fix validation rules to match the spec

### DIFF
--- a/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
+++ b/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
@@ -67,7 +67,7 @@ For the `source`:
 
 For the `destination`:
 
-- The `source`'s {{domxref("GPUTexture.usage")}} includes the `GPUTextureUsage.COPY_DST` flag.
+- The `destination`'s {{domxref("GPUTexture.usage")}} includes the `GPUTextureUsage.COPY_DST` flag.
 
 For `source` and `destination`:
 
@@ -77,10 +77,9 @@ For `source` and `destination`:
 - The source and destination `texture` {{domxref("GPUTexture.format")}}s are copy-compatible.
 - The source and destination `texture` {{domxref("GPUTexture.sampleCount")}}s are equal.
 - If the {{domxref("GPUTexture.format")}} is a [depth-or-stencil format](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format) or {{domxref("GPUTexture.sampleCount")}} is more than 1, the subresource size is equal to `size`.
-- The `texture`'s {{domxref("GPUTexture.sampleCount")}} is 1.
-- `aspect` refers to a single aspect of the {{domxref("GPUTexture.format")}}.
-- That aspect is a valid image copy source/destination according to [depth-or-stencil formats](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format).
+- If the {{domxref("GPUTexture.format")}} is a [depth-stencil format](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format), the `source` and `destination` `aspect`s both refer to all aspects of their respective textures' {{domxref("GPUTexture.format")}}s.
 - The `texture` is compatible with the `copySize`.
+- The sets of subresources defined by `source` and `destination`, combined with `copySize`, are disjoint.
 
 ## Examples
 

--- a/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
+++ b/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
@@ -77,7 +77,7 @@ For `source` and `destination`:
 - The source and destination `texture` {{domxref("GPUTexture.format")}}s are copy-compatible.
 - The source and destination `texture` {{domxref("GPUTexture.sampleCount")}}s are equal.
 - If the {{domxref("GPUTexture.format")}} is a [depth-or-stencil format](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format) or {{domxref("GPUTexture.sampleCount")}} is more than 1, the subresource size is equal to `size`.
-- If the {{domxref("GPUTexture.format")}} is a [depth-stencil format](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format), the `source` and `destination` `aspect`s both refer to all aspects of their respective textures' {{domxref("GPUTexture.format")}}s.
+- If the {{domxref("GPUTexture.format")}} is a [depth-or-stencil format](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format), the `source` and `destination` `aspect`s both refer to all aspects of their respective textures' {{domxref("GPUTexture.format")}}s.
 - The `texture` is compatible with the `copySize`.
 - The sets of subresources defined by `source` and `destination`, combined with `copySize`, are disjoint.
 

--- a/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
+++ b/files/en-us/web/api/gpucommandencoder/copytexturetotexture/index.md
@@ -79,7 +79,7 @@ For `source` and `destination`:
 - If the {{domxref("GPUTexture.format")}} is a [depth-or-stencil format](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format) or {{domxref("GPUTexture.sampleCount")}} is more than 1, the subresource size is equal to `size`.
 - If the {{domxref("GPUTexture.format")}} is a [depth-or-stencil format](https://gpuweb.github.io/gpuweb/#combined-depth-stencil-format), the `source` and `destination` `aspect`s both refer to all aspects of their respective textures' {{domxref("GPUTexture.format")}}s.
 - The `texture` is compatible with the `copySize`.
-- The sets of subresources defined by `source` and `destination`, combined with `copySize`, are disjoint.
+- The sets of subresources defined by `source` combined with `copySize`, and `destination` combined with `copySize`, are disjoint.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #44044.

The Validation section of `copyTextureToTexture()` listed several rules that belong to the [validating texture buffer copy](https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-texture-buffer-copy) algorithm, which is used by the texture↔buffer copies (`copyTextureToBuffer()`, `copyBufferToTexture()`, `writeTexture()`) but **not** by `copyTextureToTexture()`. That method instead uses [validating GPUTexelCopyTextureInfo](https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gputexelcopytextureinfo) plus its own [rules](https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copytexturetotexture). This resulted in three incorrect entries, two of which stated the opposite of the spec.

### Changes

**1. `aspect` (the issue as reported).** The page said:

> `aspect` refers to a single aspect of the `GPUTexture.format`.
> That aspect is a valid image copy source/destination according to depth-or-stencil formats.

The spec requires the opposite for this method:

> If `srcTexture.format` is a depth-stencil format: `source.aspect` and `destination.aspect` must both refer to **all aspects** of `srcTexture.format` and `dstTexture.format`, respectively.

The "single aspect" requirement is from `validating texture buffer copy`, and it does not apply here.

**2. `COPY_DST` referred to the wrong resource.** Under the *For the `destination`* heading, the page said "The **`source`**'s `GPUTexture.usage` includes the `GPUTextureUsage.COPY_DST` flag." The spec says `dstTexture.usage contains COPY_DST`. The equivalent line on [`copyTextureToBuffer()`](https://developer.mozilla.org/en-US/docs/Web/API/GPUCommandEncoder/copyTextureToBuffer) already refers to the destination correctly.

**3. `sampleCount` is not required to be 1.** The page said "The `texture`'s `GPUTexture.sampleCount` is 1", which is also from `validating texture buffer copy`. `copyTextureToTexture()` only requires that the two sample counts be *equal*, so copying multisampled textures is allowed. The removed line also contradicted the two entries directly above it: one requiring the sample counts to be equal (pointless if both had to be 1), and one describing the behavior when `sampleCount` is more than 1.

I also added the disjoint-subresources rule, which the spec lists for this method and the page was missing — it is what makes a copy from a texture to itself invalid when the regions overlap.

Rules verified against the [WebGPU spec](https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copytexturetotexture). The original report notes this is covered by the WebGPU CTS and was first surfaced in gfx-rs/wgpu#9521.