### PR TITLE
docs(css): clarify border-image-slice example source image

### DIFF
--- a/files/en-us/web/css/reference/properties/border-image-slice/index.md
+++ b/files/en-us/web/css/reference/properties/border-image-slice/index.md
@@ -125,7 +125,7 @@ The {{cssxref("border-image-repeat")}}, {{cssxref("border-image-width")}}, and {
 
 The following example shows a `<div>` with a border image set on it. The source image for the borders is as follows:
 
-![Nine multi-colored diamond laid out in three rows and three columns](/shared-assets/images/examples/border-diamonds.png)
+![Nine multi-colored diamonds laid out in three rows and three columns](/shared-assets/images/examples/border-diamonds.png)
 
 The diamonds in the source image are 30px across, so setting 30 pixels as the value for both {{cssxref("border-width")}} and `border-image-slice` will get you complete and fairly crisp diamonds in your border:
 

--- a/files/en-us/web/css/reference/properties/border-image-slice/index.md
+++ b/files/en-us/web/css/reference/properties/border-image-slice/index.md
@@ -125,7 +125,7 @@ The {{cssxref("border-image-repeat")}}, {{cssxref("border-image-width")}}, and {
 
 The following example shows a `<div>` with a border image set on it. The source image for the borders is as follows:
 
-![A multi-colored diamond pattern used as a border image source](/shared-assets/images/examples/border-diamonds.png)
+![Nine multi-colored diamond laid out in three rows and three columns](/shared-assets/images/examples/border-diamonds.png)
 
 The diamonds in the source image are 30px across, so setting 30 pixels as the value for both {{cssxref("border-width")}} and `border-image-slice` will get you complete and fairly crisp diamonds in your border:
 

--- a/files/en-us/web/css/reference/properties/border-image-slice/index.md
+++ b/files/en-us/web/css/reference/properties/border-image-slice/index.md
@@ -125,9 +125,9 @@ The {{cssxref("border-image-repeat")}}, {{cssxref("border-image-width")}}, and {
 
 The following example shows a `<div>` with a border image set on it. The source image for the borders is as follows:
 
-![nice multi-colored diamonds](border-diamonds.png)
+![A multi-colored diamond pattern used as a border image source](/shared-assets/images/examples/border-diamonds.png)
 
-The diamonds are 30px across, so setting 30 pixels as the value for both {{cssxref("border-width")}} and `border-image-slice` will get you complete and fairly crisp diamonds in your border:
+The diamonds in the source image are 30px across, so setting 30 pixels as the value for both {{cssxref("border-width")}} and `border-image-slice` will get you complete and fairly crisp diamonds in your border:
 
 ```css
 border-width: 30px;


### PR DESCRIPTION
### Description

Clarified the source image reference in the `border-image-slice` example by improving the image path and updating the alt text.

### Motivation

The `border-image-slice` example mentions the source image used for the border, but the image reference and description could be clearer. This change makes it easier to understand the relationship between the source image and the resulting border rendering.

### Additional details

- Updated the image reference to use the shared-assets path.
- Improved the image alt text for better accessibility.
- Updated the explanation to clarify that the 30px measurement refers to the source image.

### Related issues and pull requests

Fixes #43121