### PR TITLE
Fix typos: withing -> within, wll -> will, bellow -> below

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -1482,7 +1482,7 @@ The following example uses most of the different values for `theme.colors`:
 
 It will give you a browser that looks like this:
 
-![A browser window with two open tabs and dark green background color in the header area. The inactive tab has a white text color. The active tab and the toolbar have a blue background color with cyan-colored text. The URL bar has an orange background with white borders, a green text color and a white-colored vertical line separator. A red-colored line is used to separate the tabs on the top and a white line to separate the tabs from the content bellow them.](theme.png)
+![A browser window with two open tabs and dark green background color in the header area. The inactive tab has a white text color. The active tab and the toolbar have a blue background color with cyan-colored text. The URL bar has an orange background with white borders, a green text color and a white-colored vertical line separator. A red-colored line is used to separate the tabs on the top and a white line to separate the tabs from the content below them.](theme.png)
 
 In this screenshot, `"toolbar_vertical_separator"` is the white vertical line in the URL bar dividing the Reader Mode icon from the other icons.
 

--- a/files/en-us/web/css/guides/images/replaced_element_properties/index.md
+++ b/files/en-us/web/css/guides/images/replaced_element_properties/index.md
@@ -21,7 +21,7 @@ The CSS images module defines two properties which can be used to specify how th
 
 ### The `object-fit` property
 
-The `object-fit` property specifies how the replaced element's content object should be fitted to the containing element's box. The property defines how images, videos and other embeddable media formats respond to the height and width of the replaced element's content box. If the height, width, or aspect-ratio of an element differ from the resource that will be occupying space reserved for the element, the `fill`, `contain`, `cover`, `scale-down`, and `none` values define whether the browser should scale the resource, cover the allocated space, contain the asset withing the space, or allow the resource to be distorted.
+The `object-fit` property specifies how the replaced element's content object should be fitted to the containing element's box. The property defines how images, videos and other embeddable media formats respond to the height and width of the replaced element's content box. If the height, width, or aspect-ratio of an element differ from the resource that will be occupying space reserved for the element, the `fill`, `contain`, `cover`, `scale-down`, and `none` values define whether the browser should scale the resource, cover the allocated space, contain the asset within the space, or allow the resource to be distorted.
 
 When contained or scaled down, any areas of the box not covered by the replaced element will show the element's background.
 

--- a/files/en-us/web/css/guides/values_and_units/using_typed_arithmetic/index.md
+++ b/files/en-us/web/css/guides/values_and_units/using_typed_arithmetic/index.md
@@ -291,7 +291,7 @@ body {
 
 We now come to styling the `story-circle` `<div>`. We set its `width` and `height` to `1px`: it will act as a reference point with its child paragraphs positioned in a circle around it. (We don't even need to set positioning on it, as it is fine for the paragraphs to be positioned relative to the `<body>`).
 
-We then create a custom property called `--width-percentage` that contains the result of `100cqw` (100% of the width of the element's parent query container, which is the `<body>` element) divided by `1200px`, minus `0.33333`. This is the key value that wll control the amount the circle rotates by as the viewport width is changed.
+We then create a custom property called `--width-percentage` that contains the result of `100cqw` (100% of the width of the element's parent query container, which is the `<body>` element) divided by `1200px`, minus `0.33333`. This is the key value that will control the amount the circle rotates by as the viewport width is changed.
 
 ```css
 .story-circle {

--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -459,7 +459,7 @@ All HTML and SVG elements support event handler attributes defined on the [`Glob
 
 While event handler attributes, like {{domxref("Element/blur_event", "onblur")}} and {{domxref("Element/auxclick_event", "onauxclick")}}, apply to all elements, they may not have any effect. For example, the {{domxref("HTMLTrackElement/cuechange_event", "oncuechange")}} attribute can be applied to any element, but it is only relevant to the {{htmlelement("track")}} element.
 
-Event handler attributes are discouraged, considered unsafe, and may be blocked by [content security policies (CSP)](/en-US/docs/Web/Security/Practical_implementation_guides/CSP). Use the event name withing an {{domxref("EventTarget.addEventListener", "addEventListener()")}} method instead.
+Event handler attributes are discouraged, considered unsafe, and may be blocked by [content security policies (CSP)](/en-US/docs/Web/Security/Practical_implementation_guides/CSP). Use the event name within an {{domxref("EventTarget.addEventListener", "addEventListener()")}} method instead.
 
 ## See also
 


### PR DESCRIPTION
Fixes four spelling errors in prose across four unrelated pages.

| File | Was | Now |
| --- | --- | --- |
| `web/svg/reference/attribute` | Use the event name **withing** an `addEventListener()` method | within |
| `web/css/guides/images/replaced_element_properties` | contain the asset **withing** the space | within |
| `web/css/guides/values_and_units/using_typed_arithmetic` | the key value that **wll** control | will |
| `mozilla/add-ons/webextensions/manifest.json/theme` | separate the tabs from the content **bellow** them | below |

The last one is inside image alt text, so it is read aloud by screen readers.

Prose only - no code samples, examples, or rendered output are affected.