### PR TITLE
CSSMathInvert fixes

### DIFF
--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathInvert.CSSMathInvert
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathInvert()`** constructor creates a new {{domxref("CSSMathInvert")}} object which represents a CSS {{CSSXref('calc','calc()')}} used as `calc(1 / value)`
+The **`CSSMathInvert()`** constructor creates a new {{domxref("CSSMathInvert")}} object which represents the inverse (reciprocal) of a {{domxref('CSSNumericValue')}}.
 
 ## Syntax
 
@@ -19,16 +19,33 @@ new CSSMathInvert(arg)
 ### Parameters
 
 - `arg`
-  - : A {{domxref('CSSNumericValue')}}.
+  - : A number or {{domxref('CSSNumericValue')}} that represents the value to invert.
 
 ### Exceptions
 
-- [`RangeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError)
-  - : Raised if the arg is 0 or -0.
+None.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathInvert` object from a percentage, then logs the constructor name, `value`, and the object's serialization (from {{domxref("CSSStyleValue/toString","toString()")}}).
+
+```js
+const inverted = new CSSMathInvert(CSS.percent(4));
+
+console.log(inverted.constructor.name); // "CSSMathInvert"
+console.log(inverted.value); // CSSUnitValue {value: 4, unit: "percent"}
+console.log(inverted.toString()); // "calc(1 / 4%)"
+```
+
+Note that if a plain number is passed to `arg`, the `value` is rectified to a {{domxref("CSSUnitValue")}} with unit `"number"`:
+
+```js
+const invertedNumber = new CSSMathInvert(4);
+
+console.log(invertedNumber.value); // CSSUnitValue {value: 4, unit: "number"}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSMathInvert
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathInvert`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents a CSS {{CSSXref('calc','calc()')}} used as `calc(1 / <value>)`.
+The **`CSSMathInvert`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the inverse (reciprocal) of a {{domxref('CSSNumericValue')}}.
 
 {{InheritanceDiagram}}
 
@@ -21,7 +21,7 @@ The **`CSSMathInvert`** interface of the [CSS Typed Object Model API](/en-US/doc
 _Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 - {{domxref('CSSMathInvert.value')}} {{ReadOnlyInline}}
-  - : Returns a {{domxref('CSSNumericValue')}} object.
+  - : Returns a {{domxref('CSSNumericValue')}} object containing the value being inverted.
 
 ## Static methods
 
@@ -31,9 +31,33 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
+## Description
+
+When you divide one {{domxref('CSSNumericValue')}} by another using {{domxref('CSSNumericValue.div', 'div()')}}, if the divisor is a plain number, it can immediately be scaled into a value of the original type.
+
+If the divisor is a different type, the result can't be resolved to a single object.
+In this case, the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the divisor as a `CSSMathInvert`.
+
+Generally you won't construct a `CSSMathInvert` directly.
+It's produced when `div()` is called with a divisor that isn't a plain number: the result is a {{domxref('CSSMathProduct')}}, and `CSSMathInvert` is the operand holding that divisor — found by walking the product's operands, or by checking {{domxref('CSSMathValue.operator')}} for the string `"invert"`.
+
+`CSSMathInvert` serializes using CSS {{CSSXref('calc','calc()')}} syntax, as `calc(1 / <value>)`.
+
 ## Examples
 
-To do
+### Constructing a CSSMathInvert with a non-number divisor
+
+This example shows how you can use {{domxref('CSSNumericValue.div', 'div()')}} with a divisor that isn't a plain number to get a {{domxref('CSSMathProduct')}} that has a `CSSMathInvert` as one of its operands.
+The value and serialization of that operand are also logged.
+
+```js
+const product = CSS.px(200).div(CSS.percent(4));
+
+console.log(product.constructor.name); // "CSSMathProduct"
+console.log(product.values[1].constructor.name); // "CSSMathInvert"
+console.log(product.values[1].value); // CSSUnitValue {value: 4, unit: "percent"}
+console.log(product.toString()); // "calc(200px / 4%)"
+```
 
 ## Specifications
 
@@ -42,3 +66,9 @@ To do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSNumericValue.div", "div()")}}
+- {{domxref("CSSMathNegate")}}
+- {{domxref("CSSMathValue.operator")}}

--- a/files/en-us/web/api/cssmathinvert/value/index.md
+++ b/files/en-us/web/api/cssmathinvert/value/index.md
@@ -10,13 +10,27 @@ browser-compat: api.CSSMathInvert.value
 
 The **`value`** read-only property of the {{domxref("CSSMathInvert")}} interface returns the {{domxref("CSSNumericValue")}} that is being inverted.
 
+This is the parameter that was passed to the constructor when this object was created.
+
 ## Value
 
-A {{domxref('CSSNumericValue')}}.
+A {{domxref('CSSNumericValue')}} or one of its derived types.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathInvert` object, then reads its `value`.
+
+```js
+const inverted = new CSSMathInvert(CSS.percent(4));
+
+console.log(inverted.value); // CSSUnitValue {value: 4, unit: "percent"}
+```
+
+`value` returns whatever was passed to `arg` in the constructor.
+In this case, we passed `CSS.percent(4)`, so `value` is a {{domxref('CSSUnitValue')}}.
+Passing an expression such as `CSS.percent(4).add(CSS.em(2))` would result in `value` returning a {{domxref('CSSMathSum')}}.
 
 ## Specifications
 
@@ -25,3 +39,7 @@ To do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSMathNegate.value")}}

--- a/files/en-us/web/api/cssnumericvalue/div/index.md
+++ b/files/en-us/web/api/cssnumericvalue/div/index.md
@@ -29,6 +29,8 @@ A {{domxref('CSSMathProduct')}}.
 
 - {{jsxref("TypeError")}}
   - : Thrown if an invalid type was passed to the method.
+- [`RangeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError)
+  - : Thrown if `number` is, or resolves to, 0 or -0.
 
 ## Examples
 


### PR DESCRIPTION
Update `CSSMathInvert` (part of [CSS Typed OM API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API))

Adds examples and makes description more accurate/useful.

Related docs can be tracked in #44849