### PR TITLE
docs(js): clarify Map usage guidance

### DIFF
--- a/files/en-us/web/javascript/guide/keyed_collections/index.md
+++ b/files/en-us/web/javascript/guide/keyed_collections/index.md
@@ -50,7 +50,7 @@ Traditionally, {{jsxref("Object", "objects", "", 1)}} have been used to map stri
 
 These three tips can help you to decide whether to use a `Map` or an `Object`:
 
-- Use maps over objects when keys are unknown until run time, and when all keys are the same type and all values are the same type.
+- Use maps over objects when keys are unknown until run time. Maps support keys and values of any type and do not require them to all be the same type.
 - Use maps if there is a need to store primitive values as keys because object treats each key as a string whether it's a number value, boolean value or any other primitive value.
 - Use objects when there is logic that operates on individual elements.
 

--- a/files/en-us/web/javascript/guide/keyed_collections/index.md
+++ b/files/en-us/web/javascript/guide/keyed_collections/index.md
@@ -50,9 +50,9 @@ Traditionally, {{jsxref("Object", "objects", "", 1)}} have been used to map stri
 
 These three tips can help you to decide whether to use a `Map` or an `Object`:
 
-- Use maps over objects when keys are unknown until run time. Maps support keys and values of any type and do not require them to all be the same type.
-- Use maps if there is a need to store primitive values as keys because object treats each key as a string whether it's a number value, boolean value or any other primitive value.
-- Use objects when there is logic that operates on individual elements.
+- Use maps over objects when keys are unknown until run time, especially if the keys come from external input.
+- Maps support keys and values of any type and do not require keys to be serializable to strings or symbols.
+- Use objects when the shape is known ahead of time and all keys are expressible as strings.
 
 ### WeakMap object
 


### PR DESCRIPTION
### Description

Clarifies the guidance in the **"Object and Map compared"** section of the JavaScript Keyed Collections guide.

The previous wording incorrectly implied that `Map` is preferable when all keys and values are the same type. Since `Map` supports keys and values of any type, the guidance has been updated to accurately reflect its behavior while preserving the original recommendation about using `Map` when keys are unknown until run time.

### Motivation

Fixes incorrect documentation reported in issue #43272 by removing a misleading statement about `Map` key and value types.

### Additional details

This is a documentation-only change. No code or examples were modified.

### Related issues and pull requests

Fixes #43272