### PR TITLE
docs(css): rename masonry guide to grid lanes

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -12533,7 +12533,7 @@
 /en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement	/en-US/docs/Web/CSS/Guides/Grid_layout
 /en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_logical_values_and_writing_modes	/en-US/docs/Web/CSS/Guides/Grid_layout/Logical_values_and_writing_modes
 /en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid	/en-US/docs/Web/CSS/Guides/Grid_layout/Line-based_placement
-/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry	/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout
+/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry	/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes
 /en-US/docs/Web/CSS/CSS_Grid_Layout/Realising_common_layouts_using_CSS_Grid_	/en-US/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts
 /en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout	/en-US/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts
 /en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout_	/en-US/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts
@@ -12714,7 +12714,7 @@
 /en-US/docs/Web/CSS/CSS_grid_layout/Grids_logical_values_and_writing_modes	/en-US/docs/Web/CSS/Guides/Grid_layout/Logical_values_and_writing_modes
 /en-US/docs/Web/CSS/CSS_grid_layout/Layout_using_line-based_placement	/en-US/docs/Web/CSS/Guides/Grid_layout/Line-based_placement
 /en-US/docs/Web/CSS/CSS_grid_layout/Layout_using_named_grid_lines	/en-US/docs/Web/CSS/Guides/Grid_layout/Named_grid_lines
-/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout	/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout
+/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout	/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes
 /en-US/docs/Web/CSS/CSS_grid_layout/Realizing_common_layouts_using_grids	/en-US/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts
 /en-US/docs/Web/CSS/CSS_grid_layout/Relationship_of_grid_layout_with_other_layout_methods	/en-US/docs/Web/CSS/Guides/Grid_layout/Relationship_with_other_layout_methods
 /en-US/docs/Web/CSS/CSS_grid_layout/Subgrid	/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid
@@ -13010,7 +13010,7 @@
 /en-US/docs/Web/CSS/align-content	/en-US/docs/Web/CSS/Reference/Properties/align-content
 /en-US/docs/Web/CSS/align-items	/en-US/docs/Web/CSS/Reference/Properties/align-items
 /en-US/docs/Web/CSS/align-self	/en-US/docs/Web/CSS/Reference/Properties/align-self
-/en-US/docs/Web/CSS/align-tracks	/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout
+/en-US/docs/Web/CSS/align-tracks	/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes
 /en-US/docs/Web/CSS/alignment-baseline	/en-US/docs/Web/CSS/Reference/Properties/alignment-baseline
 /en-US/docs/Web/CSS/all	/en-US/docs/Web/CSS/Reference/Properties/all
 /en-US/docs/Web/CSS/alpha-value	/en-US/docs/Web/CSS/Reference/Values/alpha-value
@@ -13459,7 +13459,7 @@
 /en-US/docs/Web/CSS/justify-content	/en-US/docs/Web/CSS/Reference/Properties/justify-content
 /en-US/docs/Web/CSS/justify-items	/en-US/docs/Web/CSS/Reference/Properties/justify-items
 /en-US/docs/Web/CSS/justify-self	/en-US/docs/Web/CSS/Reference/Properties/justify-self
-/en-US/docs/Web/CSS/justify-tracks	/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout
+/en-US/docs/Web/CSS/justify-tracks	/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes
 /en-US/docs/Web/CSS/kerning	/en-US/docs/Web/CSS/Reference/Properties/font-kerning
 /en-US/docs/Web/CSS/left	/en-US/docs/Web/CSS/Reference/Properties/left
 /en-US/docs/Web/CSS/length	/en-US/docs/Web/CSS/Reference/Values/length

--- a/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
+++ b/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
@@ -176,10 +176,6 @@ This example includes an item which has positioning for columns. Items with defi
 
 {{EmbedLiveSample("positioned", "", "290px")}}
 
-## Fallbacks for grid lanes layout
-
-In browsers that do not support the `grid-lanes` display value, the `display: grid-lanes` declaration is ignored.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
+++ b/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
@@ -1,6 +1,6 @@
 ---
-title: Masonry layout
-slug: Web/CSS/Guides/Grid_layout/Masonry_layout
+title: Grid lanes
+slug: Web/CSS/Guides/Grid_layout/Grid_lanes
 page-type: guide
 status:
   - experimental
@@ -12,13 +12,13 @@ sidebar: cssref
 
 {{SeeCompatTable}}
 
-Level 3 of the [CSS grid layout](/en-US/docs/Web/CSS/Guides/Grid_layout) specification defines **masonry layout** (also known as **grid-lanes** layout), which is accessed via the {{cssxref("display")}} values `grid-lanes` and `inline-grid-lanes`. This guide details what masonry layout is and how to use it.
+Level 3 of the [CSS grid layout](/en-US/docs/Web/CSS/Guides/Grid_layout) specification defines **grid lanes layout**, which is accessed via the {{cssxref("display")}} values `grid-lanes` and `inline-grid-lanes`. This guide explains how grid lanes layout works and how to use it.
 
-Masonry layout is a layout method where one axis uses a typical strict grid layout, most often columns, and the other a **stacking** (masonry) layout. On the stacking axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to fill the gaps.
+Grid lanes layout is a layout method where one axis uses a typical strict grid layout, most often columns, while the other uses the masonry packing algorithm. On the stacking axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to fill the gaps.
 
-## Creating a masonry layout
+## Creating a grid lanes layout
 
-To create the most common masonry layout where the columns are laid out in a grid, and the rows stack like masonry, use **`display: grid-lanes`** along with {{cssxref("grid-template-columns")}}.
+To create the most common grid lanes layout, where the columns are laid out in a grid and the rows are packed using the masonry stacking algorithm, use **`display: grid-lanes`** along with {{cssxref("grid-template-columns")}}.
 
 The child elements of this container will lay out item by item along the stacking axis according to the masonry algorithm: each row of items loads into the column with the most room, causing a tightly packed layout without strict row tracks.
 
@@ -83,7 +83,7 @@ for (let i = 0; i < items.length; i++) {
 
 {{EmbedLiveSample("block-axis", "", "250px")}}
 
-It is also possible to create a masonry layout with items loading into rows.
+It is also possible to create a grid lanes layout with items loading into rows.
 
 ```js live-sample___inline-axis
 // prettier-ignore
@@ -111,9 +111,9 @@ for (let i = 0; i < items.length; i++) {
 
 On the grid axis, things will work just as you expect them to in grid layout. You can cause items to span multiple tracks while remaining in auto-placement, using the `span` keyword. Items may also be positioned using line-based positioning.
 
-### Masonry layout with spanning items
+### Grid lanes layout with spanning items
 
-In this example two of the items span two tracks, and the masonry items work around them.
+In this example two of the items span two tracks, and the remaining items are packed around them by the grid lanes layout algorithm.
 
 ```html live-sample___spanners
 <div class="grid">
@@ -144,7 +144,7 @@ In this example two of the items span two tracks, and the masonry items work aro
 
 {{EmbedLiveSample("spanners", "", "270px")}}
 
-This example includes an item which has positioning for columns. Items with definite placement are placed before the masonry layout happens.
+This example includes an item which has positioning for columns. Items with definite placement are placed before the grid lanes layout algorithm runs.
 
 ```html live-sample___positioned
 <div class="grid">
@@ -176,9 +176,9 @@ This example includes an item which has positioning for columns. Items with defi
 
 {{EmbedLiveSample("positioned", "", "290px")}}
 
-## Fallbacks for masonry layout
+## Fallbacks for grid lanes layout
 
-In browsers [that do not support masonry](#browser_compatibility), regular grid auto-placement will be used instead.
+In browsers that do not support the `grid-lanes` display values, regular grid auto-placement will be used instead.
 
 ## Specifications
 

--- a/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
+++ b/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
@@ -1,5 +1,5 @@
 ---
-title: Grid lanes
+title: Grid lanes layout
 slug: Web/CSS/Guides/Grid_layout/Grid_lanes
 page-type: guide
 status:
@@ -14,13 +14,13 @@ sidebar: cssref
 
 Level 3 of the [CSS grid layout](/en-US/docs/Web/CSS/Guides/Grid_layout) specification defines **grid lanes layout**, which is accessed via the {{cssxref("display")}} values `grid-lanes` and `inline-grid-lanes`. This guide explains how grid lanes layout works and how to use it.
 
-Grid lanes layout is a layout method where one axis uses a typical strict grid layout, most often columns, while the other uses the masonry packing algorithm. On the stacking axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to fill the gaps.
+Grid lanes layout is a layout method where one axis uses a typical strict grid layout, most often columns, and the other uses a stacking algorithm. On the stacking axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to fill the gaps.
 
 ## Creating a grid lanes layout
 
-To create the most common grid lanes layout, where the columns are laid out in a grid and the rows are packed using the masonry stacking algorithm, use **`display: grid-lanes`** along with {{cssxref("grid-template-columns")}}.
+To create the most common grid lanes layout, where the columns are laid out in a grid and the rows are packed using the grid lanes layout algorithm, use **`display: grid-lanes`** along with {{cssxref("grid-template-columns")}}.
 
-The child elements of this container will lay out item by item along the stacking axis according to the masonry algorithm: each row of items loads into the column with the most room, causing a tightly packed layout without strict row tracks.
+The child elements of this container will lay out item by item along the stacking axis according to the grid lanes layout algorithm: each row of items loads into the column with the most room, causing a tightly packed layout without strict row tracks.
 
 ```css hidden live-sample___block-axis live-sample___inline-axis live-sample___spanners live-sample___positioned
 * {
@@ -178,7 +178,7 @@ This example includes an item which has positioning for columns. Items with defi
 
 ## Fallbacks for grid lanes layout
 
-In browsers that do not support the `grid-lanes` display values, regular grid auto-placement will be used instead.
+In browsers that do not support the `grid-lanes` display value, the `display: grid-lanes` declaration is ignored.
 
 ## Specifications
 

--- a/files/en-us/web/css/guides/grid_layout/index.md
+++ b/files/en-us/web/css/guides/grid_layout/index.md
@@ -155,8 +155,8 @@ This sample animation uses {{cssxref("display")}}, {{cssxref("grid-template-colu
 - [Subgrid](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : What subgrid does with use cases and design patterns that subgrid solves.
 
-- [Masonry layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout)
-  - : Details what masonry layout is and it is used.
+- [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
+  - : Details what grid lanes layout is and how to use it.
 
 - [Box alignment in CSS grid layout](/en-US/docs/Web/CSS/Guides/Box_alignment/In_grid_layout)
   - : How box alignment works in the context of grid layout.

--- a/files/en-us/web/css/guides/grid_layout/index.md
+++ b/files/en-us/web/css/guides/grid_layout/index.md
@@ -155,7 +155,7 @@ This sample animation uses {{cssxref("display")}}, {{cssxref("grid-template-colu
 - [Subgrid](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : What subgrid does with use cases and design patterns that subgrid solves.
 
-- [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
+- [Grid lanes layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
   - : Details what grid lanes layout is and how to use it.
 
 - [Box alignment in CSS grid layout](/en-US/docs/Web/CSS/Guides/Box_alignment/In_grid_layout)

--- a/files/en-us/web/css/reference/properties/display/index.md
+++ b/files/en-us/web/css/reference/properties/display/index.md
@@ -167,10 +167,10 @@ The keyword values can be grouped into six value categories.
     - `grid`
       - : The element behaves like a block-level element and lays out its content according to the [grid model](/en-US/docs/Web/CSS/Guides/Grid_layout/Basic_concepts).
     - `grid-lanes`
-      - : The element behaves like a block-level element and lays out its content using masonry layout. Columns are defined by {{cssxref("grid-template-columns")}} and behave like a strict grid, while items are packed in the block direction to fill gaps between items of different sizes. See [Masonry layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout) for details.
+      - : The element behaves like a block-level element and lays out its content using masonry layout. Columns are defined by {{cssxref("grid-template-columns")}} and behave like a strict grid, while items are packed in the block direction to fill gaps between items of different sizes. See [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) for details.
 
     - `inline-grid-lanes`
-      - : The element behaves like an inline-level element and lays out its content using masonry layout. Rows are defined by {{cssxref("grid-template-rows")}} and behave like a strict grid, while items are packed in the inline direction to fill gaps between items of different sizes. See [Masonry layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout) for details.
+      - : The element behaves like an inline-level element and lays out its content using masonry layout. Rows are defined by {{cssxref("grid-template-rows")}} and behave like a strict grid, while items are packed in the inline direction to fill gaps between items of different sizes. See [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) for details.
     - `ruby`
       - : The element behaves like an inline-level element and lays out its content according to the ruby formatting model. It behaves like the corresponding HTML {{HTMLElement("ruby")}} elements.
 
@@ -317,7 +317,7 @@ The individual pages for the different types of value that `display` can have se
 - [Grids, logical values and writing modes](/en-US/docs/Web/CSS/Guides/Grid_layout/Logical_values_and_writing_modes)
 - [CSS grid layout and accessibility](/en-US/docs/Web/CSS/Guides/Grid_layout/Accessibility)
 - [Realizing common layouts using grids](/en-US/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts)
-- [Masonry layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout)
+- [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
 
 ### Animating display
 
@@ -515,4 +515,4 @@ You can find more examples in the pages for each separate display type under [Gr
 - SVG {{SVGAttr("display")}} attribute
 - [Block and inline layout in normal flow](/en-US/docs/Web/CSS/Guides/Display/Block_and_inline_layout)
 - [Introduction to formatting contexts](/en-US/docs/Web/CSS/Guides/Display/Formatting_contexts)
-- [Masonry layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout)
+- [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)

--- a/files/en-us/web/css/reference/properties/display/index.md
+++ b/files/en-us/web/css/reference/properties/display/index.md
@@ -167,10 +167,9 @@ The keyword values can be grouped into six value categories.
     - `grid`
       - : The element behaves like a block-level element and lays out its content according to the [grid model](/en-US/docs/Web/CSS/Guides/Grid_layout/Basic_concepts).
     - `grid-lanes`
-      - : The element behaves like a block-level element and lays out its content using masonry layout. Columns are defined by {{cssxref("grid-template-columns")}} and behave like a strict grid, while items are packed in the block direction to fill gaps between items of different sizes. See [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) for details.
-
+      - : The element behaves like a block-level element and lays out its content using grid lanes layout. Columns are defined by {{cssxref("grid-template-columns")}} and behave like a strict grid, while items are packed in the block direction to fill gaps between items of different sizes. See [Grid lanes layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) for details.
     - `inline-grid-lanes`
-      - : The element behaves like an inline-level element and lays out its content using masonry layout. Rows are defined by {{cssxref("grid-template-rows")}} and behave like a strict grid, while items are packed in the inline direction to fill gaps between items of different sizes. See [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) for details.
+      - : The element behaves like an inline-level element and lays out its content using grid lanes layout. Rows are defined by {{cssxref("grid-template-rows")}} and behave like a strict grid, while items are packed in the inline direction to fill gaps between items of different sizes. See [Grid lanes layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) for details.
     - `ruby`
       - : The element behaves like an inline-level element and lays out its content according to the ruby formatting model. It behaves like the corresponding HTML {{HTMLElement("ruby")}} elements.
 
@@ -317,7 +316,7 @@ The individual pages for the different types of value that `display` can have se
 - [Grids, logical values and writing modes](/en-US/docs/Web/CSS/Guides/Grid_layout/Logical_values_and_writing_modes)
 - [CSS grid layout and accessibility](/en-US/docs/Web/CSS/Guides/Grid_layout/Accessibility)
 - [Realizing common layouts using grids](/en-US/docs/Web/CSS/Guides/Grid_layout/Common_grid_layouts)
-- [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
+- [Grid lanes layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
 
 ### Animating display
 
@@ -515,4 +514,4 @@ You can find more examples in the pages for each separate display type under [Gr
 - SVG {{SVGAttr("display")}} attribute
 - [Block and inline layout in normal flow](/en-US/docs/Web/CSS/Guides/Display/Block_and_inline_layout)
 - [Introduction to formatting contexts](/en-US/docs/Web/CSS/Guides/Display/Formatting_contexts)
-- [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
+- [Grid lanes layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)

--- a/files/en-us/web/css/reference/properties/grid-auto-flow/index.md
+++ b/files/en-us/web/css/reference/properties/grid-auto-flow/index.md
@@ -62,7 +62,7 @@ grid-auto-flow: row dense;
 ```
 
 > [!NOTE]
-> The `masonry-auto-flow` property was dropped from CSS [Masonry layout](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout) in favor of `grid-auto-flow`.
+> The `masonry-auto-flow` property was dropped from CSS [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) in favor of `grid-auto-flow`.
 > See [csswg-drafts #10231](https://github.com/w3c/csswg-drafts/issues/10231) for details.
 
 ## Syntax

--- a/files/en-us/web/css/reference/properties/grid-auto-flow/index.md
+++ b/files/en-us/web/css/reference/properties/grid-auto-flow/index.md
@@ -61,10 +61,6 @@ grid-auto-flow: row dense;
 }
 ```
 
-> [!NOTE]
-> The `masonry-auto-flow` property was dropped from CSS [Grid lanes](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes) in favor of `grid-auto-flow`.
-> See [csswg-drafts #10231](https://github.com/w3c/csswg-drafts/issues/10231) for details.
-
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/reference/properties/grid-template-columns/index.md
+++ b/files/en-us/web/css/reference/properties/grid-template-columns/index.md
@@ -129,7 +129,7 @@ grid-template-columns: unset;
   - : Represents the formula `max(minimum, min(limit, max-content))`, where _minimum_ represents an `auto` minimum (which is often, but not always, equal to a {{cssxref("min-content")}} minimum), and _limit_ is the track sizing function passed as an argument to fit-content(). This is essentially calculated as the smaller of `minmax(auto, max-content)` and `minmax(auto, limit)`.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of columns that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout)
+- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
   - : The masonry value indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : The `subgrid` value indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.

--- a/files/en-us/web/css/reference/properties/grid-template-columns/index.md
+++ b/files/en-us/web/css/reference/properties/grid-template-columns/index.md
@@ -70,7 +70,6 @@ grid-template-columns: minmax(100px, 1fr);
 grid-template-columns: fit-content(40%);
 grid-template-columns: repeat(3, 200px);
 grid-template-columns: subgrid;
-grid-template-columns: masonry;
 
 /* <auto-track-list> values */
 grid-template-columns: 200px repeat(auto-fill, 100px) 300px;
@@ -129,8 +128,6 @@ grid-template-columns: unset;
   - : Represents the formula `max(minimum, min(limit, max-content))`, where _minimum_ represents an `auto` minimum (which is often, but not always, equal to a {{cssxref("min-content")}} minimum), and _limit_ is the track sizing function passed as an argument to fit-content(). This is essentially calculated as the smaller of `minmax(auto, max-content)` and `minmax(auto, limit)`.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of columns that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
-  - : The masonry value indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : The `subgrid` value indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.
 

--- a/files/en-us/web/css/reference/properties/grid-template-rows/index.md
+++ b/files/en-us/web/css/reference/properties/grid-template-rows/index.md
@@ -70,7 +70,6 @@ grid-template-rows: minmax(100px, 1fr);
 grid-template-rows: fit-content(40%);
 grid-template-rows: repeat(3, 200px);
 grid-template-rows: subgrid;
-grid-template-rows: masonry;
 
 /* <auto-track-list> values */
 grid-template-rows: 200px repeat(auto-fill, 100px) 300px;
@@ -131,8 +130,6 @@ This property may be specified as:
   - : Represents the formula `min(max-content, max(auto, argument))`, which is calculated similar to `auto` (i.e., `minmax(auto, max-content)`), except that the track size is clamped at _argument_ if it is greater than the `auto` minimum.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of rows that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
-  - : Indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : Indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.
 

--- a/files/en-us/web/css/reference/properties/grid-template-rows/index.md
+++ b/files/en-us/web/css/reference/properties/grid-template-rows/index.md
@@ -131,7 +131,7 @@ This property may be specified as:
   - : Represents the formula `min(max-content, max(auto, argument))`, which is calculated similar to `auto` (i.e., `minmax(auto, max-content)`), except that the track size is clamped at _argument_ if it is greater than the `auto` minimum.
 - {{cssxref("repeat", "repeat( [ &lt;positive-integer&gt; | auto-fill | auto-fit ] , &lt;track-list&gt; )")}}
   - : Represents a repeated fragment of the track list, allowing a large number of rows that exhibit a recurring pattern to be written in a more compact form.
-- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Masonry_layout)
+- [`masonry`](/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes)
   - : Indicates that this axis should be laid out according to the masonry algorithm.
 - [`subgrid`](/en-US/docs/Web/CSS/Guides/Grid_layout/Subgrid)
   - : Indicates that the grid will adopt the spanned portion of its parent grid in that axis. Rather than being specified explicitly, the sizes of the grid rows/columns will be taken from the parent grid's definition.

--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -157,7 +157,7 @@ sidebar:
       - /Web/CSS/Guides/Grid_layout/Accessibility
       - /Web/CSS/Guides/Grid_layout/Common_grid_layouts
       - /Web/CSS/Guides/Grid_layout/Subgrid
-      - /Web/CSS/Guides/Grid_layout/Masonry_layout
+      - /Web/CSS/Guides/Grid_layout/Grid_lanes
   - title: Images
     details: closed
     children:


### PR DESCRIPTION
### Description

Renames the CSS Grid guide from **"Masonry layout"** to **"Grid lanes"** to match the current CSS Grid Level 3 specification terminology.

This PR also updates internal references so they point to the renamed guide while preserving redirects for existing URLs.

### Motivation

Issue #44994 tracks updating MDN to use the current **grid lanes** terminology instead of **masonry** where appropriate. The previous PR (#44436) introduced documentation for `display: grid-lanes` and `display: inline-grid-lanes`, making the guide rename the next logical step.

### Additional details

Changes included in this PR:

- Renamed the guide:
  - `Web/CSS/Guides/Grid_layout/Masonry_layout`
  - → `Web/CSS/Guides/Grid_layout/Grid_lanes`
- Updated the guide title and slug.
- Updated the guide text to consistently refer to **grid lanes layout**, while retaining references to the **masonry algorithm** where technically appropriate.
- Updated navigation links in the Grid Layout guide.
- Updated references from the `display`, `grid-auto-flow`, `grid-template-columns`, and `grid-template-rows` reference pages.
- Updated the CSS sidebar.
- Updated redirects so existing Masonry URLs continue to resolve to the renamed guide.

### Related issues and pull requests

Follow-up to #44436

Fixes #44994