### PR TITLE
Document the experimental outline-offset inset keyword

### DIFF
--- a/files/en-us/web/css/reference/properties/outline-offset/index.md
+++ b/files/en-us/web/css/reference/properties/outline-offset/index.md
@@ -49,6 +49,9 @@ outline: 5px dashed blue;
 outline-offset: 3px;
 outline-offset: 0.2em;
 
+/* Keyword value */
+outline-offset: inset;
+
 /* Global values */
 outline-offset: inherit;
 outline-offset: initial;
@@ -61,6 +64,9 @@ outline-offset: unset;
 
 - {{cssxref("&lt;length&gt;")}}
   - : The width of the space between the element and its outline. A negative value places the outline inside the element. A value of `0` places the outline so that there is no space between it and the element.
+
+- `inset` {{experimental_inline}}
+  - : Positions the outline inside the element. The outline offset is the negated used width of the outline.
 
 ## Description
 


### PR DESCRIPTION
## Summary

- Documents the experimental inset keyword for the outline-offset CSS property.
- Adds the keyword to the syntax and values sections, including its used-value behavior.

## Why

CSSWG resolved to add inset, and WebKit has implemented it. The property page currently documents only length values.

## References

- https://github.com/WebKit/WebKit/commit/a69b24040c7a7b89336307285d1a4ddd306a2531
- https://github.com/w3c/csswg-drafts/issues/13765

## Browser compatibility

- No BCD change is included: BCD has no separate entry for this experimental keyword, and the existing compatibility table describes the property generally.

## Validation

- front-matter linter
- markdownlint-cli2
- Prettier check
- cspell
- changed-link verification
- Git whitespace check

Closes #45043

Drafted with AI assistance; reviewed by KesleyDavid.