### PR TITLE
Node.cloneNode(): Add default value to deep option as per spec.

### DIFF
--- a/files/en-us/web/api/node/clonenode/index.md
+++ b/files/en-us/web/api/node/clonenode/index.md
@@ -39,6 +39,8 @@ cloneNode(deep)
     Note that `deep` has no effect on {{glossary("void element", "void elements")}},
     such as the {{HTMLElement("img")}} and {{HTMLElement("input")}} elements.
 
+    It defaults to `false`.
+
 ### Return value
 
 The new {{domxref("Node")}} cloned.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

This PR adds the default value of the `deep` option to the article as per the [spec](https://dom.spec.whatwg.org/#ref-for-dom-node-clonenode%E2%91%A0).

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The default value of the function is important and brings the article in line with most other JS articles, eg. [DOMImplementation.createDocument()](https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument#documenttype).

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

[Source spec for the property](https://dom.spec.whatwg.org/#ref-for-dom-node-clonenode%E2%91%A0)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
N/A