### PR TITLE
Document `font-family: monospace` font size quirk

### DIFF
--- a/files/en-us/web/css/reference/properties/font-family/index.md
+++ b/files/en-us/web/css/reference/properties/font-family/index.md
@@ -124,6 +124,9 @@ font-family: "Gill Sans Extrabold", sans-serif;
 
         For example: Fira Mono, DejaVu Sans Mono, Menlo, Consolas, Liberation Mono, Monaco, Lucida Console, monospace.
 
+        > [!NOTE]
+        > When `font-family` is set to the single keyword `monospace` and no `font-size` is set, browsers use the user's monospace font size preference, which is often smaller than the size used for proportional fonts. See [Monospace font size](#monospace_font_size) for details and how to control this.
+
     - `cursive`
       - : Glyphs in cursive fonts generally have either joining strokes or other cursive characteristics beyond those of italic typefaces. The glyphs are partially or completely connected, and the result looks more like handwritten pen or brush writing than printed letter work.
 
@@ -217,6 +220,42 @@ div {
 ```
 
 {{EmbedLiveSample("Some_common_font_families", 600, 220)}}
+
+### Monospace font size
+
+Browsers maintain separate default font size preferences for proportional fonts (such as `serif` and `sans-serif`) and for monospace fonts. Typical defaults are `16px` for proportional fonts and `13px` for monospace fonts.
+
+When `font-family` is set to the single keyword `monospace`, browsers apply the monospace size preference. If users have not changed their browser preferences and {{cssxref("font-size")}} is not explicitly set, monospace text may be rendered smaller than surrounding content. The same reduction applies to elements whose user agent stylesheet sets `font-family: monospace`, such as {{HTMLElement("code")}} and {{HTMLElement("pre")}}.
+
+If the `font-family` value includes more than one family, even if the value is `monospace, monospace`, browsers do not apply the monospace font size preference, and will render the text at the inherited `font-size`. Declaring `font-family: monospace, monospace` (or a named monospace font followed by `monospace`) therefore renders at the same size as surrounding proportional text. This behavior is not specified in CSS, but it is interoperable across the major browser engines.
+
+```html
+<p class="proportional">
+  This proportional text is at the default size; generally 16px.
+</p>
+<p class="mono-only">
+  This monospace text is at the preferred size for monospace fonts; generally
+  13px.
+</p>
+<p class="mono-list">
+  This is in "monospace, monospace" font, rendered at the same size as
+  proportional text; generally 16px.
+</p>
+```
+
+```css
+.mono-only {
+  font-family: monospace;
+}
+
+.mono-list {
+  font-family: monospace, monospace;
+}
+```
+
+{{EmbedLiveSample("Monospace_font_size", 600, 120)}}
+
+If you haven't changed your font size in your browser settings, the first and last paragraphs will be the same font-size, rendered at the browser preferred font size. The middle paragraph will be rendered at the preferred mono-space font size, which is generally set to be smaller than the preferred font-size for other text.
 
 ### Valid family names
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

In Chrome, Firefox, and Safari, setting `font-family` to the single keyword `monospace` causes the browser to use the user's monospace font size preference, which is often smaller than the size used for proportional fonts.

This is an interoperable, unspecified browser quirk that had no documentation on MDN.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Readers should know about this quirk, and know about the workaround of setting `font-family: monospace, monospace` to workaround the quirk.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

* Years-old open proposal to add this to the specification: https://github.com/w3c/csswg-drafts/issues/3906
* 2006 WebKit blog post about this quirk: https://webkit.org/blog/67/strange-medium/
* https://bugzilla.mozilla.org/show_bug.cgi?id=328621 "strange default `monospace` font size -- differs from the proprtional fonts"
* Blog post by Firefox developer documenting the complexity of `font-size`: https://manishearth.github.io/blog/2017/08/10/font-size-an-unexpectedly-complex-css-property/

