### PR TITLE
FF154 CSSMath{Clamp|Max|min|Negate|Product|Sum|Value} fixes

### DIFF
--- a/files/en-us/web/api/cssmathclamp/cssmathclamp/index.md
+++ b/files/en-us/web/api/cssmathclamp/cssmathclamp/index.md
@@ -29,7 +29,7 @@ new CSSMathClamp(lower, value, upper)
 
 - [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
   - : Thrown if the parameters have conflicting unit types.
-    For example, specifying parameters that specify length and time bounds.
+    For example, mixing a length value with a time value.
 
 ## Examples
 
@@ -48,7 +48,7 @@ console.log(clamp.upper); // CSSUnitValue {value: 500, unit: "px"}
 
 ### Handling incompatible types
 
-The constructor throws a `TypeError` if the three arguments don't resolve to a compatible type
+The constructor throws a `TypeError` if the three arguments don't resolve to a compatible type.
 In the following code we mix a length with a time, and log the error.
 
 ```js

--- a/files/en-us/web/api/cssmathclamp/index.md
+++ b/files/en-us/web/api/cssmathclamp/index.md
@@ -47,6 +47,19 @@ In order to determine the value of a clamped property, you need to read its comp
 
 ## Examples
 
+### Basic usage
+
+The following code creates a `CSSMathClamp` instance from three lengths, then reads back its `lower`, `value`, and `upper` properties.
+
+```js
+const clamp = new CSSMathClamp(CSS.px(10), CSS.percent(50), CSS.px(500));
+
+console.log(clamp.constructor.name); // "CSSMathClamp"
+console.log(clamp.lower); // CSSUnitValue {value: 10, unit: "px"}
+console.log(clamp.value); // CSSUnitValue {value: 50, unit: "percent"}
+console.log(clamp.upper); // CSSUnitValue {value: 500, unit: "px"}
+```
+
 ### `clamp()` representations
 
 This example shows how {{CSSXref("clamp","clamp()")}} is represented by a {{domxref("CSSUnitValue")}} or a `CSSMathClamp`, depending on whether all of its arguments are absolute values.
@@ -65,10 +78,8 @@ First we declare a {{htmlelement("div")}} element, `#demoBox`, on which we'll se
 
 #### CSS
 
-The CSS defines the `width` and `font-size` of the demo box:
-
-- `width` is set using a `clamp()` whose three arguments are all absolute lengths, so the browser can resolve it to a single fixed value immediately.
-- `font-size` is set using a `clamp()` whose preferred value uses the relative unit `vw`, so the browser can't resolve it until layout (this will be represented by a `CSSMathClamp`).
+The `width` of the box is set using a `clamp()` whose three arguments are all absolute lengths, so the browser can resolve it to a single fixed value immediately.
+`font-size` is set using a `clamp()` whose preferred value uses the relative unit `vw`, so the browser can't resolve it until layout (this will be represented by a `CSSMathClamp`).
 
 ```css
 #demoBox {

--- a/files/en-us/web/api/cssmathclamp/index.md
+++ b/files/en-us/web/api/cssmathclamp/index.md
@@ -35,7 +35,100 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
+## Description
+
+The CSS {{CSSXref("clamp", "clamp()")}} function takes three arguments: a minimum, preferred, and maximum value, and returns the preferred value, clamped between the minimum and maximum.
+
+If all three arguments are absolute values, such as pixel lengths, `clamp()` is resolved to a single value at parse time, represented by the CSS Typed Object Model as a {{domxref("CSSUnitValue")}}.
+If the `clamp()` expression can't be resolved to a single value at parse time (say, because one of its arguments uses a relative unit like `vw` or `%`), the function is represented as a `CSSMathClamp` object, and the three arguments passed to `clamp()` (or to the `CSSMathClamp()` constructor) are exposed as the `lower`, `value`, and `upper` properties.
+
+Note that `CSSMathClamp` represents the `clamp()` function, not its resolved value.
+In order to determine the value of a clamped property, you need to read its computed style (for example with {{domxref("Window.getComputedStyle", "getComputedStyle()")}}).
+
 ## Examples
+
+### `clamp()` representations
+
+This example shows how {{CSSXref("clamp","clamp()")}} is represented by a {{domxref("CSSUnitValue")}} or a `CSSMathClamp`, depending on whether all of its arguments are absolute values.
+
+#### HTML
+
+First we declare a {{htmlelement("div")}} element, `#demoBox`, on which we'll set some clamped properties.
+
+```html
+<div id="demoBox">Text</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+The CSS defines the `width` and `font-size` of the demo box:
+
+- `width` is set using a `clamp()` whose three arguments are all absolute lengths, so the browser can resolve it to a single fixed value immediately.
+- `font-size` is set using a `clamp()` whose preferred value uses the relative unit `vw`, so the browser can't resolve it until layout (this will be represented by a `CSSMathClamp`).
+
+```css
+#demoBox {
+  width: clamp(10px, 50px, 500px);
+  font-size: clamp(1rem, 5vw, 3rem);
+}
+```
+
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+First we find the demo box's style rule and read its `width` and `font-size` values using {{domxref("CSSStyleRule.styleMap", "styleMap")}}.
+
+```js
+const demoBox = document.querySelector("#demoBox");
+
+const rules = document.getElementById("css-output").sheet.cssRules;
+const rule = [...rules].find((r) => r.selectorText === "#demoBox");
+const styleMap = rule.styleMap;
+const width = styleMap.get("width");
+const fontSize = styleMap.get("font-size");
+```
+
+We then log the type and value of the CSS Typed OM representations, followed by the computed (resolved) values.
+
+```js
+log("width");
+log(` type: ${width.constructor.name}`);
+log(` value: ${width}`);
+log(` resolved: ${getComputedStyle(demoBox).width}`);
+
+log("\nfont-size");
+log(` type: ${fontSize.constructor.name}`);
+log(` lower: ${fontSize.lower}`);
+log(` value: ${fontSize.value}`);
+log(` upper: ${fontSize.upper}`);
+log(` resolved: ${getComputedStyle(demoBox).fontSize}`);
+```
+
+#### Result
+
+`width` logs as a single `CSSUnitValue`, and its resolved value matches that value directly.
+`font-size` logs as a `CSSMathClamp`, exposing the `clamp()` function's original operands.
+
+{{EmbedLiveSample("`clamp()` representations", 300, 300)}}
 
 ### Inspecting a clamped value
 

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.md
@@ -15,22 +15,65 @@ The **`CSSMathMax()`** constructor creates a new {{domxref("CSSMathMax")}} objec
 ## Syntax
 
 ```js-nolint
-new CSSMathMax(args)
+new CSSMathMax(arg1)
+new CSSMathMax(arg1, arg2)
+new CSSMathMax(arg1, arg2, /* …, */ argN)
 ```
 
 ### Parameters
 
-- `args`
+- `arg1`, …, `argN`
   - : A list of numbers or {{domxref("CSSNumericValue")}} objects.
 
 ### Exceptions
 
-- [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
-  - : Thrown if there is a _failure_ when adding all of the values in args.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if no arguments are passed.
+- {{jsxref("TypeError")}}
+  - : Thrown if `arg1`, …, `argN` have incompatible types (for example, mixing a {{cssxref('length')}} with an {{cssxref('angle')}}), so a common type cannot be determined for comparison.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathMax` instance from three values, then reads back its `operator` and `values` properties.
+
+```js
+const max = new CSSMathMax(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(max.constructor.name); // "CSSMathMax"
+console.log(max.operator); // 'max'
+console.log(max.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(max.values[0]); // CSSUnitValue {value: 10, unit: "px"}
+```
+
+### Handling incompatible types
+
+The constructor throws a `TypeError` if the values don't resolve to a compatible type.
+In the following code we mix a length with a time, and log the error.
+
+```js
+try {
+  // Mixes a length (px) with a time (s): incompatible types
+  new CSSMathMax(CSS.px(10), CSS.s(2));
+} catch (e) {
+  console.log(e instanceof TypeError); // true
+  console.log(e.message);
+}
+```
+
+### Empty arguments
+
+The constructor throws a `SyntaxError` if called with no arguments.
+
+```js
+try {
+  new CSSMathMax();
+} catch (e) {
+  console.log(e instanceof DOMException); // true
+  console.log(e.name); // "SyntaxError"
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/index.md
@@ -31,9 +31,107 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
+## Description
+
+The CSS {{cssxref("max", "max()")}} function takes one or more comma-separated values as arguments and returns the largest of them.
+
+If all arguments are absolute values, such as pixel lengths, `max()` is resolved to a single value at parse time, represented by the CSS Typed Object Model as a {{domxref("CSSUnitValue")}}.
+If the `max()` expression can't be resolved to a single value at parse time (say, because one of its arguments uses a relative unit like `vw` or `%`), the function is represented as a `CSSMathMax` object, and the arguments passed to `max()` (or to the `CSSMathMax()` constructor) are exposed as the `values` property.
+
+Note that `CSSMathMax` represents the `max()` function, not its resolved value.
+In order to determine the value of a property using `max()`, you need to read its computed style (for example with {{domxref("Window.getComputedStyle", "getComputedStyle()")}}).
+
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathMax` instance from three values, then reads back its `operator` and `values` properties.
+
+```js
+const max = new CSSMathMax(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(max.constructor.name); // "CSSMathMax"
+console.log(max.operator); // 'max'
+console.log(max.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(max.values[0]); // CSSUnitValue {value: 10, unit: "px"}
+```
+
+### `max()` representations
+
+This example shows how {{cssxref("max", "max()")}} is represented by a {{domxref("CSSUnitValue")}} or a `CSSMathMax`, depending on whether all of its arguments are absolute values.
+
+#### HTML
+
+```html
+<div id="demoBox">Text</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+`width` is set using a `max()` whose arguments are all absolute lengths, so the browser can resolve it to a single fixed value immediately.
+`font-size` is set using a `max()` where one argument uses the relative unit `vw`, so the browser can't resolve it until layout (this will be represented by a `CSSMathMax`).
+
+```css
+#demoBox {
+  width: max(10px, 50px);
+  font-size: max(1rem, 5vw);
+}
+```
+
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+First we find the demo box's style rule and read its `width` and `font-size` values using {{domxref("CSSStyleRule.styleMap", "styleMap")}}.
+
+```js
+const demoBox = document.querySelector("#demoBox");
+
+const rules = document.getElementById("css-output").sheet.cssRules;
+const rule = [...rules].find((r) => r.selectorText === "#demoBox");
+const styleMap = rule.styleMap;
+const width = styleMap.get("width");
+const fontSize = styleMap.get("font-size");
+```
+
+We then log the type and value of the CSS Typed OM representations, followed by the computed (resolved) values.
+
+```js
+log("width");
+log(` type: ${width.constructor.name}`);
+log(` value: ${width}`);
+log(` resolved: ${getComputedStyle(demoBox).width}`);
+
+log("\nfont-size");
+log(` type: ${fontSize.constructor.name}`);
+log(` values: [${[...fontSize.values].join(", ")}]`);
+log(` resolved: ${getComputedStyle(demoBox).fontSize}`);
+```
+
+#### Result
+
+`width` is represented by a `CSSUnitValue` object, which has a value that matches the resolved width.
+`font-size` is represented by a `CSSMathMax` object that exposes the `max()` function's original operands.
+
+{{EmbedLiveSample("`max()` representations", 300, 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathmax/values/index.md
+++ b/files/en-us/web/api/cssmathmax/values/index.md
@@ -16,7 +16,32 @@ A {{domxref('CSSNumericArray')}}.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathMax` object and logs its `values` and length.
+
+```js
+const max = new CSSMathMax(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(max.values);
+// CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(max.values.length); // 3
+```
+
+We then iterate over the `values`, logging their type, value, unit, and stringified text.
+Each of these matches the {{domxref("CSSNumericValue")}} objects that were passed into the constructor (or the operands of the CSS {{cssxref("max", "max()")}} function it represents), in the same order.
+
+```js
+for (const value of max.values) {
+  console.log(
+    `${value.constructor.name}: ${value.value} ${value.unit} (${value})`,
+  );
+}
+
+// CSSUnitValue: 10 px (10px)
+// CSSUnitValue: 5 em (5em)
+// CSSUnitValue: 50 percent (50%)
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.md
@@ -15,22 +15,65 @@ The **`CSSMathMin()`** constructor creates a new {{domxref("CSSMathMin")}} objec
 ## Syntax
 
 ```js-nolint
-new CSSMathMin(args)
+new CSSMathMin(arg1)
+new CSSMathMin(arg1, arg2)
+new CSSMathMin(arg1, arg2, /* …, */ argN)
 ```
 
 ### Parameters
 
-- `args`
+- `arg1`, …, `argN`
   - : A list of numbers or {{domxref("CSSNumericValue")}} objects.
 
 ### Exceptions
 
-- [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
-  - : Thrown if there is a _failure_ when adding all of the values in args.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if no arguments are passed.
+- {{jsxref("TypeError")}}
+  - : Thrown if `arg1`, …, `argN` have incompatible types (for example, mixing a {{cssxref('length')}} with an {{cssxref('angle')}}), so a common type cannot be determined for comparison.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathMin` instance from three values, then reads back its `operator` and `values` properties.
+
+```js
+const min = new CSSMathMin(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(min.constructor.name); // "CSSMathMin"
+console.log(min.operator); // 'min'
+console.log(min.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(min.values[0]); // CSSUnitValue {value: 10, unit: "px"}
+```
+
+### Handling incompatible types
+
+The constructor throws a `TypeError` if the values don't resolve to a compatible type.
+In the following code we mix a length with a time, and log the error.
+
+```js
+try {
+  // Mixes a length (px) with a time (s): incompatible types
+  new CSSMathMin(CSS.px(10), CSS.s(2));
+} catch (e) {
+  console.log(e instanceof TypeError); // true
+  console.log(e.message);
+}
+```
+
+### Empty arguments
+
+The constructor throws a `SyntaxError` if called with no arguments.
+
+```js
+try {
+  new CSSMathMin();
+} catch (e) {
+  console.log(e instanceof DOMException); // true
+  console.log(e.name); // "SyntaxError"
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/index.md
@@ -31,9 +31,108 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
+## Description
+
+The CSS {{cssxref("min", "min()")}} function takes one or more comma-separated values as arguments and returns the smallest of them.
+
+If all arguments are absolute values, such as pixel lengths, `min()` is resolved to a single value at parse time, represented by the CSS Typed Object Model as a {{domxref("CSSUnitValue")}}.
+If the `min()` expression can't be resolved to a single value at parse time (say, because one of its arguments uses a relative unit like `vw` or `%`), the function is represented as a `CSSMathMin` object, and the arguments passed to `min()` (or to the `CSSMathMin()` constructor) are exposed as the `values` property.
+
+Note that `CSSMathMin` represents the `min()` function, not its resolved value.
+In order to determine the value of a property using `min()`, you need to read its computed style (for example with {{domxref("Window.getComputedStyle", "getComputedStyle()")}}).
+
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathMin` instance from three values, then reads back its `operator` and `values` properties.
+
+```js
+const min = new CSSMathMin(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(min.constructor.name); // "CSSMathMin"
+console.log(min.operator); // 'min'
+console.log(min.values);
+// CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(min.values[0]); // CSSUnitValue {value: 10, unit: "px"}
+```
+
+### `min()` representations
+
+This example shows how {{cssxref("min", "min()")}} is represented by a {{domxref("CSSUnitValue")}} or a `CSSMathMin`, depending on whether all of its arguments are absolute values.
+
+#### HTML
+
+```html
+<div id="demoBox">Text</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+`width` is set using a `min()` whose arguments are all absolute lengths, so the browser can resolve it to a single fixed value immediately.
+`font-size` is set using a `min()` where one argument uses the relative unit `vw`, so the browser can't resolve it until layout (this will be represented by a `CSSMathMin`).
+
+```css
+#demoBox {
+  width: min(10px, 50px);
+  font-size: min(1rem, 5vw);
+}
+```
+
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+First we find the demo box's style rule and read its `width` and `font-size` values using {{domxref("CSSStyleRule.styleMap", "styleMap")}}.
+
+```js
+const demoBox = document.querySelector("#demoBox");
+
+const rules = document.getElementById("css-output").sheet.cssRules;
+const rule = [...rules].find((r) => r.selectorText === "#demoBox");
+const styleMap = rule.styleMap;
+const width = styleMap.get("width");
+const fontSize = styleMap.get("font-size");
+```
+
+We then log the type and value of the CSS Typed OM representations, followed by the computed (resolved) values.
+
+```js
+log("width");
+log(` type: ${width.constructor.name}`);
+log(` value: ${width}`);
+log(` resolved: ${getComputedStyle(demoBox).width}`);
+
+log("\nfont-size");
+log(` type: ${fontSize.constructor.name}`);
+log(` values: [${[...fontSize.values].join(", ")}]`);
+log(` resolved: ${getComputedStyle(demoBox).fontSize}`);
+```
+
+#### Result
+
+`width` is represented by a `CSSUnitValue` object, which has a value that matches the resolved width.
+`font-size` is represented by a `CSSMathMin` object that exposes the `min()` function's original operands.
+
+{{EmbedLiveSample("`min()` representations", 300, 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathmin/values/index.md
+++ b/files/en-us/web/api/cssmathmin/values/index.md
@@ -16,7 +16,32 @@ A {{domxref('CSSNumericArray')}}.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathMin` object and logs its `values` and length.
+
+```js
+const min = new CSSMathMin(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(min.values);
+// CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(min.values.length); // 3
+```
+
+We then iterate over the `values`, logging their type, value, unit, and stringified text.
+Each of these matches the {{domxref("CSSNumericValue")}} objects that were passed into the constructor (or the operands of the CSS {{cssxref("min", "min()")}} function it represents), in the same order.
+
+```js
+for (const value of min.values) {
+  console.log(
+    `${value.constructor.name}: ${value.value} ${value.unit} (${value})`,
+  );
+}
+
+// CSSUnitValue: 10 px (10px)
+// CSSUnitValue: 5 em (5em)
+// CSSUnitValue: 50 percent (50%)
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
@@ -19,11 +19,33 @@ new CSSMathNegate(arg)
 ### Parameters
 
 - `arg`
-  - : A {{domxref('CSSNumericValue')}}.
+  - : A number or {{domxref("CSSNumericValue")}} that represents the value to negate.
+
+### Exceptions
+
+None.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathNegate` object from a length, then logs the constructor name, `value`, and the object's serialization (from {{domxref("CSSStyleValue/toString","toString()")}}).
+
+```js
+const negated = new CSSMathNegate(CSS.px(10));
+
+console.log(negated.constructor.name); // "CSSMathNegate"
+console.log(negated.value); // CSSUnitValue {value: 10, unit: "px"}
+console.log(negated.toString()); // "calc(-10px)"
+```
+
+Note that if a plain number is passed to `arg`, the `value` is rectified to a {{domxref("CSSUnitValue")}} with unit `"number"`:
+
+```js
+const negatedNumber = new CSSMathNegate(4);
+
+console.log(negatedNumber.value); // CSSUnitValue {value: 4, unit: "number"}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSMathNegate
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathNegate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) negates the value passed into it.
+The **`CSSMathNegate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the negation of a {{domxref("CSSNumericValue")}}.
 
 {{InheritanceDiagram}}
 
@@ -20,8 +20,8 @@ The **`CSSMathNegate`** interface of the [CSS Typed Object Model API](/en-US/doc
 
 _Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
-- {{domxref('CSSMathNegate.value')}} {{ReadOnlyInline}}
-  - : Returns a {{domxref('CSSNumericValue')}} object.
+- {{domxref("CSSMathNegate.value")}} {{ReadOnlyInline}}
+  - : Returns a {{domxref("CSSNumericValue")}} object.
 
 ## Static methods
 
@@ -31,9 +31,77 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
+## Description
+
+`CSSMathNegate` corresponds to applying unary minus to a numeric value (`x` becomes `-x`).
+
+Generally you won't construct a `CSSMathNegate` directly.
+It's produced by the internal negation step that {{domxref("CSSNumericValue.sub", "sub()")}} applies to its arguments before adding them: negating a {{domxref("CSSMathSum")}}, {{domxref("CSSMathProduct")}}, {{domxref("CSSMathMin")}}, {{domxref("CSSMathMax")}}, {{domxref("CSSMathClamp")}}, or {{domxref("CSSMathInvert")}} wraps it in a `CSSMathNegate`.
+Negating a plain {{domxref("CSSUnitValue")}} (a length, percentage, etc.) instead flips the sign of its `value` directly, so subtracting simple values doesn't normally produce a `CSSMathNegate`.
+
+A `CSSMathNegate` can also appear when reading a computed value: for example, {{domxref("StylePropertyMapReadOnly.get", "get()")}} on a property set with a {{cssxref("calc", "calc()")}} expression that subtracts a value returns a {{domxref("CSSMathSum")}} whose operands may include a `CSSMathNegate`.
+You can identify it by checking the {{domxref("CSSMathValue.operator", "operator")}} property for the string `"negate"`.
+
+`CSSMathNegate` serializes using CSS {{CSSXref("calc", "calc()")}} syntax, as `calc(-<value>)`.
+
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathNegate` object from a length, then logs the constructor name, `value`, and the object's serialization (from {{domxref("CSSStyleValue/toString","toString()")}}).
+
+```js
+const negated = new CSSMathNegate(CSS.px(10));
+
+console.log(negated.constructor.name); // "CSSMathNegate"
+console.log(negated.value); // CSSUnitValue {value: 10, unit: "px"}
+console.log(negated.toString()); // "calc(-10px)"
+```
+
+Note that if a plain number is passed to `arg`, the `value` is rectified to a {{domxref("CSSUnitValue")}} with unit `"number"`:
+
+```js
+const negatedNumber = new CSSMathNegate(4);
+
+console.log(negatedNumber.value); // CSSUnitValue {value: 4, unit: "number"}
+console.log(negatedNumber.toString()); // "calc(-4)"
+```
+
+### Subtracting a composite value
+
+{{domxref("CSSNumericValue.sub", "sub()")}} produces a `CSSMathNegate` when the value being subtracted is itself a composite value, such as a `CSSMathSum` (rather than a plain {{domxref("CSSUnitValue")}}).
+
+This is demonstrated by the following code.
+The `px` and `percent` can't be combined into a single value without knowing the containing block size, so the value of `composite` is represented as a `CSSMathSum`.
+When this value is subtracted, the value of `composite` is wrapped in a `CSSMathNegate`.
+
+```js
+const composite = CSS.px(10).add(CSS.percent(5)); // CSSMathSum: calc(10px + 5%)
+const result = CSS.px(100).sub(composite);
+
+console.log(result.constructor.name); // "CSSMathSum"
+console.log(result.values[1].constructor.name); // "CSSMathNegate"
+console.log(result.values[1].value); // CSSMathSum {values: CSSNumericArray, operator: "sum"}
+console.log(result.toString()); // "calc(100px - (10px + 5%))"
+```
+
+### Parsing `calc()`
+
+A `CSSMathNegate` can also be created when using {{domxref("CSSStyleValue/parse_static", "CSSStyleValue.parse()")}} to parse a {{cssxref("calc", "calc()")}} expression that can't be resolved to a single value.
+
+For example, in the following code {{domxref("CSSStyleValue/parse_static", "CSSStyleValue.parse()")}} parses a value for the `width` property that subtracts a length from a percentage (which can't be combined until layout).
+The result is a {{domxref("CSSMathSum")}} where the first value in the array is a `CSSUnitValue`, and the second value is a `CSSMathNegate` object representing negation of the second operand passed to the `calc()` function.
+
+```js
+const width = CSSStyleValue.parse("width", "calc(50% - 10px)");
+
+console.log(width.constructor.name); // "CSSMathSum"
+console.log(width.values[0]); // CSSUnitValue {value: 50, unit: 'percent'}
+console.log(width.values[1]); // CSSMathNegate {value: CSSUnitValue, operator: 'negate'}
+console.log(width.values[1].value); // CSSUnitValue {value: 10, unit: "px"}
+
+console.log(width.toString()); // "calc(50% - 10px)"
+```
 
 ## Specifications
 
@@ -42,3 +110,10 @@ To do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSNumericValue.sub", "sub()")}}
+- {{domxref("CSSStyleValue/parse_static", "CSSStyleValue.parse()")}}
+- {{domxref("CSSMathInvert")}}
+- {{domxref("CSSMathValue.operator")}}

--- a/files/en-us/web/api/cssmathnegate/value/index.md
+++ b/files/en-us/web/api/cssmathnegate/value/index.md
@@ -10,13 +10,27 @@ browser-compat: api.CSSMathNegate.value
 
 The **`value`** read-only property of the {{domxref("CSSMathNegate")}} interface returns the {{domxref("CSSNumericValue")}} that is being negated.
 
+This is the value passed to the constructor, rectified to a {{domxref("CSSNumericValue")}} (if it isn't one already).
+If a plain number was passed to the constructor the value returned by this property is the passed value wrapped in a {{domxref("CSSUnitValue")}} with `unit: "number"`.
+
 ## Value
 
-A {{domxref('CSSNumericValue')}}.
+A {{domxref("CSSNumericValue")}} or one of its derived types.
 
 ## Examples
 
-To do
+### Basic usage
+
+The following code creates a `CSSMathNegate` object, then reads its `value`.
+
+In this case, we passed `CSS.px(10)`, so `value` is a {{domxref("CSSUnitValue")}}.
+Passing a composite expression such as `CSS.px(10).add(CSS.percent(5))` would result in `value` returning a {{domxref("CSSMathSum")}}.
+
+```js
+const negated = new CSSMathNegate(CSS.px(10));
+
+console.log(negated.value); // CSSUnitValue {value: 10, unit: "px"}
+```
 
 ## Specifications
 
@@ -25,3 +39,7 @@ To do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSMathInvert.value")}}

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
@@ -15,13 +15,22 @@ The **`CSSMathProduct()`** constructor creates a {{domxref("CSSMathProduct")}} o
 ## Syntax
 
 ```js-nolint
-new CSSMathProduct(args)
+new CSSMathProduct(arg1)
+new CSSMathProduct(arg1, arg2)
+new CSSMathProduct(arg1, arg2, /* …, */ argN)
 ```
 
 ### Parameters
 
-- `args`
-  - : A list of values for the {{domxref('CSSMathProduct')}} object to be either a double integer or a {{domxref('CSSNumericValue')}}.
+- `arg1`, …, `argN`
+  - : A list of numbers or {{domxref("CSSNumericValue")}} objects.
+
+### Exceptions
+
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if no arguments are passed.
+- {{jsxref("TypeError")}}
+  - : Thrown if `arg1`, …, `argN` have incompatible types, so they cannot be multiplied.
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
@@ -8,9 +8,12 @@ status:
 browser-compat: api.CSSMathProduct.CSSMathProduct
 ---
 
-{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}{{SeeCompatTable}}
+{{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}{{SeeCompatTable}}
 
-The **`CSSMathProduct()`** constructor creates a {{domxref("CSSMathProduct")}} object that multiplies the arguments passed into it.
+The **`CSSMathProduct()`** constructor creates a new {{domxref("CSSMathProduct")}} object representing the product of the arguments passed into it.
+
+Numeric arguments are wrapped into {{domxref("CSSUnitValue")}} objects with a unit of `"number"`.
+All arguments are stored as separate items in its {{domxref("CSSMathProduct/values","values")}} property.
 
 ## Syntax
 
@@ -23,14 +26,70 @@ new CSSMathProduct(arg1, arg2, /* …, */ argN)
 ### Parameters
 
 - `arg1`, …, `argN`
-  - : A list of numbers or {{domxref("CSSNumericValue")}} objects.
+  - : One or more numbers or {{domxref("CSSNumericValue")}} objects.
 
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if no arguments are passed.
 - {{jsxref("TypeError")}}
-  - : Thrown if `arg1`, …, `argN` have incompatible types, so they cannot be multiplied.
+  - : Thrown if the types of `arg1`, …, `argN` can't be combined into a product.
+    This is rare: multiplying values of different units (a length by a time, for example) is allowed and produces a compound type.
+
+## Examples
+
+### Basic usage
+
+The following code creates a `CSSMathProduct` instance from two values, then reads back its `operator` and `values` properties.
+
+```js
+const product = new CSSMathProduct(CSS.px(10), CSS.percent(50));
+
+console.log(product.constructor.name); // "CSSMathProduct"
+console.log(product.operator); // 'product'
+console.log(product.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
+console.log(product.values[0]); // CSSUnitValue {value: 10, unit: "px"}
+```
+
+### Empty arguments
+
+The constructor throws a `SyntaxError` if called with no arguments.
+
+```js
+try {
+  new CSSMathProduct();
+} catch (e) {
+  console.log(e instanceof DOMException); // true
+  console.log(e.name); // "SyntaxError"
+}
+```
+
+### Handling incompatible percentages
+
+Multiplying a length by a time produces a valid (if unusual) compound type — unlike addition, multiplication doesn't require its arguments to share a dimension.
+
+```js
+const compound = new CSSMathProduct(CSS.px(10), CSS.s(2));
+
+console.log(compound.constructor.name); // "CSSMathProduct"
+console.log(compound.toString()); // "calc(10px * 2s)"
+```
+
+A `TypeError` can occur in the more contrived case where two or more arguments are themselves composite values that each mix a percentage with a different unit, and the product can't resolve them to a compatible type.
+In the following code, `percentageLength` mixes a percentage with a length (so its percentage resolves to `"length"`), and `percentageAngle` mixes a percentage with an angle (so its percentage resolves to `"angle"`).
+Multiplying them fails, because their percentages can't be resolved to a common type.
+
+```js
+const percentageLength = CSS.percent(50).add(CSS.px(10)); // percentage resolves to "length"
+const percentageAngle = CSS.percent(50).add(CSS.deg(10)); // percentage resolves to "angle"
+
+try {
+  new CSSMathProduct(percentageLength, percentageAngle);
+} catch (e) {
+  console.log(e instanceof TypeError); // true
+  console.log(e.message);
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/index.md
@@ -5,9 +5,9 @@ page-type: web-api-interface
 browser-compat: api.CSSMathProduct
 ---
 
-{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
+{{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}
 
-The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.mul','mul()')}} or {{domxref('CSSNumericValue.div','div()')}} on a {{domxref('CSSNumericValue')}}.
+The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the product of two or more {{domxref('CSSNumericValue')}} values — in cases where the result can't be represented as a single value.
 
 {{InheritanceDiagram}}
 
@@ -20,7 +20,7 @@ The **`CSSMathProduct`** interface of the [CSS Typed Object Model API](/en-US/do
 
 _Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
-- {{domxref('CSSMathProduct.values')}}
+- {{domxref('CSSMathProduct.values')}} {{ReadOnlyInline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
 ## Static methods
@@ -31,6 +31,109 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
+## Description
+
+A `CSSMathProduct` is produced whenever a multiplication or division can't be resolved to a single value — this happens when more than one operand carries a unit, for example, multiplying two lengths (`10px * 20px`) or a length by a percentage, rather than a value and a plain number.
+
+Calling {{domxref('CSSNumericValue.mul','mul()')}} or {{domxref('CSSNumericValue.div','div()')}} on operands that can't be combined returns a `CSSMathProduct`; if every operand is a plain number, or all but one of them are, they resolve immediately to a single {{domxref('CSSUnitValue')}} instead.
+
+[`StylePropertyMapReadOnly.get()`](/en-US/docs/Web/API/StylePropertyMapReadOnly/get) returns a `CSSMathProduct` the same way — for a {{cssxref("calc()")}} value that resolves to a multiplication or division it can't combine into one value.
+
+`CSSMathProduct` represents the product expression itself, not a resolved value.
+To get the resolved value, use {{domxref("Window.getComputedStyle", "getComputedStyle()")}}.
+
+## Examples
+
+### Basic usage
+
+The following code creates a `CSSMathProduct` instance from two values, then reads back its `operator` and `values` properties.
+
+```js
+const product = new CSSMathProduct(CSS.px(10), CSS.percent(50));
+
+console.log(product.constructor.name); // "CSSMathProduct"
+console.log(product.operator); // 'product'
+console.log(product.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
+console.log(product.values[0]); // CSSUnitValue {value: 10, unit: "px"}
+```
+
+### `calc()` representations
+
+This example shows how a {{cssxref("calc()")}} multiplication is represented by a {{domxref("CSSUnitValue")}} or a `CSSMathProduct`, depending on whether it can be resolved to a single value.
+
+#### HTML
+
+```html
+<div id="demoBox">Text</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+`width` is set using a `calc()` product of a length and a plain number, so the browser can resolve it to a single fixed value immediately.
+`font-size` is set using a `calc()` product that multiplies a plain number by a parenthesized sum of `1rem` and `5vw`; since the sum itself can't be combined into a single value (it mixes units), the product can't either, and this will be represented by a `CSSMathProduct`.
+
+```css
+#demoBox {
+  width: calc(10px * 2);
+  font-size: calc(2 * (1rem + 5vw));
+}
+```
+
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+First we find the demo box's style rule and read its `width` and `font-size` values using {{domxref("CSSStyleRule.styleMap", "styleMap")}}.
+
+```js
+const demoBox = document.querySelector("#demoBox");
+
+const rules = document.getElementById("css-output").sheet.cssRules;
+const rule = [...rules].find((r) => r.selectorText === "#demoBox");
+const styleMap = rule.styleMap;
+const width = styleMap.get("width");
+const fontSize = styleMap.get("font-size");
+```
+
+We then log the type and value of the CSS Typed OM representations, followed by the computed (resolved) values.
+
+```js
+log("width");
+log(` type: ${width.constructor.name}`);
+log(` value: ${width}`);
+log(` resolved: ${getComputedStyle(demoBox).width}`);
+
+log("\nfont-size");
+log(` type: ${fontSize.constructor.name}`);
+log(` values: [${[...fontSize.values].join(", ")}]`);
+log(` resolved: ${getComputedStyle(demoBox).fontSize}`);
+```
+
+#### Result
+
+`width` is represented by a `CSSUnitValue` object, which has a value that matches the resolved width.
+`font-size` is represented by a `CSSMathProduct` object that exposes the `calc()` product's original terms.
+
+{{EmbedLiveSample("`calc()` representations", 300, 300)}}
+
 ## Specifications
 
 {{Specifications}}
@@ -38,3 +141,11 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSNumericValue.mul", "mul()")}}
+- {{domxref("CSSNumericValue.div", "div()")}}
+- {{domxref("CSSMathValue.operator")}}
+- {{domxref("CSSMathInvert")}}
+- {{domxref("CSSMathSum")}}

--- a/files/en-us/web/api/cssmathproduct/values/index.md
+++ b/files/en-us/web/api/cssmathproduct/values/index.md
@@ -6,13 +6,41 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathProduct.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
+{{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}
 
 The **`values`** read-only property of the {{domxref("CSSMathProduct")}} interface returns a {{domxref("CSSNumericArray")}} containing the {{domxref("CSSNumericValue")}} objects being multiplied together.
 
 ## Value
 
 A {{domxref('CSSNumericArray')}}.
+
+## Examples
+
+### Basic usage
+
+The following code creates a `CSSMathProduct` object and logs its `values` and length.
+
+```js
+const product = new CSSMathProduct(CSS.px(10), CSS.percent(50));
+
+console.log(product.values);
+// CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
+console.log(product.values.length); // 2
+```
+
+We then iterate over the `values`, logging their type, value, unit, and stringified text.
+Each of these matches the {{domxref("CSSNumericValue")}} objects that were passed into the constructor (or the terms of the multiplication/division it represents), in the same order.
+
+```js
+for (const value of product.values) {
+  console.log(
+    `${value.constructor.name}: ${value.value} ${value.unit} (${value})`,
+  );
+}
+
+// CSSUnitValue: 10 px (10px)
+// CSSUnitValue: 50 percent (50%)
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.md
@@ -15,13 +15,22 @@ The **`CSSMathSum()`** constructor creates a new {{domxref("CSSMathSum")}} objec
 ## Syntax
 
 ```js-nolint
-new CSSMathSum(values)
+new CSSMathSum(arg1)
+new CSSMathSum(arg1, arg2)
+new CSSMathSum(arg1, arg2, /* …, */ argN)
 ```
 
 ### Parameters
 
-- `values`
+- `arg1`, …, `argN`
   - : One or more numbers (which are wrapped into {{domxref("CSSUnitValue")}}s of `unit: "number"`) or {{domxref("CSSNumericValue")}} objects.
+
+### Exceptions
+
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if no arguments are passed.
+- {{jsxref("TypeError")}}
+  - : Thrown if `arg1`, …, `argN` have incompatible types, so they cannot be summed.
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.md
@@ -8,9 +8,12 @@ status:
 browser-compat: api.CSSMathSum.CSSMathSum
 ---
 
-{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}{{SeeCompatTable}}
+{{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}{{SeeCompatTable}}
 
-The **`CSSMathSum()`** constructor creates a new {{domxref("CSSMathSum")}} object that represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
+The **`CSSMathSum()`** constructor creates a new {{domxref("CSSMathSum")}} object representing the sum of the arguments passed into it.
+
+Numeric arguments are wrapped into {{domxref("CSSUnitValue")}} objects with a unit of `"number"`.
+All arguments are stored as separate items in its {{domxref("CSSMathSum/values","values")}} property.
 
 ## Syntax
 
@@ -23,14 +26,57 @@ new CSSMathSum(arg1, arg2, /* …, */ argN)
 ### Parameters
 
 - `arg1`, …, `argN`
-  - : One or more numbers (which are wrapped into {{domxref("CSSUnitValue")}}s of `unit: "number"`) or {{domxref("CSSNumericValue")}} objects.
+  - : One or more numbers or {{domxref("CSSNumericValue")}} objects.
 
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if no arguments are passed.
 - {{jsxref("TypeError")}}
-  - : Thrown if `arg1`, …, `argN` have incompatible types, so they cannot be summed.
+  - : Thrown if `arg1`, …, `argN` have incompatible types.
+
+## Examples
+
+### Basic usage
+
+The following code creates a `CSSMathSum` instance from three values, then reads back its `operator` and `values` properties.
+
+```js
+const sum = new CSSMathSum(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(sum.constructor.name); // "CSSMathSum"
+console.log(sum.operator); // 'sum'
+console.log(sum.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(sum.values[0]); // CSSUnitValue {value: 10, unit: "px"}
+```
+
+### Empty arguments
+
+The constructor throws a `SyntaxError` if called with no arguments.
+
+```js
+try {
+  new CSSMathSum();
+} catch (e) {
+  console.log(e instanceof DOMException); // true
+  console.log(e.name); // "SyntaxError"
+}
+```
+
+### Handling incompatible types
+
+The constructor throws a `TypeError` if the values don't resolve to a compatible type.
+In the following code we mix a length with a time, and log the error.
+
+```js
+try {
+  // Mixes a length (px) with a time (s): incompatible types
+  new CSSMathSum(CSS.px(10), CSS.s(2));
+} catch (e) {
+  console.log(e instanceof TypeError); // true
+  console.log(e.message);
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/index.md
@@ -5,11 +5,9 @@ page-type: web-api-interface
 browser-compat: api.CSSMathSum
 ---
 
-{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
+{{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}
 
-The **`CSSMathSum`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the result obtained by calling {{domxref('CSSNumericValue.add','add()')}}, {{domxref('CSSNumericValue.sub','sub()')}}, or {{domxref('CSSNumericValue.toSum','toSum()')}} on {{domxref('CSSNumericValue')}}.
-
-A CSSMathSum is the object type returned when the [`StylePropertyMapReadOnly.get()`](/en-US/docs/Web/API/StylePropertyMapReadOnly/get) method is used on a CSS property whose value is created with a {{cssxref("calc()")}} function.
+The **`CSSMathSum`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the sum of two or more {{domxref('CSSNumericValue')}} values — in cases where the result can't be represented as a single value.
 
 {{InheritanceDiagram}}
 
@@ -22,7 +20,7 @@ A CSSMathSum is the object type returned when the [`StylePropertyMapReadOnly.get
 
 _Also inherits properties from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
-- {{domxref('CSSMathSum.values')}}
+- {{domxref('CSSMathSum.values')}} {{ReadOnlyInline}}
   - : Returns a {{domxref('CSSNumericArray')}} object which contains one or more {{domxref('CSSNumericValue')}} objects.
 
 ## Static methods
@@ -33,47 +31,110 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
 _Also inherits methods from its parent interface, {{DOMxRef("CSSMathValue")}}._
 
+## Description
+
+A `CSSMathSum` is produced whenever an addition or subtraction can't be resolved to a single value — for example, when the operands use different units, such as a length and a percentage.
+
+Calling {{domxref('CSSNumericValue.add','add()')}} or {{domxref('CSSNumericValue.sub','sub()')}} on operands that can't be combined returns a `CSSMathSum`; if every operand shares the same unit, they resolve immediately to a single {{domxref('CSSUnitValue')}} instead.
+{{domxref('CSSNumericValue.toSum','toSum()')}}, by contrast, always returns a `CSSMathSum`, even when its terms could be combined into a single value.
+
+[`StylePropertyMapReadOnly.get()`](/en-US/docs/Web/API/StylePropertyMapReadOnly/get) returns a `CSSMathSum` the same way — for a {{cssxref("calc()")}} value that resolves to an addition or subtraction it can't combine into one value.
+
+`CSSMathSum` represents the sum expression itself, not a resolved value.
+To get the resolved value, use {{domxref("Window.getComputedStyle", "getComputedStyle()")}}.
+
 ## Examples
 
-We create an element with a {{cssxref("width")}} determined using a {{cssxref("calc()")}} function, then {{domxref("console/log_static", "console.log()")}} the `operator` and `values`, and dig into the values a bit.
+### Basic usage
 
-```html
-<div>has width</div>
+The following code creates a `CSSMathSum` instance from three values, then reads back its `operator` and `values` properties.
+
+```js
+const sum = new CSSMathSum(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(sum.constructor.name); // "CSSMathSum"
+console.log(sum.operator); // 'sum'
+
+console.log(sum.values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(sum.values[0]); // CSSUnitValue {value: 10, unit: "px"}
 ```
 
-We assign a `width`
+### `calc()` representations
+
+This example shows how a {{cssxref("calc()")}} addition is represented by a {{domxref("CSSUnitValue")}} or a `CSSMathSum`, depending on whether its terms share a unit.
+
+#### HTML
+
+```html
+<div id="demoBox">Text</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+`width` is set using a `calc()` sum whose terms are both `px` lengths, so the browser can resolve it to a single fixed value immediately.
+`font-size` is set using a `calc()` sum that mixes `rem` and `vw`, so the browser can't combine the terms until layout (this will be represented by a `CSSMathSum`).
 
 ```css
-div {
-  width: calc(30% - 20px);
+#demoBox {
+  width: calc(10px + 5px);
+  font-size: calc(1rem + 5vw);
 }
 ```
 
-We add the JavaScript
-
-```js
-const styleMap = document.querySelector("div").computedStyleMap();
-
-console.log(styleMap.get("width")); // CSSMathSum {values: CSSNumericArray, operator: "sum"}
-console.log(styleMap.get("width").operator); // 'sum'
-console.log(styleMap.get("width").values); // CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, length: 2}
-console.log(styleMap.get("width").values[0]); // CSSUnitValue {value: 30, unit: "percent"}
-console.log(styleMap.get("width").values[0].value); // 30
-console.log(styleMap.get("width").values[0].unit); // 'percent'
-console.log(styleMap.get("width").values[1]); // CSSUnitValue {value: -20, unit: "px"}
-console.log(styleMap.get("width").values[1].value); //  -20
-console.log(styleMap.get("width").values[1].unit); // 'px'
+```css hidden
+#log {
+  height: 200px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
 ```
 
-{{EmbedLiveSample("Examples", 120, 300)}}
+#### JavaScript
 
-The specification is still evolving. In the future we may write the last three lines as:
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+First we find the demo box's style rule and read its `width` and `font-size` values using {{domxref("CSSStyleRule.styleMap", "styleMap")}}.
 
 ```js
-console.log(styleMap.get("width").values[1]); // CSSMathNegate {value: CSSUnitValue, operator: "negate"}
-console.log(styleMap.get("width").values[1].value); // CSSUnitValue {value: 20, unit: "px"}
-console.log(styleMap.get("width").values[1].value.unit); // 'px'
+const demoBox = document.querySelector("#demoBox");
+
+const rules = document.getElementById("css-output").sheet.cssRules;
+const rule = [...rules].find((r) => r.selectorText === "#demoBox");
+const styleMap = rule.styleMap;
+const width = styleMap.get("width");
+const fontSize = styleMap.get("font-size");
 ```
+
+We then log the type and value of the CSS Typed OM representations, followed by the computed (resolved) values.
+
+```js
+log("width");
+log(` type: ${width.constructor.name}`);
+log(` value: ${width}`);
+log(` resolved: ${getComputedStyle(demoBox).width}`);
+
+log("\nfont-size");
+log(` type: ${fontSize.constructor.name}`);
+log(` values: [${[...fontSize.values].join(", ")}]`);
+log(` resolved: ${getComputedStyle(demoBox).fontSize}`);
+```
+
+#### Result
+
+`width` is represented by a `CSSUnitValue` object, which has a value that matches the resolved width.
+`font-size` is represented by a `CSSMathSum` object that exposes the `calc()` sum's original terms.
+
+{{EmbedLiveSample("`calc()` representations", 300, 300)}}
 
 ## Specifications
 
@@ -82,3 +143,12 @@ console.log(styleMap.get("width").values[1].value.unit); // 'px'
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSNumericValue.add", "add()")}}
+- {{domxref("CSSNumericValue.sub", "sub()")}}
+- {{domxref("CSSNumericValue.toSum", "toSum()")}}
+- {{domxref("CSSMathValue.operator")}}
+- {{domxref("CSSMathNegate")}}
+- {{domxref("CSSMathProduct")}}

--- a/files/en-us/web/api/cssmathsum/values/index.md
+++ b/files/en-us/web/api/cssmathsum/values/index.md
@@ -6,13 +6,42 @@ page-type: web-api-instance-property
 browser-compat: api.CSSMathSum.values
 ---
 
-{{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
+{{APIRef("CSS Typed Object Model API")}}{{AvailableInWorkers}}
 
 The **`values`** read-only property of the {{domxref("CSSMathSum")}} interface returns a {{domxref("CSSNumericArray")}} containing the {{domxref("CSSNumericValue")}} objects being summed together.
 
 ## Value
 
 A {{domxref('CSSNumericArray')}}.
+
+## Examples
+
+### Basic usage
+
+The following code creates a `CSSMathSum` object and logs its `values` and length.
+
+```js
+const sum = new CSSMathSum(CSS.px(10), CSS.em(5), CSS.percent(50));
+
+console.log(sum.values);
+// CSSNumericArray {0: CSSUnitValue, 1: CSSUnitValue, 2: CSSUnitValue, length: 3}
+console.log(sum.values.length); // 3
+```
+
+We then iterate over the `values`, logging their type, value, unit, and stringified text.
+Each of these matches the {{domxref("CSSNumericValue")}} objects that were passed into the constructor (or the terms of the addition/subtraction it represents), in the same order.
+
+```js
+for (const value of sum.values) {
+  console.log(
+    `${value.constructor.name}: ${value.value} ${value.unit} (${value})`,
+  );
+}
+
+// CSSUnitValue: 10 px (10px)
+// CSSUnitValue: 5 em (5em)
+// CSSUnitValue: 50 percent (50%)
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathvalue/index.md
+++ b/files/en-us/web/api/cssmathvalue/index.md
@@ -7,13 +7,13 @@ browser-compat: api.CSSMathValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) a base class for classes representing complex numeric values.
+The **`CSSMathValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is a base class for classes representing complex numeric values.
 
 {{InheritanceDiagram}}
 
 ## Instance properties
 
-- {{domxref('CSSMathValue.operator')}}
+- {{domxref('CSSMathValue.operator')}} {{ReadOnlyInline}}
   - : Indicates the operator that the current subtype represents.
 
 ## Static methods

--- a/files/en-us/web/api/cssmathvalue/index.md
+++ b/files/en-us/web/api/cssmathvalue/index.md
@@ -7,14 +7,18 @@ browser-compat: api.CSSMathValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSMathValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is a base class for classes representing complex numeric values.
+The **`CSSMathValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is the base interface for objects representing complex numeric values produced by the CSS {{cssxref("calc()")}}, {{cssxref("min()")}}, {{cssxref("max()")}}, and {{cssxref("clamp()")}} functions.
+
+> [!NOTE]
+> `CSSMathValue` cannot be constructed directly.
+> Instances are returned by the platform (for example via {{domxref("StylePropertyMapReadOnly.get()")}}) as one of its subtypes, listed below.
 
 {{InheritanceDiagram}}
 
 ## Instance properties
 
 - {{domxref('CSSMathValue.operator')}} {{ReadOnlyInline}}
-  - : Indicates the operator that the current subtype represents.
+  - : Returns the operator that the current subtype represents.
 
 ## Static methods
 
@@ -36,33 +40,66 @@ _Also inherits methods from its parent interface, {{DOMxRef("CSSNumericValue")}}
 
 ## Examples
 
-We create an element with a {{cssxref("width")}} determined using a {{cssxref("calc()")}} function, then {{domxref("console/log_static", "console.log()")}} the `operator`.
+### `calc()` representations
+
+This example shows how the {{domxref("CSSMathValue.operator", "operator")}} property identifies the operation represented by a {{cssxref("calc()")}} value's `CSSMathValue` subtype, including for a nested value.
+
+#### HTML
 
 ```html
-<div>has width</div>
+<div id="demoBox">Text</div>
 ```
 
-We assign a `width` with a calculation
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+`width` is set using a `calc()` subtraction, which is represented as a `CSSMathSum` whose second term is negated.
 
 ```css
-div {
+#demoBox {
   width: calc(30% - 20px);
 }
 ```
 
-We add the JavaScript
-
-```js
-const styleMap = document.querySelector("div").computedStyleMap();
-
-console.log(styleMap.get("width")); // CSSMathSum {values: CSSNumericArray, operator: "sum"}
-console.log(styleMap.get("width").operator); // 'sum'
-console.log(styleMap.get("width").values[1].value); // -20
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
 ```
 
-{{EmbedLiveSample("Examples", 120, 300)}}
+#### JavaScript
 
-The `CSSMathValue.operator` returns `"sum"` because `styleMap.get("width").values[1].value );` is `-20`: adding a negative number.
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+We read the `width` value using {{domxref("Element.computedStyleMap()", "computedStyleMap()")}}, then log its `operator` and the `operator` of its nested value.
+
+```js
+const styleMap = document.querySelector("#demoBox").computedStyleMap();
+const width = styleMap.get("width");
+
+log(`type: ${width.constructor.name}`);
+log(`operator: ${width.operator}`);
+log(`nested value type: ${width.values[1].constructor.name}`);
+log(`nested value operator: ${width.values[1].operator}`);
+```
+
+#### Result
+
+`width` is represented by a `CSSMathSum` object whose `operator` is `"sum"`, because `calc(30% - 20px)` is represented as an addition of `30%` and the negation of `20px`.
+The second nested value's type is `CSSMathNegate` and its `operator` is `"negate"` (reflecting that negation).
+
+{{EmbedLiveSample("`calc()` representations", 300, 170)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmathvalue/operator/index.md
+++ b/files/en-us/web/api/cssmathvalue/operator/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSMathValue.operator
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`operator`** read-only property of the {{domxref("CSSMathValue")}} interface indicates the operator that the current subtype represents.
+The **`operator`** read-only property of the {{domxref("CSSMathValue")}} interface returns the operator that the current subtype represents.
 For example, if the current `CSSMathValue` subtype is `CSSMathSum`, this property will return the string `"sum"`.
 
 ## Value
@@ -29,34 +29,62 @@ A {{jsxref('String')}}.
 
 ### Basic usage
 
-We create an element with a {{cssxref("width")}} determined using a {{cssxref("calc()")}} function, then {{domxref("console/log_static", "console.log()")}} the `operator`.
+This example shows how the `operator` property identifies the operation represented by a {{cssxref("calc()")}} value's `CSSMathValue` subtype, including for a nested value.
+
+#### HTML
 
 ```html
-<div>My width has a <code>calc()</code> function</div>
+<div id="demoBox">Text</div>
 ```
 
-We assign a `width` with a calculation
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+`width` is set using a `calc()` subtraction, which is represented as a `CSSMathSum` whose second term is negated.
 
 ```css
-div {
+#demoBox {
   width: calc(50% - 0.5vw);
 }
 ```
 
-We add the JavaScript
-
-```js
-const styleMap = document.querySelector("div").computedStyleMap();
-
-console.log(styleMap.get("width")); // CSSMathSum {values: CSSNumericArray, operator: "sum"}
-console.log(styleMap.get("width").values); // CSSNumericArray {0: CSSUnitValue, 1: CSSMathNegate, length: 2}
-console.log(styleMap.get("width").operator); // 'sum'
-console.log(styleMap.get("width").values[1].operator); // 'negate'
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
 ```
 
-{{EmbedLiveSample("Basic usage", 120, 300)}}
+#### JavaScript
 
-The `CSSMathValue.operator` returns `sum` for the equation and `negate` for the operator on the second value.
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+We read the `width` value using {{domxref("Element.computedStyleMap()", "computedStyleMap()")}}, then log its `operator` and the `operator` of its nested value.
+
+```js
+const styleMap = document.querySelector("#demoBox").computedStyleMap();
+const width = styleMap.get("width");
+
+log(`operator: ${width.operator}`);
+log(`nested value operator: ${width.values[1].operator}`);
+```
+
+#### Result
+
+`width` is represented by a `CSSMathSum` object whose `operator` is `"sum"`, because `calc(50% - 0.5vw)` is represented as an addition of `50%` and the negation of `0.5vw`.
+The second nested value's `operator` is `"negate"`, reflecting that negation.
+
+{{EmbedLiveSample("Basic usage", 300, 170)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
@@ -21,6 +21,10 @@ new CSSMatrixComponent(matrix, options)
 
 - {{domxref('CSSMatrixComponent.matrix','matrix')}}
   - : A 2d or 3d matrix.
+- `options` {{optional_inline}}
+  - : An object with the following property:
+    - `is2D`
+      - : A boolean indicating whether the constructed `CSSMatrixComponent` should be treated as a 2D matrix. If omitted, this defaults to the value of `matrix`'s own {{domxref("DOMMatrixReadOnly.is2D", "is2D")}} property.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/add/index.md
+++ b/files/en-us/web/api/cssnumericvalue/add/index.md
@@ -13,12 +13,15 @@ The **`add()`** method of the {{domxref("CSSNumericValue")}} interface adds a su
 ## Syntax
 
 ```js-nolint
-add(number)
+add()
+add(number1)
+add(number1, number2)
+add(number1, number2, /* …, */ numberN)
 ```
 
 ### Parameters
 
-- `number`
+- `number1`, …, `numberN` {{optional_inline}}
   - : Either a number or a {{domxref('CSSNumericValue')}}.
 
 ### Return value

--- a/files/en-us/web/api/cssnumericvalue/add/index.md
+++ b/files/en-us/web/api/cssnumericvalue/add/index.md
@@ -26,7 +26,7 @@ add(number1, number2, /* …, */ numberN)
 
 ### Return value
 
-A {{domxref('CSSMathSum')}}
+A {{domxref('CSSMathSum')}}, or a {{domxref('CSSUnitValue')}} if `this` and every argument share the same unit.
 
 ### Exceptions
 
@@ -38,10 +38,7 @@ A {{domxref('CSSMathSum')}}
 ### Basic usage
 
 ```js
-let mathSum = CSS.px("23")
-  .add(CSS.percent("4"))
-  .add(CSS.cm("3"))
-  .add(CSS.in("9"));
+let mathSum = CSS.px(23).add(CSS.percent(4)).add(CSS.cm(3)).add(CSS.in(9));
 // Prints "calc(23px + 4% + 3cm + 9in)"
 console.log(mathSum.toString());
 ```

--- a/files/en-us/web/api/cssnumericvalue/div/index.md
+++ b/files/en-us/web/api/cssnumericvalue/div/index.md
@@ -13,12 +13,15 @@ The **`div()`** method of the {{domxref("CSSNumericValue")}} interface divides t
 ## Syntax
 
 ```js-nolint
-div(number)
+div()
+div(number1)
+div(number1, number2)
+div(number1, number2, /* …, */ numberN)
 ```
 
 ### Parameters
 
-- `number`
+- `number1`, …, `numberN` {{optional_inline}}
   - : Either a number or a {{domxref('CSSNumericValue')}}.
 
 ### Return value
@@ -30,7 +33,7 @@ A {{domxref('CSSMathProduct')}}.
 - {{jsxref("TypeError")}}
   - : Thrown if an invalid type was passed to the method.
 - [`RangeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError)
-  - : Thrown if `number` is, or resolves to, 0 or -0.
+  - : Thrown if any of `number1`, …, `numberN` is, or resolves to, 0 or -0.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/div/index.md
+++ b/files/en-us/web/api/cssnumericvalue/div/index.md
@@ -26,7 +26,7 @@ div(number1, number2, /* …, */ numberN)
 
 ### Return value
 
-A {{domxref('CSSMathProduct')}}.
+A {{domxref('CSSMathProduct')}}, or a {{domxref('CSSUnitValue')}} if `this` and every argument are plain numbers, or all but one of them are.
 
 ### Exceptions
 
@@ -40,7 +40,7 @@ A {{domxref('CSSMathProduct')}}.
 ### Basic usage
 
 ```js
-let mathProduct = CSS.px("24").div(CSS.percent("4"));
+let mathProduct = CSS.px(24).div(CSS.percent(4));
 // Prints "calc(24px / 4%)"
 mathProduct.toString();
 ```

--- a/files/en-us/web/api/cssnumericvalue/equals/index.md
+++ b/files/en-us/web/api/cssnumericvalue/equals/index.md
@@ -15,12 +15,15 @@ This allows structural equality to be tested quickly.
 ## Syntax
 
 ```js-nolint
-equals(number)
+equals()
+equals(number1)
+equals(number1, number2)
+equals(number1, number2, /* …, */ numberN)
 ```
 
 ### Parameters
 
-- `number`
+- `number1`, …, `numberN` {{optional_inline}}
   - : Either a number or a {{domxref('CSSNumericValue')}}.
 
 ### Return value

--- a/files/en-us/web/api/cssnumericvalue/max/index.md
+++ b/files/en-us/web/api/cssnumericvalue/max/index.md
@@ -14,12 +14,15 @@ The passed values must be of the same type.
 ## Syntax
 
 ```js-nolint
-max(number1, /* …, */ numberN)
+max()
+max(number1)
+max(number1, number2)
+max(number1, number2, /* …, */ numberN)
 ```
 
 ### Parameters
 
-- `number1`, …, `numberN`
+- `number1`, …, `numberN` {{optional_inline}}
   - : Either a number or a {{domxref('CSSNumericValue')}}.
 
 ### Return value

--- a/files/en-us/web/api/cssnumericvalue/min/index.md
+++ b/files/en-us/web/api/cssnumericvalue/min/index.md
@@ -14,12 +14,15 @@ The passed values must be of the same type.
 ## Syntax
 
 ```js-nolint
-min(number1, /* …, */ numberN)
+min()
+min(number1)
+min(number1, number2)
+min(number1, number2, /* …, */ numberN)
 ```
 
 ### Parameters
 
-- `number1`, …, `numberN`
+- `number1`, …, `numberN` {{optional_inline}}
   - : Either a number or a {{domxref('CSSNumericValue')}}.
 
 ### Return value

--- a/files/en-us/web/api/cssnumericvalue/mul/index.md
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.md
@@ -13,12 +13,15 @@ The **`mul()`** method of the {{domxref("CSSNumericValue")}} interface multiplie
 ## Syntax
 
 ```js-nolint
-mul(number)
+mul()
+mul(number1)
+mul(number1, number2)
+mul(number1, number2, /* …, */ numberN)
 ```
 
 ### Parameters
 
-- `number`
+- `number1`, …, `numberN` {{optional_inline}}
   - : Either a number or a {{domxref('CSSNumericValue')}}.
 
 ### Return value

--- a/files/en-us/web/api/cssnumericvalue/mul/index.md
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSNumericValue.mul
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`mul()`** method of the {{domxref("CSSNumericValue")}} interface multiplies the `CSSNumericValue` by the supplied value.
+The **`mul()`** method of the {{domxref("CSSNumericValue")}} interface multiplies the `CSSNumericValue` by the supplied values.
 
 ## Syntax
 
@@ -26,7 +26,7 @@ mul(number1, number2, /* …, */ numberN)
 
 ### Return value
 
-A {{domxref('CSSMathProduct')}}
+A {{domxref('CSSMathProduct')}}, or a {{domxref('CSSUnitValue')}} if `this` and every argument are plain numbers, or all but one of them are.
 
 ### Exceptions
 
@@ -38,12 +38,9 @@ A {{domxref('CSSMathProduct')}}
 ### Basic usage
 
 ```js
-let mathSum = CSS.px("23")
-  .mul(CSS.percent("4"))
-  .mul(CSS.cm("3"))
-  .mul(CSS.in("9"));
+let mathProduct = CSS.px(23).mul(CSS.percent(4)).mul(CSS.cm(3)).mul(CSS.in(9));
 // Prints "calc(23px * 4% * 3cm * 9in)"
-console.log(mathSum.toString());
+console.log(mathProduct.toString());
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cssnumericvalue/sub/index.md
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.md
@@ -13,13 +13,16 @@ The **`sub()`** method of the {{domxref("CSSNumericValue")}} interface subtracts
 ## Syntax
 
 ```js-nolint
-sub(number)
+sub()
+sub(number1)
+sub(number1, number2)
+sub(number1, number2, /* …, */ numberN)
 ```
 
 ### Parameters
 
-- `number`
-  - : Either a number or a {{domxref('CSSMathSum')}}.
+- `number1`, …, `numberN` {{optional_inline}}
+  - : Either a number or a {{domxref('CSSNumericValue')}}.
 
 ### Return value
 

--- a/files/en-us/web/api/cssnumericvalue/sub/index.md
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.md
@@ -26,7 +26,7 @@ sub(number1, number2, /* …, */ numberN)
 
 ### Return value
 
-A {{domxref('CSSMathSum')}}
+A {{domxref('CSSMathSum')}}, or a {{domxref('CSSUnitValue')}} if `this` and every argument share the same unit.
 
 ### Exceptions
 
@@ -38,10 +38,7 @@ A {{domxref('CSSMathSum')}}
 ### Basic usage
 
 ```js
-let mathSum = CSS.px("23")
-  .sub(CSS.percent("4"))
-  .sub(CSS.cm("3"))
-  .sub(CSS.in("9"));
+let mathSum = CSS.px(23).sub(CSS.percent(4)).sub(CSS.cm(3)).sub(CSS.in(9));
 // Prints "calc(23px - 4% - 3cm - 9in)"
 console.log(mathSum.toString());
 ```

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.md
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.md
@@ -8,17 +8,21 @@ browser-compat: api.CSSNumericValue.toSum
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`toSum()`** method of the {{domxref("CSSNumericValue")}} interface converts the object's value to a {{domxref("CSSMathSum")}} object to values of the specified unit.
+The **`toSum()`** method of the {{domxref("CSSNumericValue")}} interface converts the object's value to a {{domxref("CSSMathSum")}} of {{domxref("CSSUnitValue")}}s using only the specified units, if possible.
+If called with no units, it simplifies the value into a minimal sum of `CSSUnitValue`s instead.
 
 ## Syntax
 
 ```js-nolint
-toSum(units)
+toSum()
+toSum(unit1)
+toSum(unit1, unit2)
+toSum(unit1, unit2, /* …, */ unitN)
 ```
 
 ### Parameters
 
-- `units`
+- `unit1`, …, `unitN` {{optional_inline}}
   - : The units to convert to.
 
 ### Return value
@@ -27,8 +31,12 @@ A {{domxref('CSSMathSum')}}.
 
 ### Exceptions
 
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if any of `unit1`, …, `unitN` is not a valid unit identifier.
 - {{jsxref("TypeError")}}
-  - : Thrown if an invalid type was passed to the method.
+  - : Thrown if:
+    - The value can't be expressed as a sum of `CSSUnitValue`s — for example, because one of its terms has a compound unit (such as `px * s`) that can't be represented by a single `CSSUnitValue`.
+    - One or more units were passed to the method, and the value includes a term whose unit isn't compatible with any of them.
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.md
@@ -8,33 +8,39 @@ browser-compat: api.CSSRotate.CSSRotate
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSRotate()`** constructor creates a new
-{{domxref("CSSRotate")}} object representing the {{cssxref("transform-function/rotate", "rotate()")}} value of the
-individual {{CSSXref('transform')}} property in CSS.
+The **`CSSRotate()`** constructor creates a new {{domxref("CSSRotate")}} object representing the {{cssxref("transform-function/rotate", "rotate()")}} value of the individual {{CSSXref('transform')}} property in CSS.
+
+This can be specified as either a 2D rotation by a particular angle, or as a 3D rotation by an angle around a particular axis.
 
 ## Syntax
 
 ```js-nolint
+new CSSRotate(angle)
 new CSSRotate(x, y, z, angle)
 ```
 
 ### Parameters
 
-- {{domxref('CSSRotate.x','x')}}
-  - : A value for the x-axis of the {{domxref('CSSRotate')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
-- {{domxref('CSSRotate.y','y')}}
-  - : A value for the y-axis of the {{domxref('CSSRotate')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
-- {{domxref('CSSRotate.z','z')}}
-  - : A value for the z-axis of the {{domxref('CSSRotate')}} object to be constructed. This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
 - {{domxref('CSSRotate.angle','angle')}}
-  - : A value for the angle of the {{domxref('CSSRotate')}} object to be constructed. This
-    must be a {{domxref('CSSNumericValue')}}.
+  - : A value for the angle of the {{domxref('CSSRotate')}} object to be constructed.
+    This must be a {{domxref('CSSNumericValue')}}.
+- {{domxref('CSSRotate.x','x')}} {{optional_inline}}
+  - : A value for the x-axis of the {{domxref('CSSRotate')}} object to be constructed.
+    This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
+    Only used, and required, when constructing a 3D rotation.
+- {{domxref('CSSRotate.y','y')}} {{optional_inline}}
+  - : A value for the y-axis of the {{domxref('CSSRotate')}} object to be constructed.
+    This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
+    Only used, and required, when constructing a 3D rotation.
+- {{domxref('CSSRotate.z','z')}} {{optional_inline}}
+  - : A value for the z-axis of the {{domxref('CSSRotate')}} object to be constructed.
+    This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
+    Only used, and required, when constructing a 3D rotation.
 
 ### Exceptions
 
 - [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
-  - : Raised if the value of `CSSRotate.angle` is not an [\<angle>](/en-US/docs/Web/CSS/Reference/Values/angle) value
-    or `CSSRotate.x`, `CSSRotate.y`, `CSSRotate.z` are
+  - : Raised if the value of `CSSRotate.angle` is not an [\<angle>](/en-US/docs/Web/CSS/Reference/Values/angle) value or `CSSRotate.x`, `CSSRotate.y`, `CSSRotate.z` are
     not [\<number>](/en-US/docs/Web/CSS/Reference/Values/number) values.
 
 ## Examples

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -11,8 +11,8 @@ The **`CSSTransformComponent`** interface of the [CSS Typed Object Model API](/e
 
 ## Instance properties
 
-- {{domxref("CSSTransformComponent.is2D")}} {{ReadOnlyInline}}
-  - : Returns a boolean indicting whether the transform is 2D or 3D.
+- {{domxref("CSSTransformComponent.is2D")}}
+  - : A boolean that represents whether the transform is 2D or 3D.
 
 ## Instance methods
 

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.md
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.md
@@ -8,11 +8,11 @@ browser-compat: api.CSSTransformComponent.is2D
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`is2D`** read-only property of the {{domxref("CSSTransformComponent")}} interface indicates whether the transform is 2D or 3D.
+The **`is2D`** property of the {{domxref("CSSTransformComponent")}} interface indicates whether the transform is 2D or 3D.
 
 ## Value
 
-A boolean. True indicating the transform is a 2D transform, false if it is a 3D transform.
+A boolean. True if the transform is a 2D transform, false if it is a 3D transform.
 
 ## Examples
 

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -23,7 +23,7 @@ For example, the value `42px` (a {{cssxref("&lt;dimension&gt;")}}) would be repr
 - {{domxref('CSSUnitValue.value')}}
   - : A number representing the number of units.
     For a `CSSNumericValue` representing `42px`, this would be `42`.
-- {{domxref('CSSUnitValue.unit')}}
+- {{domxref('CSSUnitValue.unit')}} {{ReadOnlyInline}}
   - : Returns a string indicating the type of unit. For a `CSSNumericValue` representing `42px`, this would be `"px"`.
 
 ## Static methods

--- a/files/en-us/web/api/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/index.md
@@ -21,7 +21,7 @@ Custom properties are represented by `CSSUnparsedValue` and {{cssxref("var", "va
 
 ## Instance properties
 
-- {{domxref('CSSUnparsedValue.length')}}
+- {{domxref('CSSUnparsedValue.length')}} {{ReadOnlyInline}}
   - : Returns the number of items in the `CSSUnparsedValue` object.
 
 ## Instance methods

--- a/files/en-us/web/api/stylepropertymap/append/index.md
+++ b/files/en-us/web/api/stylepropertymap/append/index.md
@@ -8,24 +8,38 @@ browser-compat: api.StylePropertyMap.append
 
 {{APIRef("CSS Typed Object Model API")}}
 
-The **`append()`** method of the {{domxref("StylePropertyMap")}} interface adds the passed CSS value to the `StylePropertyMap` with the given property.
+The **`append()`** method of the {{domxref("StylePropertyMap")}} interface adds one or more values to the end of a list-valued CSS property's value list.
+
+A list-valued CSS property is one whose value is a comma-separated list of terms, such as {{cssxref("background-image")}} or {{cssxref("animation")}}.
 
 ## Syntax
 
 ```js-nolint
-append(property, value)
+append(property)
+append(property, value1)
+append(property, value1, value2)
+append(property, value1, value2, /* …, */ valueN)
 ```
 
 ### Parameters
 
 - `property`
   - : An identifier indicating the stylistic feature (e.g., font, width, background color) to add.
-- `value`
-  - : The value the given property should have.
+- `value1`, …, `valueN`
+  - : One or more values to add to the end of `property`'s value list, in the order given.
 
 ### Return value
 
 None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if:
+    - `property` is not a valid CSS list-valued property.
+    - Any of `value1`, …, `valueN` is already associated with a different property (for example, a value read from one property's entry in a `StylePropertyMap`, then passed to `append()` for another property).
+    - Any of `value1`, …, `valueN` is a {{domxref("CSSUnparsedValue")}} or {{domxref("CSSVariableReferenceValue")}} object.
+    - `property`'s current value contains a {{cssxref("var")}} reference.
 
 ## Examples
 

--- a/files/en-us/web/api/stylepropertymap/set/index.md
+++ b/files/en-us/web/api/stylepropertymap/set/index.md
@@ -13,15 +13,18 @@ The **`set()`** method of the {{domxref("StylePropertyMap")}} interface changes 
 ## Syntax
 
 ```js-nolint
-set(property, value)
+set(property)
+set(property, value1)
+set(property, value1, value2)
+set(property, value1, value2, /* …, */ valueN)
 ```
 
 ### Parameters
 
 - `property`
   - : An identifier indicating the stylistic feature (e.g., font, width, background color) to change.
-- `value`
-  - : The value the given property should have.
+- `value1`, …, `valueN`
+  - : The value(s) the given property should have.
 
 ### Return value
 

--- a/files/en-us/web/api/stylepropertymapreadonly/get/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/get/index.md
@@ -8,7 +8,9 @@ browser-compat: api.StylePropertyMapReadOnly.get
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`get()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface returns a {{domxref("CSSStyleValue")}} object for the first value of the specified property.
+The **`get()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface returns a {{domxref("CSSStyleValue")}}-derived object for the first value of the specified property.
+
+Use {{domxref("StylePropertyMapReadOnly.getAll", "getAll()")}} to get all the values of a CSS property that can have multiple values, such as {{cssxref("background-image")}} or {{cssxref("transition")}}.
 
 ## Syntax
 
@@ -19,26 +21,44 @@ get(property)
 ### Parameters
 
 - `property`
-  - : The name of the property to retrieve the value of.
+  - : The name of the property.
+    Custom property names (starting with `--`) are matched case-sensitively; standard property names are not.
 
 ### Return value
 
-A {{domxref("CSSStyleValue")}} object.
+A {{domxref("CSSStyleValue")}}-derived object, or {{jsxref("undefined")}} if `property` has no value in the map.
+
+The concrete type of the returned object depends on the property and its value.
+For example, a property assigned a keyword might return a {{domxref("CSSKeywordValue")}}, while a property assigned the result of a mathematical operation might return a {{domxref("CSSMathSum")}}.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if `property` is not a valid CSS property name.
 
 ## Examples
 
 ### Basic usage
 
-Let's get just a few properties and values. Let's start by creating a link inside a paragraph in our HTML, and adding a definition list which we will populate with JavaScript:
+This example shows how to get a few properties and their values.
+
+#### HTML
+
+First we create a link inside a paragraph:
 
 ```html
 <p>
   <a href="https://example.com">Link</a>
 </p>
-<dl id="results"></dl>
 ```
 
-We add a bit of CSS, including a custom property and an inheritable property:
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+The CSS styles the `font-weight` of the paragraph, and defines and uses a custom property for the color of the link:
 
 ```css
 p {
@@ -50,37 +70,118 @@ a {
 }
 ```
 
-We use the element's [`computedStyleMap()`](/en-US/docs/Web/API/Element/computedStyleMap) to return a `StylePropertyMapReadOnly` object. We create an array of properties of interest and use the `get()` method of `StylePropertyMapReadOnly` to get only those values.
-
-```js
-// get the element
-const myElement = document.querySelector("a");
-
-// Retrieve all computed styles with computedStyleMap()
-const styleMap = myElement.computedStyleMap();
-
-// get the <dl> we'll be populating
-const stylesList = document.querySelector("#results");
-
-// array of properties we're interested in
-const ofInterest = ["font-weight", "border-left-color", "color", "--color"];
-
-// iterate over our properties of interest
-for (const property of ofInterest) {
-  // properties
-  const cssProperty = document.createElement("dt");
-  cssProperty.innerText = property;
-  stylesList.appendChild(cssProperty);
-
-  // values
-  const cssValue = document.createElement("dd");
-  // use get() to find the value
-  cssValue.innerText = styleMap.get(property);
-  stylesList.appendChild(cssValue);
+```css hidden
+#log {
+  height: 100px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
 }
 ```
 
-{{EmbedLiveSample("Examples", 120, 300)}}
+#### JavaScript
+
+First we call [`computedStyleMap()`](/en-US/docs/Web/API/Element/computedStyleMap) on the element to get its style map: a `StylePropertyMapReadOnly` object.
+We create an array of properties of interest and use the `get()` method of `StylePropertyMapReadOnly` to log only those values.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+// get the element and its style map
+const myElement = document.querySelector("a");
+const styleMap = myElement.computedStyleMap();
+
+// array of properties we're interested in
+const properties = ["font-weight", "border-left-color", "color", "--color"];
+
+// log the value of each property of interest
+for (const property of properties) {
+  log(`${property}: ${styleMap.get(property)}`);
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Basic usage", 120, 200)}}
+
+### Getting different value types
+
+This example demonstrates that `get()` can return objects of different types, depending on the property and its value.
+
+First it applies a number of different properties to an element using CSS.
+It then reads them back via JavaScript and logs the constructor name and value of each property.
+The logging code itself isn't part of the demonstration, so it's hidden here.
+
+#### HTML
+
+First we define an {{htmlelement("div")}} with id `demoBox` to which we'll add styles.
+
+```html
+<div id="demoBox">Text</div>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+```css
+#demoBox {
+  --my-custom-property: "some text";
+  opacity: 0.5;
+  width: calc(30% - 20px);
+  display: block;
+  transform: translate(10px, 10px);
+}
+```
+
+```css hidden
+#log {
+  height: 330px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+Next we use [`computedStyleMap()`](/en-US/docs/Web/API/Element/computedStyleMap) to get the `StylePropertyMapReadOnly` object for the demo box, and iterate through each of the properties we added, logging their constructor name and value.
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+const styleMap = document.querySelector("#demoBox").computedStyleMap();
+const properties = [
+  "opacity",
+  "display",
+  "width",
+  "transform",
+  "--my-custom-property",
+];
+
+for (const property of properties) {
+  const value = styleMap.get(property);
+  log(property);
+  log(`  type: ${value.constructor.name}`);
+  log(`  value: ${value}\n`);
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Getting different value types", 120, 400)}}
 
 ## Specifications
 
@@ -92,5 +193,7 @@ for (const property of ofInterest) {
 
 ## See also
 
+- {{domxref("StylePropertyMapReadOnly.getAll", "getAll()")}}
+- {{domxref("StylePropertyMapReadOnly.has", "has()")}}
 - [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)
 - [Learning Houdini: the CSS Typed Object Model](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)

--- a/files/en-us/web/api/stylepropertymapreadonly/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.md
@@ -12,8 +12,8 @@ Retrieve an instance of this interface using {{domxref('Element.computedStyleMap
 
 ## Instance properties
 
-- {{domxref('StylePropertyMapReadOnly.size')}}
-  - : Returns an unsigned long integer containing the size of the `StylePropertyMapReadOnly` object.
+- {{domxref('StylePropertyMapReadOnly.size')}} {{ReadOnlyInline}}
+  - : Returns an unsigned integer containing the size of the `StylePropertyMapReadOnly` object.
 
 ## Instance methods
 


### PR DESCRIPTION
[CSS Typed OM API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API) fixes, in particular
- [CSSMath{Clamp|Max|min|Negate} fixes](https://github.com/mdn/content/commit/b0ffe834779cc31838932ab6365bf87642fbed12) - this add descriptions, examples, fixes up constructor syntax sections a per template.
- CSSMathValue|Product|Sum|Matxh fixes.
- CSSNumericalValue, StylePropertyMap - general template fixes. Things like fixing up readonlyinline, optional-inline on properties. As part of that fixed up parts of these, but not "completely".

Related docs can be tracked in #44849