### PR TITLE
Slight tweaks to digest field syntax and directives sections

### DIFF
--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -48,9 +48,7 @@ Content-Digest: <digest-algorithm>=<digest-value>,<digest-algorithm>=<digest-val
     Only two registered digest algorithms are considered secure: `sha-512` and `sha-256`.
     The insecure (legacy) registered digest algorithms are: `md5`, `sha` (SHA-1), `unixsum`, `unixcksum`, `adler` (ADLER32) and `crc32c`.
 - `<digest-value>`
-  - : The digest in bytes of the message content using the `<digest-algorithm>`.
-    The choice of digest algorithm also determines the encoding to use: `sha-512` and `sha-256` use {{Glossary("base64")}} encoding, while some legacy digest algorithms such as `unixsum` use a decimal integer.
-    In contrast to earlier drafts of the specification, the standard base64-encoded digest bytes are wrapped in colons (`:`, ASCII 0x3A) as part of the [dictionary syntax](https://www.rfc-editor.org/info/rfc8941/#name-byte-sequences).
+  - : The digest of the message content using the `<digest-algorithm>`, encoded as a [Byte Sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences): {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A).
 
 ## Description
 

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -39,7 +39,7 @@ Content-Digest: <digest-algorithm>=<digest-value>
 Content-Digest: <digest-algorithm>=<digest-value>,<digest-algorithm>=<digest-value>, …
 ```
 
-`Content-Digest` is a [structured field](https://www.rfc-editor.org/info/rfc9651/) Dictionary, whose keys are `<digest-algorithm>` and values are `<digest-value>`.
+`Content-Digest` is a _structured field dictionary_ ({{rfc("9651","Structured Field Values for HTTP")}}), whose keys are `<digest-algorithm>` and values are `<digest-value>`.
 
 ## Directives
 

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -39,6 +39,8 @@ Content-Digest: <digest-algorithm>=<digest-value>
 Content-Digest: <digest-algorithm>=<digest-value>,<digest-algorithm>=<digest-value>, …
 ```
 
+`Content-Digest` is a [structured field](https://www.rfc-editor.org/info/rfc9651/) Dictionary, whose keys are `<digest-algorithm>` and values are `<digest-value>`.
+
 ## Directives
 
 - `<digest-algorithm>`

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -48,7 +48,7 @@ Content-Digest: <digest-algorithm>=<digest-value>,<digest-algorithm>=<digest-val
     Only two registered digest algorithms are considered secure: `sha-512` and `sha-256`.
     The insecure (legacy) registered digest algorithms are: `md5`, `sha` (SHA-1), `unixsum`, `unixcksum`, `adler` (ADLER32) and `crc32c`.
 - `<digest-value>`
-  - : The digest of the message content using the `<digest-algorithm>`, encoded as a [Byte Sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences): {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A).
+  - : The digest of the message content using the `<digest-algorithm>`, {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A). This encoding is referred to as a [Byte Sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences) in the specification.
 
 ## Description
 

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -47,7 +47,7 @@ Repr-Digest: <digest-algorithm>=<digest-value>,…,<digest-algorithmN>=<digest-v
     Only two registered digest algorithms are considered secure: `sha-512` and `sha-256`.
     The insecure (legacy) registered digest algorithms are: `md5`, `sha` (SHA-1), `unixsum`, `unixcksum`, `adler` (ADLER32) and `crc32c`.
 - `<digest-value>`
-  - : The digest of the entire selected representation data (see [Section 8.1 of the HTTP Semantics specification](https://www.rfc-editor.org/rfc/rfc9110#section-8.1)) using the `<digest-algorithm>`, encoded as a [Byte Sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences): {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A).
+  - : The digest of the entire selected representation data (see [Section 8.1 of the HTTP Semantics specification](https://www.rfc-editor.org/rfc/rfc9110#section-8.1)) using the `<digest-algorithm>`, {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A). This encoding is referred to as a [byte sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences) in the specification.
 
 Usage of insecure digest algorithms is discouraged as collisions can realistically be forced, rendering the digest's usefulness weak.
 Unless working with legacy systems (which is unlikely since most will expect the deprecated `Digest` header and not understand this specification), consider omitting a `Repr-Digest` instead of including one with an insecure digest algorithm.

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -47,9 +47,7 @@ Repr-Digest: <digest-algorithm>=<digest-value>,…,<digest-algorithmN>=<digest-v
     Only two registered digest algorithms are considered secure: `sha-512` and `sha-256`.
     The insecure (legacy) registered digest algorithms are: `md5`, `sha` (SHA-1), `unixsum`, `unixcksum`, `adler` (ADLER32) and `crc32c`.
 - `<digest-value>`
-  - : The digest in bytes of the representation using the `<digest-algorithm>`.
-    The choice of digest algorithm also determines the encoding to use: `sha-512` and `sha-256` use {{Glossary("base64")}} encoding, while some legacy digest algorithms such as `unixsum` use a decimal integer.
-    In contrast to earlier drafts of the specification, the standard-base64-encoded digest bytes are wrapped in colons (`:`, ASCII 0x3A) as part of the [dictionary syntax](https://www.rfc-editor.org/info/rfc8941/#name-byte-sequences).
+  - : The digest of the entire selected representation data (see [Section 8.1 of the HTTP Semantics specification](https://www.rfc-editor.org/rfc/rfc9110#section-8.1)) using the `<digest-algorithm>`, encoded as a [Byte Sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences): {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A).
 
 Usage of insecure digest algorithms is discouraged as collisions can realistically be forced, rendering the digest's usefulness weak.
 Unless working with legacy systems (which is unlikely since most will expect the deprecated `Digest` header and not understand this specification), consider omitting a `Repr-Digest` instead of including one with an insecure digest algorithm.

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -38,7 +38,7 @@ Repr-Digest: <digest-algorithm>=<digest-value>
 Repr-Digest: <digest-algorithm>=<digest-value>,…,<digest-algorithmN>=<digest-valueN>
 ```
 
-`Repr-Digest` is a [structured field](https://www.rfc-editor.org/info/rfc9651/) Dictionary, whose keys are `<digest-algorithm>` and values are `<digest-value>`.
+`Repr-Digest` is a _structured field dictionary_ ({{rfc("9651","Structured Field Values for HTTP")}}), whose keys are `<digest-algorithm>` and values are `<digest-value>`.
 
 ## Directives
 

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -38,6 +38,8 @@ Repr-Digest: <digest-algorithm>=<digest-value>
 Repr-Digest: <digest-algorithm>=<digest-value>,…,<digest-algorithmN>=<digest-valueN>
 ```
 
+`Repr-Digest` is a [structured field](https://www.rfc-editor.org/info/rfc9651/) Dictionary, whose keys are `<digest-algorithm>` and values are `<digest-value>`.
+
 ## Directives
 
 - `<digest-algorithm>`


### PR DESCRIPTION
- Note Content-Digest/Repr-Digest are structured field Dictionaries
- Fix digest-value encoding claim on Content-Digest/Repr-Digest pages

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

* Tweak the syntax to more clearly mention structured fields
* Update the <digest-value> of the directives section to make it clear how the value is calculated and serialized

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/45058 and https://github.com/mdn/content/issues/45059

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
