### PR TITLE
Move insecure-algorithm and legacy Digest text to notes

### DIFF
--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -18,10 +18,6 @@ For example, in [range requests](/en-US/docs/Web/HTTP/Guides/Range_requests), a 
 For this reason, a `Content-Digest` is identical to a {{HTTPHeader("Repr-Digest")}} when a representation is sent in a single message.
 
 > [!NOTE]
-> `Content-Digest` supports several hashing algorithms, some of which are deprecated for security reasons.
-> See [Section 5 of RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html#section-5) for the relevant security considerations.
-
-> [!NOTE]
 > A `Digest` header was defined in earlier specifications, but it didn't distinguish between a message's content and a resource's representation.
 > It was obsoleted by `Content-Digest` and `Repr-Digest`.
 

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -17,7 +17,6 @@ In certain cases, a {{HTTPHeader("Repr-Digest")}} can be used to validate the in
 For example, in [range requests](/en-US/docs/Web/HTTP/Guides/Range_requests), a `Repr-Digest` will always have the same value if only the requested byte ranges differ, whereas the content digest will be different for each part.
 For this reason, a `Content-Digest` is identical to a {{HTTPHeader("Repr-Digest")}} when a representation is sent in a single message.
 
-
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -17,6 +17,14 @@ In certain cases, a {{HTTPHeader("Repr-Digest")}} can be used to validate the in
 For example, in [range requests](/en-US/docs/Web/HTTP/Guides/Range_requests), a `Repr-Digest` will always have the same value if only the requested byte ranges differ, whereas the content digest will be different for each part.
 For this reason, a `Content-Digest` is identical to a {{HTTPHeader("Repr-Digest")}} when a representation is sent in a single message.
 
+> [!NOTE]
+> `Content-Digest` supports several hashing algorithms, some of which are deprecated for security reasons.
+> See [Section 5 of RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html#section-5) for the relevant security considerations.
+
+> [!NOTE]
+> A `Digest` header was defined in earlier specifications, but it didn't distinguish between a message's content and a resource's representation.
+> It was obsoleted by `Content-Digest` and `Repr-Digest`.
+
 <table class="properties">
   <tbody>
     <tr>
@@ -49,12 +57,6 @@ Content-Digest: <digest-algorithm>=<digest-value>,<digest-algorithm>=<digest-val
   - : The digest in bytes of the message content using the `<digest-algorithm>`.
     The choice of digest algorithm also determines the encoding to use: `sha-512` and `sha-256` use {{Glossary("base64")}} encoding, while some legacy digest algorithms such as `unixsum` use a decimal integer.
     In contrast to earlier drafts of the specification, the standard base64-encoded digest bytes are wrapped in colons (`:`, ASCII 0x3A) as part of the [dictionary syntax](https://www.rfc-editor.org/info/rfc8941/#name-byte-sequences).
-
-## Description
-
-A `Digest` header was defined in previous specifications, but it proved problematic as the scope of what the digest applied to was not clear.
-Specifically, it was difficult to distinguish whether a digest applied to the entire resource representation or to the specific content of an HTTP message.
-As such, two separate headers were specified (`Content-Digest` and `Repr-Digest`) to convey HTTP message content digests and resource representation digests, respectively.
 
 ## Examples
 

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -17,9 +17,6 @@ In certain cases, a {{HTTPHeader("Repr-Digest")}} can be used to validate the in
 For example, in [range requests](/en-US/docs/Web/HTTP/Guides/Range_requests), a `Repr-Digest` will always have the same value if only the requested byte ranges differ, whereas the content digest will be different for each part.
 For this reason, a `Content-Digest` is identical to a {{HTTPHeader("Repr-Digest")}} when a representation is sent in a single message.
 
-> [!NOTE]
-> A `Digest` header was defined in earlier specifications, but it didn't distinguish between a message's content and a resource's representation.
-> It was obsoleted by `Content-Digest` and `Repr-Digest`.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -16,6 +16,14 @@ Details about the representation can be determined from {{Glossary("Representati
 The representation digest applies to the whole representation rather than the encoding or chunking of the messages that are used to send it.
 A {{HTTPHeader("Content-Digest")}} applies to the content of a specific message, and will have different values based on the {{HTTPHeader("Content-Encoding")}} and {{HTTPHeader("Content-Range")}} of each message.
 
+> [!NOTE]
+> `Repr-Digest` supports several hashing algorithms, some of which are deprecated for security reasons.
+> See [Section 5 of RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html#section-5) for the relevant security considerations.
+
+> [!NOTE]
+> A `Digest` header was defined in earlier specifications, but it didn't distinguish between a message's content and a resource's representation.
+> It was obsoleted by `Content-Digest` and `Repr-Digest`.
+
 <table class="properties">
   <tbody>
     <tr>
@@ -48,15 +56,6 @@ Repr-Digest: <digest-algorithm>=<digest-value>,…,<digest-algorithmN>=<digest-v
   - : The digest in bytes of the representation using the `<digest-algorithm>`.
     The choice of digest algorithm also determines the encoding to use: `sha-512` and `sha-256` use {{Glossary("base64")}} encoding, while some legacy digest algorithms such as `unixsum` use a decimal integer.
     In contrast to earlier drafts of the specification, the standard-base64-encoded digest bytes are wrapped in colons (`:`, ASCII 0x3A) as part of the [dictionary syntax](https://www.rfc-editor.org/info/rfc8941/#name-byte-sequences).
-
-Usage of insecure digest algorithms is discouraged as collisions can realistically be forced, rendering the digest's usefulness weak.
-Unless working with legacy systems (which is unlikely since most will expect the deprecated `Digest` header and not understand this specification), consider omitting a `Repr-Digest` instead of including one with an insecure digest algorithm.
-
-## Description
-
-A `Digest` header was defined in previous specifications, but it proved problematic as the scope of what the digest applied to was not clear.
-Specifically, it was difficult to distinguish whether a digest applied to the entire resource representation or to the specific content of an HTTP message.
-As such, two separate headers were specified (`Content-Digest` and `Repr-Digest`) to convey HTTP message content digests and resource representation digests, respectively.
 
 ## Examples
 

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -16,14 +16,6 @@ Details about the representation can be determined from {{Glossary("Representati
 The representation digest applies to the whole representation rather than the encoding or chunking of the messages that are used to send it.
 A {{HTTPHeader("Content-Digest")}} applies to the content of a specific message, and will have different values based on the {{HTTPHeader("Content-Encoding")}} and {{HTTPHeader("Content-Range")}} of each message.
 
-> [!NOTE]
-> `Repr-Digest` supports several hashing algorithms, some of which are deprecated for security reasons.
-> See [Section 5 of RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html#section-5) for the relevant security considerations.
-
-> [!NOTE]
-> A `Digest` header was defined in earlier specifications, but it didn't distinguish between a message's content and a resource's representation.
-> It was obsoleted by `Content-Digest` and `Repr-Digest`.
-
 <table class="properties">
   <tbody>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Move insecure-algorithm and legacy Digest text to notes

Addresses mdn/content#45058 (point 3) and #45059 (point 4): the
Repr-Digest-only paragraph discouraging insecure algorithms overstepped
RFC 9530, which already covers this in Section 5, so it's replaced with
a short note pointing there (now on both pages for consistency). The
Description section rehashing the obsolete Digest header was a
distraction; it's now a short note instead, matching the existing
stacked-note pattern used on the Refresh header page.

### Motivation

The current format puts tangential information into the body of the page. The description section, for instance, doesn't really contain much description of the page. Where possible, I've tried to minimize distraction of duplication.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Relates to https://github.com/mdn/content/issues/45058 and https://github.com/mdn/content/issues/45059

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
