### PR TITLE
Update writing guidelines for Values section for CSS property pages

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -231,7 +231,9 @@ JavaScript built-in object reference pages follow the same basic rules as API re
 
 ### Properties
 
-CSS property reference pages include a "Syntax" section, which used to be found at the top of the page but is increasingly commonly found below a section containing a block of code showing typical usage of the feature, plus a live example to illustrate what the feature does (see {{CSSxRef("animation")}} for example).
+CSS property reference pages include a "Syntax" section. It is follows a live example that illustrates what the property does. For shorthand properties, it follows the "Constituent properties" section.
+
+The "Syntax" section itself begins with a code block to illustrate typical declarations for the property (see {{CSSxRef("animation")}} for example).
 
 > [!NOTE]
 > We do this because CSS formal syntax is complex, not used by many of the MDN readership, and off-putting for beginners. Real syntax and examples are more useful to the majority of people.

--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -238,13 +238,9 @@ CSS property reference pages include a "Syntax" section, which used to be found 
 
 Inside the syntax section you'll find the following contents.
 
-#### Optional explanation text
-
-Some CSS properties are self-explanatory and don't really need extra explanation (for example {{CSSxRef("color")}}). Some on the other hand are more complex and need explanation on syntax order, including multiple values, etc. (see {{CSSxRef("animation")}}). In such cases you can include extra explanation before any of the subsections.
-
 #### Values section
 
-Next, you should include a "Values" section — this contains a description list explaining the CSS value types that make up the value of the property. Each value type should be wrapped in angle brackets and linked to the MDN reference page covering that value type if a page exists for it. For example, see the {{CSSxRef("border")}} property reference — this reference three value types, only one of which is linked ({{CSSxRef("&lt;color&gt;")}}).
+Next, you should include a "Values" section — this contains an introductory sentence explaining the syntax order, multiple values, etc., followed by a definition list of the CSS value types that make up the value of the property. Each value type should be wrapped in angle brackets and linked to the MDN reference page covering that value type if a page exists for it. For example, see the {{CSSxRef("border")}} property reference — this reference three value types, which are linked to their respective data-type reference pages.
 
 #### Formal syntax
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -236,11 +236,17 @@ CSS property reference pages include a "Syntax" section, which used to be found 
 > [!NOTE]
 > We do this because CSS formal syntax is complex, not used by many of the MDN readership, and off-putting for beginners. Real syntax and examples are more useful to the majority of people.
 
-Inside the syntax section you'll find the following contents.
+Inside the "Syntax" section, you'll find the following sub-sections.
 
 #### Values section
 
-Next, you should include a "Values" section — this contains an introductory sentence explaining the syntax order, multiple values, etc., followed by a definition list of the CSS value types that make up the value of the property. Each value type should be wrapped in angle brackets and linked to the MDN reference page covering that value type if a page exists for it. For example, see the {{CSSxRef("border")}} property reference — this reference three value types, which are linked to their respective data-type reference pages.
+You should include a "Values" section.
+
+This section begins with an introductory sentence explaining how the property's value is constructed — a single value, one or two values, or a space- or comma-separated list — along with any constraint on order or combination. Begin this sentence with "This property is specified as" and end it with a colon, so that it leads into the definition list of the CSS value types and keywords that make up the value of the property. For example, the `font-style` property [Values](/en-US/docs/Web/CSS/Reference/Properties/font-style#values) section leads its definition list with this sentence:
+
+> This property is specified as one of the following keyword values. The `oblique` keyword can optionally be followed by an `<angle>`:
+
+In the definition list, wrap each value type in angle brackets and link it to the MDN reference page covering that value type if a page exists for it. For an example, see the "Values" section of {{CSSxRef("list-style-image"}}.
 
 #### Formal syntax
 


### PR DESCRIPTION
The values sections on property pages are a DL of data types, preceded by an explanation of the value's syntax.
updated the writing guidelines to reflect this.

Removed optional explanation text and clarified the 'Values' section description.
