### PR TITLE
docs(css): clarify negative lookahead analogy

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_has/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_has/index.md
@@ -240,7 +240,7 @@ The analogous construct in CSS would be `.abc:has(+ .xyz)`: it selects the eleme
 
 ### Negative lookahead (?!pattern)
 
-Similarly, for the negative lookahead case, in the regular expression `abc(?!xyz)`, the string `abc` is matched only if it is _not_ followed by `xyz`. The analogous CSS construct `.abc:has(+ :not(.xyz))` doesn't select the element `.abc` if the next element is `.xyz`.
+Similarly, for the negative lookahead case, in the regular expression `abc(?!xyz)`, the string `abc` is matched only if it is _not_ followed by `xyz`. The analogous CSS construct `.abc:has(+ :not(.xyz))` doesn't select the element `.abc` if the next element is `.xyz` or if there is no next element.
 
 ## Performance considerations
 

--- a/files/en-us/web/css/reference/selectors/_colon_has/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_has/index.md
@@ -128,6 +128,8 @@ h1:has(+ h2) {
 
 This example shows two similar texts side-by-side for comparison – the left one with an `H1` heading followed by a paragraph and the right one with an `H1` heading followed by an `H2` heading and then a paragraph. In the example on the right, `:has()` helps to select the `H1` element that is immediately followed by an `H2` element (indicated by the next-sibling combinator [`+`](/en-US/docs/Web/CSS/Reference/Selectors/Next-sibling_combinator)) and the CSS rule reduces the spacing after such an `H1` element. Without the `:has()` pseudo-class, you cannot use CSS selectors to select a preceding sibling of a different type or a parent element.
 
+This usage of `:has()` is analogous to a [lookahead assertion](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) in regular expressions because they both allow you to select elements (or strings in regular expressions) based on what _follows_ it, which is only possible if the processor is able to "rewind". In the regular expression `abc(?=xyz)`, the string `abc` is matched only if it is immediately followed by the string `xyz`. As it is a lookahead operation, the `xyz` is not included in the match. The analogous construct in CSS would be `.abc:has(+ .xyz)`: it selects the element `.abc` only if there is a next sibling `.xyz`. The part `:has(+ .xyz)` looks ahead for the next element `.xyz`, but then selects the previous element `.abc` instead. Similarly, you can implement negative lookahead like `abc(?!xyz)` by negating the `:has()`: `.abc:not(:has(+ .xyz))` only matches `.abc` elements that are not followed by `.xyz` (either because the next sibling does not match `.xyz` or because it's the last child node).
+
 ### With the :is() pseudo-class
 
 This example builds on the previous example to show how to select multiple elements with `:has()`.
@@ -227,20 +229,6 @@ body:has(video):has(audio) {
   /* styles to apply if the content contains both audio AND video */
 }
 ```
-
-## Analogy between :has() and regular expressions
-
-Interestingly, we can relate some CSS `:has()` constructs with the [lookahead assertion](/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion) in regular expressions because they both allow you to select elements (or strings in regular expressions) based on a condition without actually selecting the condition matching the element (or string) itself.
-
-### Positive lookahead (?=pattern)
-
-In the regular expression `abc(?=xyz)`, the string `abc` is matched only if it is immediately followed by the string `xyz`. As it is a lookahead operation, the `xyz` is not included in the match.
-
-The analogous construct in CSS would be `.abc:has(+ .xyz)`: it selects the element `.abc` only if there is a next sibling `.xyz`. The part `:has(+ .xyz)` acts as a lookahead operation because the element `.abc` is selected and not the element `.xyz`.
-
-### Negative lookahead (?!pattern)
-
-Similarly, for the negative lookahead case, in the regular expression `abc(?!xyz)`, the string `abc` is matched only if it is _not_ followed by `xyz`. The analogous CSS construct `.abc:has(+ :not(.xyz))` doesn't select the element `.abc` if the next element is `.xyz` or if there is no next element.
 
 ## Performance considerations
 


### PR DESCRIPTION
## Summary

Clarifies the limitation of the `.abc:has(+ :not(.xyz))` analogy in the negative lookahead section of the `:has()` documentation. Unlike a regular-expression negative lookahead, the selector does not match when there is no following element.

## Related issue

Closes #45038

## Test plan

- `markdownlint-cli2 files/en-us/web/css/reference/selectors/_colon_has/index.md`
- `prettier --check files/en-us/web/css/reference/selectors/_colon_has/index.md`
- MDN front-matter linter
- MDN filecheck
- `git diff --check`