### PR TITLE
Clarify end-of-session event guidance for sendBeacon()

### DIFF
--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -103,8 +103,8 @@ thus hurting performance. Others, such as Safari and Chrome on Android, handle i
 
 Firefox will also exclude pages from the bfcache if they contain `beforeunload` handlers.
 
-The `pagehide` event is compatible with the bfcache, but it is not reliably fired, especially on mobile.
-For end-of-session analytics, use `visibilitychange` rather than `pagehide`.
+The `pagehide` event is not as problematic as `unload` or `beforeunload`, because it is compatible with the bfcache.
+However, it suffers from the same reliability problems as the other two events, so we recommend that developers avoid it as well, and use `visibilitychange`.
 
 ## Examples
 

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -83,6 +83,9 @@ document.addEventListener("visibilitychange", () => {
 });
 ```
 
+The `visibilitychange` event also fires when the user switches to another browser tab, not only when they leave or close the page.
+Code that treats a transition to `hidden` as the end of a session should account for this behavior.
+
 #### Avoid unload and beforeunload
 
 In the past, many websites have used the [`unload`](/en-US/docs/Web/API/Window/unload_event)
@@ -100,10 +103,8 @@ thus hurting performance. Others, such as Safari and Chrome on Android, handle i
 
 Firefox will also exclude pages from the bfcache if they contain `beforeunload` handlers.
 
-#### Use pagehide as a fallback
-
-To support browsers which don't implement `visibilitychange`, use the [`pagehide`](/en-US/docs/Web/API/Window/pagehide_event) event.
-Like `beforeunload` and `unload`, this event is not reliably fired, especially on mobile. However, it is compatible with the bfcache.
+The `pagehide` event is compatible with the bfcache, but it is not reliably fired, especially on mobile.
+For end-of-session analytics, use `visibilitychange` rather than `pagehide`.
 
 ## Examples
 


### PR DESCRIPTION
### Description

- removes the obsolete "Use pagehide as a fallback" subsection
- explains that visibilitychange can also fire when the user switches browser tabs
- clarifies that pagehide is compatible with the bfcache but remains unreliable, especially on mobile

### Motivation

All modern browsers implement visibilitychange, so recommending pagehide as a compatibility fallback is no longer necessary. The expanded guidance makes both the visibilitychange caveat and the remaining pagehide limitation explicit.

### Validation

The focused file passes the repository pre-commit hook, URL and changed-xref checks, front matter validation, Prettier, Markdownlint, cSpell, and git diff checking.

### Related issues and pull requests

Fixes #44927

AI assistance disclosure: Codex was used to trace the existing guidance and cited issue context, help draft the documentation change, and run the listed validation. I reviewed the final wording and diff against the referenced browser-lifecycle guidance.