### PR TITLE
Add note about monospace font-family

### DIFF
--- a/files/en-us/web/css/reference/properties/font-family/index.md
+++ b/files/en-us/web/css/reference/properties/font-family/index.md
@@ -123,6 +123,7 @@ font-family: "Gill Sans Extrabold", sans-serif;
       - : All glyphs have the same fixed width.
 
         For example: Fira Mono, DejaVu Sans Mono, Menlo, Consolas, Liberation Mono, Monaco, Lucida Console, monospace.
+
         > [!NOTE]
         > Browsers may render `font-family: monospace` at a smaller font size than defined (a common default being 0.8125em). To avoid this behavior, define multiple values, such as `font-family: monospace, monospace`.
     - `cursive`

--- a/files/en-us/web/css/reference/properties/font-family/index.md
+++ b/files/en-us/web/css/reference/properties/font-family/index.md
@@ -123,7 +123,8 @@ font-family: "Gill Sans Extrabold", sans-serif;
       - : All glyphs have the same fixed width.
 
         For example: Fira Mono, DejaVu Sans Mono, Menlo, Consolas, Liberation Mono, Monaco, Lucida Console, monospace.
-
+        > [!NOTE]
+        > Browsers may render `font-family: monospace` at a smaller font size than defined (a common default being 0.8125em). To avoid this behavior, define multiple values, such as `font-family: monospace, monospace`.
     - `cursive`
       - : Glyphs in cursive fonts generally have either joining strokes or other cursive characteristics beyond those of italic typefaces. The glyphs are partially or completely connected, and the result looks more like handwritten pen or brush writing than printed letter work.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Mention the unexpected `font-family: monospace` behavior and a workaround for it.

### Motivation

This behavior is unintuitive and may confuse developers unfamiliar with it. For this reason I think that it is good to have a note explicitly mentioning it on the MDN page.

### Additional details

I can't find this behavior in the spec itself, but there are many references to it online:
- https://meyerweb.com/eric/thoughts/2010/02/12/fixed-monospace-sizing/
- https://stackoverflow.com/questions/38781089/font-family-monospace-monospace

And you can try it out yourself:
```html
<p style="font-family: monospace, monospace">Normal text</p>
<p style="font-family: monospace">Small text</p>
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
