### PR TITLE
docs(css): clarify regex negative lookahead analogy for :has() regarding last-child

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_has/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_has/index.md
@@ -240,7 +240,16 @@ The analogous construct in CSS would be `.abc:has(+ .xyz)`: it selects the eleme
 
 ### Negative lookahead (?!pattern)
 
-Similarly, for the negative lookahead case, in the regular expression `abc(?!xyz)`, the string `abc` is matched only if it is _not_ followed by `xyz`. The analogous CSS construct `.abc:has(+ :not(.xyz))` doesn't select the element `.abc` if the next element is `.xyz`.
+Similarly, for the negative lookahead case, in the regular expression `abc(?!xyz)`, the string `abc` is matched only if it is _not_ followed by `xyz` (which includes when `abc` appears at the end of the string with no following characters).
+
+The basic CSS construct `.abc:has(+ :not(.xyz))` selects the element `.abc` if there is a next sibling and that sibling is not `.xyz`. Note that unlike the regular expression, this basic selector will not match if `.abc` has no following sibling (i.e. when it is the last child). To fully replicate the negative lookahead behavior including the last element, you can combine it with the [`:last-child`](/en-US/docs/Web/CSS/Reference/Selectors/:last-child) pseudo-class:
+
+```css
+.abc:has(+ :not(.xyz)),
+.abc:last-child {
+  /* styles applied when not followed by .xyz or when it is the last element */
+}
+```
 
 ## Performance considerations
 


### PR DESCRIPTION
<!-- MDN Content Pull Request -->

### Summary

This PR addresses and resolves #45038 by clarifying the analogy between regular expression negative lookaheads \(?!pattern)\ and CSS \:has()\ selectors.

### Changes Made

- In \iles/en-us/web/css/reference/selectors/_colon_has/index.md\, updated the **Negative lookahead (?!pattern)** section to explain that while \.abc:has(+ :not(.xyz))\ handles the case where a next sibling is present and is not \.xyz\, it does not match when \.abc\ is the last element (with no following sibling).
- Added the recommended CSS pattern (\.abc:has(+ :not(.xyz)), .abc:last-child\) to fully replicate the negative lookahead behavior for all cases.

Fixes #45038