### PR TITLE
Updated  @media overflow-inline example

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@media/overflow-inline/index.md
+++ b/files/en-us/web/css/reference/at-rules/@media/overflow-inline/index.md
@@ -26,8 +26,8 @@ The `overflow-inline` feature is specified as a keyword value chosen from the li
 ### HTML
 
 ```html
-<p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis
+<p class="overflowing">
+  <strong>This paragraph is overflowing</strong>. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis
   eleifend, fringilla velit ac, aliquam tellus. Vestibulum ante ipsum primis in
   faucibus orci luctus et ultrices posuere cubilia Curae; Nunc velit erat,
   tempus id rutrum sed, dapibus ut urna. Integer vehicula nibh a justo imperdiet
@@ -36,18 +36,32 @@ The `overflow-inline` feature is specified as a keyword value chosen from the li
   Proin sit amet tincidunt risus. Sed nec augue congue eros accumsan tincidunt
   sed eget ex.
 </p>
+
+<p class="not-overflowing">
+  <strong>This paragraph does not overflow</strong>. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac turpis
+  eleifend, fringilla velit ac, aliquam tellus. Vestibulum ante ipsum primis in
+  faucibus orci luctus et ultrices posuere cubilia Curae;
+</p>
 ```
 
 ### CSS
 
 ```css
 p {
+  border: 2px solid black;
+  margin-block: 1em;
+}
+
+.overflowing {
   white-space: nowrap;
 }
 
 @media (overflow-inline: scroll) {
   p {
+    /* applies to all paragraphs because this feature detects
+       how overflow is handled by the device */
     color: red;
+    border-style: dashed;
   }
 }
 ```


### PR DESCRIPTION
### Description

Updated the example. The current example makes it look like the media query detects if an element is overflowing, not how the device handles overflow. I added a paragraph that isn't overflowing, and a note in the CSS to explain that it's about how the device handles overflow.

### Motivation

There is a note at the top of the page that explains this, but with the example only showing it working on an overflowing paragraph, which I think a lot of people will skip to, and then assume it will detect overflows. Just wanted to help make it more clear that isn't how this works.

