### PR TITLE
Remove incorrect private+no-store guidance from HTTP caching guide

### DIFF
--- a/files/en-us/web/http/guides/caching/index.md
+++ b/files/en-us/web/http/guides/caching/index.md
@@ -335,8 +335,6 @@ In such a case, using the `private` directive will cause the personalized respon
 Cache-Control: private
 ```
 
-In such a case, even if `no-store` is given, `private` must also be given.
-
 ### Provide up-to-date content every time
 
 The `no-store` directive prevents a response from being stored, but does not delete any already-stored response for the same URL.


### PR DESCRIPTION
### Description

Removes the sentence under **Don't cache / Do not share with others** that claimed `private` must also be given even when `no-store` is present.

### Motivation

That guidance contradicts the Cache-Control reference and the HTTP caching spec: `no-store` is already the most restrictive directive, so requiring `private` alongside it is incorrect. Maintainer confirmation was to remove the paragraph.

### Additional details

Minimal docs-only change in `files/en-us/web/http/guides/caching/index.md`.

### Related issues and pull requests

Fixes #39127