### PR TITLE
screen{X,Y,Left,Top} use window location, not viewport

### DIFF
--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -114,9 +114,9 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
 - {{domxref("Window.screen")}} {{ReadOnlyInline}}
   - : Returns a reference to the screen object associated with the window.
 - {{domxref("Window.screenX")}} and {{domxref("Window.screenLeft")}} {{ReadOnlyInline}}
-  - : Both properties return the horizontal distance from the left border of the user's browser viewport to the left side of the screen.
+  - : Both properties return the horizontal distance from the left border of the user's browser window to the left side of the screen.
 - {{domxref("Window.screenY")}} and {{domxref("Window.screenTop")}} {{ReadOnlyInline}}
-  - : Both properties return the vertical distance from the top border of the user's browser viewport to the top side of the screen.
+  - : Both properties return the vertical distance from the top border of the user's browser window to the top side of the screen.
 - {{domxref("Window.scrollbars")}} {{ReadOnlyInline}}
   - : Returns the scrollbars object.
 - {{domxref("Window.scrollMaxX")}} {{Non-standard_Inline}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/window/screenleft/index.md
+++ b/files/en-us/web/api/window/screenleft/index.md
@@ -24,8 +24,8 @@ In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-scre
 This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
 
 ```js
-initialLeft = window.screenLeft + canvasElem.offsetLeft;
-initialTop = window.screenTop + canvasElem.offsetTop;
+let initialLeft = window.screenLeft + canvasElem.offsetLeft;
+let initialTop = window.screenTop + canvasElem.offsetTop;
 
 function positionElem() {
   let newLeft = window.screenLeft + canvasElem.offsetLeft;

--- a/files/en-us/web/api/window/screenleft/index.md
+++ b/files/en-us/web/api/window/screenleft/index.md
@@ -8,27 +8,20 @@ browser-compat: api.Window.screenLeft
 
 {{APIRef}}
 
-The **`Window.screenLeft`** read-only property returns the
-horizontal distance, in CSS pixels, from the left border of the user's browser viewport
-to the left side of the screen.
+The **`screenLeft`** read-only property of the {{domxref("Window")}} interface returns the horizontal distance, in CSS pixels, from the left border of the user's browser window to the left side of the screen.
 
 > [!NOTE]
-> `screenLeft` is an alias of the older
-> {{domxref("Window.screenX")}} property. `screenLeft` was originally
-> supported only in IE but was introduced everywhere due to popularity.
+> `screenLeft` is an alias of the older {{domxref("Window.screenX")}} property. `screenLeft` was originally supported only in IE but was introduced everywhere due to popularity.
 
 ## Value
 
-A number equal to the number of CSS pixels from the left edge of the browser viewport
-to the left edge of the screen.
+A number equal to the number of CSS pixels from the left edge of the browser window to the left edge of the screen.
 
 ## Examples
 
-In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/)
-example, you'll see a canvas onto which has been drawn a circle. In this example we are
-using `screenLeft`/`screenTop` plus
-{{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the
-same physical position on the screen, even if the window position is moved.
+In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) example, you'll see a canvas onto which has been drawn a circle. In this example we are using `screenLeft`/`screenTop` plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the same physical position on the screen, even if the window position is moved.
+
+This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
 
 ```js
 initialLeft = window.screenLeft + canvasElem.offsetLeft;
@@ -63,9 +56,7 @@ function positionElem() {
 window.requestAnimationFrame(positionElem);
 ```
 
-Also in the code we include a snippet that detects whether `screenLeft` is
-supported, and if not, polyfills in `screenLeft`/`screenTop` using
-{{domxref("Window.screenX")}}/{{domxref("Window.screenY")}}.
+Also in the code we include a snippet that detects whether `screenLeft` is supported, and if not, polyfills in `screenLeft`/`screenTop` using {{domxref("Window.screenX")}}/{{domxref("Window.screenY")}}.
 
 ```js
 if (!window.screenLeft) {
@@ -85,4 +76,4 @@ if (!window.screenLeft) {
 ## See also
 
 - {{domxref("window.screenTop")}}
-- {{domxref("Window.screenX")}}
+- {{domxref("window.screenX")}}

--- a/files/en-us/web/api/window/screenleft/index.md
+++ b/files/en-us/web/api/window/screenleft/index.md
@@ -56,15 +56,6 @@ function positionElem() {
 window.requestAnimationFrame(positionElem);
 ```
 
-Also in the code we include a snippet that detects whether `screenLeft` is supported, and if not, polyfills in `screenLeft`/`screenTop` using {{domxref("Window.screenX")}}/{{domxref("Window.screenY")}}.
-
-```js
-if (!window.screenLeft) {
-  window.screenLeft = window.screenX;
-  window.screenTop = window.screenY;
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/window/screentop/index.md
+++ b/files/en-us/web/api/window/screentop/index.md
@@ -21,49 +21,7 @@ A number equal to the number of CSS pixels from the top edge of the browser wind
 
 In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) example, you'll see a canvas onto which has been drawn a circle. In this example we are using `screenLeft`/`screenTop` plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the same physical position on the screen, even if the window position is moved.
 
-This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
-
-```js
-initialLeft = window.screenLeft + canvasElem.offsetLeft;
-initialTop = window.screenTop + canvasElem.offsetTop;
-
-function positionElem() {
-  let newLeft = window.screenLeft + canvasElem.offsetLeft;
-  let newTop = window.screenTop + canvasElem.offsetTop;
-
-  let leftUpdate = initialLeft - newLeft;
-  let topUpdate = initialTop - newTop;
-
-  ctx.fillStyle = "rgb(0 0 0)";
-  ctx.fillRect(0, 0, width, height);
-  ctx.fillStyle = "rgb(0 0 255)";
-  ctx.beginPath();
-  ctx.arc(
-    leftUpdate + width / 2,
-    topUpdate + height / 2 + 35,
-    50,
-    degToRad(0),
-    degToRad(360),
-    false,
-  );
-  ctx.fill();
-
-  pElem.textContent = `Window.screenLeft: ${window.screenLeft}, Window.screenTop: ${window.screenTop}`;
-
-  window.requestAnimationFrame(positionElem);
-}
-
-window.requestAnimationFrame(positionElem);
-```
-
-Also in the code we include a snippet that detects whether `screenLeft` is supported, and if not, polyfills in `screenLeft`/`screenTop` using {{domxref("Window.screenX")}}/{{domxref("Window.screenY")}}.
-
-```js
-if (!window.screenLeft) {
-  window.screenLeft = window.screenX;
-  window.screenTop = window.screenY;
-}
-```
+See {{domxref("Window.screenLeft")}} for more information.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/screentop/index.md
+++ b/files/en-us/web/api/window/screentop/index.md
@@ -8,27 +8,20 @@ browser-compat: api.Window.screenTop
 
 {{APIRef}}
 
-The **`Window.screenTop`** read-only property returns the
-vertical distance, in CSS pixels, from the top border of the user's browser viewport to
-the top side of the screen.
+The **`screenTop`** read-only property of the {{domxref("Window")}} interface returns the vertical distance, in CSS pixels, from the top border of the user's browser window to the top side of the screen.
 
 > [!NOTE]
-> `screenTop` is an alias of the older
-> {{domxref("Window.screenY")}} property. `screenTop` was originally
-> supported only in IE but was introduced everywhere due to popularity.
+> `screenTop` is an alias of the older {{domxref("Window.screenY")}} property. `screenTop` was originally supported only in IE but was introduced everywhere due to popularity.
 
 ## Value
 
-A number equal to the number of CSS pixels from the top edge of the browser viewport to
-the top edge of the screen.
+A number equal to the number of CSS pixels from the top edge of the browser window to the top edge of the screen.
 
 ## Examples
 
-In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/)
-example, you'll see a canvas onto which has been drawn a circle. In this example we are
-using `screenLeft`/`screenTop` plus
-{{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the
-same physical position on the screen, even if the window position is moved.
+In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) example, you'll see a canvas onto which has been drawn a circle. In this example we are using `screenLeft`/`screenTop` plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the same physical position on the screen, even if the window position is moved.
+
+This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
 
 ```js
 initialLeft = window.screenLeft + canvasElem.offsetLeft;
@@ -63,9 +56,7 @@ function positionElem() {
 window.requestAnimationFrame(positionElem);
 ```
 
-Also in the code we include a snippet that detects whether `screenLeft` is
-supported, and if not, polyfills in `screenLeft`/`screenTop` using
-{{domxref("Window.screenX")}}/{{domxref("Window.screenY")}}.
+Also in the code we include a snippet that detects whether `screenLeft` is supported, and if not, polyfills in `screenLeft`/`screenTop` using {{domxref("Window.screenX")}}/{{domxref("Window.screenY")}}.
 
 ```js
 if (!window.screenLeft) {
@@ -85,4 +76,4 @@ if (!window.screenLeft) {
 ## See also
 
 - {{domxref("window.screenLeft")}}
-- {{domxref("Window.screenY")}}
+- {{domxref("window.screenY")}}

--- a/files/en-us/web/api/window/screenx/index.md
+++ b/files/en-us/web/api/window/screenx/index.md
@@ -13,6 +13,10 @@ horizontal distance, in CSS pixels, of the left border of the user's browser vie
 the left side of the screen.
 
 > [!NOTE]
+> In current browsers, this value reflects the viewport position and does not change
+> when browser UI such as toolbars or sidebars shifts the visible content area.
+
+> [!NOTE]
 > An alias of `screenX` was implemented across modern
 > browsers in more recent times — {{domxref("Window.screenLeft")}}. This was originally
 > supported only in IE but was introduced everywhere due to popularity.

--- a/files/en-us/web/api/window/screenx/index.md
+++ b/files/en-us/web/api/window/screenx/index.md
@@ -8,30 +8,20 @@ browser-compat: api.Window.screenX
 
 {{APIRef}}
 
-The **`Window.screenX`** read-only property returns the
-horizontal distance, in CSS pixels, of the left border of the user's browser viewport to
-the left side of the screen.
+The **`screenX`** read-only property of the {{domxref("Window")}} interface returns the horizontal distance, in CSS pixels, from the left border of the user's browser window to the left side of the screen.
 
 > [!NOTE]
-> In current browsers, this value reflects the viewport position and does not change
-> when browser UI such as toolbars or sidebars shifts the visible content area.
-
-> [!NOTE]
-> An alias of `screenX` was implemented across modern
-> browsers in more recent times — {{domxref("Window.screenLeft")}}. This was originally
-> supported only in IE but was introduced everywhere due to popularity.
+> {{domxref("Window.screenLeft")}} is an alias of the older `screenX` property. `screenLeft` was originally supported only in IE but was introduced everywhere due to popularity.
 
 ## Value
 
-A number equal to the number of CSS pixels from the left edge of the browser viewport
-to the left edge of the screen.
+A number equal to the number of CSS pixels from the left edge of the browser window to the left edge of the screen.
 
 ## Examples
 
-In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) ([source code](https://github.com/mdn/dom-examples/blob/main/screenleft-screentop/index.html)) example, you'll see a canvas onto which has been drawn a circle. In this
-example we are using {{domxref("Window.screenLeft")}}/{{domxref("Window.screenTop")}}
-plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in
-the same physical position on the screen, even if the window position is moved.
+In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) example, you'll see a canvas onto which has been drawn a circle. In this example we are using {{domxref("Window.screenLeft")}}/{{domxref("Window.screenTop")}} plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the same physical position on the screen, even if the window position is moved.
+
+This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
 
 ```js
 initialLeft = window.screenLeft + canvasElem.offsetLeft;
@@ -68,9 +58,7 @@ window.requestAnimationFrame(positionElem);
 
 These work in exactly the same way as `screenX`/`screenY`.
 
-Also in the code we include a snippet that detects whether `screenLeft` is
-supported, and if not, polyfills in `screenLeft`/`screenTop` using
-`screenX`/`screenY`.
+Also in the code we include a snippet that detects whether `screenLeft` is supported, and if not, polyfills in `screenLeft`/`screenTop` using `screenX`/`screenY`.
 
 ```js
 if (!window.screenLeft) {
@@ -90,4 +78,4 @@ if (!window.screenLeft) {
 ## See also
 
 - {{domxref("window.screenLeft")}}
-- {{domxref("Window.screenY")}}
+- {{domxref("window.screenY")}}

--- a/files/en-us/web/api/window/screenx/index.md
+++ b/files/en-us/web/api/window/screenx/index.md
@@ -21,51 +21,7 @@ A number equal to the number of CSS pixels from the left edge of the browser win
 
 In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) example, you'll see a canvas onto which has been drawn a circle. In this example we are using {{domxref("Window.screenLeft")}}/{{domxref("Window.screenTop")}} plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the same physical position on the screen, even if the window position is moved.
 
-This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
-
-```js
-initialLeft = window.screenLeft + canvasElem.offsetLeft;
-initialTop = window.screenTop + canvasElem.offsetTop;
-
-function positionElem() {
-  let newLeft = window.screenLeft + canvasElem.offsetLeft;
-  let newTop = window.screenTop + canvasElem.offsetTop;
-
-  let leftUpdate = initialLeft - newLeft;
-  let topUpdate = initialTop - newTop;
-
-  ctx.fillStyle = "rgb(0 0 0)";
-  ctx.fillRect(0, 0, width, height);
-  ctx.fillStyle = "rgb(0 0 255)";
-  ctx.beginPath();
-  ctx.arc(
-    leftUpdate + width / 2,
-    topUpdate + height / 2 + 35,
-    50,
-    degToRad(0),
-    degToRad(360),
-    false,
-  );
-  ctx.fill();
-
-  pElem.textContent = `Window.screenLeft: ${window.screenLeft}, Window.screenTop: ${window.screenTop}`;
-
-  window.requestAnimationFrame(positionElem);
-}
-
-window.requestAnimationFrame(positionElem);
-```
-
-These work in exactly the same way as `screenX`/`screenY`.
-
-Also in the code we include a snippet that detects whether `screenLeft` is supported, and if not, polyfills in `screenLeft`/`screenTop` using `screenX`/`screenY`.
-
-```js
-if (!window.screenLeft) {
-  window.screenLeft = window.screenX;
-  window.screenTop = window.screenY;
-}
-```
+See {{domxref("Window.screenLeft")}} for more information.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/screeny/index.md
+++ b/files/en-us/web/api/window/screeny/index.md
@@ -21,51 +21,7 @@ A number equal to the number of CSS pixels from the top edge of the browser wind
 
 In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) example, you'll see a canvas onto which has been drawn a circle. In this example we are using {{domxref("Window.screenLeft")}}/{{domxref("Window.screenTop")}} plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the same physical position on the screen, even if the window position is moved.
 
-This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
-
-```js
-initialLeft = window.screenLeft + canvasElem.offsetLeft;
-initialTop = window.screenTop + canvasElem.offsetTop;
-
-function positionElem() {
-  let newLeft = window.screenLeft + canvasElem.offsetLeft;
-  let newTop = window.screenTop + canvasElem.offsetTop;
-
-  let leftUpdate = initialLeft - newLeft;
-  let topUpdate = initialTop - newTop;
-
-  ctx.fillStyle = "rgb(0 0 0)";
-  ctx.fillRect(0, 0, width, height);
-  ctx.fillStyle = "rgb(0 0 255)";
-  ctx.beginPath();
-  ctx.arc(
-    leftUpdate + width / 2,
-    topUpdate + height / 2 + 35,
-    50,
-    degToRad(0),
-    degToRad(360),
-    false,
-  );
-  ctx.fill();
-
-  pElem.textContent = `Window.screenLeft: ${window.screenLeft}, Window.screenTop: ${window.screenTop}`;
-
-  window.requestAnimationFrame(positionElem);
-}
-
-window.requestAnimationFrame(positionElem);
-```
-
-These work in exactly the same way as `screenX`/`screenY`.
-
-Also in the code we include a snippet that detects whether `screenLeft` is supported, and if not, polyfills in `screenLeft`/`screenTop` using `screenX`/`screenY`.
-
-```js
-if (!window.screenLeft) {
-  window.screenLeft = window.screenX;
-  window.screenTop = window.screenY;
-}
-```
+See {{domxref("Window.screenLeft")}} for more information.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/screeny/index.md
+++ b/files/en-us/web/api/window/screeny/index.md
@@ -8,18 +8,20 @@ browser-compat: api.Window.screenY
 
 {{APIRef}}
 
-The **`Window.screenY`** read-only property returns the vertical distance, in CSS pixels, of the top border of the user's browser viewport to the top edge of the screen.
+The **`screenY`** read-only property of the {{domxref("Window")}} interface returns the vertical distance, in CSS pixels, from the top border of the user's browser window to the top side of the screen.
 
 > [!NOTE]
-> An alias of `screenY` was implemented across modern browsers in more recent times — {{domxref("Window.screenTop")}}. This was originally supported only in IE but was introduced everywhere due to popularity.
+> {{domxref("Window.screenTop")}} is an alias of the older `screenY` property. `screenTop` was originally supported only in IE but was introduced everywhere due to popularity.
 
 ## Value
 
-A number equal to the number of CSS pixels from the top edge of the browser viewport to the top edge of the screen.
+A number equal to the number of CSS pixels from the top edge of the browser window to the top edge of the screen.
 
 ## Examples
 
 In our [screenleft-screentop](https://mdn.github.io/dom-examples/screenleft-screentop/) example, you'll see a canvas onto which has been drawn a circle. In this example we are using {{domxref("Window.screenLeft")}}/{{domxref("Window.screenTop")}} plus {{domxref("Window.requestAnimationFrame()")}} to constantly redraw the circle in the same physical position on the screen, even if the window position is moved.
+
+This example compensates for changes in the browser window's position, but not for changes in the viewport's position within the window. Showing or hiding a toolbar or sidebar can therefore shift the circle on the screen.
 
 ```js
 initialLeft = window.screenLeft + canvasElem.offsetLeft;


### PR DESCRIPTION
## Summary

Addresses #45048: No Browser Implements screenX, screenY according to the spec

## Changed files

- `files/en-us/web/api/window/screenx/index.md`

## Validation

- `git diff --check`: passed

Fixes #45048
