### PR TITLE
fix(css): clarify wbr line breaking behavior

### DIFF
--- a/files/en-us/web/css/guides/text/wrapping_breaking_text/index.md
+++ b/files/en-us/web/css/guides/text/wrapping_breaking_text/index.md
@@ -189,7 +189,7 @@ CSS provides additional hyphenation control: the {{cssxref("hyphenate-limit-char
 
 ## The `<wbr>` element
 
-If you know where you want a long string to be allowed to break, then it is also possible to insert the HTML {{HTMLElement("wbr")}} element. This can be useful in cases such as displaying a long URL on a page. The `<wbr>` element introduces a line break opportunity, but does not force a break. The browser may use this opportunity when the text needs to wrap.
+If you know where you want a long string to be allowed to break, you can also use the HTML {{HTMLElement("wbr")}} element. The `<wbr>` element introduces a line break opportunity, but does not force a break. The browser will only break the word at these positions if there is a need to do so. This allows you to preserve meaningful segments in the string, such as long URLs.
 
 In the example below, the browser may break the text at the location of the {{HTMLElement("wbr")}}.
 

--- a/files/en-us/web/css/guides/text/wrapping_breaking_text/index.md
+++ b/files/en-us/web/css/guides/text/wrapping_breaking_text/index.md
@@ -189,7 +189,7 @@ CSS provides additional hyphenation control: the {{cssxref("hyphenate-limit-char
 
 ## The `<wbr>` element
 
-If you know where you want a long string to be allowed to break, you can also use the HTML {{HTMLElement("wbr")}} element. The `<wbr>` element introduces a line break opportunity, but does not force a break. The browser will only break the word at these positions if there is a need to do so. This allows you to preserve meaningful segments in the string, such as long URLs.
+If you know where you want a long string to be allowed to break, you can also use the HTML {{HTMLElement("wbr")}} element. The `<wbr>` element introduces a line break opportunity—if the word overflows, it will wrap at this position. This allows you to preserve meaningful segments in the string, such as long URLs.
 
 In the example below, the browser may break the text at the location of the {{HTMLElement("wbr")}}.
 

--- a/files/en-us/web/css/guides/text/wrapping_breaking_text/index.md
+++ b/files/en-us/web/css/guides/text/wrapping_breaking_text/index.md
@@ -189,9 +189,9 @@ CSS provides additional hyphenation control: the {{cssxref("hyphenate-limit-char
 
 ## The `<wbr>` element
 
-If you know where you want a long string to break, then it is also possible to insert the HTML {{HTMLElement("wbr")}} element. This can be useful in cases such as displaying a long URL on a page. You can then add the property in order to break the string in sensible places that will make it easier to read.
+If you know where you want a long string to be allowed to break, then it is also possible to insert the HTML {{HTMLElement("wbr")}} element. This can be useful in cases such as displaying a long URL on a page. The `<wbr>` element introduces a line break opportunity, but does not force a break. The browser may use this opportunity when the text needs to wrap.
 
-In the below example the text breaks in the location of the {{HTMLElement("wbr")}}.
+In the example below, the browser may break the text at the location of the {{HTMLElement("wbr")}}.
 
 ```html live-sample___wbr
 <div class="box">


### PR DESCRIPTION
### Description

Clarifies that the `<wbr>` element introduces a line-breaking opportunity rather than forcing a line break.

### Motivation

The previous wording could imply that text always breaks at every `<wbr>`, which may make its behavior seem similar to `<br>`. This update explains that the browser may use the break opportunity when the text needs to wrap.

### Additional details

The existing example and behavior are unchanged; only the description of `<wbr>` behavior has been clarified.

### Related issues and pull requests

Fixes #44391