### PR TITLE
Add HTML Processing Instruction docs

### DIFF
--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -44,7 +44,7 @@ Initially, `ProcessingInstruction` nodes were only supported in XML documents, n
 
 ### Basic usage
 
-This example creates an `<xml-stylesheet>` processing instruction and adds it to the top of the example XML document.
+This example creates an `<xml-stylesheet>` processing instruction and adds it to the top of an example XML document.
 
 ```js
 const doc = new DOMParser().parseFromString("<foo />", "application/xml");

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -23,6 +23,8 @@ createProcessingInstruction(target, data)
 - `data`
   - : A string containing any information the processing instruction should carry, after the target. The data is up to you, but it can't contain `?>`, since that closes the processing instruction.
 
+HTML also has [additional restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` and not be prefixed with `xml` or the `InvalidCharacterError` exception is thrown. Processing instructions with invalid names in HTML documents are parsed as comments.
+
 ### Return value
 
 - The resulting {{ domxref("ProcessingInstruction") }} node.

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -10,8 +10,6 @@ browser-compat: api.Document.createProcessingInstruction
 
 `createProcessingInstruction()` generates a new [processing instruction](/en-US/docs/Web/API/ProcessingInstruction) node and returns it.
 
-The new node usually will be inserted into an XML document in order to accomplish anything with it, such as with {{ domxref("node.insertBefore") }}.
-
 ## Syntax
 
 ```js-nolint
@@ -20,8 +18,6 @@ createProcessingInstruction(target, data)
 
 ### Parameters
 
-- `piNode`
-  - : The resulting {{ domxref("ProcessingInstruction") }} node.
 - `target`
   - : A string containing the first part of the processing instruction (i.e., `<?target … ?>`)
 - `data`
@@ -29,7 +25,7 @@ createProcessingInstruction(target, data)
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+- The resulting {{ domxref("ProcessingInstruction") }} node.
 
 ### Exceptions
 
@@ -37,6 +33,12 @@ None ({{jsxref("undefined")}}).
   - : Thrown if either of the following are true:
     - The [`target`](#target) value is not a valid [XML name](https://www.w3.org/TR/xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
     - The _closing processing instruction sequence_ (`?>`) is part of the [`data`](#data) value.
+
+## Description
+
+The new node usually will be inserted into a document in order to accomplish anything with it, such as with {{ domxref("node.insertBefore") }}.
+
+Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
 
 ## Examples
 

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -44,6 +44,8 @@ Initially, `ProcessingInstruction` nodes were only supported in XML documents, n
 
 ### Basic usage
 
+This example creates an `<xml-stylesheet>` processing instruction and adds it to the top of the example XML document.
+
 ```js
 const doc = new DOMParser().parseFromString("<foo />", "application/xml");
 const pi = doc.createProcessingInstruction(

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -23,8 +23,6 @@ createProcessingInstruction(target, data)
 - `data`
   - : A string containing any information the processing instruction should carry, after the target. The data is up to you, but it can't contain `?>`, since that closes the processing instruction.
 
-HTML also has [additional restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` and not be prefixed with `xml` or the `InvalidCharacterError` exception is thrown. Processing instructions with invalid names in HTML documents are parsed as comments.
-
 ### Return value
 
 - The resulting {{ domxref("ProcessingInstruction") }} node.

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -40,7 +40,7 @@ HTML also has [additional restrictions on the `target` name](https://html.spec.w
 
 The new node usually will be inserted into a document in order to accomplish anything with it, such as with {{ domxref("node.insertBefore") }}.
 
-Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
+Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a processing instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
 
 ## Examples
 

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Document.createProcessingInstruction
 
 {{APIRef("DOM")}}
 
-`createProcessingInstruction()` generates a new [processing instruction](/en-US/docs/Web/API/ProcessingInstruction) node and returns it.
+The **`createProcessingInstruction()`** method of the {{domxref("Document")}} interface creates a new {{domxref("ProcessingInstruction")}} object and returns it.
 
 ## Syntax
 
@@ -21,26 +21,28 @@ createProcessingInstruction(target, data)
 - `target`
   - : A string containing the first part of the processing instruction (i.e., `<?target … ?>`)
 - `data`
-  - : A string containing any information the processing instruction should carry, after the target. The data is up to you, but it can't contain `?>`, since that closes the processing instruction.
+  - : A string containing any information the processing instruction should carry, after the target. The data can contain any character pattern, except that it can't contain `?>`, since that closes the processing instruction.
 
 ### Return value
 
-- The resulting {{ domxref("ProcessingInstruction") }} node.
+- A {{ domxref("ProcessingInstruction") }} node.
 
 ### Exceptions
 
 - `InvalidCharacterError` {{domxref("DOMException")}}
   - : Thrown if either of the following are true:
     - The [`target`](#target) value is not a valid [XML name](https://www.w3.org/TR/xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
-    - The _closing processing instruction sequence_ (`?>`) is part of the [`data`](#data) value.
+    - The _closing processing instruction sequence_ (`?>`) is included as part of the [`data`](#data) value.
 
 ## Description
 
-The new node usually will be inserted into a document in order to accomplish anything with it, such as with {{ domxref("node.insertBefore") }}.
+The `createProcessingInstruction()` method creates a new processing instruction. The new node will usually be inserted into a document to accomplish a task with it, using a method such as {{ domxref("node.insertBefore") }}.
 
-Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a processing instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
+Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a processing instruction will be interpreted as a comment and represented as a {{domxref("Comment")}} object in the DOM tree.
 
 ## Examples
+
+### Basic usage
 
 ```js
 const doc = new DOMParser().parseFromString("<foo />", "application/xml");

--- a/files/en-us/web/api/processinginstruction/getattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/getattribute/index.md
@@ -1,0 +1,84 @@
+---
+title: "ProcessingInstruction: getAttribute() method"
+short-title: getAttribute()
+slug: Web/API/ProcessingInstruction/getAttribute
+page-type: web-api-instance-method
+browser-compat: api.ProcessingInstruction.getAttribute
+---
+
+{{APIRef("DOM")}}
+
+The **`getAttribute()`** method of the
+{{domxref("ProcessingInstruction")}} interface returns the value of a specified attribute on the
+processing instruction.
+
+If the given attribute does not exist, the value returned will be `null`.
+
+## Syntax
+
+```js-nolint
+getAttribute(attributeName)
+```
+
+### Parameters
+
+- `attributeName`
+  - : The name of the attribute whose value you want to get.
+
+### Return value
+
+A string containing the value of `attributeName` if the attribute exists, otherwise `null`.
+
+## Examples
+
+```js
+const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+
+console.log(pi.getAttribute("name"));
+// Logs:
+// "placeholder"
+```
+
+## Description
+
+### Lower casing
+
+When called on an HTML element in a DOM flagged as an HTML document,
+`getAttribute()` lower-cases its argument before proceeding.
+
+### Decoded character references in attribute values
+
+HTML [character references](/en-US/docs/Glossary/Character_reference) in an attribute's source markup (for example, `&lt;`, `&amp;`, or `&#x3C;`) are decoded by the HTML parser when the document is parsed, so `getAttribute()` returns the decoded value, not the original source.
+
+Given:
+
+```js
+const pi = document.createProcessingInstruction(
+  "start",
+  'data-payload="&lt;b&gt;hi&lt;/b&gt;"',
+);
+
+pi.getAttribute("data-payload");
+// <b>hi</b>
+```
+
+Treating the return value from `getAttribute()` as already-escaped HTML is unsafe. If you read an attribute that holds untrusted data and then assign it to {{domxref("Element.innerHTML", "innerHTML")}} or insert it into the document as markup, any HTML references used to escape special characters will already be decoded, and the result can be exploited for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
+
+Use {{domxref("Node.textContent", "textContent")}} (or another text-safe API) for untrusted data instead of `innerHTML`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ProcessingInstruction.hasAttribute()")}}
+- {{domxref("ProcessingInstruction.hasAttributes()")}}
+- {{domxref("ProcessingInstruction.getAttributeNames()")}}
+- {{domxref("ProcessingInstruction.setAttribute()")}}
+- {{domxref("ProcessingInstruction.removeAttribute()")}}
+- {{domxref("ProcessingInstruction.toggleAttribute()")}}

--- a/files/en-us/web/api/processinginstruction/getattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/getattribute/index.md
@@ -27,29 +27,17 @@ getAttribute(attributeName)
 
 ### Return value
 
-A string containing the value of `attributeName` if the attribute exists, otherwise `null`.
-
-## Examples
-
-### Basic usage
-
-```js
-const pi = document.createProcessingInstruction("start", 'name="placeholder"');
-
-console.log(pi.getAttribute("name"));
-// Logs:
-// "placeholder"
-```
+A string containing the value of `attributeName` if the attribute exists; otherwise `null`.
 
 ## Description
 
 ### Casing
 
-Processing instruction arguments are case sensitive
+Processing instruction arguments are case-sensitive.
 
 ### Decoded character references in attribute values
 
-HTML [character references](/en-US/docs/Glossary/Character_reference) in an attribute's source markup (for example, `&lt;`, `&amp;`, or `&#x3C;`) are decoded by the HTML parser when the document is parsed, so `getAttribute()` returns the decoded value, not the original source.
+HTML [character references](/en-US/docs/Glossary/Character_reference) in an attribute's source markup (for example, `&lt;`, `&amp;`, or `&#x3C;`) are decoded by the HTML parser when the document is parsed, so `getAttribute()` returns the decoded value, not the source.
 
 For example:
 
@@ -61,6 +49,18 @@ const pi = document.createProcessingInstruction(
 
 pi.getAttribute("data-payload");
 // <b>hi</b>
+```
+
+## Examples
+
+### Basic usage
+
+```js
+const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+
+console.log(pi.getAttribute("name"));
+// Logs:
+// "placeholder"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/processinginstruction/getattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/getattribute/index.md
@@ -45,7 +45,6 @@ console.log(pi.getAttribute("name"));
 
 ### Lower casing
 
-When called on an HTML element in a DOM flagged as an HTML document,
 `getAttribute()` lower-cases its argument before proceeding.
 
 ### Decoded character references in attribute values
@@ -63,10 +62,6 @@ const pi = document.createProcessingInstruction(
 pi.getAttribute("data-payload");
 // <b>hi</b>
 ```
-
-Treating the return value from `getAttribute()` as already-escaped HTML is unsafe. If you read an attribute that holds untrusted data and then assign it to {{domxref("Element.innerHTML", "innerHTML")}} or insert it into the document as markup, any HTML references used to escape special characters will already be decoded, and the result can be exploited for [cross-site scripting (XSS)](/en-US/docs/Web/Security/Attacks/XSS).
-
-Use {{domxref("Node.textContent", "textContent")}} (or another text-safe API) for untrusted data instead of `innerHTML`.
 
 ## Specifications
 

--- a/files/en-us/web/api/processinginstruction/getattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/getattribute/index.md
@@ -43,9 +43,9 @@ console.log(pi.getAttribute("name"));
 
 ## Description
 
-### Lower casing
+### Casing
 
-`getAttribute()` lower-cases its argument before proceeding.
+Processing instruction arguments are case sensitive
 
 ### Decoded character references in attribute values
 

--- a/files/en-us/web/api/processinginstruction/getattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/getattribute/index.md
@@ -31,6 +31,8 @@ A string containing the value of `attributeName` if the attribute exists, otherw
 
 ## Examples
 
+### Basic usage
+
 ```js
 const pi = document.createProcessingInstruction("start", 'name="placeholder"');
 
@@ -50,7 +52,7 @@ When called on an HTML element in a DOM flagged as an HTML document,
 
 HTML [character references](/en-US/docs/Glossary/Character_reference) in an attribute's source markup (for example, `&lt;`, `&amp;`, or `&#x3C;`) are decoded by the HTML parser when the document is parsed, so `getAttribute()` returns the decoded value, not the original source.
 
-Given:
+For example:
 
 ```js
 const pi = document.createProcessingInstruction(

--- a/files/en-us/web/api/processinginstruction/getattributenames/index.md
+++ b/files/en-us/web/api/processinginstruction/getattributenames/index.md
@@ -47,7 +47,7 @@ const pi = document.createProcessingInstruction(
 
 console.log(pi.getAttributeNames());
 // logs:
-// ['name']
+// ['name', 'more']
 
 // Iterate over processing instruction's attributes
 for (const name of pi.getAttributeNames()) {

--- a/files/en-us/web/api/processinginstruction/getattributenames/index.md
+++ b/files/en-us/web/api/processinginstruction/getattributenames/index.md
@@ -30,7 +30,7 @@ An {{jsxref("Array")}} of strings.
 ## Description
 
 Using `getAttributeNames()` along with
-{{domxref("ProcessingInstruction.getAttribute","getAttribute()")}}, is a memory-efficient and
+{{domxref("ProcessingInstruction.getAttribute","getAttribute()")}} is a memory-efficient and
 performant alternative to accessing `ProcessingInstruction.data`.
 
 The names returned by **`getAttributeNames()`** are _qualified_ attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (_not_ the actual namespace), followed by a colon, followed by the attribute name (for example, **`xlink:href`**). Any attributes without a namespace prefix have their names returned as-is (for example, **`href`**).

--- a/files/en-us/web/api/processinginstruction/getattributenames/index.md
+++ b/files/en-us/web/api/processinginstruction/getattributenames/index.md
@@ -13,12 +13,6 @@ The **`getAttributeNames()`** method of the
 {{jsxref("Array")}} of strings. If the processing instruction has no attributes it returns an empty
 array.
 
-Using `getAttributeNames()` along with
-{{domxref("ProcessingInstruction.getAttribute","getAttribute()")}}, is a memory-efficient and
-performant alternative to accessing `ProcessingInstruction.data`.
-
-The names returned by **`getAttributeNames()`** are _qualified_ attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (_not_ the actual namespace), followed by a colon, followed by the attribute name (for example, **`xlink:href`**). Any attributes without a namespace prefix have their names returned as-is (for example, **`href`**).
-
 ## Syntax
 
 ```js-nolint
@@ -33,12 +27,23 @@ None.
 
 An {{jsxref("Array")}} of strings.
 
+## Description
+
+Using `getAttributeNames()` along with
+{{domxref("ProcessingInstruction.getAttribute","getAttribute()")}}, is a memory-efficient and
+performant alternative to accessing `ProcessingInstruction.data`.
+
+The names returned by **`getAttributeNames()`** are _qualified_ attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (_not_ the actual namespace), followed by a colon, followed by the attribute name (for example, **`xlink:href`**). Any attributes without a namespace prefix have their names returned as-is (for example, **`href`**).
+
 ## Examples
 
 ### Basic usage
 
 ```js
-const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+const pi = document.createProcessingInstruction(
+  "start",
+  'name="placeholder" more="info"',
+);
 
 console.log(pi.getAttributeNames());
 // logs:
@@ -51,6 +56,7 @@ for (const name of pi.getAttributeNames()) {
 }
 // logs:
 // name placeholder
+// more info
 ```
 
 ## Specifications

--- a/files/en-us/web/api/processinginstruction/getattributenames/index.md
+++ b/files/en-us/web/api/processinginstruction/getattributenames/index.md
@@ -1,0 +1,70 @@
+---
+title: "ProcessingInstruction: getAttributeNames() method"
+short-title: getAttributeNames()
+slug: Web/API/ProcessingInstruction/getAttributeNames
+page-type: web-api-instance-method
+browser-compat: api.ProcessingInstruction.getAttributeNames
+---
+
+{{APIRef("DOM")}}
+
+The **`getAttributeNames()`** method of the
+{{domxref("ProcessingInstruction")}} interface returns the attribute names of the processing instruction as an
+{{jsxref("Array")}} of strings. If the processing instruction has no attributes it returns an empty
+array.
+
+Using `getAttributeNames()` along with
+{{domxref("ProcessingInstruction.getAttribute","getAttribute()")}}, is a memory-efficient and
+performant alternative to accessing `ProcessingInstruction.data`.
+
+The names returned by **`getAttributeNames()`** are _qualified_ attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (_not_ the actual namespace), followed by a colon, followed by the attribute name (for example, **`xlink:href`**), while any attributes which have no namespace prefix have their names returned as-is (for example, **`href`**).
+
+## Syntax
+
+```js-nolint
+getAttributeNames()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+An ({{jsxref("Array")}}) of strings.
+
+## Examples
+
+```js
+const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+
+console.log(pi.getAttributeNames("name"));
+// logs:
+// ['name']
+
+// Iterate over processing instruction's attributes
+for (const name of pi.getAttributeNames()) {
+  const value = pi.getAttribute(name);
+  console.log(name, value);
+}
+
+// logs:
+// name placeholder
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ProcessingInstruction.hasAttribute()")}}
+- {{domxref("ProcessingInstruction.hasAttributes()")}}
+- {{domxref("ProcessingInstruction.getAttribute()")}}
+- {{domxref("ProcessingInstruction.setAttribute()")}}
+- {{domxref("ProcessingInstruction.removeAttribute()")}}
+- {{domxref("ProcessingInstruction.toggleAttribute()")}}

--- a/files/en-us/web/api/processinginstruction/getattributenames/index.md
+++ b/files/en-us/web/api/processinginstruction/getattributenames/index.md
@@ -17,7 +17,7 @@ Using `getAttributeNames()` along with
 {{domxref("ProcessingInstruction.getAttribute","getAttribute()")}}, is a memory-efficient and
 performant alternative to accessing `ProcessingInstruction.data`.
 
-The names returned by **`getAttributeNames()`** are _qualified_ attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (_not_ the actual namespace), followed by a colon, followed by the attribute name (for example, **`xlink:href`**), while any attributes which have no namespace prefix have their names returned as-is (for example, **`href`**).
+The names returned by **`getAttributeNames()`** are _qualified_ attribute names, meaning that attributes with a namespace prefix have their names returned with that namespace prefix (_not_ the actual namespace), followed by a colon, followed by the attribute name (for example, **`xlink:href`**). Any attributes without a namespace prefix have their names returned as-is (for example, **`href`**).
 
 ## Syntax
 
@@ -31,14 +31,16 @@ None.
 
 ### Return value
 
-An ({{jsxref("Array")}}) of strings.
+An {{jsxref("Array")}} of strings.
 
 ## Examples
+
+### Basic usage
 
 ```js
 const pi = document.createProcessingInstruction("start", 'name="placeholder"');
 
-console.log(pi.getAttributeNames("name"));
+console.log(pi.getAttributeNames());
 // logs:
 // ['name']
 
@@ -47,7 +49,6 @@ for (const name of pi.getAttributeNames()) {
   const value = pi.getAttribute(name);
   console.log(name, value);
 }
-
 // logs:
 // name placeholder
 ```

--- a/files/en-us/web/api/processinginstruction/hasattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/hasattribute/index.md
@@ -1,0 +1,55 @@
+---
+title: "ProcessingInstruction: hasAttribute() method"
+short-title: hasAttribute()
+slug: Web/API/ProcessingInstruction/hasAttribute
+page-type: web-api-instance-method
+browser-compat: api.ProcessingInstruction.hasAttribute
+---
+
+{{APIRef("DOM")}}
+
+The **`ProcessingInstruction.hasAttribute()`** method returns a
+**Boolean** value indicating whether the specified element has the
+specified attribute or not.
+
+## Syntax
+
+```js-nolint
+hasAttribute(name)
+```
+
+### Parameters
+
+- `name`
+  - : is a string representing the name of the attribute.
+
+### Return value
+
+A boolean.
+
+## Examples
+
+```js
+const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+
+console.log(pi.hasAttribute("name"));
+// logs:
+// true
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ProcessingInstruction.hasAttributes()")}}
+- {{domxref("ProcessingInstruction.getAttribute()")}}
+- {{domxref("ProcessingInstruction.getAttributeNames()")}}
+- {{domxref("ProcessingInstruction.setAttribute()")}}
+- {{domxref("ProcessingInstruction.removeAttribute()")}}
+- {{domxref("ProcessingInstruction.toggleAttribute()")}}

--- a/files/en-us/web/api/processinginstruction/hasattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/hasattribute/index.md
@@ -8,8 +8,8 @@ browser-compat: api.ProcessingInstruction.hasAttribute
 
 {{APIRef("DOM")}}
 
-The **`ProcessingInstruction.hasAttribute()`** method returns a
-**Boolean** value indicating whether the specified element has the
+The **`hasAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface returns a
+boolean value indicating whether the specified element has the
 specified attribute or not.
 
 ## Syntax
@@ -21,13 +21,15 @@ hasAttribute(name)
 ### Parameters
 
 - `name`
-  - : is a string representing the name of the attribute.
+  - : A string representing the name of the attribute.
 
 ### Return value
 
 A boolean.
 
 ## Examples
+
+### Basic usage
 
 ```js
 const pi = document.createProcessingInstruction("start", 'name="placeholder"');

--- a/files/en-us/web/api/processinginstruction/hasattributes/index.md
+++ b/files/en-us/web/api/processinginstruction/hasattributes/index.md
@@ -28,6 +28,8 @@ A boolean.
 
 ## Examples
 
+### Basic usage
+
 ```js
 const pi = document.createProcessingInstruction("start", 'name="placeholder"');
 

--- a/files/en-us/web/api/processinginstruction/hasattributes/index.md
+++ b/files/en-us/web/api/processinginstruction/hasattributes/index.md
@@ -1,0 +1,58 @@
+---
+title: "ProcessingInstruction: hasAttributes() method"
+short-title: hasAttributes()
+slug: Web/API/ProcessingInstruction/hasAttributes
+page-type: web-api-instance-method
+browser-compat: api.ProcessingInstruction.hasAttributes
+---
+
+{{ApiRef("DOM")}}
+
+The **`hasAttributes()`** method of the {{domxref("ProcessingInstruction")}}
+interface returns a boolean value indicating whether the current element has any
+attributes or not.
+
+## Syntax
+
+```js-nolint
+hasAttributes()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A boolean.
+
+## Examples
+
+```js
+const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+
+const pi2 = document.createProcessingInstruction("start", "");
+
+console.log(pi.hasAttributes());
+console.log(pi2.hasAttributes());
+// logs:
+// true
+// false
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ProcessingInstruction.hasAttribute()")}}
+- {{domxref("ProcessingInstruction.getAttribute()")}}
+- {{domxref("ProcessingInstruction.getAttributeNames()")}}
+- {{domxref("ProcessingInstruction.setAttribute()")}}
+- {{domxref("ProcessingInstruction.removeAttribute()")}}
+- {{domxref("ProcessingInstruction.toggleAttribute()")}}

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -9,12 +9,14 @@ browser-compat: api.ProcessingInstruction
 
 The **`ProcessingInstruction`** interface represents a [processing instruction](https://www.w3.org/TR/xml/#sec-pi) — a {{domxref("Node")}} that embeds an instruction targeting a specific application, which can be ignored by any application that doesn't recognize the instruction.
 
+{{InheritanceDiagram}}
+
 ## Constructor
 
 - {{domxref("ProcessingInstruction.ProcessingInstruction()")}}
   - : Creates a new ProcessingInstruction object instance.
 
-    Developers cannot use the `ProcessingInstruction()` constructor directly to create a new `ProcessingInstruction` instance, and must use the {{domxref("document.createProcessingInstruction()")}} method instead. Attempting to use the `ProcessingInstruction()` constructor directly results in an "illegal constructor" error.
+    Developers cannot use the `ProcessingInstruction()` constructor directly to create a new `ProcessingInstruction` instance; doing so results in an "illegal constructor" error. Instead, use the {{domxref("document.createProcessingInstruction()")}} method.
 
 ## Instance properties
 
@@ -49,35 +51,37 @@ These methods provide easier access to the {domxref("CharacterData.data", "data"
 
 ## Description
 
-Processing instructions are, as the name suggests, are instructions about how to process the document. They can include stylesheets for XML documents, placeholders for HTML documents, or other processing instructions.
+Processing instructions, as the name suggests, specify how to process a document. They can include stylesheets for XML documents, placeholders for HTML documents, or other processing instructions.
 
-They are {{domxref("Node", "Nodes")}} and not {{domxref("Element", "Elements")}} in that they do not change the shape of the {{domxref("Document Object Model", "Document Object Model (DOM)")}} in that they do not have children or cause nesting as demonstrated in the [Patching example](#usage_with_template_for_patching) later.
+Processing instructions are {{domxref("Node", "Nodes")}} rather than {{domxref("Element", "Elements")}}. They don't have children or cause nesting (as demonstrated in our [Patching example](#usage_with_template_for_patching), and therefore don't change the shape of the {{domxref("Document Object Model", "Document Object Model (DOM)")}}.
 
-{{InheritanceDiagram}}
+Initially, `ProcessingInstruction` nodes were only supported in XML documents, not HTML documents. In non-supporting browsers, processing instructions will be interpreted as comments and represented as {{domxref("Comment")}} objects in the DOM tree.
 
-Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
+Processing instructions are normally created using the {{domxref("document.createProcessingInstruction()")}} method. When written in documents directly, they begin and end with `<?` and `?>` tags, and contain a `target` and optional `data` attributes. For example:
 
-When written in documents directly, rather than created by {{domxref("document.createProcessingInstruction()")}}, they begin with `<?`, followed by the `target`, optional `data` attributes and end with `?>`. For example: `<?my-target name="my-name"?>`.
+```xml
+<?my-target name="my-name"?>`.
+```
 
-When written in HTML, processing instructions can be provided with or without the trailing `?`, and the browser will add it if not supplied. That is both `<?my-target?>` and `<?my-target>` are acceptable and will both include the trailing `?` when processed into the DOM by the parser. XML, being stricter, requires the trailing `?`.
+When written in HTML, processing instructions can be provided with or without the trailing `?`, and the browser will add it if not supplied when parsing the DOM. Both `<?my-target?>` and `<?my-target>` are therefore valid. XML is stricter and requires the trailing `?`.
 
 HTML also has [more restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) in the HTML parser for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` or it is processed as a comment.
 
-Although the syntax is identical to that for processing instructions, the [XML declaration](/en-US/docs/Web/XML/Guides/XML_introduction#xml_declaration) (`<?xml version="1.0"?>`) is not considered to be a processing instruction and is not added as such to the DOM.
+Although the syntax is identical to that of processing instructions, the [XML declaration](/en-US/docs/Web/XML/Guides/XML_introduction#xml_declaration) (`<?xml version="1.0"?>`) is not considered to be a processing instruction and is not added to the DOM.
 
-User-defined processing instructions cannot begin with `"xml"`, as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (see, for example, `<?xml-stylesheet ?>`).
+User-defined processing instructions cannot begin with `"xml"`, as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (for example, `<?xml-stylesheet ?>`).
 
-For backwards compatibility, if the target is `xml` or `xml-stylesheet` then they are parsed as comments in HTML documents. This applies whether in the original HTML or inserted with the likes of {{domxref("Element.innerHTML")}}. These can be created as processing instruction targets with {{domxref("document.createProcessingInstruction()")}}.
+For backwards compatibility, if the target is `xml` or `xml-stylesheet`, the processing instruction is parsed as a comment in an HTML document. This applies whether it is included in the original HTML or inserted using a method such as {{domxref("Element.innerHTML")}}.
 
 ## Examples
 
 ### Basic usage
 
+This example shows a processing instruction with a `target` of `display` and `data` of `table-view`.
+
 ```xml
 <?display table-view?>
 ```
-
-This example shows a processing instruction whose `target` is `display` and who's data is `table-view`.
 
 ### Reserved XML target example
 
@@ -85,9 +89,11 @@ This example shows a processing instruction whose `target` is `display` and who'
 <?xml-stylesheet href="styles.css"?>
 ```
 
-This example shows a processing instruction whose `xml-stylesheet` is `display` and who's data is `href="styles.css"`.
+This example shows a processing instruction with a target of `xml-stylesheet` and `data` of `href="styles.css"`.
 
 ### Usage with `<template for>` patching
+
+This example uses the `<?start>` and `<?end>` processing instructions as placeholders and later on fills in the contents using `<template for>`. Both exclude the optional trailing `?`.
 
 <!-- Have prettier ignore this, as indentation is important and discussed next -->
 <!-- prettier-ignore-start -->
@@ -107,11 +113,11 @@ This example shows a processing instruction whose `xml-stylesheet` is `display` 
 ```
 <!-- prettier-ignore-end -->
 
-Uses the `<?start>` and `<?end>` processing instructions as placeholders and later on fills in the contents using `<template for>`. Both exclude the optional trailing `?`.
-
-This example also demonstrates the lack of children and nesting as shown with the indentation in the previous example. The `<?start>` and `<?end>` processing instructions, although linked in terms of `<template for>`, are not linked in terms of the DOM and do not cause the `Loading..` text contents in between to be a child (as demonstrated by the lack of indentation).
+This example also demonstrates the lack of processing instruction children and nesting. The `<?start>` and `<?end>` processing instructions, although linked in terms of `<template for>`, are not linked in terms of the DOM and do not cause the `Loading...` content in between to be a child (as demonstrated by the lack of indentation).
 
 ### Using methods as opposed to the `data` attribute
+
+This example creates a processing instruction using the `createProcessingInstruction()` method. It then logs the processing instruction's data (accessed via its {{domxref("CharacterData.data")}} property) and attributes (accessed via its {{domxref("ProcessingInstruction.getAttribute()")}} method).
 
 ```js
 const pi = document.createProcessingInstruction(

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -61,13 +61,13 @@ When written in documents directly, rather than created by {{domxref("document.c
 
 When written in HTML, processing instructions can be provided with or without the trailing `?`, and the browser will add it if not supplied. That is both `<?my-target?>` and `<?my-target>` are acceptable and will both include the trailing `?` when processed into the DOM by the parser. XML, being stricter, requires the trailing `?`.
 
-HTML also has [more restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` or it is processed as a comment.
+HTML also has [more restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) in the HTML parser for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` or it is processed as a comment.
 
 Although the syntax is identical to that for processing instructions, the [XML declaration](/en-US/docs/Web/XML/Guides/XML_introduction#xml_declaration) (`<?xml version="1.0"?>`) is not considered to be a processing instruction and is not added as such to the DOM.
 
 User-defined processing instructions cannot begin with `"xml"`, as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (see, for example, `<?xml-stylesheet ?>`).
 
-For backwards compatibility, `xml`-prefixed processing instructions are parsed as comments in HTML documents.
+For backwards compatibility, if the target is `xml` or `xml-stylesheet` then they are parsed as comments in HTML documents. This applies whether in the original HTML or inserted with the likes of {{domxref("Element.innerHTML")}}. These can be created as processing instruction targets with {{domxref("document.createProcessingInstruction()")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -9,23 +9,12 @@ browser-compat: api.ProcessingInstruction
 
 The **`ProcessingInstruction`** interface represents a [processing instruction](https://www.w3.org/TR/xml/#sec-pi) — a {{domxref("Node")}} that embeds an instruction targeting a specific application, which can be ignored by any application that doesn't recognize the instruction.
 
-> [!WARNING]
-> Until recently, `ProcessingInstruction` were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
+## Constructor
 
-A processing instruction may be different than the [XML declaration](/en-US/docs/Web/XML/Guides/XML_introduction#xml_declaration).
+- {{domxref("ProcessingInstruction.ProcessingInstruction()")}}
+  - : Creates a new ProcessingInstruction object instance.
 
-> [!NOTE]
-> User-defined processing instructions cannot begin with `"xml"`, as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (see, for example, `<?xml-stylesheet ?>`.
-
-For example:
-
-```html
-<?xml version="1.0"?>
-```
-
-is a processing instruction whose `target` is `xml`.
-
-{{InheritanceDiagram}}
+    Developers cannot use the `ProcessingInstruction()` constructor directly to create a new `ProcessingInstruction` instance, and must use the {{domxref("document.createProcessingInstruction()")}} method instead. Attempting to use the `ProcessingInstruction()` constructor directly results in an "illegal constructor" error.
 
 ## Instance properties
 
@@ -55,6 +44,76 @@ _This interface also inherits methods from its parent interfaces, {{domxref("Cha
   - : Sets the named attribute of the current node to a new value.
 - {{domxref("ProcessingInstruction.toggleAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Toggles a boolean attribute, removing it if it is present and adding it if it is not present, on the specified element.
+
+These methods provide easier access to the {domxref("CharacterData.data", "data")} string attributes.
+
+## Description
+
+Processing instructions are, as the name suggests, are instructions about how to process the document. They can include stylesheets for XML documents, placeholders for HTML documents, or other processing instructions.
+
+They are {{domxref("Node", "Nodes")}} and not {{domxref("Element", "Elements")}} in that they do not change the shape of the {{domxref("Document Object Model", "Document Object Model (DOM)")}} in that they do not have children or cause nesting as demonstrated in the [Patching example](#usage_with_template_for_patching) later.
+
+{{InheritanceDiagram}}
+
+Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
+
+When written in XML or HTML directly, rather than created by {{domxref("document.createProcessingInstruction()")}}, they begin with `<?`, followed by the `target`, optional `data` attributes and end with `?>`. For example: `<?my-target name="my-name"?>`.
+
+When written in HTML, processing instructions can be provided with or without the trailing `?`, and the browser will add it if not supplied. That is both `<?my-target?>` and `<?my-target>` are acceptable and will both include the trailing `?` when processed into the DOM by the parser. XML, being stricter, requires the trailing `?`.
+
+Although the syntax is identical to that for processing instructions, the [XML declaration](/en-US/docs/Web/XML/Guides/XML_introduction#xml_declaration) (`<?xml version="1.0"?>`) is not considered to be a processing instruction and is not added as such to the DOM.
+
+User-defined processing instructions cannot begin with `"xml"`, as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (see, for example, `<?xml-stylesheet ?>`).
+
+## Examples
+
+### Basic usage
+
+```xml
+<?display table-view?>
+```
+
+This example shows a processing instruction whose `target` is `display` and who's data is `table-view`.
+
+### Reserved XML target example
+
+```xml
+<?xml-stylesheet href="styles.css"?>
+```
+
+This example shows a processing instruction whose `xml-stylesheet` is `display` and who's data is `href="styles.css"`.
+
+### Usage with `<template for>` patching
+
+```html
+<body>
+  <div><?start name="placeholder"> Loading... <?end></div>
+  ...
+  <template for="placeholder"> Lorem Ipsum... </template>
+  ...
+</body>
+```
+
+Uses the `<?start>` and `<?end>` processing instructions as placeholders and later on fills in the contents using `<template for>`. Both exclude the optional trailing `?`.
+
+This example also demonstrates the lack of children and nesting as shown with the indentation in the previous example. The `<?start>` and `<?end>` processing instructions, although linked in terms of `<template for>`, are not linked in terms of the DOM and do not cause the `Loading..` text contents in between to be a child (as demonstrated by the lack of indentation).
+
+### Using methods as opposed to the `data` attribute
+
+```js
+const pi = document.createProcessingInstruction(
+  "my-target",
+  "my-data1='value1' my-data2='value2'",
+);
+
+console.log(pi.data);
+console.log(pi.getAttribute("my-data1"));
+console.log(pi.getAttribute("my-data1"));
+// logs
+// my-data1='value1' my-data2='value2'
+// value1
+// value2
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -117,7 +117,7 @@ This example also demonstrates the lack of processing instruction children and n
 
 ### Using methods as opposed to the `data` attribute
 
-This example creates a processing instruction using the `createProcessingInstruction()` method. It then logs the processing instruction's data (accessed via its {{domxref("CharacterData.data")}} property) and attributes (accessed via its {{domxref("ProcessingInstruction.getAttribute()")}} method).
+This example creates a processing instruction using the `createProcessingInstruction()` method. It then logs the processing instruction's data (accessed via its {{domxref("CharacterData.data")}} property) and then its two attributes individually (accessed via its {{domxref("ProcessingInstruction.getAttribute()")}} method).
 
 ```js
 const pi = document.createProcessingInstruction(

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -10,7 +10,7 @@ browser-compat: api.ProcessingInstruction
 The **`ProcessingInstruction`** interface represents a [processing instruction](https://www.w3.org/TR/xml/#sec-pi); that is, a {{domxref("Node")}} which embeds an instruction targeting a specific application but that can be ignored by any other applications which don't recognize the instruction.
 
 > [!WARNING]
-> `ProcessingInstruction` nodes are only supported in XML documents, not in HTML documents. In these, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree.
+> Until recently, `ProcessingInstruction` were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
 
 A processing instruction may be different than the [XML declaration](/en-US/docs/Web/XML/Guides/XML_introduction#xml_declaration).
 
@@ -39,7 +39,22 @@ _This interface also inherits properties from its parent interfaces, {{domxref("
 
 ## Instance methods
 
-_This interface doesn't have any specific method, but inherits methods from its parent interfaces, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
+_This interface also inherits methods from its parent interfaces, {{domxref("CharacterData")}}, {{domxref("Node")}}, and {{domxref("EventTarget")}}._
+
+- {{domxref("ProcessingInstruction.getAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Retrieves the value of the named attribute from the current node and returns it as a string.
+- {{domxref("ProcessingInstruction.getAttributeNames()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Returns an array of attribute names from the current element.
+- {{domxref("ProcessingInstruction.hasAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Returns a boolean value indicating if the element has the specified attribute or not.
+- {{domxref("ProcessingInstruction.hasAttributes()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Returns a boolean value indicating if the element has one or more HTML attributes present.
+- {{domxref("ProcessingInstruction.removeAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Removes the named attribute from the current node.
+- {{domxref("ProcessingInstruction.setAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Sets the value of a named attribute of the current node.
+- {{domxref("ProcessingInstruction.toggleAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : Toggles a boolean attribute, removing it if it is present and adding it if it is not present, on the specified element.
 
 ## Specifications
 

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -7,7 +7,7 @@ browser-compat: api.ProcessingInstruction
 
 {{APIRef("DOM")}}
 
-The **`ProcessingInstruction`** interface represents a [processing instruction](https://www.w3.org/TR/xml/#sec-pi); that is, a {{domxref("Node")}} which embeds an instruction targeting a specific application but that can be ignored by any other applications which don't recognize the instruction.
+The **`ProcessingInstruction`** interface represents a [processing instruction](https://www.w3.org/TR/xml/#sec-pi) — a {{domxref("Node")}} that embeds an instruction targeting a specific application, which can be ignored by any application that doesn't recognize the instruction.
 
 > [!WARNING]
 > Until recently, `ProcessingInstruction` were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
@@ -44,7 +44,7 @@ _This interface also inherits methods from its parent interfaces, {{domxref("Cha
 - {{domxref("ProcessingInstruction.getAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Retrieves the value of the named attribute from the current node and returns it as a string.
 - {{domxref("ProcessingInstruction.getAttributeNames()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Returns an array of attribute names from the current element.
+  - : Returns an array of attribute names from the current node.
 - {{domxref("ProcessingInstruction.hasAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a boolean value indicating if the element has the specified attribute or not.
 - {{domxref("ProcessingInstruction.hasAttributes()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
@@ -52,7 +52,7 @@ _This interface also inherits methods from its parent interfaces, {{domxref("Cha
 - {{domxref("ProcessingInstruction.removeAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Removes the named attribute from the current node.
 - {{domxref("ProcessingInstruction.setAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
-  - : Sets the value of a named attribute of the current node.
+  - : Sets the named attribute of the current node to a new value.
 - {{domxref("ProcessingInstruction.toggleAttribute()")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Toggles a boolean attribute, removing it if it is present and adding it if it is not present, on the specified element.
 

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -85,14 +85,23 @@ This example shows a processing instruction whose `xml-stylesheet` is `display` 
 
 ### Usage with `<template for>` patching
 
+<!-- Have prettier ignore this, as indentation is important and discussed next -->
+<!-- prettier-ignore-start -->
 ```html
 <body>
-  <div><?start name="placeholder"> Loading... <?end></div>
+  <div>
+    <?start name="placeholder">
+    Loading...
+    <?end>
+  </div>
   ...
-  <template for="placeholder"> Lorem Ipsum... </template>
+  <template for="placeholder">
+    Lorem Ipsum...
+  </template>
   ...
 </body>
 ```
+<!-- prettier-ignore-end -->
 
 Uses the `<?start>` and `<?end>` processing instructions as placeholders and later on fills in the contents using `<template for>`. Both exclude the optional trailing `?`.
 

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -57,7 +57,7 @@ Processing instructions are {{domxref("Node", "Nodes")}} rather than {{domxref("
 
 Initially, `ProcessingInstruction` nodes were only supported in XML documents, not HTML documents. In non-supporting browsers, processing instructions will be interpreted as comments and represented as {{domxref("Comment")}} objects in the DOM tree.
 
-Processing instructions are normally created using the {{domxref("document.createProcessingInstruction()")}} method. When written in documents directly, they begin and end with `<?` and `?>` tags, and contain a `target` and optional `data` attributes. For example:
+When written in documents directly, rather than created by {{domxref("document.createProcessingInstruction()")}}, they begin and end with `<?` and `?>` delimiters, and contain a `target` and optional `data` attributes. For example:
 
 ```xml
 <?my-target name="my-name"?>`.

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -57,13 +57,17 @@ They are {{domxref("Node", "Nodes")}} and not {{domxref("Element", "Elements")}}
 
 Initially, `ProcessingInstruction` nodes were only supported in XML documents, not in HTML documents. In non-supporting browsers, a process instruction will be considered as a comment and be represented as a {{domxref("Comment")}} object in the tree. Check the [browser compatibility](#browser_compatibility) section for support information.
 
-When written in XML or HTML directly, rather than created by {{domxref("document.createProcessingInstruction()")}}, they begin with `<?`, followed by the `target`, optional `data` attributes and end with `?>`. For example: `<?my-target name="my-name"?>`.
+When written in documents directly, rather than created by {{domxref("document.createProcessingInstruction()")}}, they begin with `<?`, followed by the `target`, optional `data` attributes and end with `?>`. For example: `<?my-target name="my-name"?>`.
 
 When written in HTML, processing instructions can be provided with or without the trailing `?`, and the browser will add it if not supplied. That is both `<?my-target?>` and `<?my-target>` are acceptable and will both include the trailing `?` when processed into the DOM by the parser. XML, being stricter, requires the trailing `?`.
+
+HTML also has [more restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` or it is processed as a comment.
 
 Although the syntax is identical to that for processing instructions, the [XML declaration](/en-US/docs/Web/XML/Guides/XML_introduction#xml_declaration) (`<?xml version="1.0"?>`) is not considered to be a processing instruction and is not added as such to the DOM.
 
 User-defined processing instructions cannot begin with `"xml"`, as `xml`-prefixed processing-instruction target names are reserved by the XML specification for particular, standard uses (see, for example, `<?xml-stylesheet ?>`).
+
+For backwards compatibility, `xml`-prefixed processing instructions are parsed as comments in HTML documents.
 
 ## Examples
 

--- a/files/en-us/web/api/processinginstruction/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/processinginstruction/index.md
@@ -1,0 +1,65 @@
+---
+title: "ProcessingInstruction: ProcessingInstruction() constructor"
+short-title: ProcessingInstruction()
+slug: Web/API/ProcessingInstruction/ProcessingInstruction
+page-type: web-api-constructor
+browser-compat: api.ProcessingInstruction.ProcessingInstruction
+---
+
+{{APIRef("DOM")}}
+
+The **`ProcessingInstruction()`** constructor creates a new {{domxref("ProcessingInstruction")}} object instance.
+
+## Syntax
+
+```js-nolint
+new ProcessingInstruction(target, data)
+```
+
+### Parameters
+
+- `target`
+  - : A string representing the type of event.
+- `data`
+  - : A string containing any information the processing instruction should carry, after the target. The data is up to you, but it can't contain `?>`, since that closes the processing instruction.
+
+### Return value
+
+Processing instructions are, as the name suggests, are instructions about how to process the document. They can include stylesheets for XML documents, placeholders for HTML documents, or other processing instructions.
+
+A new {{domxref("ProcessingInstruction")}} object, if used internally by the browser.
+
+Developers cannot use the `ProcessingInstruction()` constructor directly to create a new `ProcessingInstruction` instance, and must use the {{domxref("document.createProcessingInstruction()")}} method instead. Attempting to use the `ProcessingInstruction()` constructor directly results in an "illegal constructor" error.
+
+### Exceptions
+
+- `InvalidCharacterError` {{domxref("DOMException")}}
+  - : Thrown if either of the following are true:
+    - The [`target`](#target) value is not a valid [XML name](https://www.w3.org/TR/xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
+    - The _closing processing instruction sequence_ (`?>`) is part of the [`data`](#data) value.
+
+- {{jsxref("TypeError")}}
+  - : Thrown with the message `"Illegal constructor"` when used directly.
+
+## Examples
+
+```js
+const doc = new DOMParser().parseFromString("<foo />", "application/xml");
+const pi = doc.createProcessingInstruction(
+  "xml-stylesheet",
+  'href="mycss.css"',
+);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [document.createProcessingInstruction()](/en-US/docs/Web/API/Document/createProcessingInstruction)
+- The [DOM API](/en-US/docs/Web/API/Document_Object_Model)

--- a/files/en-us/web/api/processinginstruction/removeattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/removeattribute/index.md
@@ -1,0 +1,63 @@
+---
+title: "ProcessingInstruction: removeAttribute() method"
+short-title: removeAttribute()
+slug: Web/API/ProcessingInstruction/removeAttribute
+page-type: web-api-instance-method
+browser-compat: api.ProcessingInstruction.removeAttribute
+---
+
+{{ APIRef("DOM") }}
+
+The {{domxref("ProcessingInstruction")}} method
+**`removeAttribute()`** removes the attribute with the
+specified name from the Processing Instruction.
+
+## Syntax
+
+```js-nolint
+removeAttribute(attrName)
+```
+
+### Parameters
+
+- `attrName`
+  - : A string specifying the name of the attribute to remove from the
+    processing instruction. If the specified attribute does not exist, `removeAttribute()`
+    returns without generating an error.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Usage notes
+
+You should use `removeAttribute()` instead of setting the attribute value to `null` either directly or using {{domxref("ProcessingInstruction.setAttribute", "setAttribute()")}}.
+Many attributes will not behave as expected if you set them to `null`.
+
+## Examples
+
+```js
+const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+
+pi.removeAttribute("name");
+console.log(pi);
+// logs:
+// <?start?>
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ProcessingInstruction.hasAttribute()")}}
+- {{domxref("ProcessingInstruction.hasAttributes()")}}
+- {{domxref("ProcessingInstruction.getAttribute()")}}
+- {{domxref("ProcessingInstruction.getAttributeNames()")}}
+- {{domxref("ProcessingInstruction.setAttribute()")}}
+- {{domxref("ProcessingInstruction.toggleAttribute()")}}

--- a/files/en-us/web/api/processinginstruction/removeattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/removeattribute/index.md
@@ -31,10 +31,12 @@ None ({{jsxref("undefined")}}).
 
 ## Usage notes
 
-You should use `removeAttribute()` instead of setting the attribute value to `null` either directly or using {{domxref("ProcessingInstruction.setAttribute", "setAttribute()")}}.
+You should use `removeAttribute()` instead of setting the attribute value to `null` (either directly or using {{domxref("ProcessingInstruction.setAttribute", "setAttribute()")}}).
 Many attributes will not behave as expected if you set them to `null`.
 
 ## Examples
+
+### Basic usage
 
 ```js
 const pi = document.createProcessingInstruction("start", 'name="placeholder"');

--- a/files/en-us/web/api/processinginstruction/removeattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/removeattribute/index.md
@@ -8,9 +8,7 @@ browser-compat: api.ProcessingInstruction.removeAttribute
 
 {{ APIRef("DOM") }}
 
-The {{domxref("ProcessingInstruction")}} method
-**`removeAttribute()`** removes the attribute with the
-specified name from the Processing Instruction.
+The **`removeAttribute()`** method of the {{domxref("ProcessingInstruction")}} removes the attribute with the specified name from the processing instruction.
 
 ## Syntax
 

--- a/files/en-us/web/api/processinginstruction/setattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/setattribute/index.md
@@ -46,6 +46,8 @@ None ({{jsxref("undefined")}}).
     - The `prefix` must have at least one character, and cannot contain ASCII whitespace, `NULL`, `/`, or `>` (U+0000, U+002F, or U+003E, respectively).
     - The `localName` must have at least one character, and may not contain ASCII whitespace, `NULL`, `/`, `=` or `>` (U+0000, U+002F, U+003D, or U+003E, respectively).
 
+HTML also has [additional restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` and not be prefixed with `xml` or the `InvalidCharacterError` exception is thrown. Processing instructions with invalid names in HTML documents are parsed as comments.
+
 ## Description
 
 **`setAttribute()`** sets the value of an attribute on the specified processing instruction.

--- a/files/en-us/web/api/processinginstruction/setattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/setattribute/index.md
@@ -46,8 +46,6 @@ None ({{jsxref("undefined")}}).
     - The `prefix` must have at least one character, and cannot contain ASCII whitespace, `NULL`, `/`, or `>` (U+0000, U+002F, or U+003E, respectively).
     - The `localName` must have at least one character, and may not contain ASCII whitespace, `NULL`, `/`, `=` or `>` (U+0000, U+002F, U+003D, or U+003E, respectively).
 
-HTML also has [additional restrictions on the `target` name](https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-target-state) for backwards compatibility. Effectively, it must match `[A-Za-z_][-_A-Za-z0-9]*` and not be prefixed with `xml` or the `InvalidCharacterError` exception is thrown. Processing instructions with invalid names in HTML documents are parsed as comments.
-
 ## Description
 
 **`setAttribute()`** sets the value of an attribute on the specified processing instruction.

--- a/files/en-us/web/api/processinginstruction/setattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/setattribute/index.md
@@ -9,7 +9,7 @@ browser-compat: api.ProcessingInstruction.setAttribute
 {{APIRef("DOM")}}
 
 The **`setAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface sets the value of an attribute on the specified processing instruction.
-If the attribute already exists, the value is updated; otherwise a new attribute is added with the specified name and value.
+If the attribute already exists, the value is updated; otherwise, a new attribute is added with the specified name and value.
 
 ## Syntax
 
@@ -25,16 +25,16 @@ setAttribute(qualifiedName, value)
 
     The format of the qualified name is `prefix:localName` or `localName`, where the parts are defined as:
     - `prefix` {{optional_inline}}
-      - : A "short alias" for the namespace, as returned by the {{DOMxRef("Attr.prefix", "prefix")}} property.
+      - : A "short alias" for the namespace, as returned by the {{DOMxRef("Attr.prefix")}} property.
     - `localName`
-      - : The local name of the attribute, as returned by the {{DOMxRef("Attr.localName", "localName")}} property.
+      - : The local name of the attribute, as returned by the {{DOMxRef("Attr.localName")}} property.
 
 - `value`
   - : A string containing the value to assign to the attribute.
 
-    A specified non-string value specified is converted automatically into a string.
+    Specified non-string values are automatically converted into strings.
 
-    For Boolean attributes you should set `value` to the empty string (`""`) or the attribute's name, with no leading or trailing whitespace.
+    For Boolean attributes, you should, by convention, set `value` to the empty string (`""`) or the attribute's name, with no leading or trailing whitespace.
 
 ### Return value
 
@@ -53,16 +53,18 @@ None ({{jsxref("undefined")}}).
 ## Description
 
 **`setAttribute()`** sets the value of an attribute on the specified processing instruction.
-If the attribute already exists, the value is updated; otherwise a new attribute is added with the specified name and value.
+If the attribute already exists, the value is updated; otherwise, a new attribute is added with the specified name and value.
 
 To set the value of a Boolean attribute, such as `disabled`, you can specify any value.
 It doesn't matter what value you use; if the attribute is present, its value is considered to be `true`.
 By convention we enable boolean attributes by setting their value to either the name of the attribute or the empty string (`""`).
-The absence of a boolean attribute means its value is `false`; you must call {{domxref("ProcessingInstruction.removeAttribute()")}} to "undo" the effect of enabling a boolean attribute
+The absence of a boolean attribute means its value is `false`; you must call {{domxref("ProcessingInstruction.removeAttribute()")}} to "undo" the effect of enabling a boolean attribute.
 
 To get the current value of an attribute, use {{domxref("ProcessingInstruction.getAttribute", "getAttribute()")}}; to remove an attribute, call {{domxref("ProcessingInstruction.removeAttribute", "removeAttribute()")}}.
 
-## Example
+## Examples
+
+### Basic usage
 
 ```js
 const pi = document.createProcessingInstruction("start", 'name="placeholder"');

--- a/files/en-us/web/api/processinginstruction/setattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/setattribute/index.md
@@ -33,7 +33,7 @@ setAttribute(qualifiedName, value)
 
     Specified non-string values are automatically converted into strings.
 
-    For Boolean attributes, you should, by convention, set `value` to the empty string (`""`) or the attribute's name, with no leading or trailing whitespace.
+    For boolean attributes, you should, by convention, set `value` to the empty string (`""`) or the attribute's name, with no leading or trailing whitespace.
 
 ### Return value
 
@@ -53,7 +53,7 @@ If the attribute already exists, the value is updated; otherwise, a new attribut
 
 To set the value of a Boolean attribute, such as `disabled`, you can specify any value.
 It doesn't matter what value you use; if the attribute is present, its value is considered to be `true`.
-By convention we enable boolean attributes by setting their value to either the name of the attribute or the empty string (`""`).
+By convention, we enable boolean attributes by setting their value to either the name of the attribute or the empty string (`""`).
 The absence of a boolean attribute means its value is `false`; you must call {{domxref("ProcessingInstruction.removeAttribute()")}} to "undo" the effect of enabling a boolean attribute.
 
 To get the current value of an attribute, use {{domxref("ProcessingInstruction.getAttribute", "getAttribute()")}}; to remove an attribute, call {{domxref("ProcessingInstruction.removeAttribute", "removeAttribute()")}}.

--- a/files/en-us/web/api/processinginstruction/setattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/setattribute/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ProcessingInstruction.setAttribute
 
 {{APIRef("DOM")}}
 
-The **`setAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface sets the value of an attribute on the specified processing instruction.
+The **`setAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface sets the value of an attribute on the processing instruction.
 If the attribute already exists, the value is updated; otherwise, a new attribute is added with the specified name and value.
 
 ## Syntax
@@ -21,7 +21,6 @@ setAttribute(qualifiedName, value)
 
 - `qualifiedName`
   - : A string containing the qualified name of the attribute whose value is to be set.
-    The attribute name is automatically converted to all lower-case when `setAttribute()` is called on an HTML processing instruction in an HTML document.
 
     The format of the qualified name is `prefix:localName` or `localName`, where the parts are defined as:
     - `prefix` {{optional_inline}}
@@ -47,9 +46,6 @@ None ({{jsxref("undefined")}}).
     - The `prefix` must have at least one character, and cannot contain ASCII whitespace, `NULL`, `/`, or `>` (U+0000, U+002F, or U+003E, respectively).
     - The `localName` must have at least one character, and may not contain ASCII whitespace, `NULL`, `/`, `=` or `>` (U+0000, U+002F, U+003D, or U+003E, respectively).
 
-    > [!NOTE]
-    > Earlier versions of the specification were more restrictive, requiring that the `qualifiedName` be a valid [XML name](https://www.w3.org/TR/xml/#dt-name).
-
 ## Description
 
 **`setAttribute()`** sets the value of an attribute on the specified processing instruction.
@@ -69,10 +65,10 @@ To get the current value of an attribute, use {{domxref("ProcessingInstruction.g
 ```js
 const pi = document.createProcessingInstruction("start", 'name="placeholder"');
 
-pi.setAttribute("name", "placeholder");
+pi.setAttribute("name", "new text");
 console.log(pi);
 // logs:
-// <?start?>
+// <?start name="new text"?>
 ```
 
 ## Specifications

--- a/files/en-us/web/api/processinginstruction/setattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/setattribute/index.md
@@ -1,0 +1,91 @@
+---
+title: "ProcessingInstruction: setAttribute() method"
+short-title: setAttribute()
+slug: Web/API/ProcessingInstruction/setAttribute
+page-type: web-api-instance-method
+browser-compat: api.ProcessingInstruction.setAttribute
+---
+
+{{APIRef("DOM")}}
+
+The **`setAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface sets the value of an attribute on the specified processing instruction.
+If the attribute already exists, the value is updated; otherwise a new attribute is added with the specified name and value.
+
+## Syntax
+
+```js-nolint
+setAttribute(qualifiedName, value)
+```
+
+### Parameters
+
+- `qualifiedName`
+  - : A string containing the qualified name of the attribute whose value is to be set.
+    The attribute name is automatically converted to all lower-case when `setAttribute()` is called on an HTML processing instruction in an HTML document.
+
+    The format of the qualified name is `prefix:localName` or `localName`, where the parts are defined as:
+    - `prefix` {{optional_inline}}
+      - : A "short alias" for the namespace, as returned by the {{DOMxRef("Attr.prefix", "prefix")}} property.
+    - `localName`
+      - : The local name of the attribute, as returned by the {{DOMxRef("Attr.localName", "localName")}} property.
+
+- `value`
+  - : A string containing the value to assign to the attribute.
+
+    A specified non-string value specified is converted automatically into a string.
+
+    For Boolean attributes you should set `value` to the empty string (`""`) or the attribute's name, with no leading or trailing whitespace.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- `InvalidCharacterError` {{domxref("DOMException")}}
+  - : Thrown if either the [`prefix`](#prefix) or [`localName`](#localname) is not valid:
+    - The `prefix` must have at least one character, and cannot contain ASCII whitespace, `NULL`, `/`, or `>` (U+0000, U+002F, or U+003E, respectively).
+    - The `localName` must have at least one character, and may not contain ASCII whitespace, `NULL`, `/`, `=` or `>` (U+0000, U+002F, U+003D, or U+003E, respectively).
+
+    > [!NOTE]
+    > Earlier versions of the specification were more restrictive, requiring that the `qualifiedName` be a valid [XML name](https://www.w3.org/TR/xml/#dt-name).
+
+## Description
+
+**`setAttribute()`** sets the value of an attribute on the specified processing instruction.
+If the attribute already exists, the value is updated; otherwise a new attribute is added with the specified name and value.
+
+To set the value of a Boolean attribute, such as `disabled`, you can specify any value.
+It doesn't matter what value you use; if the attribute is present, its value is considered to be `true`.
+By convention we enable boolean attributes by setting their value to either the name of the attribute or the empty string (`""`).
+The absence of a boolean attribute means its value is `false`; you must call {{domxref("ProcessingInstruction.removeAttribute()")}} to "undo" the effect of enabling a boolean attribute
+
+To get the current value of an attribute, use {{domxref("ProcessingInstruction.getAttribute", "getAttribute()")}}; to remove an attribute, call {{domxref("ProcessingInstruction.removeAttribute", "removeAttribute()")}}.
+
+## Example
+
+```js
+const pi = document.createProcessingInstruction("start", 'name="placeholder"');
+
+pi.setAttribute("name", "placeholder");
+console.log(pi);
+// logs:
+// <?start?>
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ProcessingInstruction.hasAttribute()")}}
+- {{domxref("ProcessingInstruction.hasAttributes()")}}
+- {{domxref("ProcessingInstruction.getAttribute()")}}
+- {{domxref("ProcessingInstruction.getAttributeNames()")}}
+- {{domxref("ProcessingInstruction.removeAttribute()")}}
+- {{domxref("ProcessingInstruction.toggleAttribute()")}}

--- a/files/en-us/web/api/processinginstruction/toggleattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/toggleattribute/index.md
@@ -1,0 +1,69 @@
+---
+title: "ProcessingInstruction: toggleAttribute() method"
+short-title: toggleAttribute()
+slug: Web/API/ProcessingInstruction/toggleAttribute
+page-type: web-api-instance-method
+browser-compat: api.ProcessingInstruction.toggleAttribute
+---
+
+{{APIRef("DOM")}}
+
+The **`toggleAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface toggles a Boolean attribute on the given processing instruction, removing it if present and adding it if not present.
+
+## Syntax
+
+```js-nolint
+toggleAttribute(name)
+toggleAttribute(name, force)
+```
+
+### Parameters
+
+- `name`
+  - : A string specifying the name of the attribute to be toggled.
+    The attribute name is automatically converted to all lower-case when `toggleAttribute()` is called on an HTML processing instruction in an HTML document.
+- `force` {{optional_inline}}
+  - : A boolean value which has the following effects:
+    - if not specified at all, the `toggleAttribute` method "toggles" the attribute named `name` — removing it if it is present, or else adding it if it is not present
+    - if true, the `toggleAttribute` method adds an attribute named `name`
+    - if false, the `toggleAttribute` method removes the attribute named `name`
+
+### Return value
+
+`true` if attribute **`name`** is eventually
+present, and `false` otherwise.
+
+### Exceptions
+
+- `InvalidCharacterError` {{domxref("DOMException")}}
+  - : The specified attribute `name` contains one or more characters that are not valid in attribute names.
+    The `name` must have at least one character, and may not contain ASCII whitespace, `NULL`, `/`, `=` or `>` (U+0000, U+002F, U+003D, or U+003E, respectively).
+
+## Examples
+
+```js
+const pi = document.createProcessingInstruction("start", 'name=""');
+
+pi.toggleAttribute("name");
+pi.toggleAttribute("surname");
+console.log(pi);
+// logs:
+// <?start surname?>
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("ProcessingInstruction.hasAttribute()")}}
+- {{domxref("ProcessingInstruction.hasAttributes()")}}
+- {{domxref("ProcessingInstruction.getAttribute()")}}
+- {{domxref("ProcessingInstruction.getAttributeNames()")}}
+- {{domxref("ProcessingInstruction.setAttribute()")}}
+- {{domxref("ProcessingInstruction.removeAttribute()")}}

--- a/files/en-us/web/api/processinginstruction/toggleattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/toggleattribute/index.md
@@ -24,8 +24,8 @@ toggleAttribute(name, force)
 - `force` {{optional_inline}}
   - : A boolean value that has the following effects:
     - If not specified at all, the attribute is removed if it is present and added if it is not present.
-    - If set to true, the attribute is added if it is not present, but it isn't removed if it is present.
-    - If false, the attribute is removed if it is present, but it isn't added if it is not present.
+    - If set to `true`, the attribute is added if it is not present, but it isn't removed if it is present.
+    - If set to `false`, the attribute is removed if it is present, but it isn't added if it is not present.
 
 ### Return value
 

--- a/files/en-us/web/api/processinginstruction/toggleattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/toggleattribute/index.md
@@ -21,7 +21,6 @@ toggleAttribute(name, force)
 
 - `name`
   - : A string specifying the name of the attribute to be toggled.
-    The attribute name is automatically converted to all lower-case when `toggleAttribute()` is called on an HTML processing instruction in an HTML document.
 - `force` {{optional_inline}}
   - : A boolean value that has the following effects:
     - If not specified at all, the attribute is removed if it is present and added if it is not present.
@@ -49,7 +48,7 @@ pi.toggleAttribute("name");
 pi.toggleAttribute("surname");
 console.log(pi);
 // logs:
-// <?start surname?>
+// <?start surname=""?>
 ```
 
 ## Specifications

--- a/files/en-us/web/api/processinginstruction/toggleattribute/index.md
+++ b/files/en-us/web/api/processinginstruction/toggleattribute/index.md
@@ -8,7 +8,7 @@ browser-compat: api.ProcessingInstruction.toggleAttribute
 
 {{APIRef("DOM")}}
 
-The **`toggleAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface toggles a Boolean attribute on the given processing instruction, removing it if present and adding it if not present.
+The **`toggleAttribute()`** method of the {{domxref("ProcessingInstruction")}} interface toggles a boolean attribute on the given processing instruction, removing it if present and adding it if not present.
 
 ## Syntax
 
@@ -23,15 +23,14 @@ toggleAttribute(name, force)
   - : A string specifying the name of the attribute to be toggled.
     The attribute name is automatically converted to all lower-case when `toggleAttribute()` is called on an HTML processing instruction in an HTML document.
 - `force` {{optional_inline}}
-  - : A boolean value which has the following effects:
-    - if not specified at all, the `toggleAttribute` method "toggles" the attribute named `name` — removing it if it is present, or else adding it if it is not present
-    - if true, the `toggleAttribute` method adds an attribute named `name`
-    - if false, the `toggleAttribute` method removes the attribute named `name`
+  - : A boolean value that has the following effects:
+    - If not specified at all, the attribute is removed if it is present and added if it is not present.
+    - If set to true, the attribute is added if it is not present, but it isn't removed if it is present.
+    - If false, the attribute is removed if it is present, but it isn't added if it is not present.
 
 ### Return value
 
-`true` if attribute **`name`** is eventually
-present, and `false` otherwise.
+`true` if the attribute is present after the `toggleAttribute()` operation completes, and `false` if not.
 
 ### Exceptions
 
@@ -40,6 +39,8 @@ present, and `false` otherwise.
     The `name` must have at least one character, and may not contain ASCII whitespace, `NULL`, `/`, `=` or `>` (U+0000, U+002F, U+003D, or U+003E, respectively).
 
 ## Examples
+
+### Basic usage
 
 ```js
 const pi = document.createProcessingInstruction("start", 'name=""');


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->
### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

Chrome 150 supports Processing Instructions in HTML documents.

Prior to this they were treated as comments by all browsers [as noted in the current docs](https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction)

> Warning: ProcessingInstruction nodes are only supported in XML documents, not in HTML documents. In these, a process instruction will be considered as a comment and be represented as a [Comment](https://developer.mozilla.org/en-US/docs/Web/API/Comment) object in the tree.

This warning is now no longer accurate.

Chrome also added some extra methods (`getAttribute`, `getAttributeNames`...etc) similar to the equivalents on `Element` so this PR adds those docs (based on the Element versions).

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

Incorrect and missing docs

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://chromestatus.com/feature/6534495085920256

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
