### PR TITLE
Document that define() reads static observedAttributes

### DIFF
--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -58,6 +58,8 @@ To define an autonomous custom element, you should omit the `options` parameter.
 
 To define a customized built-in element, you must pass the `options` parameter with its `extends` property set to the name of the built-in element that you are extending, and this must correspond to the interface that your custom element class definition inherits from. For example, to customize the {{htmlelement("p")}} element, you must pass `{extends: "p"}` to `define()`, and the class definition for your element must inherit from {{domxref("HTMLParagraphElement")}}.
 
+If your custom element class implements an `attributeChangedCallback()` lifecycle callback, the browser reads the static `observedAttributes` property from the constructor when `define()` is called. The list of attribute names it returns determines which attribute changes trigger the callback. This means that `observedAttributes` must be declared as a static property (or static getter) on the class, and that it is read when the element is defined, not when elements are created or upgraded: if it returns `undefined`, the element observes no attributes, and `attributeChangedCallback()` will never be invoked.
+
 ### Valid custom element names
 
 Custom element names must:


### PR DESCRIPTION
## Summary

~~Fixes~~ #45065.

When a custom element class implements an `attributeChangedCallback()`, the browser reads the static `observedAttributes` property from the constructor at definition time (per the [HTML spec](https://html.spec.whatwg.org/multipage/custom-elements.html#concept-element-definition), the *create an element definition* algorithm performs `Get(constructor, "observedAttributes")` when the attribute changed callback is present).

This PR documents that behavior in the **Description** section of the `CustomElementRegistry.define()` page: `observedAttributes` must be a static property/getter, is read at definition time (not at element creation), and if it returns `undefined` no attributes are observed.

## Verification

Verified against the WHATWG HTML spec source:
- If `lifecycleCallbacks["attributeChangedCallback"]` is not null, then `observedAttributesIterable` is the result of `Get(constructor, "observedAttributes")`.
- If the result is not `undefined`, it is converted to a sequence of strings; otherwise `observedAttributes` remains an empty sequence.

This behavior is also what Lit relies on (see [reactive-element.ts](https://github.com/lit/lit/blob/c42ee1e96b8fd61f7256f61d715daef572e76e52/packages/reactive-element/src/reactive-element.ts#L659)).