### PR TITLE
Document hue interpolation method default in color-mix()

### DIFF
--- a/files/en-us/web/css/reference/values/color_value/color-mix/index.md
+++ b/files/en-us/web/css/reference/values/color_value/color-mix/index.md
@@ -72,6 +72,13 @@ The [`<rectangular-color-space>`](/en-US/docs/Web/CSS/Reference/Values/color-int
 
 The `<polar-color-space>` category includes [`hsl`](/en-US/docs/Web/CSS/Reference/Values/color_value/hsl), [`hwb`](/en-US/docs/Web/CSS/Reference/Values/color_value/hwb), [`lch`](/en-US/docs/Web/CSS/Reference/Values/color_value/lch), and [`oklch`](/en-US/docs/Web/CSS/Reference/Values/color_value/oklch). With these you can optionally follow the color space name with a {{CSSXref("&lt;hue-interpolation-method&gt;")}}. This value defaults to `shorter hue`, but can also be set to `longer hue`, `increasing hue`, or `decreasing hue`.
 
+If you omit the hue interpolation method when mixing in a polar color space, it defaults to `shorter hue`. For example, the following two declarations are equivalent:
+
+```css
+color-mix(in lch, red, blue);
+color-mix(in lch shorter hue, red, blue);
+```
+
 ### Color percentages
 
 Each color can be declared with a `<percentage>` value between `0%` and `100%`, which specifies the amount of the corresponding color to mix. The percentages are normalized if the total value of the declared percentages does not equal `100%`.


### PR DESCRIPTION
## Summary

Fixes #44894 (content part).

The `color-mix()` page's syntax examples already show calls both with and without a hue interpolation method, but it was not explicitly demonstrated that omitting the method is valid and what it defaults to. This PR adds, in the **Color interpolation method** section, a note and a short example showing that omitting the hue interpolation method when mixing in a polar color space defaults to `shorter hue`, and that `color-mix(in lch, red, blue)` and `color-mix(in lch shorter hue, red, blue)` are equivalent.

The browser-compat-data part of the issue is tracked separately in [mdn/browser-compat-data#28693](https://github.com/mdn/browser-compat-data/issues/28693).

## Verification

Verified against the CSS Color 5 spec ([csswg-drafts](https://github.com/w3c/csswg-drafts) `css-color-5/Overview.bs`): `<color-interpolation-method>` is `in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? ]`, and the hue interpolation method is not the default (''shorter'') only when explicitly written — i.e. the default is `shorter`.