### PR TITLE
Describe contain: paint clipping to overflow clip edge

### DIFF
--- a/files/en-us/web/css/reference/properties/contain/index.md
+++ b/files/en-us/web/css/reference/properties/contain/index.md
@@ -125,7 +125,7 @@ The keywords have the following meanings:
 - `style`
   - : For properties that can affect more than just an element and its descendants, the effects don't escape the containing element. Counters and quotes are scoped to the element and its contents.
 - `paint`
-  - : Descendants of the element don't display outside its bounds. If the containing box is offscreen, the browser does not need to paint its contained elements — these must also be offscreen as they are contained completely by that box. If a descendant overflows the containing element's bounds, then that descendant will be clipped to the containing element's border-box.
+  - : Descendants of the element don't display outside its bounds. If the containing box is offscreen, the browser does not need to paint its contained elements — these must also be offscreen as they are contained completely by that box. If a descendant overflows the containing element's bounds, then that descendant will be clipped to the containing element's overflow clip edge. By default, this edge corresponds to the padding-box edge, but it can be extended using the `overflow-clip-margin` property.
 
 ## Description
 


### PR DESCRIPTION
#45101.

Per CSS Containment Level 2 ([css-contain-2 §containment-paint](https://www.w3.org/TR/css-contain-2/#containment-paint)), the contents of a paint-contained element are clipped to its **overflow clip edge** (taking corner clipping into account), not its border-box. The overflow clip edge defaults to the padding-box edge and can be extended via `overflow-clip-margin` ([css-overflow-3](https://drafts.csswg.org/css-overflow-3/#overflow-clip-margin)).

Verified against the spec sources:
- `css-contain-2/Overview.bs`: "must be clipped to the overflow clip edge of the paint containment box"
- `css-overflow-3/Overview.bs`: overflow-clip-margin "If omitted, defaults to padding-box"