### PR TITLE
Note that cell backgrounds override colgroup backgrounds

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/html_table_basics/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/html_table_basics/index.md
@@ -677,6 +677,9 @@ Let's look at how the above code renders:
 Notice how the different columns receive the styles specified in the classes.
 
 > [!NOTE]
+> If you're following along in your own editor using the [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/basic/minimal-table.css) template, note that it sets background colors on the `th` and `td` cells. Because cell backgrounds are painted over the column backgrounds, the column shading in this example won't be visible unless you override those rules first — for example, by adding `td, th { background-color: transparent; }` to your CSS.
+
+> [!NOTE]
 > Even though `<colgroup>` and `<col>` mainly facilitate styling, they are an HTML feature, so we've covered them here rather than in our CSS modules. It is also fair to say that they are a _limited_ feature — as shown on the [`<colgroup>` reference page](/en-US/docs/Web/HTML/Reference/Elements/colgroup#usage_notes), only a limited subset of styles can be applied to a `<col>` element, and most of the other settings that were historically available have been deprecated (removed, or flagged for removal).
 
 ## Interactive recap of table concepts


### PR DESCRIPTION
~~Fixes~~ #44816.

The `HTML table basics` learning article's colgroup section tells readers to add background colors to `<col>` elements. However, the [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/basic/minimal-table.css) template used for the hands-on exercises sets background colors on `th` and `td` cells, which are painted over the column backgrounds — so the column shading is not visible when following along with the template.

This PR adds a note in the colgroup section telling readers to override the cell background rules (e.g. `td, th { background-color: transparent; }`) so the column styles show through.

## Verification

Confirmed the behavior in `minimal-table.css`:
- `th { background-color: rgb(235,235,235); }`
- `tr:nth-child(even) td { background-color: rgb(250,250,250); }`
- `tr:nth-child(odd) td { background-color: rgb(245,245,245); }`

Cell backgrounds are painted over `<col>` backgrounds, so the example's column shading is hidden unless the cell backgrounds are made transparent.