### PR TITLE
Fix broken anchors in the DOM events table

### DIFF
--- a/files/en-us/web/api/document_object_model/events/index.md
+++ b/files/en-us/web/api/document_object_model/events/index.md
@@ -78,9 +78,6 @@ This topic provides an index to the main _sorts_ of events you might be interest
       </td>
       <td>
         Events fired on
-        <a href="/en-US/docs/Web/API/Document#clipboard_events"
-          ><code>Document</code></a
-        >,
         <a href="/en-US/docs/Web/API/Element#clipboard_events"
           ><code>Element</code></a
         >,
@@ -199,8 +196,8 @@ This topic provides an index to the main _sorts_ of events you might be interest
       <td>
         <p>
           Drag events fired on
-          <a href="/en-US/docs/Web/API/Document#drag_drop_events"
-            ><code>Document</code></a
+          <a href="/en-US/docs/Web/API/HTMLElement#drag_drop_events"
+            ><code>HTMLElement</code></a
           >
         </p>
         <p>
@@ -356,7 +353,7 @@ This topic provides an index to the main _sorts_ of events you might be interest
       </td>
       <td>
         Events fired on
-        <a href="/en-US/docs/Web/API/HTMLElement#input_events"
+        <a href="/en-US/docs/Web/API/HTMLElement#events"
           ><code>HTMLElement</code></a
         >,
         <a href="/en-US/docs/Web/API/HTMLInputElement#events"
@@ -375,9 +372,6 @@ This topic provides an index to the main _sorts_ of events you might be interest
       </td>
       <td>
         Events fired on
-        <a href="/en-US/docs/Web/API/Document#keyboard_events"
-          ><code>Document</code></a
-        >,
         <a href="/en-US/docs/Web/API/Element#keyboard_events"
           ><code>Element</code></a
         >.
@@ -520,7 +514,7 @@ This topic provides an index to the main _sorts_ of events you might be interest
         </p>
         <p>
           Events fired on
-          <a href="/en-US/docs/Web/API/NetworkInformation#event_handler"
+          <a href="/en-US/docs/Web/API/NetworkInformation#events"
             ><code>NetworkInformation</code></a
           >
           (<a href="/en-US/docs/Web/API/Network_Information_API"


### PR DESCRIPTION
## Description

Fixes five anchor links in the DOM events table that point to sections which no longer exist.

`Document` and `HTMLElement` used to list their events in categorized subsections, so anchors such as `Document#keyboard_events` resolved. Both pages now use a single `Events` section, leaving those fragments pointing at nothing. This changes them to `#events`, which is already how the rest of this table links (`AbortSignal#events`, `WebSocket#events`, and so on).

In each case the target section does document the events the row describes:

- Clipboard → `Document#events` lists `copy`, `cut`, `paste`.
- Drag → `Document#events` lists `drag`, `dragstart`, `dragend`, `drop`, and the rest.
- Inputs → `HTMLElement#events` lists `input` and `change`.
- Keyboard → `Document#events` lists `keydown`, `keypress`, `keyup`.
- Network/Connection → `NetworkInformation#event_handler` becomes `#events`, matching the heading on that page, which documents the `change` event.

Other broken anchors in this table are left alone: they point at event categories the target interfaces do not currently document, so repointing them would resolve the link without taking the reader anywhere useful.

## Motivation

These links currently drop the reader at the top of the target page rather than at the events they were sent to find.
