### PR TITLE
Use the SVGElement macro for the svg element

### DIFF
--- a/files/en-us/glossary/contentful_paint/index.md
+++ b/files/en-us/glossary/contentful_paint/index.md
@@ -9,7 +9,7 @@ Several performance metrics such as {{Glossary("First_contentful_paint", "First 
 
 Contentful paints are paint operations that render significant content and are therefore significant for performance measurements. These stand apart from less important paints that contain no useful content for the user, such as background color paints. For example, a page that loads, sets the background color, but then shows no actual content for a long period afterwards is not as useful as one that shows text, images, or other content.
 
-What exactly counts as "content" is heuristic-based to some extent and may not perfectly align with user perception or developer intent. This means paints drawn to screen in different ways may count as "contentful" or not, even if they appear the same to the user. For example, using a {{htmlelement("div")}} with a background color would not be contentful, while using an {{htmlelement("img")}} or {{htmlelement("svg")}} for that color may be considered contentful.
+What exactly counts as "content" is heuristic-based to some extent and may not perfectly align with user perception or developer intent. This means paints drawn to screen in different ways may count as "contentful" or not, even if they appear the same to the user. For example, using a {{htmlelement("div")}} with a background color would not be contentful, while using an {{htmlelement("img")}} or {{svgelement("svg")}} for that color may be considered contentful.
 
 The types of paints considered contentful also differ slightly between metrics:
 


### PR DESCRIPTION
## Description

The Contentful paint glossary page wraps `svg` in the `HTMLElement` macro, which generates a link to `/en-US/docs/Web/HTML/Reference/Elements/svg`. That page doesn't exist — `<svg>` is documented at `/en-US/docs/Web/SVG/Reference/Element/svg`. The `SVGElement` macro produces the correct link.

The Viewport glossary page already uses this pattern in the same kind of sentence: `{{htmlelement("iframe")}}, {{svgelement("svg")}}, or {{htmlelement("object")}}`.

## Motivation

The link currently 404s.
