### PR TITLE
Update Marionette documentation links to their new location

### DIFF
--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -56,7 +56,7 @@ No notable changes
 
 - Updated the command `WebDriver:PerformAction` to no longer accept `undefined` as value for various parameters of the `pointerMove` and `wheel` actions ([Firefox bug 1781066](https://bugzil.la/1781066)).
 
-- Updated the [Selenium Atoms](https://firefox-source-docs.mozilla.org/testing/marionette/SeleniumAtoms.html) to match a recent WebDriver specification change ([Firefox bug 1771942](https://bugzil.la/1771942)).
+- Updated the [Selenium Atoms](https://firefox-source-docs.mozilla.org/remote/marionette/SeleniumAtoms.html) to match a recent WebDriver specification change ([Firefox bug 1771942](https://bugzil.la/1771942)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -65,7 +65,7 @@ Firefox 141 was released on [July 22, 2025](https://whattrainisitnow.com/release
 
 #### Marionette
 
-- To avoid unnecessary 200ms delays for each call to `WebDriver:ElementClick` - even when no navigation occurs - we lowered the click-and-wait timeout for a potential navigation to 50ms for backward compatibility. The [timeout is now also configurable](https://firefox-source-docs.mozilla.org/testing/marionette/Prefs.html#marionette-navigate-after-click-timeout) and [can be completely disabled](https://firefox-source-docs.mozilla.org/testing/marionette/Prefs.html#marionette-navigate-after-click-enabled) by users through a preference ([Firefox bug 1972271](https://bugzil.la/1972271)).
+- To avoid unnecessary 200ms delays for each call to `WebDriver:ElementClick` - even when no navigation occurs - we lowered the click-and-wait timeout for a potential navigation to 50ms for backward compatibility. The [timeout is now also configurable](https://firefox-source-docs.mozilla.org/remote/marionette/Prefs.html#marionette-navigate-after-click-timeout) and [can be completely disabled](https://firefox-source-docs.mozilla.org/remote/marionette/Prefs.html#marionette-navigate-after-click-enabled) by users through a preference ([Firefox bug 1972271](https://bugzil.la/1972271)).
 - Added support in Marionette for interacting with CHIPS cookies (Cookies Having Independent Partitioned State) ([Firefox bug 1972830](https://bugzil.la/1972830)).
 
 ## Changes for add-on developers

--- a/files/en-us/mozilla/firefox/releases/27/index.md
+++ b/files/en-us/mozilla/firefox/releases/27/index.md
@@ -87,4 +87,4 @@ _No change._
 
 ## See also
 
-- [List of changes](https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&component=Marionette&product=Testing&target_milestone=mozilla27) in [Marionette](https://firefox-source-docs.mozilla.org/testing/marionette/index.html) for Firefox 27.
+- [List of changes](https://bugzilla.mozilla.org/buglist.cgi?resolution=FIXED&component=Marionette&product=Testing&target_milestone=mozilla27) in [Marionette](https://firefox-source-docs.mozilla.org/remote/marionette/index.html) for Firefox 27.


### PR DESCRIPTION
## Description

The Marionette documentation moved from `firefox-source-docs.mozilla.org/testing/marionette/` to `/remote/marionette/`, and the old URLs now return a 301 to the new location. This updates the four affected links across three Firefox release notes pages.

Two of the links carry anchors (`#marionette-navigate-after-click-timeout` and `#marionette-navigate-after-click-enabled`); both still resolve on the new page.

## Motivation

The links currently redirect rather than resolving directly.
