### PR TITLE
docs: document baseVal value when viewBox attribute is unset

### DIFF
--- a/files/en-us/web/api/svganimatedrect/baseval/index.md
+++ b/files/en-us/web/api/svganimatedrect/baseval/index.md
@@ -16,6 +16,8 @@ This property reflects the SVG element's {{SVGAttr("viewBox")}} attribute value 
 
 A {{domxref("DOMRect")}} object representing the current non-animated value of the `viewBox` attribute.
 
+If the {{SVGAttr("viewBox")}} attribute is not set on the element, the value is a zero-initialized rectangle (`x`, `y`, `width`, and `height` all equal to `0`), as required by the SVG2 specification's [rules for reflecting an empty initial value](https://svgwg.org/svg2-draft/types.html#SVGObjectInitialization). Chrome returns such a zero rectangle in this case, but **Firefox returns `null` instead** ([bug 888307](https://bugzilla.mozilla.org/show_bug.cgi?id=888307), closed as "won't fix"). When no animation is applied, the same behavior applies to {{domxref("SVGAnimatedRect.animVal", "animVal")}}.
+
 ## Examples
 
 ```html
@@ -33,6 +35,16 @@ console.log(animatedRect.x); // 0
 console.log(animatedRect.y); // 0
 console.log(animatedRect.width); // 200
 console.log(animatedRect.height); // 100
+```
+
+When the `viewBox` attribute is not set, the value differs between browsers:
+
+```js
+const svg2 = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+const baseVal2 = svg2.viewBox.baseVal;
+console.log(baseVal2);
+// DOMRect {x: 0, y: 0, width: 0, height: 0} in Chrome
+// null in Firefox
 ```
 
 ## Specifications


### PR DESCRIPTION
{"title":"docs: document baseVal value when viewBox attribute is unset","head":"fufu1209:fix-svganimatedrect-baseval-unset","base":"main","body":"### Description\n\nAddresses #8907. The `SVGAnimatedRect.baseVal` page did not mention what happens when the `viewBox` attribute is **not set** on the element, which is a real cross-browser difference:\n\n- Per the [SVG2 spec](https://svgwg.org/svg2-draft/types.html#SVGObjectInitialization) (\"Reflecting an empty initial value\"), the value must be a zero-initialized rectangle (`x`, `y`, `width`, `height` all `0`).\n- Chrome returns such a `DOMRect` (verified locally with `document.createElementNS(...).viewBox.baseVal` -> `{x: 0, y: 0, width: 0, height: 0}`).\n- Firefox returns `null` instead — [bug 888307](https://bugzilla.mozilla.org/show_bug.cgi?id=888307) has been \"won't fix\" since 2013, so the divergence is long-standing and undocumented.\n\nChanges:\n- Added the unset-attribute behavior (with the spec link and the Firefox bug reference) to the **Value** section.\n- Added a short example demonstrating the difference.\n\n### Motivation\n\nDevelopers debugging SVG code that reads `viewBox.baseVal` hit this divergence with no documentation explaining it.\n\n### Related issues and pull requests\n\nFixes #8907\n"}
