### PR TITLE
Fix incorrect media feature name in @custom-media example

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@custom-media/index.md
+++ b/files/en-us/web/css/reference/at-rules/@custom-media/index.md
@@ -59,7 +59,7 @@ Because a `@custom-media` value is just a normal `<media-query-list>`, you can c
 The `not` operator negates an entire media condition. This is useful when you want a rule to apply only when a specific condition is `false`.
 
 ```css
-@custom-media --no-script not (script);
+@custom-media --no-script not (scripting);
 
 @media (--no-script) {
 }


### PR DESCRIPTION
### Description
Corrects an invalid CSS media feature name in the `@custom-media` example. The example used `not (script)`, but `script` is not a valid media feature, it should be `not (scripting)`.

### Additional details
See the [`scripting` media feature reference](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting) for the valid feature name and its accepted values.

### Related issues and pull requests
Fixes #45125