### PR TITLE
Fix incorrect sidebar group on Window pages

### DIFF
--- a/files/en-us/web/api/window/afterprint_event/index.md
+++ b/files/en-us/web/api/window/afterprint_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.afterprint_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`afterprint`** event is fired after the associated document has started printing or the print preview has been closed.
 

--- a/files/en-us/web/api/window/beforeprint_event/index.md
+++ b/files/en-us/web/api/window/beforeprint_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.beforeprint_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`beforeprint`** event is fired when the associated document is about to be printed or previewed for printing.
 

--- a/files/en-us/web/api/window/beforeunload_event/index.md
+++ b/files/en-us/web/api/window/beforeunload_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.beforeunload_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`beforeunload`** event is fired when the current window, contained document, and associated resources are about to be unloaded. The document is still visible and the event is still cancelable at this point.
 

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.blur
 ---
 
-{{APIRef}}{{deprecated_header}}
+{{APIRef("HTML DOM")}}{{deprecated_header}}
 
 The **`Window.blur()`** method does nothing.
 

--- a/files/en-us/web/api/window/blur_event/index.md
+++ b/files/en-us/web/api/window/blur_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.blur_event
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("UI Events")}}
 
 The **`blur`** event fires when an element has lost focus.
 

--- a/files/en-us/web/api/window/blur_event/index.md
+++ b/files/en-us/web/api/window/blur_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.blur_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`blur`** event fires when an element has lost focus.
 

--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.cancelAnimationFrame
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`window.cancelAnimationFrame()`** method cancels an
 animation frame request previously scheduled through a call to

--- a/files/en-us/web/api/window/captureevents/index.md
+++ b/files/en-us/web/api/window/captureevents/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.captureEvents
 ---
 
-{{APIRef}} {{Deprecated_Header}}
+{{APIRef("HTML DOM")}} {{Deprecated_Header}}
 
 The **`Window.captureEvents()`** method does nothing. Its original behavior has been removed from the specification, but the method itself has been retained so as not to break code that calls it.
 

--- a/files/en-us/web/api/window/close/index.md
+++ b/files/en-us/web/api/window/close/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.close
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`Window.close()`** method closes the current window, or
 the window on which it was called.

--- a/files/en-us/web/api/window/closed/index.md
+++ b/files/en-us/web/api/window/closed/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.closed
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`Window.closed`** read-only property indicates whether
 the referenced window is closed or not.

--- a/files/en-us/web/api/window/crossoriginisolated/index.md
+++ b/files/en-us/web/api/window/crossoriginisolated/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.crossOriginIsolated
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 The **`crossOriginIsolated`** read-only property of the {{domxref("Window")}} interface returns a boolean value that indicates whether the document is cross-origin isolated.
 

--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.devicePixelRatio
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`devicePixelRatio`** of {{domxref("Window")}} interface returns the ratio of the resolution in _physical pixels_ to the resolution in _CSS pixels_ for the current display device.
 

--- a/files/en-us/web/api/window/document/index.md
+++ b/files/en-us/web/api/window/document/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.document
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 **`window.document`** returns a reference to the [document](/en-US/docs/Web/API/Document) contained in the window.
 

--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.error_event
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("UI Events")}}
 
 The `error` event is fired on a {{domxref("Window")}} object when a resource failed to load or couldn't be used — for example if a script has an execution error.
 

--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.error_event
 ---
 
-{{APIRe("HTML DOM")}}
+{{APIRef("HTML DOM")}}
 
 The `error` event is fired on a {{domxref("Window")}} object when a resource failed to load or couldn't be used — for example if a script has an execution error.
 

--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.error_event
 ---
 
-{{APIRef}}
+{{APIRe("HTML DOM")}}
 
 The `error` event is fired on a {{domxref("Window")}} object when a resource failed to load or couldn't be used — for example if a script has an execution error.
 

--- a/files/en-us/web/api/window/external/index.md
+++ b/files/en-us/web/api/window/external/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.external
 ---
 
-{{APIRef}} {{deprecated_header}}
+{{APIRef("HTML DOM")}} {{deprecated_header}}
 
 The `external` property of the {{domxref("Window")}} API returns an instance of the `External` interface, which was intended to contain functions related to adding external search providers to the browser. However, this is now deprecated, and the contained methods are now dummy functions that do nothing as per spec.
 

--- a/files/en-us/web/api/window/focus/index.md
+++ b/files/en-us/web/api/window/focus/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.focus
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Makes a request to bring the window to the front. It may fail due to user settings and the window isn't guaranteed to be frontmost before this method returns.
 

--- a/files/en-us/web/api/window/focus_event/index.md
+++ b/files/en-us/web/api/window/focus_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.focus_event
 ---
 
-{{APIRef}}
+{{APIRef("UI Events")}}
 
 The **`focus`** event fires when an element has received focus.
 

--- a/files/en-us/web/api/window/frameelement/index.md
+++ b/files/en-us/web/api/window/frameelement/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.frameElement
 ---
 
-{{ApiRef}}
+{{ApiRef("HTML DOM")}}
 
 The **`Window.frameElement`** property
 returns the element (such as {{HTMLElement("iframe")}} or {{HTMLElement("object")}})

--- a/files/en-us/web/api/window/frames/index.md
+++ b/files/en-us/web/api/window/frames/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.frames
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 Returns the window itself, which is an array-like object, listing the direct sub-frames
 of the current window.

--- a/files/en-us/web/api/window/gamepadconnected_event/index.md
+++ b/files/en-us/web/api/window/gamepadconnected_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.gamepadconnected_event
 ---
 
-{{APIRef}}
+{{APIRef("Gamepad API")}}
 
 The `gamepadconnected` event is fired when the browser detects that a gamepad has been connected or the first time a button/axis of the gamepad is used.
 

--- a/files/en-us/web/api/window/gamepaddisconnected_event/index.md
+++ b/files/en-us/web/api/window/gamepaddisconnected_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.gamepaddisconnected_event
 ---
 
-{{APIRef}}
+{{APIRef("Gamepad API")}}
 
 The `gamepaddisconnected` event is fired when the browser detects that a gamepad has been disconnected.
 

--- a/files/en-us/web/api/window/hashchange_event/index.md
+++ b/files/en-us/web/api/window/hashchange_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.hashchange_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`hashchange`** event is fired when the fragment identifier of the URL has changed (the part of the URL beginning with and following the `#` symbol).
 

--- a/files/en-us/web/api/window/history/index.md
+++ b/files/en-us/web/api/window/history/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.history
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The `Window.history` read-only property returns a reference to the {{domxref("History")}} object, which provides an interface for manipulating the browser _session history_ (pages visited in the tab or frame that the current page is loaded in).
 

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.Window
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 The **`Window`** interface represents a window containing a {{glossary("DOM")}} document; the `document` property points to the [DOM document](/en-US/docs/Web/API/Document) loaded in that window.
 

--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.innerHeight
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The read-only **`innerHeight`** property of the
 {{domxref("Window")}} interface returns the interior height of the window in pixels,

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.innerWidth
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The read-only {{domxref("Window")}} property **`innerWidth`** returns the interior width of the window in pixels (that is, the width of the window's {{Glossary("layout viewport")}}). That includes the width of the vertical scroll bar, if one is present.
 

--- a/files/en-us/web/api/window/issecurecontext/index.md
+++ b/files/en-us/web/api/window/issecurecontext/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.isSecureContext
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 The **`isSecureContext`** read-only property of the {{domxref("Window")}} interface returns a boolean indicating whether the current [context is secure](/en-US/docs/Web/Security/Defenses/Secure_Contexts) (`true`) or not (`false`).
 

--- a/files/en-us/web/api/window/languagechange_event/index.md
+++ b/files/en-us/web/api/window/languagechange_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.languagechange_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`languagechange`** event is fired at the global scope object when the user's preferred language changes.
 

--- a/files/en-us/web/api/window/length/index.md
+++ b/files/en-us/web/api/window/length/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.length
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns the number of frames (either {{HTMLElement("frame")}} or
 {{HTMLElement("iframe")}} elements) in the window.

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.load_event
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("UI Events")}}
 
 The **`load`** event is fired when the whole page has loaded, including all dependent resources such as stylesheets, scripts (including async, deferred, and module scripts), iframes, and images, except those that are [loaded lazily](/en-US/docs/Web/Performance/Guides/Lazy_loading#images_iframes_videos_and_audio).
 This is in contrast to {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}}, which is fired as soon as the page DOM has been loaded, without waiting for resources to finish loading.

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.load_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`load`** event is fired when the whole page has loaded, including all dependent resources such as stylesheets, scripts (including async, deferred, and module scripts), iframes, and images, except those that are [loaded lazily](/en-US/docs/Web/Performance/Guides/Lazy_loading#images_iframes_videos_and_audio).
 This is in contrast to {{domxref("Document/DOMContentLoaded_event", "DOMContentLoaded")}}, which is fired as soon as the page DOM has been loaded, without waiting for resources to finish loading.

--- a/files/en-us/web/api/window/location/index.md
+++ b/files/en-us/web/api/window/location/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.location
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The read-only **`location`** property of the {{domxref("Window")}} interface returns a {{domxref("Location")}} object with information about the current location of the document.
 

--- a/files/en-us/web/api/window/locationbar/index.md
+++ b/files/en-us/web/api/window/locationbar/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.locationbar
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns the `locationbar` object.
 

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.matchMedia
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The {{domxref("Window")}} interface's **`matchMedia()`** method
 returns a new {{domxref("MediaQueryList")}} object that can then be used to determine if

--- a/files/en-us/web/api/window/menubar/index.md
+++ b/files/en-us/web/api/window/menubar/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.menubar
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns the `menubar` object.
 

--- a/files/en-us/web/api/window/message_event/index.md
+++ b/files/en-us/web/api/window/message_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.message_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The `message` event is fired on a {{domxref('Window')}} object when the window receives a message, for example from a call to [`Window.postMessage()`](/en-US/docs/Web/API/Window/postMessage) from another browsing context.
 

--- a/files/en-us/web/api/window/messageerror_event/index.md
+++ b/files/en-us/web/api/window/messageerror_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.messageerror_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The `messageerror` event is fired on a {{domxref('Window')}} object when it receives a message that can't be deserialized.
 

--- a/files/en-us/web/api/window/moveby/index.md
+++ b/files/en-us/web/api/window/moveby/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.moveBy
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`moveBy()`** method of the {{domxref("Window")}}
 interface moves the current window by a specified amount.

--- a/files/en-us/web/api/window/moveto/index.md
+++ b/files/en-us/web/api/window/moveto/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.moveTo
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`moveTo()`** method of the {{domxref("Window")}}
 interface moves the current window to the specified coordinates.

--- a/files/en-us/web/api/window/name/index.md
+++ b/files/en-us/web/api/window/name/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.name
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The `Window.name` property
 gets/sets the name of the window's browsing context.

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.navigator
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`Window.navigator`** read-only property returns a
 reference to the {{domxref("Navigator")}} object, which has methods and properties about

--- a/files/en-us/web/api/window/offline_event/index.md
+++ b/files/en-us/web/api/window/offline_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.offline_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`offline`** event of the {{domxref("Window")}} interface is fired when the browser has lost access to the network and the value of {{domxref("Navigator.onLine")}} switches to `false`.
 

--- a/files/en-us/web/api/window/online_event/index.md
+++ b/files/en-us/web/api/window/online_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.online_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`online`** event of the {{domxref("Window")}} interface is fired when the browser has gained access to the network and the value of {{domxref("Navigator.onLine")}} switches to `true`.
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.open
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`open()`** method of the [`Window`](/en-US/docs/Web/API/Window) interface loads a specified resource into a new or existing browsing context (that is, a tab, a window, or an [iframe](/en-US/docs/Web/HTML/Reference/Elements/iframe)) under a specified name.
 

--- a/files/en-us/web/api/window/origin/index.md
+++ b/files/en-us/web/api/window/origin/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.origin
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 The **`origin`** read-only property of the {{domxref("Window")}} interface returns the origin of the global scope, serialized as a string.
 

--- a/files/en-us/web/api/window/originagentcluster/index.md
+++ b/files/en-us/web/api/window/originagentcluster/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.originAgentCluster
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`originAgentCluster`** read-only property of the {{domxref("Window")}} interface returns `true` if this window belongs to an _origin-keyed [agent cluster](https://tc39.es/ecma262/#sec-agent-clusters)_: this means that the operating system has provided dedicated resources (for example an operating system process) to this window's origin that are not shared with windows from other origins.
 

--- a/files/en-us/web/api/window/outerheight/index.md
+++ b/files/en-us/web/api/window/outerheight/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.outerHeight
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`Window.outerHeight`** read-only property returns the height in pixels of the whole browser window, including any sidebar, window chrome, and window-resizing borders/handles.
 

--- a/files/en-us/web/api/window/outerwidth/index.md
+++ b/files/en-us/web/api/window/outerwidth/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.outerWidth
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 **`Window.outerWidth`** read-only property returns the width of the outside of the browser window. It represents the width of the whole browser window including sidebar (if expanded), window chrome and window resizing borders/handles.
 

--- a/files/en-us/web/api/window/parent/index.md
+++ b/files/en-us/web/api/window/parent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.parent
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`Window.parent`** property is a reference to the parent
 of the current window or subframe.

--- a/files/en-us/web/api/window/personalbar/index.md
+++ b/files/en-us/web/api/window/personalbar/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.personalbar
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns the `personalbar` object.
 

--- a/files/en-us/web/api/window/print/index.md
+++ b/files/en-us/web/api/window/print/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.print
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Opens the print dialog to print the current document.
 

--- a/files/en-us/web/api/window/releaseevents/index.md
+++ b/files/en-us/web/api/window/releaseevents/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.releaseEvents
 ---
 
-{{APIRef}}{{Deprecated_Header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}
 
 Releases the window from trapping events of a specific type.
 

--- a/files/en-us/web/api/window/reporterror/index.md
+++ b/files/en-us/web/api/window/reporterror/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.reportError
 ---
 
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 The **`reportError()`** method of the {{DOMxRef("Window")}} interface may be used to report errors to the console or event handlers of global scopes, emulating an uncaught JavaScript exception.
 

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.requestAnimationFrame
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`window.requestAnimationFrame()`** method tells the
 browser you wish to perform an animation. It requests the browser to call a

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.resize_event
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`resize`** event fires when the document view (window) has been resized.
 

--- a/files/en-us/web/api/window/resizeby/index.md
+++ b/files/en-us/web/api/window/resizeby/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.resizeBy
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`Window.resizeBy()`** method resizes the current window
 by a specified amount.

--- a/files/en-us/web/api/window/resizeto/index.md
+++ b/files/en-us/web/api/window/resizeto/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.resizeTo
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`Window.resizeTo()`** method dynamically resizes the
 window.

--- a/files/en-us/web/api/window/screenleft/index.md
+++ b/files/en-us/web/api/window/screenleft/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.screenLeft
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`Window.screenLeft`** read-only property returns the
 horizontal distance, in CSS pixels, from the left border of the user's browser viewport

--- a/files/en-us/web/api/window/screentop/index.md
+++ b/files/en-us/web/api/window/screentop/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.screenTop
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`Window.screenTop`** read-only property returns the
 vertical distance, in CSS pixels, from the top border of the user's browser viewport to

--- a/files/en-us/web/api/window/screenx/index.md
+++ b/files/en-us/web/api/window/screenx/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.screenX
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`Window.screenX`** read-only property returns the
 horizontal distance, in CSS pixels, of the left border of the user's browser viewport to

--- a/files/en-us/web/api/window/screeny/index.md
+++ b/files/en-us/web/api/window/screeny/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.screenY
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`Window.screenY`** read-only property returns the vertical distance, in CSS pixels, of the top border of the user's browser viewport to the top edge of the screen.
 

--- a/files/en-us/web/api/window/scroll/index.md
+++ b/files/en-us/web/api/window/scroll/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.scroll
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`scroll()`** method of the {{domxref("Window")}} interface scrolls the window to a particular place in the document.
 

--- a/files/en-us/web/api/window/scrollbars/index.md
+++ b/files/en-us/web/api/window/scrollbars/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.scrollbars
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns the `scrollbars` object.
 

--- a/files/en-us/web/api/window/scrollby/index.md
+++ b/files/en-us/web/api/window/scrollby/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.scrollBy
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`scrollBy()`** method of the {{domxref("Window")}} interface scrolls the document in the window by the given amount.
 

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.scrollTo
 ---
 
-{{APIRef}}
+{{APIRef("CSSOM view API")}}
 
 The **`scrollTo()`** method of the {{domxref("Window")}} interface scrolls to a particular set of coordinates in the document.
 

--- a/files/en-us/web/api/window/self/index.md
+++ b/files/en-us/web/api/window/self/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.self
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`Window.self`** read-only property returns the window itself, as a {{glossary("WindowProxy")}}. It can be used with dot notation on a `window` object (that is, `window.self`) or standalone (`self`). The advantage of the standalone notation is that a similar notation exists for non-window contexts, such as in {{domxref("Worker", "Web Workers", "", 1)}}. By using `self`, you can refer to the global scope in a way that will work not only in a window context (`self` will resolve to `window.self`) but also in a worker context (`self` will then resolve to {{domxref("WorkerGlobalScope.self")}}).
 

--- a/files/en-us/web/api/window/status/index.md
+++ b/files/en-us/web/api/window/status/index.md
@@ -8,7 +8,7 @@ status:
 browser-compat: api.Window.status
 ---
 
-{{APIRef}}{{Deprecated_Header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}
 
 The **`status`** property of the
 {{domxref("Window")}} interface was originally intended to set the text in the status

--- a/files/en-us/web/api/window/statusbar/index.md
+++ b/files/en-us/web/api/window/statusbar/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.statusbar
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns the `statusbar` object.
 

--- a/files/en-us/web/api/window/stop/index.md
+++ b/files/en-us/web/api/window/stop/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Window.stop
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`window.stop()`** stops further resource loading in the current
 browsing context, equivalent to the stop button in the browser.

--- a/files/en-us/web/api/window/storage_event/index.md
+++ b/files/en-us/web/api/window/storage_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.storage_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`storage`** event of the {{domxref("Window")}} interface fires when another document that shares the same storage area (either {{domxref("Window/localStorage", "localStorage")}} or {{domxref("Window/sessionStorage", "sessionStorage")}}) as the current window updates that storage area. The event is _not_ fired on the window that made the change.
 

--- a/files/en-us/web/api/window/toolbar/index.md
+++ b/files/en-us/web/api/window/toolbar/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.toolbar
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns the `toolbar` object.
 

--- a/files/en-us/web/api/window/top/index.md
+++ b/files/en-us/web/api/window/top/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.top
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 Returns a reference to the topmost window in the window hierarchy.
 

--- a/files/en-us/web/api/window/unload_event/index.md
+++ b/files/en-us/web/api/window/unload_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.unload_event
 ---
 
-{{APIRef("HTML DOM")}}
+{{APIRef("UI Events")}}
 
 > [!WARNING]
 > Developers should avoid using this event. See "Usage notes" below.

--- a/files/en-us/web/api/window/unload_event/index.md
+++ b/files/en-us/web/api/window/unload_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.Window.unload_event
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 > [!WARNING]
 > Developers should avoid using this event. See "Usage notes" below.

--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
@@ -9,7 +9,7 @@ status:
 browser-compat: api.Window.webkitConvertPointFromNodeToPage
 ---
 
-{{APIRef}}{{Non-standard_header}}{{Deprecated_Header}}
+{{APIRef("HTML DOM")}}{{Non-standard_header}}{{Deprecated_Header}}
 
 Given a {{domxref("WebKitPoint")}} specified in a particular DOM {{domxref("Node")}}'s coordinate system, the {{domxref("Window")}} method **`webkitConvertPointFromNodeToPage()`** returns a `Point` which specifies the same position in the page's coordinate system. This method is non-standard and _should not be used_.
 

--- a/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
@@ -9,7 +9,7 @@ status:
 browser-compat: api.Window.webkitConvertPointFromPageToNode
 ---
 
-{{APIRef}}{{Deprecated_Header}}{{Non-standard_header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 Given a {{domxref("WebKitPoint")}} specified in the page's coordinate system, the
 {{domxref("Window")}} method **`webkitConvertPointFromPageToNode()`**

--- a/files/en-us/web/api/window/window/index.md
+++ b/files/en-us/web/api/window/window/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.Window.window
 ---
 
-{{APIRef}}
+{{APIRef("HTML DOM")}}
 
 The **`window`** property of a {{domxref("Window")}} object points to the window object itself.
 

--- a/files/en-us/web/api/workerglobalscope/fonts/index.md
+++ b/files/en-us/web/api/workerglobalscope/fonts/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.WorkerGlobalScope.fonts
 ---
 
-{{APIRef("DOM")}}{{AvailableInWorkers("worker")}}
+{{APIRef("CSS Font Loading API")}}{{AvailableInWorkers("worker")}}
 
 The **`fonts`** property of the {{domxref("WorkerGlobalScope")}} interface returns the {{domxref("FontFaceSet")}} interface of the worker.
 

--- a/files/en-us/web/api/workerglobalscope/issecurecontext/index.md
+++ b/files/en-us/web/api/workerglobalscope/issecurecontext/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.isSecureContext
 ---
 
-{{APIRef("DOM")}}{{AvailableInWorkers("worker")}}
+{{APIRef("HTML DOM")}}{{AvailableInWorkers("worker")}}
 
 The **`isSecureContext`** read-only property of the {{domxref("WorkerGlobalScope")}} interface returns a boolean indicating whether the current [context is secure](/en-US/docs/Web/Security/Defenses/Secure_Contexts) (`true`) or not (`false`).
 

--- a/files/en-us/web/api/workerglobalscope/languagechange_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/languagechange_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.WorkerGlobalScope.languagechange_event
 ---
 
-{{APIRef("DOM")}}{{AvailableInWorkers("worker")}}
+{{APIRef("HTML DOM")}}{{AvailableInWorkers("worker")}}
 
 The **`languagechange`** event is fired at the global scope object when the user's preferred language changes.
 

--- a/files/en-us/web/api/workerglobalscope/rejectionhandled_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/rejectionhandled_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.WorkerGlobalScope.rejectionhandled_event
 ---
 
-{{APIRef("DOM")}}{{AvailableInWorkers("worker")}}
+{{APIRef("HTML DOM")}}{{AvailableInWorkers("worker")}}
 
 The **`rejectionhandled`** event is sent to the script's global scope (typically {{domxref("WorkerGlobalScope")}}) whenever a rejected {{jsxref("Promise")}} is handled late, i.e., when a handler is attached to the promise after its rejection had caused an {{domxref("WorkerGlobalScope.unhandledrejection_event", "unhandledrejection")}} event.
 

--- a/files/en-us/web/api/workerglobalscope/unhandledrejection_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/unhandledrejection_event/index.md
@@ -6,7 +6,7 @@ page-type: web-api-event
 browser-compat: api.WorkerGlobalScope.unhandledrejection_event
 ---
 
-{{APIRef("DOM")}}{{AvailableInWorkers("worker")}}
+{{APIRef("HTML DOM")}}{{AvailableInWorkers("worker")}}
 
 The **`unhandledrejection`** event is sent to the global scope (typically {{domxref("WorkerGlobalScope")}}) of a script when a {{jsxref("Promise")}} that has no rejection handler is rejected.
 


### PR DESCRIPTION
### Description
Changes the sidebar group macro on the `Window` page from `{{APIRef("DOM")}}` to `{{APIRef("HTML DOM")}}`, so the sidebar shows "HTML DOM API" instead of the misleading "Document Object Model (DOM)".

### Additional details
- [HTML Standard: the `Window` object](https://html.spec.whatwg.org/multipage/nav-history-apis.html#window)
- [DOM Standard interfaces list](https://dom.spec.whatwg.org/#interface-window) (does not include `Window`)

### Related issues and pull requests
Fixes #45123