### PR TITLE
docs: history APIs silently no-op on rate limiting per spec

### DIFF
--- a/files/en-us/web/api/history/back/index.md
+++ b/files/en-us/web/api/history/back/index.md
@@ -35,7 +35,10 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the associated document is not fully active. Browsers also throttle navigations and may throw this error, generate a warning, or ignore the call if it's called too frequently.
+  - : Thrown if the associated document is not fully active.
+
+> [!NOTE]
+> Calling `back()` too frequently may be blocked by the user agent. When blocked, the call is silently ignored — no exception is thrown. The exact rate limit is implementation-defined.
 
 ## Examples
 

--- a/files/en-us/web/api/history/forward/index.md
+++ b/files/en-us/web/api/history/forward/index.md
@@ -31,7 +31,10 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the associated document is not fully active. Browsers also throttle navigations and may throw this error, generate a warning, or ignore the call if it's called too frequently.
+  - : Thrown if the associated document is not fully active.
+
+> [!NOTE]
+> Calling `forward()` too frequently may be blocked by the user agent. When blocked, the call is silently ignored — no exception is thrown. The exact rate limit is implementation-defined.
 
 ## Examples
 

--- a/files/en-us/web/api/history/go/index.md
+++ b/files/en-us/web/api/history/go/index.md
@@ -38,7 +38,10 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the associated document is not fully active. Browsers also throttle navigations and may throw this error, generate a warning, or ignore the call if it's called too frequently.
+  - : Thrown if the associated document is not fully active.
+
+> [!NOTE]
+> Calling `go()` too frequently may be blocked by the user agent. When blocked, the call is silently ignored — no exception is thrown. The exact rate limit is implementation-defined.
 
 ## Examples
 

--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -51,9 +51,12 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the associated document is not fully active, or if the provided `url` parameter is not a valid URL, or if the method is called too frequently.
+  - : Thrown if the associated document is not fully active, or if the provided `url` parameter is not a valid URL.
 - `DataCloneError` {{domxref("DOMException")}}
   - : Thrown if the provided `state` parameter is not serializable.
+
+> [!NOTE]
+> Calling `pushState()` too frequently may be blocked by the user agent. When blocked, the call is silently ignored — no exception is thrown. The exact rate limit is implementation-defined.
 
 ## Description
 

--- a/files/en-us/web/api/history/replacestate/index.md
+++ b/files/en-us/web/api/history/replacestate/index.md
@@ -40,9 +40,12 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the associated document is not fully active, or if the provided `url` parameter is not a valid URL, or if the method is called too frequently.
+  - : Thrown if the associated document is not fully active, or if the provided `url` parameter is not a valid URL.
 - `DataCloneError` {{domxref("DOMException")}}
   - : Thrown if the provided `state` parameter is not serializable.
+
+> [!NOTE]
+> Calling `replaceState()` too frequently may be blocked by the user agent. When blocked, the call is silently ignored — no exception is thrown. The exact rate limit is implementation-defined.
 
 ## Examples
 


### PR DESCRIPTION
~~Fixes~~ #44477.

The History API pages claimed that `pushState()`, `replaceState()`, `back()`, `go()`, and `forward()` throw a `SecurityError` when called too frequently. Per whatwg/html#12492 (merged 2026-06-16), the spec changed: the navigable's "allowed to perform a navigation or history update" algorithm now returns `blocked` when the API is invoked too frequently, and the method silently returns instead of throwing.

I checked the current HTML spec before making this change: the shared history push/replace state steps and the delta traverse steps both consult the navigable's allowed-to-perform check and return on `blocked`. The remaining `SecurityError` cases (document not fully active, invalid/cross-origin URL) are unchanged.

Changes (5 pages):
- `History/pushState` and `History/replaceState`: removed "or if the method is called too frequently" from the `SecurityError` description; added a note that rate-limited calls are silently ignored, with the rate limit being implementation-defined.
- `History/back`, `History/go`, `History/forward`: removed the sentence about throwing/warning/ignoring on throttling; added the same note.

The pages described behavior that no longer matches the spec or current Chromium behavior, which misled developers who relied on catching a `SecurityError` to detect rate limiting.
