### PR TITLE
Fix typo: dependant to dependent in Translator measureInputUsage docs

### DIFF
--- a/files/en-us/web/api/translator/measureinputusage/index.md
+++ b/files/en-us/web/api/translator/measureinputusage/index.md
@@ -32,7 +32,7 @@ measureInputUsage(input, options)
 
 A {{jsxref("Promise")}} that fulfills with a number specifying the {{domxref("Translator.inputQuota", "inputQuota")}} usage of the given input text.
 
-This number is implementation-dependant; if it is less than the {{domxref("Translator.inputQuota", "inputQuota")}}, the string can be translated.
+This number is implementation-dependent; if it is less than the {{domxref("Translator.inputQuota", "inputQuota")}}, the string can be translated.
 
 ### Exceptions
 


### PR DESCRIPTION
## Summary

Fixes a typo in one MDN page by replacing $(System.Collections.Hashtable.old) with $(System.Collections.Hashtable.new).

## Why

Small editorial corrections improve clarity and consistency.
