### PR TITLE
Fix typo: dependant to dependent in Summarizer.create docs

### DIFF
--- a/files/en-us/web/api/summarizer/create_static/index.md
+++ b/files/en-us/web/api/summarizer/create_static/index.md
@@ -41,7 +41,7 @@ Summarizer.create(options)
     - `sharedContext`
       - : A {{domxref("Summarizer.sharedContext", "sharedContext")}} string describing the context the pieces of text to summarize are being used in, which helps the `Summarizer` generate more suitable summaries.
     - `signal`
-      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependant on when {{domxref("AbortController.abort()")}} is called:
+      - : An {{domxref("AbortSignal")}} object instance, which allows a `create()` operation to be aborted via the associated {{domxref("AbortController")}}. The exact effect is dependent on when {{domxref("AbortController.abort()")}} is called:
         - If `abort()` is called before the `create()` promise resolves, the `create()` operation is cancelled.
         - If `abort()` is called after the `create()` promise fulfills, it has the same effect as calling {{domxref("Summarizer.destroy()")}}: The resources assigned to the resulting `Summarizer` instance are released, and any ongoing and subsequent `Summarizer` method calls will reject with an `AbortError`.
     - `type`


### PR DESCRIPTION
## Summary

Fixes a typo in one MDN page.

## Why

Small editorial corrections improve clarity and consistency.
