### PR TITLE
docs(css): Improve contain: paint's clipping bounds description

### DIFF
--- a/files/en-us/web/css/reference/properties/contain/index.md
+++ b/files/en-us/web/css/reference/properties/contain/index.md
@@ -125,7 +125,7 @@ The keywords have the following meanings:
 - `style`
   - : For properties that can affect more than just an element and its descendants, the effects don't escape the containing element. Counters and quotes are scoped to the element and its contents.
 - `paint`
-  - : Descendants of the element don't display outside its bounds. If the containing box is offscreen, the browser does not need to paint its contained elements — these must also be offscreen as they are contained completely by that box. If a descendant overflows the containing element's bounds, then that descendant will be clipped to the containing element's border-box.
+  - : Descendants of the element don't display outside its bounds. If the containing box is offscreen, the browser does not need to paint its contained elements — these must also be offscreen as they are contained completely by that box. If a descendant overflows the containing element's bounds, then that descendant will be clipped to the containing element's overflow clip edge. By default, this edge corresponds to the padding-box for non-replaced elements.
 
 ## Description
 


### PR DESCRIPTION
### Description

Changes the previously inaccurate "border-box" to "overflow clip edge, which defaults to padding-box for non-replaced elements".

### Motivation

Makes the "contain" reference page more precise.

### Additional details

Does not mention the behavior of replaced elements, for which the overflow clip edge currently defaults to content-box, for two reasons:

1. It would make the description less concise.
2. The behavior is still being worked out (https://drafts.csswg.org/css-overflow-4/#overflow-clip-margin).

### Related issues and pull requests

Fixes #45101 