### PR TITLE
Update Firefox 154 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -69,11 +69,19 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Improved the handling of `deltaX` and `deltaY` properties for asynchronous widget wheel scroll events by taking the layout viewport into account. ([Firefox bug 1971979](https://bugzil.la/1971979)).
+- Fixed the bug when a navigation would resolve prematurely for subframes when calling `history.replaceState` or when navigating to an error page (e.g., blocked by X-Frame-Options). ([Firefox bug 2051908](https://bugzil.la/2051908)).
 
-<!-- #### Marionette -->
+#### WebDriver BiDi
+
+- Added a download id to `browsingContext.downloadWillBegin` and `browsingContext.downloadEnd` events to make it easier to identify which events belong to the same download. ([Firefox bug 2040936](https://bugzil.la/2040936)).
+- Added support for an `ignore` state for the `unhandledPromptBehavior` property for file pickers when creating a new session with the `session.new` command. With this state, file pickers will not be handled automatically by the protocol. ([Firefox bug 1999693](https://bugzil.la/1999693)).
+- Added a `userContext` field (a.k.a. Firefox container) to the payload of several WebDriver BiDi events and commands, which makes it easier to filter out incoming data for clients subscribing to events by user context id. ([Firefox bug 2018611](https://bugzil.la/2018611)).
+- Implemented the `browsingContext.startScreencast` and `browsingContext.stopScreencast` commands, which will record a browsing context and save the result as a video file. ([Firefox bug 2042671](https://bugzil.la/2042671)).
+- Updated the `emulation.setLocaleOverride` command to allow overriding the `Accept-Language` header for fetch and `WebSocket` requests in workers. ([Firefox bug 2052932](https://bugzil.la/2052932)).
+- Fixed the bug when the `script.realmDestroyed` event was missing for a worker after cross-process navigation. ([Firefox bug 2018154](https://bugzil.la/2018154)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -67,7 +67,7 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
 #### General
 

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -72,7 +72,7 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### General
 
 - Improved the handling of `deltaX` and `deltaY` properties for asynchronous widget wheel scroll events by taking the layout viewport into account. ([Firefox bug 1971979](https://bugzil.la/1971979)).
-- Fixed the bug when a navigation would resolve prematurely for subframes when calling `history.replaceState` or when navigating to an error page (e.g., blocked by X-Frame-Options). ([Firefox bug 2051908](https://bugzil.la/2051908)).
+- Fixed a bug where a navigation would resolve prematurely for subframes when calling `history.replaceState` or when navigating to an error page (e.g., blocked by X-Frame-Options). ([Firefox bug 2051908](https://bugzil.la/2051908)).
 
 #### WebDriver BiDi
 
@@ -81,7 +81,7 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - Added a `userContext` field (a.k.a. Firefox container) to the payload of several WebDriver BiDi events and commands, which makes it easier to filter out incoming data for clients subscribing to events by user context id. ([Firefox bug 2018611](https://bugzil.la/2018611)).
 - Implemented the `browsingContext.startScreencast` and `browsingContext.stopScreencast` commands, which will record a browsing context and save the result as a video file. ([Firefox bug 2042671](https://bugzil.la/2042671)).
 - Updated the `emulation.setLocaleOverride` command to allow overriding the `Accept-Language` header for fetch and `WebSocket` requests in workers. ([Firefox bug 2052932](https://bugzil.la/2052932)).
-- Fixed the bug when the `script.realmDestroyed` event was missing for a worker after cross-process navigation. ([Firefox bug 2018154](https://bugzil.la/2018154)).
+- Fixed a bug where the `script.realmDestroyed` event was missing for a worker after cross-process navigation. ([Firefox bug 2018154](https://bugzil.la/2018154)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Changes for WebDriver conformance for the Firefox 154 release are based on the [release-noteworthy bugs in this list](https://bugzilla.mozilla.org/buglist.cgi?status_whiteboard_type=allwordssubstr&v2=fixed&v1=fixed&status_whiteboard=%5Bwebdriver%3Arelnote%5D%20&o2=notequals&o1=equals&list_id=18077854&o3=notsubstring&query_format=advanced&v3=%5Bwptsync%20downstream%5D&columnlist=component%2Cresolution%2Cassigned_to%2Cshort_desc%2Cbug_type%2Cstatus_whiteboard&f3=status_whiteboard&resolution=FIXED&f1=cf_status_firefox154&component=Agent&component=Marionette&component=WebDriver%20BiDi&product=Remote%20Protocol&f2=cf_status_firefox153).