### PR TITLE
Fix issues with descriptions of BigInt.asIntN() and asUintN()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -41,7 +41,7 @@ BigInt.asIntN(bits, bigint)
 
 ### Return value
 
-The value of `bigint` modulo `2 ** bits`, as a signed integer.
+A BigInt containing the value of `bigint` expressed as a two's compliment integer, truncated to `bits` bits, and interpreted as a two's compliment integer.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asintn/index.md
@@ -41,7 +41,7 @@ BigInt.asIntN(bits, bigint)
 
 ### Return value
 
-A BigInt containing the value of `bigint` expressed as a two's compliment integer, truncated to `bits` bits, and interpreted as a two's compliment integer.
+A BigInt containing the bit representation of `bigint` truncated to `bits` bits, interpreted as a signed integer.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -41,7 +41,7 @@ BigInt.asUintN(bits, bigint)
 
 ### Return value
 
-A BigInt containing the value of `bigint` expressed as a two's compliment integer, truncated to `bits` bits, and interpreted as an unsigned integer.
+A BigInt containing the bit representation of `bigint` truncated to `bits` bits, interpreted as an unsigned integer.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -41,7 +41,7 @@ BigInt.asUintN(bits, bigint)
 
 ### Return value
 
-The value of `bigint` modulo 2<sup>`bits`</sup>, as a BigInt.
+A BigInt containing the value of `bigint` expressed as a two's compliment integer, truncated to `bits` bits, and interpreted as an unsigned integer.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/asuintn/index.md
@@ -41,7 +41,7 @@ BigInt.asUintN(bits, bigint)
 
 ### Return value
 
-The value of `bigint` modulo `2 ** bits`, as an unsigned integer.
+The value of `bigint` modulo 2<sup>`bits`</sup>, as a BigInt.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -251,9 +251,9 @@ Note that built-in operations expecting BigInts often truncate the BigInt to a f
 ## Static methods
 
 - {{jsxref("BigInt.asIntN()")}}
-  - : Truncates a BigInt value to a specified number of bits, interpreted as a signed integer value, and returns that value as a BigInt.
+  - : Truncates a `BigInt` value to the given number of least significant bits and returns that value as a signed integer.
 - {{jsxref("BigInt.asUintN()")}}
-  - : Truncates a BigInt value to a specified number of bits, interpreted as an unsigned integer value, and returns that value as a BigInt.
+  - : Truncates a `BigInt` value to the given number of least significant bits and returns that value as an unsigned integer.
 
 ## Instance properties
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -251,9 +251,9 @@ Note that built-in operations expecting BigInts often truncate the BigInt to a f
 ## Static methods
 
 - {{jsxref("BigInt.asIntN()")}}
-  - : Clamps a BigInt value to a signed integer value, and returns that value.
+  - : Truncates a BigInt value to a specified number of bits, interpreted as a signed integer value, and returns that value as a BigInt.
 - {{jsxref("BigInt.asUintN()")}}
-  - : Clamps a BigInt value to an unsigned integer value, and returns that value.
+  - : Truncates a BigInt value to a specified number of bits, interpreted as an unsigned integer value, and returns that value as a BigInt.
 
 ## Instance properties
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
These descriptions were inaccurate in various ways, describing the behaviour of these functions as "clamping", and that `asIntN()` gave the value modulo 2^bits.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.asintn

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
