### PR TITLE
Normalize fill values and macro casing in SVG docs

### DIFF
--- a/files/en-us/web/svg/reference/attribute/fr/index.md
+++ b/files/en-us/web/svg/reference/attribute/fr/index.md
@@ -99,13 +99,7 @@ This example has `fr` equal to `5%` and is representing how the attributes `fx` 
     stroke="black"
     stroke-width="2" />
 
-  <circle
-    cx="60"
-    cy="60"
-    r="50"
-    fill="transparent"
-    stroke="white"
-    stroke-width="2" />
+  <circle cx="60" cy="60" r="50" fill="none" stroke="white" stroke-width="2" />
   <circle cx="45" cy="45" r="2" fill="white" stroke="white" />
   <circle cx="60" cy="60" r="2" fill="white" stroke="white" />
   <text x="38" y="40" fill="white" font-family="sans-serif" font-size="10pt">

--- a/files/en-us/web/svg/reference/attribute/fy/index.md
+++ b/files/en-us/web/svg/reference/attribute/fy/index.md
@@ -91,13 +91,7 @@ svg {
     stroke="black"
     stroke-width="2" />
 
-  <circle
-    cx="60"
-    cy="60"
-    r="50"
-    fill="transparent"
-    stroke="white"
-    stroke-width="2" />
+  <circle cx="60" cy="60" r="50" fill="none" stroke="white" stroke-width="2" />
   <circle cx="35" cy="35" r="2" fill="white" stroke="white" />
   <circle cx="60" cy="60" r="2" fill="white" stroke="white" />
   <text x="38" y="40" fill="white" font-family="sans-serif" font-size="10pt">

--- a/files/en-us/web/svg/reference/attribute/index.md
+++ b/files/en-us/web/svg/reference/attribute/index.md
@@ -272,7 +272,7 @@ Below is a list of all of the attributes available in SVG, along with links to r
 - {{SVGAttr("xChannelSelector")}}
 - {{SVGAttr("xlink:actuate")}}
 - {{SVGAttr("xlink:arcrole")}}
-- {{SVGAttr("xlink:href")}}{{deprecated_inline}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
 - {{SVGAttr("xlink:role")}}
 - {{SVGAttr("xlink:show")}}
 - {{SVGAttr("xlink:title")}}

--- a/files/en-us/web/svg/reference/attribute/side/index.md
+++ b/files/en-us/web/svg/reference/attribute/side/index.md
@@ -48,20 +48,8 @@ text {
     <textPath href="#circle2" side="right">Text on right of path</textPath>
   </text>
 
-  <circle
-    id="circle1"
-    cx="100"
-    cy="100"
-    r="70"
-    fill="transparent"
-    stroke="silver" />
-  <circle
-    id="circle2"
-    cx="320"
-    cy="100"
-    r="70"
-    fill="transparent"
-    stroke="silver" />
+  <circle id="circle1" cx="100" cy="100" r="70" fill="none" stroke="silver" />
+  <circle id="circle2" cx="320" cy="100" r="70" fill="none" stroke="silver" />
 </svg>
 ```
 

--- a/files/en-us/web/svg/reference/attribute/visibility/index.md
+++ b/files/en-us/web/svg/reference/attribute/visibility/index.md
@@ -87,7 +87,7 @@ svg {
     height="100"
     stroke="black"
     stroke-width="5"
-    fill="transparent" />
+    fill="none" />
   <g stroke="seagreen" stroke-width="5" fill="skyblue">
     <rect x="20" y="20" width="80" height="80" visibility="visible" />
     <rect x="120" y="20" width="80" height="80" visibility="hidden" />

--- a/files/en-us/web/svg/reference/element/image/index.md
+++ b/files/en-us/web/svg/reference/element/image/index.md
@@ -56,7 +56,7 @@ SVG files displayed with `<image>` are [treated as an image](/en-US/docs/Web/SVG
       - : Doesn't set a preference for the fetch priority.
         It is used if no value or an invalid value is set.
         This is the default.
-- {{SVGAttr("xlink:href")}}{{deprecated_inline}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : Points at a URL for the image file.
     _Value type_: **[\<URL>](/en-US/docs/Web/SVG/Guides/Content_type#url)**; _Default value_: _none_; _Animatable_: **no**
 

--- a/files/en-us/web/svg/reference/element/use/index.md
+++ b/files/en-us/web/svg/reference/element/use/index.md
@@ -11,13 +11,13 @@ The effect is the same as if the nodes were deeply cloned into a non-exposed DOM
 
 ## Usage context
 
-{{SVGInfo}}
+{{svginfo}}
 
 ## Attributes
 
 - {{SVGAttr("href")}}
   - : The URL to an element/fragment that needs to be duplicated. See [Usage notes](#usage_notes) for details on common pitfalls.<br/> _Value type_: [**`<URL>`**](/en-US/docs/Web/SVG/Guides/Content_type#url); _Default value_: none; _Animatable_: **yes**
-- {{SVGAttr("xlink:href")}} {{Deprecated_Inline}}
+- {{SVGAttr("xlink:href")}} {{deprecated_inline}}
   - : An [`<IRI>`](/en-US/docs/Web/SVG/Guides/Content_type#iri) reference to an element/fragment that needs to be duplicated. If both {{SVGAttr("href")}} and {{SVGAttr("xlink:href")}} are present, the value given by {{SVGAttr("href")}} is used.<br/> _Value type_: [**`<IRI>`**](/en-US/docs/Web/SVG/Guides/Content_type#iri); _Default value_: none; _Animatable_: **yes**
     > [!WARNING]
     > Since SVG 2, the {{SVGAttr("xlink:href")}} attribute is deprecated in favor of {{SVGAttr("href")}}. See {{SVGAttr("xlink:href")}} page for more information.

--- a/files/en-us/web/svg/reference/element/view/index.md
+++ b/files/en-us/web/svg/reference/element/view/index.md
@@ -20,7 +20,7 @@ The **`<view>`** [SVG](/en-US/docs/Web/SVG) element defines a particular view of
 - {{SVGAttr("viewBox")}}
   - : This attribute defines the bound of the SVG viewport for the pattern fragment.
     _Value type_: **[\<list-of-numbers>](/en-US/docs/Web/SVG/Guides/Content_type#list-of-ts)**; _Default value_: none; _Animatable_: **yes**
-- {{SVGAttr("zoomAndPan")}} {{Deprecated_Inline}}
+- {{SVGAttr("zoomAndPan")}} {{deprecated_inline}}
   - : This attribute specifies whether the SVG document can be magnified and panned.
     _Value type_: **disable | magnify**; _Default value_: magnify; _Animatable_: **no**
 

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/basic_shapes/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/basic_shapes/index.md
@@ -18,18 +18,18 @@ The code to generate that image looks something like this:
 ```xml
 <svg width="200" height="250" xmlns="http://www.w3.org/2000/svg">
 
-  <rect x="10" y="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>
-  <rect x="60" y="10" rx="10" ry="10" width="30" height="30" stroke="black" fill="transparent" stroke-width="5"/>
+  <rect x="10" y="10" width="30" height="30" stroke="black" fill="none" stroke-width="5"/>
+  <rect x="60" y="10" rx="10" ry="10" width="30" height="30" stroke="black" fill="none" stroke-width="5"/>
 
-  <circle cx="25" cy="75" r="20" stroke="red" fill="transparent" stroke-width="5"/>
-  <ellipse cx="75" cy="75" rx="20" ry="5" stroke="red" fill="transparent" stroke-width="5"/>
+  <circle cx="25" cy="75" r="20" stroke="red" fill="none" stroke-width="5"/>
+  <ellipse cx="75" cy="75" rx="20" ry="5" stroke="red" fill="none" stroke-width="5"/>
 
   <line x1="10" x2="50" y1="110" y2="150" stroke="orange" stroke-width="5"/>
   <polyline points="60 110 65 120 70 115 75 130 80 125 85 140 90 135 95 150 100 145"
-      stroke="orange" fill="transparent" stroke-width="5"/>
+      stroke="orange" fill="none" stroke-width="5"/>
 
   <polygon points="50 160 55 180 70 180 60 190 65 205 50 195 35 205 40 190 30 180 45 180"
-      stroke="green" fill="transparent" stroke-width="5"/>
+      stroke="green" fill="none" stroke-width="5"/>
 
   <path d="M20,230 Q40,205 50,230 T90,230" fill="none" stroke="blue" stroke-width="5"/>
 </svg>

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/gradients/index.md
@@ -167,13 +167,7 @@ The second point is called the focal point and is defined by the `fx` and `fy` a
     stroke="black"
     stroke-width="2" />
 
-  <circle
-    cx="60"
-    cy="60"
-    r="50"
-    fill="transparent"
-    stroke="white"
-    stroke-width="2" />
+  <circle cx="60" cy="60" r="50" fill="none" stroke="white" stroke-width="2" />
   <circle cx="35" cy="35" r="2" fill="white" stroke="white" />
   <circle cx="60" cy="60" r="2" fill="white" stroke="white" />
   <text x="38" y="40" fill="white" font-family="sans-serif" font-size="10pt">

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/paths/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/paths/index.md
@@ -133,13 +133,13 @@ z
 So our path above could be shortened to:
 
 ```xml
-<path d="M 10 10 H 90 V 90 H 10 Z" fill="transparent" stroke="black" />
+<path d="M 10 10 H 90 V 90 H 10 Z" fill="none" stroke="black" />
 ```
 
 The relative forms of these commands can also be used to draw the same picture. Relative commands are called by using lowercase letters, and rather than moving the cursor to an exact coordinate, they move it relative to its last position. For instance, since our rectangle is 80×80, the `<path>` element could have been written as:
 
 ```xml
-<path d="M 10 10 h 80 v 80 h -80 Z" fill="transparent" stroke="black" />
+<path d="M 10 10 h 80 v 80 h -80 Z" fill="none" stroke="black" />
 ```
 
 The path will move to point (`10`, `10`) and then move horizontally 80 points to the right, then 80 points down, then 80 points to the left, and then back to the start.
@@ -164,30 +164,15 @@ The last set of coordinates here (`x`, `y`) specify where the line should end. T
 
 ```html live-sample___cubic_bezier_curves
 <svg width="190" height="160" xmlns="http://www.w3.org/2000/svg">
-  <path d="M 10 10 C 20 20, 40 20, 50 10" stroke="black" fill="transparent" />
-  <path d="M 70 10 C 70 20, 110 20, 110 10" stroke="black" fill="transparent" />
-  <path
-    d="M 130 10 C 120 20, 180 20, 170 10"
-    stroke="black"
-    fill="transparent" />
-  <path d="M 10 60 C 20 80, 40 80, 50 60" stroke="black" fill="transparent" />
-  <path d="M 70 60 C 70 80, 110 80, 110 60" stroke="black" fill="transparent" />
-  <path
-    d="M 130 60 C 120 80, 180 80, 170 60"
-    stroke="black"
-    fill="transparent" />
-  <path
-    d="M 10 110 C 20 140, 40 140, 50 110"
-    stroke="black"
-    fill="transparent" />
-  <path
-    d="M 70 110 C 70 140, 110 140, 110 110"
-    stroke="black"
-    fill="transparent" />
-  <path
-    d="M 130 110 C 120 140, 180 140, 170 110"
-    stroke="black"
-    fill="transparent" />
+  <path d="M 10 10 C 20 20, 40 20, 50 10" stroke="black" fill="none" />
+  <path d="M 70 10 C 70 20, 110 20, 110 10" stroke="black" fill="none" />
+  <path d="M 130 10 C 120 20, 180 20, 170 10" stroke="black" fill="none" />
+  <path d="M 10 60 C 20 80, 40 80, 50 60" stroke="black" fill="none" />
+  <path d="M 70 60 C 70 80, 110 80, 110 60" stroke="black" fill="none" />
+  <path d="M 130 60 C 120 80, 180 80, 170 60" stroke="black" fill="none" />
+  <path d="M 10 110 C 20 140, 40 140, 50 110" stroke="black" fill="none" />
+  <path d="M 70 110 C 70 140, 110 140, 110 110" stroke="black" fill="none" />
+  <path d="M 130 110 C 120 140, 180 140, 170 110" stroke="black" fill="none" />
 </svg>
 ```
 
@@ -276,7 +261,7 @@ An example of this syntax is shown below, and in the figure to the left the spec
   <path
     d="M 10 80 C 40 10, 65 10, 95 80 S 150 150, 180 80"
     stroke="black"
-    fill="transparent" />
+    fill="none" />
 </svg>
 ```
 
@@ -329,7 +314,7 @@ q dx1 dy1, dx dy
 
 ```html live-sample___quadratic_bezier
 <svg width="190" height="160" xmlns="http://www.w3.org/2000/svg">
-  <path d="M 10 80 Q 95 10 180 80" stroke="black" fill="transparent" />
+  <path d="M 10 80 Q 95 10 180 80" stroke="black" fill="none" />
 </svg>
 ```
 
@@ -377,10 +362,7 @@ This only works if the previous command was a `Q` or a `T` command. If not, then
 
 ```html live-sample___shortcut_quadratic_bezier
 <svg width="190" height="160" xmlns="http://www.w3.org/2000/svg">
-  <path
-    d="M 10 80 Q 52.5 10, 95 80 T 180 80"
-    stroke="black"
-    fill="transparent" />
+  <path d="M 10 80 Q 52.5 10, 95 80 T 180 80" stroke="black" fill="none" />
 </svg>
 ```
 
@@ -524,14 +506,14 @@ For the unrotated ellipse in the image above, there are only two different arcs 
       cy="229.512"
       rx="36"
       ry="60"
-      fill="transparent"
+      fill="none"
       stroke="red" />
     <ellipse
       cx="115.779"
       cy="155.778"
       rx="36"
       ry="60"
-      fill="transparent"
+      fill="none"
       stroke="red" />
   </g>
 </svg>

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/texts/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/texts/index.md
@@ -71,7 +71,7 @@ This element fetches via its `href` attribute an arbitrary path and aligns the c
 
 ```html
 <svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
-  <path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="transparent" />
+  <path id="my_path" d="M 20,20 C 80,60 100,40 120,20" fill="none" />
   <text>
     <textPath href="#my_path">A curve.</textPath>
   </text>


### PR DESCRIPTION
### Description

- `fill="transparent"` -> `fill="none"`
- `{{Deprecated_Inline}}` -> `{{deprecated_inline}}`

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852