### PR TITLE
fix: (Element.prefix) value can be a string or null

### DIFF
--- a/files/en-us/web/api/element/prefix/index.md
+++ b/files/en-us/web/api/element/prefix/index.md
@@ -14,7 +14,7 @@ specified.
 
 ## Value
 
-A string.
+A string or `null`.
 
 ## Examples
 


### PR DESCRIPTION
### Description

The value of `Element.prefix` can not only be a string but also `null`.

### Motivation

Provide accurate and eye-catching information.

### Additional details

None.

### Related issues and pull requests

None.