### PR TITLE
docs: add alarms.clearAll() return value Safari exception

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -22,7 +22,10 @@ None.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a boolean. This will be `true` if any alarms were cleared, `false` otherwise. Note that Chrome always passes `true` here.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with a boolean. This is `true` if any alarms were cleared, `false` otherwise.
+
+> [!NOTE]
+> Chrome always passes `true` and Safari `undefined`. The return type is subject to change and may always return `undefined` for all browsers in the future. It is best to not rely on the return type.
 
 ## Examples
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/45149

### Description

This PR adds the return type Safari exception to the return type section.

### Motivation

To help developers handle edge cases.

### Additional details

Return type discussion in WECG:
https://github.com/w3c/webextensions/issues/1055

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/45149

@kiaraarose @xeenon FYI