### PR TITLE
docs: add DNS over HTTPS glossary entry

### DIFF
--- a/files/en-us/glossary/dns_over_https/index.md
+++ b/files/en-us/glossary/dns_over_https/index.md
@@ -1,0 +1,19 @@
+---
+title: DNS over HTTPS (DoH)
+slug: Glossary/DNS_over_HTTPS
+page-type: glossary-definition
+sidebar: glossarysidebar
+---
+
+**DNS over HTTPS** (**DoH**) is a protocol for performing {{Glossary("DNS")}} resolution over an encrypted {{Glossary("HTTPS")}} connection. Instead of sending queries and responses as plain text, DoH carries them inside HTTPS requests, which prevents on-path parties from reading or modifying the domain names a client looks up.
+
+Traditional DNS traffic is unencrypted, so network operators and other observers can see which hostnames a user resolves and can tamper with the answers. By encrypting this traffic and reusing the standard HTTPS port (443), DoH improves the privacy and integrity of name resolution and makes DNS queries harder to single out from other web traffic.
+
+## See also
+
+- {{RFC(8484, "DNS Queries over HTTPS (DoH)")}}
+- [DNS over HTTPS](https://en.wikipedia.org/wiki/DNS_over_HTTPS) on Wikipedia
+- Related glossary terms:
+  - {{glossary("DNS")}}
+  - {{glossary("HTTPS")}}
+  - {{glossary("TLS")}}


### PR DESCRIPTION
### Description
  
Adds a new Glossary entry for DNS over HTTPS (DoH) at Glossary/DNS_over_HTTPS defining the term and its purpose in two short paragraphs.
  
### Motivation
  
The glossary had no entry for DoH, so readers encountering the term in MDN content had nowhere to look it up. This fills that gap with a concise, original definition that links to related glossary terms.
  
### Additional details
  
Primary technical source is RFC 8484 ("DNS Queries over HTTPS (DoH)"), cited via the {{RFC}} macro, consistent with the existing HTTPS RR entry. Structure, front matter, and See-also formatting follow neighboring glossary entries (DNS, HTTPS, HTTPS RR) and the "How to add a glossary entry" guide.
  
### Related issues and pull requests
  
Fixes #45120
