### PR TITLE
docs(firefox): add relnote for JSON viewer breadcrumb path

### DIFF
--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -16,7 +16,10 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Changes for web developers
 
-<!-- ### Developer Tools -->
+### Developer Tools
+
+- The [JSON viewer](https://firefox-source-docs.mozilla.org/devtools-user/json_viewer/index.html) now shows a breadcrumb path at the bottom of the panel indicating the location of the selected entry within the JSON structure.
+  ([Firefox bug 1850288](https://bugzil.la/1850288)).
 
 <!-- ### HTML -->
 


### PR DESCRIPTION
### Description

Adds a Developer Tools entry to the Firefox 154 release notes documenting the new JSON viewer breadcrumb path, which shows the location of the selected entry at the bottom of the panel.

### Motivation

The JSON viewer breadcrumb path shipped enabled in Firefox 154 (marked `dev-doc-needed`) but had no release note. This gives readers following the notes a pointer to the new behavior and its Bugzilla tracking bug.

### Additional details

- Firefox source docs — JSON viewer: https://firefox-source-docs.mozilla.org/devtools-user/json_viewer/index.html
- Gecko bug: https://bugzil.la/1850288

This PR covers the release note only. The Firefox DevTools reference  documentation lives in the separate  [firefox-source-docs](https://firefox-source-docs.mozilla.org/devtools-user/) repository, so the JSON viewer reference page itself is out of scope here.

### Related issues and pull requests

Fixes #45024
