### PR TITLE
Fix incorrect WebM MIME type in noembed example

### DIFF
--- a/files/en-us/web/html/reference/elements/noembed/index.md
+++ b/files/en-us/web/html/reference/elements/noembed/index.md
@@ -24,7 +24,7 @@ The message inside `<noembed>` tag will appear only when your browser does not s
 
 ```html
 <embed
-  type="vide/webm"
+  type="video/webm"
   src="/media/examples/flower.mp4"
   width="200"
   height="200" />


### PR DESCRIPTION
## Summary

Corrects the malformed `vide/webm` MIME type in the `<embed>` example on the `<noembed>` documentation page.

The MIME type is corrected from `vide/webm` to `video/webm`.

## Test plan

- Verified the change is limited to the MIME type in the example.
- Ran the relevant repository validation checks.