### PR TITLE
Fix `HTMLOutputElement.htmlFor` code example

### DIFF
--- a/files/en-us/web/api/htmloutputelement/htmlfor/index.md
+++ b/files/en-us/web/api/htmloutputelement/htmlfor/index.md
@@ -20,7 +20,7 @@ Although the `htmlFor` property itself is read-only in the sense that you can't 
 
 ```js
 const outputElem = document.getElementById("result");
-for (const id of outputElem.htmlFor.split(" ")) {
+for (const id of outputElem.htmlFor) {
   const elem = document.getElementById(id);
   elem.style.outline = "2px solid red";
 }

--- a/files/en-us/web/api/htmlscriptelement/blocking/index.md
+++ b/files/en-us/web/api/htmlscriptelement/blocking/index.md
@@ -24,7 +24,7 @@ Although the `blocking` property itself is read-only in the sense that you can't
 
 ```js
 const el = document.getElementById("el");
-console.log(el.blocking); // Output: "render"
+console.log(el.blocking); // Output: DOMTokenList ["render"]
 ```
 
 ## Specifications


### PR DESCRIPTION

### Description

Fixed the example code that wasn't working.

### Motivation

The `htmlFor` property is of type `DOMTokenList` and cannot be split using `split()`.

### Additional details

[HTML Spec](https://html.spec.whatwg.org/multipage/form-elements.html#dom-output-htmlfor)

### Related issues and pull requests

Since this was a minor fix, there are no issues.
