### PR TITLE
Fix stacking context hierarchy diagram (remove non-context)

### DIFF
--- a/files/en-us/web/css/guides/positioned_layout/stacking_context/index.md
+++ b/files/en-us/web/css/guides/positioned_layout/stacking_context/index.md
@@ -202,7 +202,6 @@ Root
 └── ARTICLE #3
   │
   ├── SECTION #4
-  ├────  ARTICLE #3 content
   ├── SECTION #5
   └── SECTION #6
 ```


### PR DESCRIPTION
## Summary

- Removes `ARTICLE #3 content` from the stacking context hierarchy diagram on the Stacking context guide.
- That node is not a stacking context: it has the default `position: static` and `z-index: auto`, so it should not appear in the hierarchy of stacking contexts.
- Aligns the diagram with CSS stacking rules and with the discussion on the issue (including maintainer confirmation).

Fixes #42705

## Test plan

- [ ] Confirm the hierarchy diagram under “The hierarchy of stacking contexts in the above example is as follows:” no longer lists `ARTICLE #3 content`.
- [ ] Confirm ARTICLE #3 and SECTION #4–#6 remain listed as stacking contexts.
- [ ] Spot-check that the surrounding explanation still matches the corrected diagram.