### PR TITLE
Enterprise policy concept page

### DIFF
--- a/.vscode/dictionaries/terms-abbreviations.txt
+++ b/.vscode/dictionaries/terms-abbreviations.txt
@@ -241,6 +241,7 @@ focusability
 fontface
 fontfaces
 footguns
+Forcelist
 forgeable
 FOUC
 Fourway

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/managed/index.md
@@ -10,11 +10,9 @@ A {{WebExtAPIRef("storage.StorageArea")}} object that represents the `managed` s
 
 ## Provisioning managed storage
 
-The procedure for provisioning managed storage varies between browsers. For Chrome instructions, see the ["Manifest for storage areas"](https://developer.chrome.com/docs/extensions/reference/manifest/storage) article.
+The procedure for provisioning managed storage varies by browser and is supported only by Firefox and Chrome. See [Enterprise policies and extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies) for a comparison and links to each browser's documentation.
 
-For Firefox, you need to create a [JSON manifest (native manifest) file in a specific format and location](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or use the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty).
-
-Here's an example native manifest:
+Here's an example using a Firefox native [managed storage manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests):
 
 ```json
 {
@@ -27,7 +25,7 @@ Here's an example native manifest:
 }
 ```
 
-Given this manifest, the [favourite-colour](https://github.com/mdn/webextensions-examples/tree/main/favourite-colour) extension could access the data using code like this:
+Given this manifest, the [favourite-colour](https://github.com/mdn/webextensions-examples/tree/main/favourite-colour) extension can access the data using code like this:
 
 ```js
 let storageItem = browser.storage.managed.get("colour");

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -15,7 +15,7 @@ Fired when {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}}, {{WebE
 > In Firefox, the listener receives all the keys from a storage area where {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} executes. The listener may be invoked when there is no change to the data. To find details of the changed items, examine each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
 
 > [!NOTE]
-> Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup (from the [JSON manifest (native manifest) file](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty)).
+> Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup. See [Enterprise policies and extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies) for information on how managed storage is provisioned.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/get/index.md
@@ -34,7 +34,7 @@ If the operation fails, the promise is rejected with an error message.
 If managed storage is not set, `undefined` is returned.
 
 > [!WARNING]
-> In Firefox, if an extension's managed storage has not been configured with a [native manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or using the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)).
+> In Firefox, if an extension's managed storage has not been configured (see [Enterprise policies and extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies)), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getkeys/index.md
@@ -29,7 +29,7 @@ If the operation fails, the promise is rejected with an error message.
 If managed storage is not set, `undefined` is returned.
 
 > [!WARNING]
-> In Firefox, if an extension's managed storage has not been configured with a [native manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or using the [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error. This issue is related to the lack of support for the [`storage.managed_schema`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key (see [Firefox bug 1771731](https://bugzil.la/1771731)).
+> In Firefox, if an extension's managed storage has not been configured (see [Enterprise policies and extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies)), an exception is thrown when using this function to access managed storage (see [Firefox bug 1868153](https://bugzil.la/1868153)). This issue can be avoided by catching the error.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -12,7 +12,7 @@ Fires when one or more items in a storage area change. Compared to {{WebExtAPIRe
 > In Firefox, the listener receives all the keys from a storage area where {{WebExtAPIRef('storage.StorageArea.set','storageArea.set')}} executes. The listener may also be invoked when there is no change to the data. To find details of the changed items, examine each key's {{WebExtAPIRef('storage.StorageChange')}} object. See [Firefox bug 1833153](https://bugzil.la/1833153).
 
 > [!NOTE]
-> Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup (from the [JSON manifest (native manifest) file](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) or [`3rdparty` enterprise policy](https://mozilla.github.io/policy-templates/#3rdparty)).
+> Firefox does not fire this event for changes to `storage.managed` because managed storage is only read on browser startup. See [Enterprise policies and extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies) for information on how managed storage is provisioned.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -68,7 +68,7 @@ Other browsers have similar restrictions over the websites extensions can be ins
 > [!NOTE]
 > Because these restrictions include addons.mozilla.org, users who try to use your extension immediately after installation may find that it doesn't work. To avoid this, you should add an appropriate warning or an [onboarding page](https://extensionworkshop.com/documentation/develop/onboard-upboard-offboard-users/) to move users away from `addons.mozilla.org`.
 
-The set of domains can be restricted further through enterprise policies: Firefox recognizes the `restricted_domains` policy as documented at [ExtensionSettings in mozilla/policy-templates](https://github.com/mozilla/policy-templates/blob/master/README.md#extensionsettings). Chrome's `runtime_blocked_hosts` policy is documented at [Configure ExtensionSettings policy](https://support.google.com/chrome/a/answer/9867568).
+The set of domains can be restricted further through [enterprise policies](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies): Firefox recognizes the `restricted_domains` policy as documented in [ExtensionSettings](https://firefox-admin-docs.mozilla.org/reference/policies/extensionsettings/) in the Firefox administrator reference. Chrome's `runtime_blocked_hosts` policy is documented at [Configure ExtensionSettings policy](https://support.google.com/chrome/a/answer/9867568).
 
 ### Limitations
 

--- a/files/en-us/mozilla/add-ons/webextensions/enterprise_policies/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/enterprise_policies/index.md
@@ -1,0 +1,86 @@
+---
+title: Enterprise policies and extensions
+slug: Mozilla/Add-ons/WebExtensions/Enterprise_policies
+page-type: guide
+sidebar: addonsidebar
+---
+
+An enterprise policy is a setting applied by a system administrator, so a browser or extension is configured the same for everyone in an organization. Users and extensions cannot modify the policies.
+
+Browsers expose two kinds of policies that are relevant to extensions:
+
+- **Installation and lifecycle policies**, which control whether an extension is installed, force-installed, blocked, or locked so users can't remove it.
+- **Configuration data policies**, which enable an administrator to supply values that an extension uses to modify its behavior, for example, to set a default server URL or block features. The extension reads these values using the {{WebExtAPIRef("storage.managed")}} API.
+
+Firefox, Chrome, and Safari take different approaches to defining these policies.
+
+## Firefox
+
+### Installation and lifecycle policies
+
+Firefox administrators configure a JSON file named `policies.json` (deployed through `enterprise policies`, sometimes together with an MDM tool) to control installation and lifecycle behavior. The policies most relevant to extensions are:
+
+- `Extensions`
+  - : Controls installation, uninstallation, and locking of specific extensions.
+- `ExtensionSettings`
+  - : A more general policy that manages installation origins, update URLs, permissions, and blocked or allowed extension lists; it also supports the `restricted_domains` setting referenced in [Content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#restricted_domains).
+- `ExtensionUpdate`
+  - : Enables or turns off extension updates.
+- `InstallAddonsPermission`
+  - : Configures the default install policy and the origins extensions can be installed from.
+- `BlockAboutAddons`
+  - : Blocks access to `about:addons`.
+
+For a full list of policies and the file's JSON syntax, see the [Firefox policy reference](https://firefox-admin-docs.mozilla.org/reference/policies/) and the Mozilla [policy-templates](https://github.com/mozilla/policy-templates) on GitHub.
+
+### Configuration data: the `3rdparty` policy and native manifests
+
+Firefox offers two ways for an administrator to supply configuration data to an extension:
+
+- The [`3rdparty` policy](https://firefox-admin-docs.mozilla.org/reference/policies/3rdparty.html), which nests arbitrary data under `policies > 3rdparty > Extensions > <extension ID>` in `policies.json`.
+- A [managed storage native manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests) JSON file. This file is provisioned outside the extension (for example, by an installer or device management tool) at a fixed OS-specific location.
+
+Both mechanisms populate the {{WebExtAPIRef("storage.managed")}} storage area. Firefox doesn't require the extension to declare a `managed_schema` in the [storage](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) manifest key to describe the shape of this data.
+
+> [!NOTE]
+> In Firefox, you must restart the browser to load changes to the native manifest or the `3rdparty` policy into managed storage. As a result, {{WebExtAPIRef("storage.onChanged")}} never fires for managed storage. If managed storage is not configured for an extension, calling {{WebExtAPIRef("storage.StorageArea.get()", "storage.managed.get()")}} or {{WebExtAPIRef("storage.StorageArea.getKeys()", "storage.managed.getKeys()")}} throws an exception rather than returning `undefined` (see [Firefox bug 1868153](https://bugzil.la/1868153)).
+
+## Chrome
+
+### Installation and lifecycle policies
+
+Installation and lifecycle are controlled by policies including:
+
+- [`ExtensionInstallForcelist`](https://chromeenterprise.google/policies/extension-install-forcelist/), which force-installs a list of extensions that users can't remove or disable.
+- [`ExtensionSettings`](https://chromeenterprise.google/policies/extension-settings/), a superset policy that also controls update URLs, blocked permissions, and blocked and allowed hosts, and overrides `ExtensionInstallForcelist` where both apply.
+
+See [Configure ExtensionSettings policy](https://support.google.com/chrome/a/answer/9867568) and the [Chrome Enterprise policy list](https://chromeenterprise.google/policies/) for the full set.
+
+### Configuration data
+
+Chrome extensions declare the shape of their managed configuration data with a [`storage.managed_schema`](https://developer.chrome.com/docs/extensions/reference/manifest/storage) JSON schema file referenced from `manifest.json`. Administrators then supply values that match that schema through platform-specific policy management (for example, the Windows registry, a macOS configuration profile, or the Google Admin console). Values that don't validate against the schema aren't published to the extension.
+
+## Safari
+
+Safari's enterprise support, delivered through declarative device management (MDM) on supervised Apple devices, covers only installation and lifecycle: allowing, always enabling, or always turning off specific extensions; controlling private-browsing access; and restricting the domains an extension can access.
+
+There is no Safari equivalent of `storage.managed`; Apple's declarative configuration has no mechanism for an administrator to push arbitrary configuration data into an extension.
+
+See [Safari extensions management: declarative device management](https://support.apple.com/guide/deployment/safari-extensions-management-declarative-depff7fad9d8/web) for the full configuration reference.
+
+## Comparison
+
+|                                             | Firefox                                                           | Chrome                                                            | Safari                              |
+| ------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------- |
+| Force-install / block / lock extensions     | Yes (`Extensions`, `ExtensionSettings`)                           | Yes (`ExtensionInstallForcelist`, `ExtensionSettings`)            | Yes (declarative device management) |
+| Restrict host/domain access                 | Yes (`ExtensionSettings` `restricted_domains`)                    | Yes (`ExtensionSettings` `runtime_blocked_hosts`)                 | Yes (per-extension domain access)   |
+| Deliver configuration data to the extension | Yes, via `storage.managed` (`3rdparty` policy or native manifest) | Yes, using `storage.managed` (`managed_schema` + platform policy) | Not supported                       |
+| Schema required for configuration data      | No                                                                | Yes (`managed_schema`)                                            | N/A                                 |
+| Configuration data changes apply live       | No — requires browser restart                                     | Yes                                                               | N/A                                 |
+
+## See also
+
+- [Extension Workshop: Enterprise](https://extensionworkshop.com/documentation/enterprise/) a guide to developing and distributing extensions for Firefox enterprise deployments, including [adding policy support to an extension](https://extensionworkshop.com/documentation/enterprise/enterprise-development/)
+- {{WebExtAPIRef("storage.managed")}}
+- [manifest.json/storage](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage)
+- [Native manifests](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#managed_storage_manifests)

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.md
@@ -35,7 +35,7 @@ sidebar: addonsidebar
 
 Use the `storage` key to specify the name of the schema file that defines the structure of data in managed storage.
 
-Managed data declares the enterprise policies supported by the app. Policies are analogous to options but are configured by a system administrator instead of the user, enabling the app to be configured for all users of an organization.
+Managed data declares the [enterprise policies](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies) that an extension implements. Policies are like options but are configured by a system administrator, not the user, enabling an enterprise to determine which extension features are available to users.
 
 After declaring the policies, they are read from the {{WebExtAPIRef("storage.managed")}} API. However, if a policy value does not conform to the schema, then it is not published by the `storage.managed` API. It's up to the app to enforce the policies configured by the administrator.
 

--- a/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
@@ -158,7 +158,12 @@ This allows the extension with the ID `ping_pong@example.org` to connect by pass
 
 ## Managed storage manifests
 
-The managed storage manifest is a file with a name that matches the ID specified in the extension's [browser_specific_settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key with the `.json` extension. It contains a JSON object with these properties:
+The managed storage manifest is a file named with the ID specified in the extension's [browser_specific_settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key with the `.json` extension.
+
+> [!NOTE]
+> This is one of two ways to provision managed storage in Firefox. See [Enterprise policies and extensions](/en-US/docs/Mozilla/Add-ons/WebExtensions/Enterprise_policies) for the alternative and how the provisioning options compare with Chrome and Safari.
+
+The file contains a JSON object with these properties.
 
 <table class="fullwidth-table standard-table">
   <thead>

--- a/files/sidebars/addonsidebar.yaml
+++ b/files/sidebars/addonsidebar.yaml
@@ -24,6 +24,7 @@ sidebar:
       - /Mozilla/Add-ons/WebExtensions/Content_Security_Policy
       - /Mozilla/Add-ons/WebExtensions/Native_messaging
       - /Mozilla/Add-ons/WebExtensions/Native_manifests
+      - /Mozilla/Add-ons/WebExtensions/Enterprise_policies
       - /Mozilla/Add-ons/WebExtensions/User_actions
       - /Mozilla/Add-ons/WebExtensions/Differences_between_API_implementations
       - /Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities


### PR DESCRIPTION
### Description

This change adds an Enterprise policies and extensions concept page that provides information on the installation and lifecycle policies and configuration data policies for Firefox, Chrome, and Safari. It also updates various pages that mention these features to point back to this new concept page.

### Motivation

To provide a single, cross-browser point of reference for enterprise policies and how they affect extensions.

### Related issues and pull requests

Fixes #40018