### PR TITLE
Web Components: fix fear of collision and API focus

### DIFF
--- a/files/en-us/web/api/web_components/index.md
+++ b/files/en-us/web/api/web_components/index.md
@@ -15,12 +15,13 @@ Web Components is a suite of different technologies allowing you to create reusa
 
 As developers, we all know that reusing code as much as possible is a good idea. This has traditionally not been so easy for custom markup structures — think of the complex HTML (and associated style and script) you've sometimes had to write to render custom UI controls, and how using them multiple times can turn your page into a mess if you are not careful.
 
-Web Components aims to solve such problems — it consists of three main technologies, which can be used together to create versatile custom elements with encapsulated functionality that can be reused wherever you like without fear of code collisions.
+Web Components aims to solve such problems — it consists of three main technologies, which can be used together to create versatile custom elements with encapsulated functionality that can be reused with less risk of naming and styling collisions:
 
 - **Custom elements**
   - : A set of JavaScript APIs that allow you to define custom elements and their behavior, which can then be used as desired in your user interface.
 - **Shadow DOM**
-  - : A set of JavaScript APIs for attaching an encapsulated "shadow" DOM tree to an element — which is rendered separately from the main document DOM — and controlling associated functionality. In this way, you can keep an element's features private, so they can be scripted and styled without the fear of collision with other parts of the document.
+  - : A mechanisms for attaching an encapsulated "shadow" DOM tree to an element, either imperatively via JavaScript APIs or declaratively in HTML.
+    These allow you to keep an element's features private, so their styles and IDs don't collide with other parts of the document.
 - **HTML templates**
   - : The {{HTMLElement("template")}} and {{HTMLElement("slot")}} elements enable you to write markup templates that are not displayed in the rendered page. These can then be reused multiple times as the basis of a custom element's structure.
 

--- a/files/en-us/web/api/web_components/index.md
+++ b/files/en-us/web/api/web_components/index.md
@@ -20,8 +20,8 @@ Web Components aims to solve such problems — it consists of three main technol
 - **Custom elements**
   - : A set of JavaScript APIs that allow you to define custom elements and their behavior, which can then be used as desired in your user interface.
 - **Shadow DOM**
-  - : A mechanisms for attaching an encapsulated "shadow" DOM tree to an element, either imperatively via JavaScript APIs or declaratively in HTML.
-    These allow you to keep an element's features private, so their styles and IDs don't collide with other parts of the document.
+  - : A mechanism for attaching an encapsulated "shadow" DOM tree to an element, either imperatively via JavaScript APIs or declaratively in HTML.
+    This allows you to keep an element's features private, so their styles and IDs don't collide with other parts of the document.
 - **HTML templates**
   - : The {{HTMLElement("template")}} and {{HTMLElement("slot")}} elements enable you to write markup templates that are not displayed in the rendered page. These can then be reused multiple times as the basis of a custom element's structure.
 


### PR DESCRIPTION
Fixes #45161

The issue correctly highlights that web components overstates the level and intent of protection provided by the shadow DOM. I've taken issue posters words for that. Also noted that this presented shadow DOM as JavaScript API, but it has evolved since this was written to also have a declarative API.