### PR TITLE
FF154 Relnote: Json Viewer breadcrumb

### DIFF
--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -16,7 +16,10 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Changes for web developers
 
-<!-- ### Developer Tools -->
+### Developer Tools
+
+- The [JSON Viewer](https://firefox-source-docs.mozilla.org/devtools-user/json_viewer/index.html) now displays a breadcrumb at the bottom of the panel indicating the location of the selected entry within the JSON structure.
+  ([Firefox bug 1805447](https://bugzil.la/1850288)).
 
 <!-- ### HTML -->
 

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -19,7 +19,7 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 ### Developer Tools
 
 - The [JSON Viewer](https://firefox-source-docs.mozilla.org/devtools-user/json_viewer/index.html) now displays a breadcrumb at the bottom of the panel indicating the location of the selected entry within the JSON structure.
-  ([Firefox bug 1805447](https://bugzil.la/1850288)).
+  ([Firefox bug 1850288](https://bugzil.la/1850288)).
 
 <!-- ### HTML -->
 


### PR DESCRIPTION
FF154 adds support for a breadcrumb being displayed at the bottom of the JSON view. This adds a release note.

Related docs work can be tracked in #45024