### PR TITLE
add librsvg and resvg to proper-names dictionary

### DIFF
--- a/.vscode/dictionaries/proper-names.txt
+++ b/.vscode/dictionaries/proper-names.txt
@@ -371,6 +371,7 @@ Leyla
 Lianghekou
 Libera.Chat
 Libertinus
+librsvg
 Lighttpd
 LINDDUN
 Lindenberg
@@ -530,6 +531,7 @@ Rekapi
 Remy
 Resian
 Resig
+resvg
 Rigby
 Rivendell
 Robison

--- a/files/en-us/web/api/preferenceobject/requestoverride/index.md
+++ b/files/en-us/web/api/preferenceobject/requestoverride/index.md
@@ -37,7 +37,7 @@ A {{jsxref("Promise")}} which resolves to {{jsxref("undefined")}} on success, or
 
 ### Basic usage
 
-The following example requests an override of the {{domxref("PreferenceObject.colorScheme", "colorScheme")}}.
+The following example requests an override of the {{domxref("PreferenceManager.colorScheme", "colorScheme")}}.
 
 ```js
 await navigator.preferences.colorScheme.requestOverride("dark");

--- a/files/en-us/web/http/reference/headers/content-digest/index.md
+++ b/files/en-us/web/http/reference/headers/content-digest/index.md
@@ -161,7 +161,7 @@ Repr-Digest: sha-256=:bMGjiT1wkArOzyB9ReAdpW51FV4mHlQygPXGp+TtzG4=:
 ```
 
 Instead of omitting `Content-Digest` when there is no content, a server can explicitly compute it over an empty string.
-Per [Section 6.3 of RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html#section-6.3), this lets a recipient, particularly when the digest is covered by an HTTP message signature, verify that no content was added or removed, rather than only that the header was left out:
+Per [Section 6.3 of RFC 9530](https://www.rfc-editor.org/info/rfc9530/#section-6.3), this lets a recipient, particularly when the digest is covered by an HTTP message signature, verify that no content was added or removed, rather than only that the header was left out:
 
 ```http
 HTTP/1.1 200 OK

--- a/files/en-us/web/http/reference/headers/repr-digest/index.md
+++ b/files/en-us/web/http/reference/headers/repr-digest/index.md
@@ -47,7 +47,7 @@ Repr-Digest: <digest-algorithm>=<digest-value>,…,<digest-algorithmN>=<digest-v
     Only two registered digest algorithms are considered secure: `sha-512` and `sha-256`.
     The insecure (legacy) registered digest algorithms are: `md5`, `sha` (SHA-1), `unixsum`, `unixcksum`, `adler` (ADLER32) and `crc32c`.
 - `<digest-value>`
-  - : The digest of the entire selected representation data (see [Section 8.1 of the HTTP Semantics specification](https://www.rfc-editor.org/rfc/rfc9110#section-8.1)) using the `<digest-algorithm>`, {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A). This encoding is referred to as a [byte sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences) in the specification.
+  - : The digest of the entire selected representation data (see [Section 8.1 of the HTTP Semantics specification](https://www.rfc-editor.org/info/rfc9110/#section-8.1)) using the `<digest-algorithm>`, {{Glossary("base64")}}-encoded and wrapped in colons (`:`, ASCII 0x3A). This encoding is referred to as a [byte sequence](https://www.rfc-editor.org/info/rfc9651/#name-byte-sequences) in the specification.
 
 ## Examples
 
@@ -162,7 +162,7 @@ Repr-Digest: sha-256=:bMGjiT1wkArOzyB9ReAdpW51FV4mHlQygPXGp+TtzG4=:
 ```
 
 Instead of omitting `Content-Digest` when there is no content, a server can explicitly compute it over an empty string.
-Per [Section 6.3 of RFC 9530](https://www.rfc-editor.org/rfc/rfc9530.html#section-6.3), this lets a recipient, particularly when the digest is covered by an HTTP message signature, verify that no content was added or removed, rather than only that the header was left out:
+Per [Section 6.3 of RFC 9530](https://www.rfc-editor.org/info/rfc9530/#section-6.3), this lets a recipient, particularly when the digest is covered by an HTTP message signature, verify that no content was added or removed, rather than only that the header was left out:
 
 ```http
 HTTP/1.1 200 OK


### PR DESCRIPTION
Closes #45164

Adds `librsvg` and `resvg` to .vscode/dictionaries/proper-names.txt.

Both words appear in files/en-us/web/svg/tutorials/svg_from_scratch/
tools_for_svg/index.md and are project names used correctly:
- librsvg: the GNOME SVG rendering library
- resvg: the linebender Rust SVG renderer