### PR TITLE
StylePropertyMap fixes -draft

### DIFF
--- a/files/en-us/web/api/stylepropertymap/append/index.md
+++ b/files/en-us/web/api/stylepropertymap/append/index.md
@@ -65,3 +65,11 @@ buttonEl.attributeStyleMap.append(
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMap.set()")}}
+- {{domxref("StylePropertyMap.delete()")}}
+- {{domxref("StylePropertyMap.clear()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymap/clear/index.md
+++ b/files/en-us/web/api/stylepropertymap/clear/index.md
@@ -45,3 +45,11 @@ buttonEl.attributeStyleMap.clear();
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMap.set()")}}
+- {{domxref("StylePropertyMap.append()")}}
+- {{domxref("StylePropertyMap.delete()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymap/delete/index.md
+++ b/files/en-us/web/api/stylepropertymap/delete/index.md
@@ -25,6 +25,11 @@ delete(property)
 
 None ({{jsxref("undefined")}}).
 
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if `property` is not a valid CSS property name.
+
 ## Examples
 
 ### Basic usage
@@ -46,3 +51,11 @@ buttonEl.attributeStyleMap.delete("background-image");
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMap.set()")}}
+- {{domxref("StylePropertyMap.append()")}}
+- {{domxref("StylePropertyMap.clear()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymap/index.md
+++ b/files/en-us/web/api/stylepropertymap/index.md
@@ -7,7 +7,12 @@ browser-compat: api.StylePropertyMap
 
 {{APIRef("CSS Typed Object Model API")}}
 
-The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) provides a representation of a CSS declaration block that is an alternative to {{DOMxRef("CSSStyleDeclaration")}}.
+The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) provides a representation of a CSS declaration block that can be read and modified.
+
+This exposes each value as a typed {{domxref("CSSStyleValue")}} object (such as a {{domxref("CSSUnitValue")}} with a numeric `value` and a `unit`), so it can be read and set without parsing or serializing strings.
+It can be obtained from an element's inline style using {{domxref("HTMLElement.attributeStyleMap")}}.
+
+Note that this is the writable counterpart to {{domxref("StylePropertyMapReadOnly")}}, which it inherits from and which is used for read-only styles (such as computed styles) — and, like its parent, an alternative to {{domxref("CSSStyleDeclaration")}}, which represents every value as a string (e.g., `"10px"`).
 
 {{InheritanceDiagram}}
 
@@ -32,6 +37,62 @@ _Also inherits methods from its parent interface, {{DOMxRef("StylePropertyMapRea
 - {{DOMxRef("StylePropertyMap.set()")}}
   - : Changes the CSS declaration with the given property.
 
+## Examples
+
+### Basic usage
+
+This example gets a `StylePropertyMap` for a button's [style attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/style) via {{domxref("HTMLElement.attributeStyleMap")}}, then uses `set()`, `append()`, `has()`, and `delete()` to modify it.
+
+```html
+<button>Styled button</button>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText += `${text}\n`;
+}
+```
+
+```js
+const buttonEl = document.querySelector("button");
+const styleMap = buttonEl.attributeStyleMap;
+
+log(`styleMap type: ${styleMap.constructor.name}`);
+
+// set some declarations
+styleMap.set("padding-top", CSS.px(10));
+styleMap.set("background-color", "gold");
+
+// add an extra background image on top of the background color
+styleMap.append(
+  "background-image",
+  "linear-gradient(180deg, transparent, rgb(0 0 0 / 20%))",
+);
+
+log(`Has background-image: ${styleMap.has("background-image")}`);
+
+// remove the background image again
+styleMap.delete("background-image");
+
+log(`Has background-image after delete: ${styleMap.has("background-image")}`);
+```
+
+{{EmbedLiveSample("Basic usage", 120, 220)}}
+
 ## Specifications
 
 {{Specifications}}
@@ -39,3 +100,10 @@ _Also inherits methods from its parent interface, {{DOMxRef("StylePropertyMapRea
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly")}}
+- {{domxref("HTMLElement.attributeStyleMap")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymap/set/index.md
+++ b/files/en-us/web/api/stylepropertymap/set/index.md
@@ -30,6 +30,15 @@ set(property, value1, value2, /* …, */ valueN)
 
 None ({{jsxref("undefined")}}).
 
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if:
+    - `property` is not a valid CSS property.
+    - `property` is a single-valued property and more than one value is given.
+    - Any of `value1`, …, `valueN` is already associated with a different property (for example, a value read from one property's entry in a `StylePropertyMap`, then passed to `set()` for another property).
+    - Two or more values are given, and any of them is a {{domxref("CSSUnparsedValue")}} or {{domxref("CSSVariableReferenceValue")}} object.
+
 ## Examples
 
 ### Basic usage
@@ -51,3 +60,11 @@ buttonEl.attributeStyleMap.set("padding-top", CSS.px(10));
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMap.append()")}}
+- {{domxref("StylePropertyMap.delete()")}}
+- {{domxref("StylePropertyMap.clear()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/entries/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/entries/index.md
@@ -8,7 +8,7 @@ browser-compat: api.StylePropertyMapReadOnly.entries
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`StylePropertyMapReadOnly.entries()`** method returns an array of a given object's own enumerable property `[key, value]` pairs, in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
+The **`entries()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface returns a new iterator that yields `[property, values]` pairs for each declaration in the object.
 
 ## Syntax
 
@@ -22,13 +22,14 @@ None.
 
 ### Return value
 
-An array of the given `StylePropertyMapReadOnly` object's own enumerable property `[key, value]` pairs.
+A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+Each item yielded is a two-element array of `[property, values]`, where `property` is a CSS property name and `values` is an array of {{domxref("CSSStyleValue")}} objects, as returned by {{domxref("StylePropertyMapReadOnly.getAll", "getAll()")}} for that property.
 
 ## Examples
 
 ### Basic usage
 
-The following code shows an example of using `StylePropertyMapReadOnly.entries()` method on an elements computed styles.
+The following code shows an example of using the `entries()` method on an element's computed styles.
 
 ```js
 // grab a DOM element
@@ -37,10 +38,10 @@ const buttonEl = document.querySelector("button");
 // we can retrieve all computed styles with `computedStyleMap`
 const allComputedStyles = buttonEl.computedStyleMap();
 
-// entries returns an iterable of the items
+// entries returns an iterator of [property, values] pairs
 const iterableStyles = allComputedStyles.entries();
 
-// returns a two item array with align-content as the first item and CSSStyleValue as the second
+// returns a two item array: "align-content" as the property, and an array of CSSStyleValue objects as the values
 console.log(iterableStyles.next().value);
 ```
 
@@ -51,3 +52,15 @@ console.log(iterableStyles.next().value);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly.forEach()")}}
+- {{domxref("StylePropertyMapReadOnly.get()")}}
+- {{domxref("StylePropertyMapReadOnly.getAll()")}}
+- {{domxref("StylePropertyMapReadOnly.has()")}}
+- {{domxref("StylePropertyMapReadOnly.keys()")}}
+- {{domxref("StylePropertyMapReadOnly.size")}}
+- {{domxref("StylePropertyMapReadOnly.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
@@ -8,7 +8,7 @@ browser-compat: api.StylePropertyMapReadOnly.forEach
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`StylePropertyMapReadOnly.forEach()`** method executes a provided function once for each element of {{domxref('StylePropertyMapReadOnly')}}.
+The **`forEach()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface executes a provided function once for each declaration in the object.
 
 ## Syntax
 
@@ -20,17 +20,15 @@ forEach(callbackFn, thisArg)
 ### Parameters
 
 - `callbackFn`
-  - : The function to execute for each element, taking three arguments:
+  - : The function to execute for each declaration, taking three arguments:
     - `currentValue`
-      - : The value of the current element being processed.
-    - `index` {{optional_inline}}
-      - : The index of the current element being processed.
-    - `array` {{optional_inline}}
-      - : The StylePropertyMapReadOnly that `forEach()` is being called on.
-
-- `thisArg` {{Optional_inline}}
-  - : Value to use as **`this`** (i.e., the reference
-    `Object`) when executing `callback`.
+      - : The value of the current declaration being processed — an array of {{domxref("CSSStyleValue")}} objects, as returned by {{domxref("StylePropertyMapReadOnly.getAll", "getAll()")}} for that property.
+    - `key` {{optional_inline}}
+      - : The CSS property name of the current declaration being processed.
+    - `map` {{optional_inline}}
+      - : The `StylePropertyMapReadOnly` that `forEach()` is being called on.
+- `thisArg` {{optional_inline}}
+  - : Value to use as **`this`** when executing `callbackFn`.
 
 ### Return value
 
@@ -49,9 +47,9 @@ const buttonEl = document.querySelector(".example");
 // we can retrieve all computed styles with `computedStyleMap`
 const allComputedStyles = buttonEl.computedStyleMap();
 
-// forEach will allow us to run code over each prop/val pair
-allComputedStyles.forEach((elem, index, arr) => {
-  // code to run for each pair
+// forEach will allow us to run code over each property/values pair
+allComputedStyles.forEach((values, property, map) => {
+  // code to run for each declaration
 });
 ```
 
@@ -62,3 +60,15 @@ allComputedStyles.forEach((elem, index, arr) => {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly.entries()")}}
+- {{domxref("StylePropertyMapReadOnly.get()")}}
+- {{domxref("StylePropertyMapReadOnly.getAll()")}}
+- {{domxref("StylePropertyMapReadOnly.has()")}}
+- {{domxref("StylePropertyMapReadOnly.keys()")}}
+- {{domxref("StylePropertyMapReadOnly.size")}}
+- {{domxref("StylePropertyMapReadOnly.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/getall/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/getall/index.md
@@ -25,6 +25,11 @@ getAll(property)
 
 An array of {{domxref("CSSStyleValue")}} objects.
 
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if `property` is not a valid CSS property name.
+
 ## Examples
 
 ### Basic usage
@@ -51,3 +56,11 @@ console.log(allBkImages); // logs an array with each background image as an item
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly.entries()")}}
+- {{domxref("StylePropertyMapReadOnly.get()")}}
+- {{domxref("StylePropertyMapReadOnly.has()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/has/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/has/index.md
@@ -25,6 +25,11 @@ has(property)
 
 A boolean value.
 
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if `property` is not a valid CSS property name.
+
 ## Examples
 
 ### Basic usage
@@ -48,3 +53,11 @@ console.log(hasPadTop); // logs true if padding-top is present in style attribut
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly.entries()")}}
+- {{domxref("StylePropertyMapReadOnly.get()")}}
+- {{domxref("StylePropertyMapReadOnly.getAll()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.md
@@ -7,20 +7,24 @@ browser-compat: api.StylePropertyMapReadOnly
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`StylePropertyMapReadOnly`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) provides a read-only representation of a CSS declaration block that is an alternative to {{domxref("CSSStyleDeclaration")}}.
-Retrieve an instance of this interface using {{domxref('Element.computedStyleMap','Element.computedStyleMap()')}}.
+The **`StylePropertyMapReadOnly`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API) provides a read-only representation of a CSS declaration block.
+
+This exposes each value as a typed {{domxref("CSSStyleValue")}} object (such as a {{domxref("CSSUnitValue")}} with a numeric `value` and a `unit`), so it can be read without parsing.
+It can be obtained from an element using {{domxref('Element.computedStyleMap','Element.computedStyleMap()')}}.
+
+Note that this is an alternative to {{domxref("CSSStyleDeclaration")}}, which represents every value as a string (e.g., `"10px"`).
 
 ## Instance properties
 
 - {{domxref('StylePropertyMapReadOnly.size')}} {{ReadOnlyInline}}
-  - : Returns an unsigned integer containing the size of the `StylePropertyMapReadOnly` object.
+  - : Returns a non-negative integer containing the number of declarations in the `StylePropertyMapReadOnly` object.
 
 ## Instance methods
 
 - {{domxref('StylePropertyMapReadOnly.entries()')}}
-  - : Returns an array of a given object's own enumerable property `[key, value]` pairs, in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
+  - : Returns a new iterator that yields `[property, values]` pairs for each declaration in the object.
 - {{domxref('StylePropertyMapReadOnly.forEach()')}}
-  - : Executes a provided function once for each element of `StylePropertyMapReadOnly`.
+  - : Executes a provided function once for each declaration in the object.
 - {{domxref('StylePropertyMapReadOnly.get()')}}
   - : Returns the value of the specified property.
 - {{domxref('StylePropertyMapReadOnly.getAll()')}}
@@ -28,9 +32,9 @@ Retrieve an instance of this interface using {{domxref('Element.computedStyleMap
 - {{domxref('StylePropertyMapReadOnly.has()')}}
   - : Indicates whether the specified property is in the `StylePropertyMapReadOnly` object.
 - {{domxref('StylePropertyMapReadOnly.keys()')}}
-  - : Returns a new _array iterator_ containing the keys for each item in `StylePropertyMapReadOnly`.
+  - : Returns a new iterator that yields the CSS property name of each declaration in the object.
 - {{domxref('StylePropertyMapReadOnly.values()')}}
-  - : Returns a new _array iterator_ containing the values for each index in the `StylePropertyMapReadOnly` object.
+  - : Returns a new iterator that yields the values of each declaration in the object.
 
 ## Examples
 
@@ -92,3 +96,10 @@ for (const [prop, val] of stylePropertyMap) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMap")}}
+- {{domxref("Element.computedStyleMap()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/keys/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/keys/index.md
@@ -8,7 +8,7 @@ browser-compat: api.StylePropertyMapReadOnly.keys
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`StylePropertyMapReadOnly.keys()`** method returns a new _array iterator_ containing the keys for each item in `StylePropertyMapReadOnly`.
+The **`keys()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface returns a new iterator that yields the CSS property name of each declaration in the object.
 
 ## Syntax
 
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A new {{jsxref("Array")}}.
+A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
 
 ## Examples
 
@@ -37,7 +37,7 @@ const buttonEl = document.querySelector("button");
 // we can retrieve all computed styles with `computedStyleMap`
 const allComputedStyles = buttonEl.computedStyleMap();
 
-// keys returns an iterable list of properties
+// keys returns an iterator of property names
 const props = allComputedStyles.keys();
 console.log(props.next().value); // returns align-content
 ```
@@ -49,3 +49,15 @@ console.log(props.next().value); // returns align-content
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly.entries()")}}
+- {{domxref("StylePropertyMapReadOnly.forEach()")}}
+- {{domxref("StylePropertyMapReadOnly.get()")}}
+- {{domxref("StylePropertyMapReadOnly.getAll()")}}
+- {{domxref("StylePropertyMapReadOnly.has()")}}
+- {{domxref("StylePropertyMapReadOnly.size")}}
+- {{domxref("StylePropertyMapReadOnly.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/size/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/size/index.md
@@ -8,11 +8,11 @@ browser-compat: api.StylePropertyMapReadOnly.size
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`size`** read-only property of the {{domxref("StylePropertyMapReadOnly")}} interface returns a positive integer containing the size of the `StylePropertyMapReadOnly` object.
+The **`size`** read-only property of the {{domxref("StylePropertyMapReadOnly")}} interface returns a non-negative integer containing the number of declarations in the `StylePropertyMapReadOnly` object.
 
 ## Value
 
-A positive integer.
+A non-negative integer.
 
 ## Examples
 
@@ -39,3 +39,15 @@ console.log(amountStyles); // logs 338
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly.entries()")}}
+- {{domxref("StylePropertyMapReadOnly.forEach()")}}
+- {{domxref("StylePropertyMapReadOnly.get()")}}
+- {{domxref("StylePropertyMapReadOnly.getAll()")}}
+- {{domxref("StylePropertyMapReadOnly.has()")}}
+- {{domxref("StylePropertyMapReadOnly.keys()")}}
+- {{domxref("StylePropertyMapReadOnly.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/stylepropertymapreadonly/values/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/values/index.md
@@ -8,7 +8,7 @@ browser-compat: api.StylePropertyMapReadOnly.values
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`StylePropertyMapReadOnly.values()`** method returns a new _array iterator_ containing the values for each index in the `StylePropertyMapReadOnly` object.
+The **`values()`** method of the {{domxref("StylePropertyMapReadOnly")}} interface returns a new iterator that yields the values of each declaration in the object.
 
 ## Syntax
 
@@ -22,7 +22,8 @@ None.
 
 ### Return value
 
-A new {{jsxref("Array")}}.
+A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+Each item yielded is an array of {{domxref("CSSStyleValue")}} objects, as returned by {{domxref("StylePropertyMapReadOnly.getAll", "getAll()")}} for that property.
 
 ## Examples
 
@@ -37,9 +38,9 @@ const buttonEl = document.querySelector("button");
 // we can retrieve all computed styles with `computedStyleMap`
 const allComputedStyles = buttonEl.computedStyleMap();
 
-// values returns an iterable list of the CSS values
+// values returns an iterator of CSSStyleValue arrays, one per declaration
 const vals = allComputedStyles.values();
-console.log(vals.next().value); // returns a CSSStyleValue
+console.log(vals.next().value); // returns an array of CSSStyleValue objects
 ```
 
 ## Specifications
@@ -49,3 +50,15 @@ console.log(vals.next().value); // returns a CSSStyleValue
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("StylePropertyMapReadOnly.entries()")}}
+- {{domxref("StylePropertyMapReadOnly.forEach()")}}
+- {{domxref("StylePropertyMapReadOnly.get()")}}
+- {{domxref("StylePropertyMapReadOnly.getAll()")}}
+- {{domxref("StylePropertyMapReadOnly.has()")}}
+- {{domxref("StylePropertyMapReadOnly.keys()")}}
+- {{domxref("StylePropertyMapReadOnly.size")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)


### PR DESCRIPTION
[CSS Typed OM API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API) fixes, in particular StylePropertyMap and StylePropertyMapReadOnly

Related docs can be tracked in #44849