### PR TITLE
CSS Typed OM" CSSTransform{Value|Component} and CSSRotate

### DIFF
--- a/files/en-us/web/api/cssnumericarray/entries/index.md
+++ b/files/en-us/web/api/cssnumericarray/entries/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericarray/keys/index.md
+++ b/files/en-us/web/api/cssnumericarray/keys/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericarray/values/index.md
+++ b/files/en-us/web/api/cssnumericarray/values/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 

--- a/files/en-us/web/api/cssrotate/angle/index.md
+++ b/files/en-us/web/api/cssrotate/angle/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSRotate.angle
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`angle`** property of the {{domxref("CSSRotate")}} interface gets and sets the angle of rotation.
+The **`angle`** property of the {{domxref("CSSRotate")}} interface represents the angle of rotation.
 A positive angle denotes a clockwise rotation, a negative angle a counter-clockwise one.
 
 ## Value
@@ -17,7 +17,17 @@ A {{domxref("CSSNumericValue")}}
 
 ## Examples
 
-To Do
+### Reading and setting the angle
+
+```js
+const rotate = new CSSRotate(CSS.deg(45));
+
+console.log(rotate.angle.value); // 45
+console.log(rotate.angle.unit); // "deg"
+
+rotate.angle = CSS.deg(90);
+console.log(rotate.toString()); // "rotate(90deg)"
+```
 
 ## Specifications
 
@@ -26,3 +36,12 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSRotate.CSSRotate", "CSSRotate()")}}
+- {{domxref("CSSRotate.x")}}
+- {{domxref("CSSRotate.y")}}
+- {{domxref("CSSRotate.z")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/cssrotate/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSRotate.CSSRotate
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSRotate()`** constructor creates a new {{domxref("CSSRotate")}} object representing the {{cssxref("transform-function/rotate", "rotate()")}} value of the individual {{CSSXref('transform')}} property in CSS.
+The **`CSSRotate()`** constructor creates a new {{domxref("CSSRotate")}} object representing the {{cssxref("transform-function/rotate", "rotate()")}} value of the individual {{cssxref("transform")}} property in CSS.
 
 This can be specified as either a 2D rotation by a particular angle, or as a 3D rotation by an angle around a particular axis.
 
@@ -21,31 +21,57 @@ new CSSRotate(x, y, z, angle)
 
 ### Parameters
 
-- {{domxref('CSSRotate.angle','angle')}}
-  - : A value for the angle of the {{domxref('CSSRotate')}} object to be constructed.
-    This must be a {{domxref('CSSNumericValue')}}.
-- {{domxref('CSSRotate.x','x')}} {{optional_inline}}
-  - : A value for the x-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
+- {{domxref("CSSRotate.angle", "angle")}}
+  - : A value for the angle of rotation of the {{domxref("CSSRotate")}} object to be constructed.
+    This must be a {{domxref("CSSNumericValue")}}.
+- {{domxref("CSSRotate.x", "x")}} {{optional_inline}}
+  - : A number or {{domxref("CSSNumericValue")}} value indicating the x-coordinate of the rotation axis vector of the {{domxref("CSSRotate")}} object to be constructed.
+    Only used, and required, when constructing a 3D rotation; the 2-argument form implies a rotation axis of `(0, 0, 1)` (the z-axis).
+- {{domxref("CSSRotate.y", "y")}} {{optional_inline}}
+  - : A number or {{domxref("CSSNumericValue")}} value indicating the y-coordinate of the rotation axis vector of the {{domxref("CSSRotate")}} object to be constructed.
     Only used, and required, when constructing a 3D rotation.
-- {{domxref('CSSRotate.y','y')}} {{optional_inline}}
-  - : A value for the y-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
-    Only used, and required, when constructing a 3D rotation.
-- {{domxref('CSSRotate.z','z')}} {{optional_inline}}
-  - : A value for the z-axis of the {{domxref('CSSRotate')}} object to be constructed.
-    This must either be a number (which is wrapped into a {{domxref("CSSUnitValue")}} of `unit: "number"`) or a {{domxref("CSSNumericValue")}}.
+- {{domxref("CSSRotate.z", "z")}} {{optional_inline}}
+  - : A number or {{domxref("CSSNumericValue")}} value indicating the z-coordinate of the rotation axis vector of the {{domxref("CSSRotate")}} object to be constructed.
     Only used, and required, when constructing a 3D rotation.
 
 ### Exceptions
 
 - [`TypeError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)
-  - : Raised if the value of `CSSRotate.angle` is not an [\<angle>](/en-US/docs/Web/CSS/Reference/Values/angle) value or `CSSRotate.x`, `CSSRotate.y`, `CSSRotate.z` are
-    not [\<number>](/en-US/docs/Web/CSS/Reference/Values/number) values.
+  - : Raised if the value of the `angle` property is not an [`<angle>`](/en-US/docs/Web/CSS/Reference/Values/angle) value or `CSSRotate.x`, `CSSRotate.y`, `CSSRotate.z` are not [`<number>`](/en-US/docs/Web/CSS/Reference/Values/number) values.
 
 ## Examples
 
-To do
+### Constructing a 2D rotation
+
+The 2-argument form takes only an angle, and implies a rotation around the z-axis (equivalent to `rotate3d(0, 0, 1, angle)`):
+
+```js
+const rotate2D = new CSSRotate(CSS.deg(45));
+
+console.log(rotate2D.is2D); // true
+console.log(rotate2D.toString()); // "rotate(45deg)"
+```
+
+### Constructing a 3D rotation
+
+The 4-argument form takes the rotation axis coordinates followed by the angle:
+
+```js
+const rotate3D = new CSSRotate(1, 1, 0, CSS.deg(45));
+
+console.log(rotate3D.is2D); // false
+console.log(rotate3D.toString()); // "rotate3d(1, 1, 0,45deg)"
+```
+
+### Handling an invalid angle
+
+```js
+try {
+  const rotate = new CSSRotate(CSS.px(45));
+} catch (e) {
+  console.log(e); // TypeError: px is not an angle
+}
+```
 
 ## Specifications
 
@@ -54,3 +80,13 @@ To do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSRotate.angle")}}
+- {{domxref("CSSRotate.x")}}
+- {{domxref("CSSRotate.y")}}
+- {{domxref("CSSRotate.z")}}
+- {{domxref("CSSTransformComponent")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSRotate
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSRotate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the rotate value of the individual {{CSSXRef('transform')}} property in CSS.
+The **`CSSRotate`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents the value of a rotation function in the {{cssxref("transform")}} property in CSS.
 
 {{InheritanceDiagram}}
 
@@ -18,24 +18,133 @@ The **`CSSRotate`** interface of the [CSS Typed Object Model API](/en-US/docs/We
 
 ## Instance properties
 
-_Also inherits properties from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+_Also inherits properties from its parent interface, {{domxref("CSSTransformComponent")}}._
 
-- {{domxref('CSSRotate.x','x')}}
-  - : Returns or sets the x-axis value.
-- {{domxref('CSSRotate.y','y')}}
-  - : Returns or sets the y-axis value.
-- {{domxref('CSSRotate.z','z')}}
-  - : Returns or sets the z-axis value.
-- {{domxref('CSSRotate.angle','angle')}}
-  - : Returns or sets the angle value.
+- {{domxref("CSSRotate.angle", "angle")}}
+  - : Represents the angle of rotation.
+- {{domxref("CSSRotate.x", "x")}}
+  - : Represents the x-coordinate of the rotation axis vector.
+- {{domxref("CSSRotate.y", "y")}}
+  - : Represents the y-coordinate of the rotation axis vector.
+- {{domxref("CSSRotate.z", "z")}}
+  - : Represents the z-coordinate of the rotation axis vector.
 
 ## Instance methods
 
-_Also inherits methods from its parent interface, {{DOMxRef("CSSTransformComponent")}}._
+_Also inherits methods from its parent interface, {{domxref("CSSTransformComponent")}}._
+
+## Description
+
+The **`CSSRotate`** interface is used to represent rotation functions in a list of {{cssxref("transform-function")}}s defined for a CSS {{cssxref("transform")}} property.
+This includes rotations declared with: {{cssxref("transform-function/rotate", "rotate()")}}, {{cssxref("transform-function/rotate3d", "rotate3d()")}}, {{cssxref("transform-function/rotateX", "rotateX()")}}, {{cssxref("transform-function/rotateY", "rotateY()")}}, or {{cssxref("transform-function/rotateZ", "rotateZ()")}}.
+
+The list itself is represented by a {{domxref("CSSTransformValue")}} object that can be iterated to get the objects representing each of the functions (and may include objects representing other transforms).
+
+A rotation is defined by an axis vector (`x`, `y`, `z`) and an `angle` of rotation around that axis.
+The 2-argument constructor form is shorthand for a rotation around the z-axis: it sets the axis to `(0, 0, 1)`, which is why a 2D CSS {{cssxref("transform-function/rotate", "rotate()")}} is equivalent to `rotate3d(0, 0, 1, angle)`.
+The 4-argument form lets you specify any axis, for an arbitrary 3D rotation.
 
 ## Examples
 
-To do.
+### Basic usage
+
+This example constructs a `CSSRotate` and logs its structure and properties.
+
+```js
+const rotate = new CSSRotate(CSS.deg(45));
+
+console.log(rotate); // CSSRotate {x: CSSUnitValue, y: CSSUnitValue, z: CSSUnitValue, angle: CSSUnitValue, is2D: true}
+console.log(rotate.angle.value, rotate.angle.unit); // 45 "deg"
+console.log(rotate.x.value, rotate.y.value, rotate.z.value); // 0 0 1
+console.log(rotate.toString()); // "rotate(45deg)"
+```
+
+### Incrementing a rotation
+
+This example demonstrates how `CSSRotate` might be used.
+
+Note that there is hidden logging code that isn't relevant to the example.
+
+#### HTML
+
+First we define the elements for the box to rotate, and the button we use to rotate it.
+
+```html
+<div id="increment-box"></div>
+<button id="increment-button">Rotate 15°</button>
+```
+
+```html hidden
+<pre id="log"></pre>
+```
+
+#### CSS
+
+The CSS for the box we will rotate is shown below.
+Note that the box is initially rotated by 15 degrees.
+
+```css
+#increment-box {
+  width: 100px;
+  height: 100px;
+  margin-bottom: 1rem;
+  background-color: #66d;
+  transform: rotate(15deg);
+  transition: transform 0.3s ease;
+}
+```
+
+```css hidden
+#log {
+  height: 80px;
+  overflow: scroll;
+  padding: 0.5rem;
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
+
+```js hidden
+const logElement = document.querySelector("#log");
+function log(text) {
+  logElement.innerText = `${logElement.innerText}${text}\n`;
+  logElement.scrollTop = logElement.scrollHeight;
+}
+```
+
+The code first gets a handle to the box we're rotating, then uses {{domxref("Element.computedStyleMap", "computedStyleMap()")}} to get and log the initial transform angle.
+
+```js
+const incrementBox = document.getElementById("increment-box");
+
+let angle = incrementBox.computedStyleMap().get("transform")[0].angle.value;
+log(`initial angle: ${angle}deg`);
+```
+
+Then we get the button and add a handler to rotate it 15 degrees each time the button is clicked.
+Note that we use `CSSRotate` to define the rotation, add it to a {{domxref("CSSTransformValue")}}, and then set that as the style for the box.
+
+```js
+const incrementButton = document.getElementById("increment-button");
+incrementButton.addEventListener("click", () => {
+  angle = (angle + 15) % 360;
+  const rotate = new CSSRotate(CSS.deg(angle));
+
+  incrementBox.attributeStyleMap.set(
+    "transform",
+    new CSSTransformValue([rotate]),
+  );
+  log(`angle: ${angle}deg`);
+});
+```
+
+#### Result
+
+This example starts with a box already rotated `15deg` in CSS.
+Click the button to rotate it.
+
+{{EmbedLiveSample("Incrementing a rotation", 120, 300)}}
 
 ## Specifications
 
@@ -44,3 +153,17 @@ To do.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformComponent")}}
+- {{domxref("CSSTransformValue")}}
+- {{domxref("CSSTranslate")}}
+- {{domxref("CSSScale")}}
+- {{domxref("CSSSkew")}}
+- {{domxref("CSSSkewX")}}
+- {{domxref("CSSSkewY")}}
+- {{domxref("CSSPerspective")}}
+- {{domxref("CSSMatrixComponent")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/cssrotate/x/index.md
+++ b/files/en-us/web/api/cssrotate/x/index.md
@@ -8,15 +8,24 @@ browser-compat: api.CSSRotate.x
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`x`** property of the {{domxref("CSSRotate")}} interface gets and sets the abscissa or x-axis of the translating vector.
+The **`x`** property of the {{domxref("CSSRotate")}} interface represents the x-coordinate of the vector denoting the axis of rotation.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. If set to a number, this is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 
-To Do
+### Reading and setting the rotation axis
+
+```js
+const rotate = new CSSRotate(1, 1, 0, CSS.deg(45));
+
+console.log(rotate.x.value); // 1
+
+rotate.x = 0;
+console.log(rotate.x); // CSSUnitValue {value: 0, unit: "number"}
+```
 
 ## Specifications
 
@@ -25,3 +34,12 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSRotate.CSSRotate", "CSSRotate()")}}
+- {{domxref("CSSRotate.y")}}
+- {{domxref("CSSRotate.z")}}
+- {{domxref("CSSRotate.angle")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -8,15 +8,24 @@ browser-compat: api.CSSRotate.y
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`y`** property of the {{domxref("CSSRotate")}} interface gets and sets the ordinate or y-axis of the translating vector.
+The **`y`** property of the {{domxref("CSSRotate")}} interface represents the y-coordinate of the vector denoting the axis of rotation.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. If set to a number, this is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 
-To Do
+### Reading and setting the rotation axis
+
+```js
+const rotate = new CSSRotate(1, 1, 0, CSS.deg(45));
+
+console.log(rotate.y.value); // 1
+
+rotate.y = 0;
+console.log(rotate.y); // CSSUnitValue {value: 0, unit: "number"}
+```
 
 ## Specifications
 
@@ -25,3 +34,12 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSRotate.CSSRotate", "CSSRotate()")}}
+- {{domxref("CSSRotate.x")}}
+- {{domxref("CSSRotate.z")}}
+- {{domxref("CSSRotate.angle")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -8,16 +8,24 @@ browser-compat: api.CSSRotate.z
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`z`** property of the {{domxref("CSSRotate")}} interface represents the z-component of the translating vector.
-A positive value moves the element towards the viewer and a negative value farther away.
+The **`z`** property of the {{domxref("CSSRotate")}} interface represents the z-coordinate of the vector denoting the axis of rotation.
 
 ## Value
 
-A {{domxref("CSSNumericValue")}}. Can be set to a number, which is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
+A {{domxref("CSSNumericValue")}}. If set to a number, this is wrapped in a {{domxref("CSSUnitValue")}} of `unit: "number"`.
 
 ## Examples
 
-To Do
+### Reading and setting the rotation axis
+
+```js
+const rotate = new CSSRotate(1, 1, 0, CSS.deg(45));
+
+console.log(rotate.z.value); // 0
+
+rotate.z = 1;
+console.log(rotate.z); // CSSUnitValue {value: 1, unit: "number"}
+```
 
 ## Specifications
 
@@ -26,3 +34,12 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSRotate.CSSRotate", "CSSRotate()")}}
+- {{domxref("CSSRotate.x")}}
+- {{domxref("CSSRotate.y")}}
+- {{domxref("CSSRotate.angle")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -7,7 +7,7 @@ browser-compat: api.CSSTransformComponent
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSTransformComponent`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is part of the {{domxref('CSSTransformValue')}} interface.
+The **`CSSTransformComponent`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) is the base interface for objects that represent individual {{cssxref("transform-function", "transform functions")}}, such as [`rotate()`](/en-US/docs/Web/CSS/Reference/Values/transform-function/rotate) and [`scale()`](/en-US/docs/Web/CSS/Reference/Values/transform-function/scale).
 
 ## Instance properties
 
@@ -17,26 +17,49 @@ The **`CSSTransformComponent`** interface of the [CSS Typed Object Model API](/e
 ## Instance methods
 
 - {{domxref("CSSTransformComponent.toMatrix()")}}
-  - : Returns a new {{domxref('DOMMatrix')}} object.
+  - : Returns a new {{domxref("DOMMatrix")}} object.
 - {{domxref("CSSTransformComponent.toString()")}}
   - : A string in the form of a CSS [transform function](/en-US/docs/Web/CSS/Reference/Values/transform-function).
 
-    This will use the value of `is2D` to return either a 2D or 3D transform. For example if the component represents {{domxref("CSSRotate")}} and `is2D` is false then the string returned will be in the form of the CSS transformation {{cssxref("transform-function/rotate3d", "rotate3d()")}} function. If true the string returned will be in the form of the 2-dimensional {{cssxref("transform-function/rotate", "rotate()")}} function.
+## Interfaces based on `CSSTransformComponent`
 
-## Interfaces based on CSSTransformComponent
+- {{domxref("CSSTranslate")}}
+- {{domxref("CSSRotate")}}
+- {{domxref("CSSScale")}}
+- {{domxref("CSSSkew")}}
+- {{domxref("CSSSkewX")}}
+- {{domxref("CSSSkewY")}}
+- {{domxref("CSSPerspective")}}
+- {{domxref("CSSMatrixComponent")}}
 
-- {{domxref('CSSTranslate')}}
-- {{domxref('CSSRotate')}}
-- {{domxref('CSSScale')}}
-- {{domxref('CSSSkew')}}
-- {{domxref('CSSSkewX')}}
-- {{domxref('CSSSkewY')}}
-- {{domxref('CSSPerspective')}}
-- {{domxref('CSSMatrixComponent')}}
+## Description
+
+The `CSSTransformComponent` interface is the abstract base interface for objects that represent a single {{cssxref("transform-function")}} in the `transform-list` of values as used by the CSS {{cssxref("transform")}} property.
+
+A `CSSTransformComponent` in isolation can't represent a CSS property value.
+Instead, the {{domxref("CSSTransformValue")}} interface represents the `transform-list` itself, and can be iterated to get each of the values in the transform.
+
+The [concrete interfaces representing each transform function](#interfaces_based_on_csstransformcomponent) are listed in the previous section (the interface has no constructor of its own, so it can't be instantiated directly).
+
+The interface has an `is2D` property for determining whether a component is a 2D or 3D transform.
+This is used to format the output, ignoring 3D attributes when a component represents a 2D transform.
+This allows a single interface to represent both the 2D and 3D forms of a given transform function.
 
 ## Examples
 
-To do
+### Basic usage
+
+This example shows how you might construct a {{domxref("CSSTranslate")}} instance (one of the `CSSTransformComponent`-derived types) and read its matrix and string forms.
+
+```js
+const translate = new CSSTranslate(CSS.px(10), CSS.px(20));
+
+console.log(translate.is2D); // true
+console.log(translate.toString()); // "translate(10px, 20px)"
+
+const matrix = translate.toMatrix();
+console.log(matrix.e, matrix.f); // 10 20
+```
 
 ## Specifications
 
@@ -45,3 +68,10 @@ To do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue")}}
+- {{domxref("DOMMatrix")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.md
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.md
@@ -8,15 +8,37 @@ browser-compat: api.CSSTransformComponent.is2D
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`is2D`** property of the {{domxref("CSSTransformComponent")}} interface indicates whether the transform is 2D or 3D.
+The **`is2D`** property of the {{domxref("CSSTransformComponent")}} interface represents whether the transform is 2D or 3D.
 
 ## Value
 
-A boolean. True if the transform is a 2D transform, false if it is a 3D transform.
+A boolean.
+`true` if the transform is a 2D transform, `false` if it is a 3D transform.
+
+## Description
+
+The property can be both read and written, and is used in other methods to determine the form of the output.
+
+For example, if the component represents {{domxref("CSSRotate")}} and `is2D` is `false`, then the string returned by {{domxref("CSSTransformComponent.toString()")}} will be in the form of the CSS transformation {{cssxref("transform-function/rotate3d", "rotate3d()")}} function.
+If the value is `true`, the string returned will be in the form of the 2-dimensional {{cssxref("transform-function/rotate", "rotate()")}} function.
+
+More generally, when `is2D` is `true`, any attributes of the component that are only relevant to 3D transforms (such as {{domxref("CSSTranslate.z")}}) are ignored, and have no effect on the component's serialization ({{domxref("CSSTransformComponent.toString()")}}) or its {{domxref("CSSTransformComponent.toMatrix()", "matrix")}}.
 
 ## Examples
 
-To Do
+### Reading and setting is2D
+
+```js
+const translate = new CSSTranslate(CSS.px(10), CSS.px(20), CSS.px(30));
+
+console.log(translate.is2D); // false
+console.log(translate.toString()); // "translate3d(10px, 20px, 30px)"
+
+translate.is2D = true;
+
+console.log(translate.toString()); // "translate(10px, 20px)"
+console.log(translate.z.toString()); // "30px" — z is still set, just ignored
+```
 
 ## Specifications
 
@@ -25,3 +47,11 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformComponent.toString()")}}
+- {{domxref("CSSTransformComponent.toMatrix()")}}
+- {{domxref("CSSTransformValue.is2D")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformComponent.toMatrix
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`toMatrix()`** method of the {{domxref("CSSTransformComponent")}} interface returns a {{domxref('DOMMatrix')}} object.
+The **`toMatrix()`** method of the {{domxref("CSSTransformComponent")}} interface returns a {{domxref("DOMMatrix")}} object.
 
 All transform functions can be represented mathematically as a 4x4 transformation matrix.
 
@@ -29,7 +29,7 @@ None.
 
 ### Return value
 
-A {{domxref('DOMMatrix')}} object
+A {{domxref("DOMMatrix")}} object.
 
 ### Exceptions
 
@@ -38,7 +38,28 @@ A {{domxref('DOMMatrix')}} object
 
 ## Examples
 
-To Do
+### Converting a component to a matrix
+
+```js
+const translate = new CSSTranslate(CSS.px(10), CSS.px(20));
+
+const matrix = translate.toMatrix();
+console.log(matrix.e, matrix.f); // 10 20
+```
+
+### Handling incompatible units
+
+`toMatrix()` throws if a length can't be resolved to pixels, such as a percentage:
+
+```js
+const translate = new CSSTranslate(CSS.percent(50), CSS.px(20));
+
+try {
+  translate.toMatrix();
+} catch (e) {
+  console.log(e); // TypeError
+}
+```
 
 ## Specifications
 
@@ -47,3 +68,11 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformComponent.is2D")}}
+- {{domxref("CSSTransformComponent.toString()")}}
+- {{domxref("CSSTransformValue.toMatrix()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.md
@@ -30,7 +30,15 @@ If true the string returned will be in the form of the 2-dimensional {{cssxref("
 
 ## Examples
 
-To Do
+### Serializing 2D and 3D components
+
+```js
+const translate2D = new CSSTranslate(CSS.px(10), CSS.px(20));
+console.log(translate2D.toString()); // "translate(10px, 20px)"
+
+const translate3D = new CSSTranslate(CSS.px(10), CSS.px(20), CSS.px(30));
+console.log(translate3D.toString()); // "translate3d(10px, 20px, 30px)"
+```
 
 ## Specifications
 
@@ -39,3 +47,11 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformComponent.is2D")}}
+- {{domxref("CSSTransformComponent.toMatrix()")}}
+- {{domxref("CSSTransformValue")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformValue.CSSTransformValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSTransformValue()`** constructor creates a new {{domxref("CSSTransformValue")}} object which represents a list of individual transform objects.
+The **`CSSTransformValue()`** constructor creates a new {{domxref("CSSTransformValue")}} object, representing a `transform-list` value made up of the given {{domxref("CSSTransformComponent")}} objects.
 
 ## Syntax
 
@@ -19,20 +19,38 @@ new CSSTransformValue(transforms)
 ### Parameters
 
 - `transforms`
-  - : A list of {{domxref("CSSTransformComponent")}} objects to iterate over.
-
-### Return value
-
-A new {{domxref("CSSTransformValue")}}.
+  - : An array of {{domxref("CSSTransformComponent")}} objects.
 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Raised if transforms is empty.
+  - : Thrown if `transforms` is empty.
 
 ## Examples
 
-To do
+### Basic usage
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+console.log(transform.length); // 2
+console.log(transform.toString()); // "translate(10px, 20px) scale(2, 3)"
+```
+
+### Handling an empty array
+
+The constructor throws a `TypeError` if `transforms` is empty:
+
+```js
+try {
+  const transform = new CSSTransformValue([]);
+} catch (e) {
+  console.log(e); // TypeError
+}
+```
 
 ## Specifications
 
@@ -41,3 +59,16 @@ To do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformComponent")}}
+- {{domxref("CSSTransformValue.entries()")}}
+- {{domxref("CSSTransformValue.forEach()")}}
+- {{domxref("CSSTransformValue.is2D")}}
+- {{domxref("CSSTransformValue.keys()")}}
+- {{domxref("CSSTransformValue.length")}}
+- {{domxref("CSSTransformValue.toMatrix()")}}
+- {{domxref("CSSTransformValue.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/entries/index.md
+++ b/files/en-us/web/api/csstransformvalue/entries/index.md
@@ -8,32 +8,38 @@ browser-compat: api.CSSTransformValue.entries
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSTransformValue.entries()`** method
-returns an array of a given object's own enumerable
-property `[key, value]` pairs in the same order as that provided by a
-[`for...in`](/en-US/docs/Web/JavaScript/Reference/Statements/for...in) loop (the difference being that a for-in loop enumerates
-properties in the prototype chain as well).
+The **`entries()`** method of the {{domxref("CSSTransformValue")}} interface returns a new _array iterator_ that yields `[index, value]` pairs for each item in the object.
 
 ## Syntax
 
 ```js-nolint
-entries(obj)
+entries()
 ```
 
 ### Parameters
 
-- `obj`
-  - : The {{domxref('CSSTransformValue')}} whose enumerable own property
-    `[key, value]` pairs are to be returned.
+None.
 
 ### Return value
 
-An array of the given `CSSTransformValue` object's own enumerable property
-`[key, value]` pairs.
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 
-To Do
+### Iterating over index/value pairs
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+for (const [index, component] of transform.entries()) {
+  console.log(index, component.toString());
+}
+// 0 "translate(10px, 20px)"
+// 1 "scale(2, 3)"
+```
 
 ## Specifications
 
@@ -42,3 +48,13 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
+- {{domxref("CSSTransformValue.forEach()")}}
+- {{domxref("CSSTransformValue.keys()")}}
+- {{domxref("CSSTransformValue.length")}}
+- {{domxref("CSSTransformValue.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/foreach/index.md
+++ b/files/en-us/web/api/csstransformvalue/foreach/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformValue.forEach
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSTransformValue.forEach()`** method executes a provided function once for each element of the `CSSTransformValue`.
+The **`forEach()`** method of the {{domxref("CSSTransformValue")}} interface executes a provided function once for each item in the object.
 
 ## Syntax
 
@@ -22,14 +22,13 @@ forEach(callbackFn, thisArg)
 - `callbackFn`
   - : The function to execute for each element, taking three arguments:
     - `currentValue`
-      - : The value of the current element being processed.
+      - : The item being processed.
     - `index` {{optional_inline}}
       - : The index of the current element being processed.
     - `array` {{optional_inline}}
       - : The `CSSTransformValue` that `forEach()` is being called on.
-
-- `thisArg` {{Optional_inline}}
-  - : Value to use as **`this`** (i.e., the reference `Object`) when executing `callback`.
+- `thisArg` {{optional_inline}}
+  - : Value to use as `this` when executing `callbackFn`.
 
 ### Return value
 
@@ -37,7 +36,20 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
-To Do
+### Iterating with forEach()
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+transform.forEach((component, index) => {
+  console.log(index, component.toString());
+});
+// 0 "translate(10px, 20px)"
+// 1 "scale(2, 3)"
+```
 
 ## Specifications
 
@@ -46,3 +58,13 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
+- {{domxref("CSSTransformValue.entries()")}}
+- {{domxref("CSSTransformValue.keys()")}}
+- {{domxref("CSSTransformValue.length")}}
+- {{domxref("CSSTransformValue.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/index.md
@@ -7,7 +7,10 @@ browser-compat: api.CSSTransformValue
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSTransformValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents `transform-list` values as used by the CSS {{CSSxref('transform')}} property.
+The **`CSSTransformValue`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model) represents `transform-list` values as used by the CSS {{cssxref("transform")}} property.
+It is an iterable of {{domxref("CSSTransformComponent")}} objects, each representing a single {{cssxref("transform-function")}}.
+
+The items can be accessed and set by index (`transformValue[0]`), and as an iterable it can be used with a {{jsxref("Statements/for...of", "for...of")}} loop or the spread syntax.
 
 {{InheritanceDiagram}}
 
@@ -19,39 +22,84 @@ The **`CSSTransformValue`** interface of the [CSS Typed Object Model API](/en-US
 ## Instance properties
 
 - {{domxref("CSSTransformValue.length")}} {{ReadOnlyInline}}
-  - : Returns how many transform components are contained within the `CSSTransformValue`.
+  - : Returns the number of items in the object.
 - {{domxref("CSSTransformValue.is2D")}} {{ReadOnlyInline}}
   - : Returns a boolean indicating whether the transform is 2D or 3D.
 
 ## Instance methods
 
-_Also inherits methods from its parent interface, {{DOMxRef("CSSStyleValue")}}._
+_Also inherits methods from its parent interface, {{domxref("CSSStyleValue")}}._
 
 - {{domxref("CSSTransformValue.toMatrix()")}}
-  - : Returns a new {{domxref('DOMMatrix')}} object.
-- {{domxref('CSSTransformValue.entries()')}}
-  - : Returns an array of a given object's own enumerable property `[key, value]` pairs in the same order as that provided by a {{jsxref("Statements/for...in", "for...in")}} loop (the difference being that a for-in loop enumerates properties in the prototype chain as well).
-- {{domxref('CSSTransformValue.forEach()')}}
-  - : Executes a provided function once for each element of the `CSSTransformValue` object.
-- {{domxref('CSSTransformValue.keys()')}}
-  - : Returns a new _array iterator_ object that contains the keys for each index in the `CSSTransformValue` object.
-- {{domxref('CSSTransformValue.values()')}}
-  - : Returns a new _array iterator_ object that contains the values for each index in the `CSSTransformValue` object.
+  - : Returns a new {{domxref("DOMMatrix")}} object.
+- {{domxref("CSSTransformValue.entries()")}}
+  - : Returns a new _array iterator_ that yields `[index, value]` pairs for each item in the object.
+- {{domxref("CSSTransformValue.forEach()")}}
+  - : Executes a provided function once for each item in the object.
+- {{domxref("CSSTransformValue.keys()")}}
+  - : Returns a new _array iterator_ that yields the index of each item in the object.
+- {{domxref("CSSTransformValue.values()")}}
+  - : Returns a new _array iterator_ that yields each item in the object.
 
-## Interfaces based on CSSTransformValue
+## Description
 
-- {{domxref('CSSTranslate')}}
-- {{domxref('CSSRotate')}}
-- {{domxref('CSSScale')}}
-- {{domxref('CSSSkew')}}
-- {{domxref('CSSSkewX')}}
-- {{domxref('CSSSkewY')}}
-- {{domxref('CSSPerspective')}}
-- {{domxref('CSSMatrixComponent')}}
+Each item in a `CSSTransformValue` is a {{domxref("CSSTransformComponent")}}-derived object, such as a {{domxref("CSSScale")}} or {{domxref("CSSTranslate")}}, representing a single {{cssxref("transform-function", "transform function")}} object.
+
+The {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}} constructor throws a {{jsxref("TypeError")}} if given an empty array — a `CSSTransformValue` always contains at least one component.
+
+{{domxref("CSSTransformValue.is2D")}} is `true` only if every component's own `is2D` is `true`; if any component is a 3D transform, the whole `CSSTransformValue` is treated as 3D.
 
 ## Examples
 
-To Do.
+### Creating, reading, and updating a `CSSTransformValue`
+
+This example creates a `CSSTransformValue`, then reads its items via `length`, indexed access, and iteration, and finally replaces one of the items by assigning to its index.
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+console.log(transform.length); // 2
+console.log(transform[0].toString()); // "translate(10px, 20px)"
+
+for (const component of transform) {
+  console.log(component.toString());
+}
+// "translate(10px, 20px)"
+// "scale(2, 3)"
+
+transform[1] = new CSSScale(4, 5);
+console.log(transform[1].toString()); // "scale(4, 5)"
+```
+
+### Reading a transform from a computed style map
+
+A `CSSTransformValue` instance is returned when you read the value of the {{cssxref("transform")}} property from a {{domxref("StylePropertyMapReadOnly")}}.
+This example reads the computed `transform` of a button styled with `transform: scale(0.95)`.
+See the [`CSSTransformValue` with `CSSScale`](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide#csstransformvalue_with_cssscale) section of the CSS Typed OM guide for more detail on this example.
+
+```html
+<button id="btn">Styled button</button>
+```
+
+```css
+#btn {
+  display: inline-block;
+  transform: scale(0.95);
+}
+```
+
+```js
+const styleMap = document.getElementById("btn").computedStyleMap();
+const transform = styleMap.get("transform");
+
+console.log(transform); // CSSTransformValue {0: CSSScale, length: 1, is2D: true}
+console.log(transform.length); // 1
+console.log(transform[0].x); // CSSUnitValue {value: 0.95, unit: "number"}
+console.log(transform.is2D); // true
+```
 
 ## Specifications
 
@@ -60,3 +108,14 @@ To Do.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformComponent")}}
+- {{domxref("CSSImageValue")}}
+- {{domxref("CSSKeywordValue")}}
+- {{domxref("CSSNumericValue")}}
+- {{domxref("CSSPositionValue")}}
+- {{domxref("CSSUnparsedValue")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/is2d/index.md
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.md
@@ -10,15 +10,31 @@ browser-compat: api.CSSTransformValue.is2D
 
 The **`is2D`** read-only property of the {{domxref("CSSTransformValue")}} interface returns whether the transform is 2D or 3D.
 
-In the case of the `CSSTransformValue`, this property returns true unless any of the individual functions return false for `Is2D`, in which case, it returns false.
+`is2D` is `true` only if every {{domxref("CSSTransformComponent")}} in the `CSSTransformValue` is itself 2D (see {{domxref("CSSTransformComponent.is2D")}}), otherwise it is `false`.
 
 ## Value
 
-A boolean. True indicates that the transform is a 2D transform, false that it is a 3D transform.
+A boolean. `true` if every object in the value is 2D, otherwise `false`.
 
 ## Examples
 
-To Do
+### Comparing 2D and 3D transforms
+
+```js
+const transform2D = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+console.log(transform2D.is2D); // true
+
+const transform3D = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20), CSS.px(30)),
+  new CSSScale(2, 3),
+]);
+
+console.log(transform3D.is2D); // false
+```
 
 ## Specifications
 
@@ -27,3 +43,11 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
+- {{domxref("CSSTransformComponent.is2D")}}
+- {{domxref("CSSTransformValue.toMatrix()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/keys/index.md
+++ b/files/en-us/web/api/csstransformvalue/keys/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformValue.keys
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSTransformValue.keys()`** method returns a new _array iterator_ object that contains the keys for each index in the array.
+The **`keys()`** method of the {{domxref("CSSTransformValue")}} interface returns a new _array iterator_ that yields the index of each item in the object.
 
 ## Syntax
 
@@ -22,11 +22,24 @@ None.
 
 ### Return value
 
-A new {{jsxref("Array")}}.
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 
-To Do
+### Iterating over indexes
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+for (const index of transform.keys()) {
+  console.log(index);
+}
+// 0
+// 1
+```
 
 ## Specifications
 
@@ -35,3 +48,13 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
+- {{domxref("CSSTransformValue.entries()")}}
+- {{domxref("CSSTransformValue.forEach()")}}
+- {{domxref("CSSTransformValue.length")}}
+- {{domxref("CSSTransformValue.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/length/index.md
+++ b/files/en-us/web/api/csstransformvalue/length/index.md
@@ -8,15 +8,24 @@ browser-compat: api.CSSTransformValue.length
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`length`** read-only property of the {{domxref("CSSTransformValue")}} interface returns the number of transform components in the list.
+The **`length`** read-only property of the {{domxref("CSSTransformValue")}} interface returns the number of items in the object.
 
 ## Value
 
-An integer representing the number of transform components in the list.
+An integer.
 
 ## Examples
 
-To Do
+### Basic usage
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+console.log(transform.length); // 2
+```
 
 ## Specifications
 
@@ -25,3 +34,13 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
+- {{domxref("CSSTransformValue.entries()")}}
+- {{domxref("CSSTransformValue.forEach()")}}
+- {{domxref("CSSTransformValue.keys()")}}
+- {{domxref("CSSTransformValue.values()")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformvalue/tomatrix/index.md
@@ -8,7 +8,9 @@ browser-compat: api.CSSTransformValue.toMatrix
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`toMatrix()`** method of the {{domxref("CSSTransformValue")}} interface returns a {{domxref('DOMMatrix')}} object.
+The **`toMatrix()`** method of the {{domxref("CSSTransformValue")}} interface returns a {{domxref("DOMMatrix")}} object.
+
+The returned matrix is the product of the matrices of each {{domxref("CSSTransformComponent")}} in the `CSSTransformValue`, computed by calling {{domxref("CSSTransformComponent.toMatrix()")}} on each component in turn and multiplying the results together, in order.
 
 ## Syntax
 
@@ -22,7 +24,7 @@ None.
 
 ### Return value
 
-A {{domxref('DOMMatrix')}} object.
+A {{domxref("DOMMatrix")}} object.
 
 ### Exceptions
 
@@ -31,7 +33,34 @@ A {{domxref('DOMMatrix')}} object.
 
 ## Examples
 
-To Do
+### Converting a transform to a matrix
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+const matrix = transform.toMatrix();
+console.log(matrix.a, matrix.d); // 2 3
+console.log(matrix.e, matrix.f); // 10 20
+```
+
+### Handling incompatible units
+
+`toMatrix()` throws if a component's length can't be resolved to pixels, such as a percentage:
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.percent(50), CSS.px(20)),
+]);
+
+try {
+  transform.toMatrix();
+} catch (e) {
+  console.log(e); // TypeError
+}
+```
 
 ## Specifications
 
@@ -40,3 +69,11 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
+- {{domxref("CSSTransformComponent.toMatrix()")}}
+- {{domxref("CSSTransformValue.is2D")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/csstransformvalue/values/index.md
+++ b/files/en-us/web/api/csstransformvalue/values/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSTransformValue.values
 
 {{APIRef("CSS Typed Object Model API")}} {{AvailableInWorkers}}
 
-The **`CSSTransformValue.values()`** returns a new _array iterator_ object that contains the values for each index in the `CSSTransformValue` object.
+The **`values()`** method of the {{domxref("CSSTransformValue")}} interface returns a new _array iterator_ that yields each item in the object.
 
 ## Syntax
 
@@ -22,11 +22,24 @@ None.
 
 ### Return value
 
-A new {{jsxref("Array")}}.
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 
-To Do
+### Iterating over values
+
+```js
+const transform = new CSSTransformValue([
+  new CSSTranslate(CSS.px(10), CSS.px(20)),
+  new CSSScale(2, 3),
+]);
+
+for (const component of transform.values()) {
+  console.log(component.toString());
+}
+// "translate(10px, 20px)"
+// "scale(2, 3)"
+```
 
 ## Specifications
 
@@ -35,3 +48,13 @@ To Do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("CSSTransformValue.CSSTransformValue", "CSSTransformValue()")}}
+- {{domxref("CSSTransformValue.entries()")}}
+- {{domxref("CSSTransformValue.forEach()")}}
+- {{domxref("CSSTransformValue.keys()")}}
+- {{domxref("CSSTransformValue.length")}}
+- [Using the CSS Typed OM](/en-US/docs/Web/API/CSS_Typed_OM_API/Guide)
+- [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 

--- a/files/en-us/web/api/cssunparsedvalue/values/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.md
@@ -22,7 +22,7 @@ None.
 
 ### Return value
 
-A new [iterable iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
+A new [iterable iterator object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator).
 
 ## Examples
 


### PR DESCRIPTION
[CSS Typed OM API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API) fixes, in particular

Fixes to `CSSTransformValue`, `CSSTransformValueComponent` `CSSRotate` - these are in a kind of hierarchy (i.e Rotate is a component). 

Related docs can be tracked in #44849