### PR TITLE
[Editorial review] BiDi - New script module pages: getRealms, realmCreated, realmDestroyed

### DIFF
--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextcreated/index.md
@@ -7,11 +7,11 @@ browser-compat: webdriver.bidi.browsingContext.contextCreated_event
 sidebar: webdriver
 ---
 
-The `browsingContext.contextCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a new context is created in the browser.
+The `browsingContext.contextCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a new [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) is created in the browser.
 
 ## Event data
 
-The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following fields:
+The `params` field in the event notification is a context object with the following fields:
 
 - `children`
   - : An array of [context objects](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) that represents child contexts.

--- a/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/browsingcontext/contextdestroyed/index.md
@@ -7,11 +7,11 @@ browser-compat: webdriver.bidi.browsingContext.contextDestroyed_event
 sidebar: webdriver
 ---
 
-The `browsingContext.contextDestroyed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a context is discarded from the browser, such as when a tab is closed or when an `<iframe>` is removed from the DOM.
+The `browsingContext.contextDestroyed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`browsingContext`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext) module fires when a [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) is discarded from the browser, such as when a tab is closed or when an `<iframe>` is removed from the DOM.
 
 ## Event data
 
-The `params` field in the event notification is a [context object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) with the following fields, describing the discarded context and its subtree:
+The `params` field in the event notification is a context object with the following fields, describing the discarded context and its subtree:
 
 - `children`
   - : An array of [context objects](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree#contexts) that represents child contexts.

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
@@ -28,9 +28,9 @@ All log entry objects include the following fields:
     - `realm`
       - : A string that contains the ID of the realm.
     - `context` {{optional_inline}}
-      - : A string that contains the ID of the context in which the log entry was created.
+      - : A string that contains the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) in which the log entry was created.
     - `userContext` {{optional_inline}}
-      - : A string that contains the ID of the user context in which the script-related event occurred.
+      - : A string that contains the ID of the [user context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browser#user_contexts) in which the script-related event occurred.
 - `stackTrace` {{optional_inline}}
   - : An object with a `callFrames` array that represents the JavaScript stack at the point the entry was created. Each item in the array is a stack frame with the following fields: `columnNumber`, `functionName`, `lineNumber`, and `url`.
 - `text`

--- a/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/log/entryadded/index.md
@@ -24,7 +24,7 @@ All log entry objects include the following fields:
     - `"warn"`: A warning message (from {{domxref("console/warn_static", "console.warn()")}}).
     - `"error"`: An error message (from {{domxref("console/error_static", "console.error()")}} or {{domxref("console/assert_static", "console.assert()")}}).
 - `source`
-  - : An object that identifies the [realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms) where the log entry was created. It contains the following fields:
+  - : An object that identifies the [realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#realms) where the log entry was created. It contains the following fields:
     - `realm`
       - : A string that contains the ID of the realm.
     - `context` {{optional_inline}}
@@ -32,7 +32,7 @@ All log entry objects include the following fields:
     - `userContext` {{optional_inline}}
       - : A string that contains the ID of the user context in which the script-related event occurred.
 - `stackTrace` {{optional_inline}}
-  - : An object with a `callFrames` array that represents the [JavaScript stack](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/stackTrace) at the point the entry was created. Each item in the array is a stack frame with the following fields: `columnNumber`, `functionName`, `lineNumber`, and `url`.
+  - : An object with a `callFrames` array that represents the JavaScript stack at the point the entry was created. Each item in the array is a stack frame with the following fields: `columnNumber`, `functionName`, `lineNumber`, and `url`.
 - `text`
   - : A string that contains the log message or `null` if not available. For console entries, it is the concatenation of all stringified arguments joined by spaces, and for JavaScript errors, it is generally the error message.
     The exact format is browser-dependent, so don't rely on this value for assertions in tests.

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
@@ -38,7 +38,7 @@ The `params` field can contain:
     Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
     If not specified, realms of all contexts are returned.
 - `type` {{optional_inline}}
-  - : A string that contains the type of realm you want.
+  - : A string that contains the [type of realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#types_of_realms) you want.
     It can take one of the following values:
 
     - `"window"`: A realm whose global object is a {{domxref("Window")}}.
@@ -75,8 +75,8 @@ The `result` object in the response contains the following field:
       - : A string that contains the name of the sandbox realm.
         This field is included only for a sandbox realm, which is of type `"window"`.
     - `type`
-      - : A string that indicates the type of the realm.
-        It has one of the same values as the [`type`](#type) parameter.
+      - : A string that indicates the type of realm.
+        See the [`type`](#type) parameter for possible values.
 
 ### Errors
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
@@ -8,7 +8,7 @@ sidebar: webdriver
 ---
 
 The `script.getRealms` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`script`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script) module returns a list of all [realms](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#realms).
-You can optionally filter the list by [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) or by the type of realm.
+You can optionally filter the list by [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) or by the [type of realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#types_of_realms).
 
 ## Syntax
 
@@ -41,7 +41,7 @@ The `params` field can contain:
   - : A string that contains the [type of realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#types_of_realms) you want.
     It can take one of the following values:
     - `"window"`: A realm whose global object is a {{domxref("Window")}}.
-      This includes sandbox realms.
+      This includes [sandbox realms](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#sandbox_realms).
     - `"worker"`: A realm whose global object is a {{domxref("WorkerGlobalScope")}}, but not one of the more specific dedicated, shared, or service worker global scopes.
     - `"dedicated-worker"`: A realm whose global object is a {{domxref("DedicatedWorkerGlobalScope")}}.
     - `"shared-worker"`: A realm whose global object is a {{domxref("SharedWorkerGlobalScope")}}.

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
@@ -40,7 +40,6 @@ The `params` field can contain:
 - `type` {{optional_inline}}
   - : A string that contains the [type of realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#types_of_realms) you want.
     It can take one of the following values:
-
     - `"window"`: A realm whose global object is a {{domxref("Window")}}.
       This includes sandbox realms.
     - `"worker"`: A realm whose global object is a {{domxref("WorkerGlobalScope")}}, but not one of the more specific dedicated, shared, or service worker global scopes.
@@ -60,7 +59,6 @@ The `result` object in the response contains the following field:
 - `realms`
   - : An array of realm objects, one for each matching realm, or an empty array if there are no matching realms.
     The value of the `type` field in each object determines the other fields that are present:
-
     - `context` {{optional_inline}}
       - : A string that contains the ID of the context to which the realm belongs.
         This field is included only when the `type` field value is `"window"`.

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
@@ -1,0 +1,211 @@
+---
+title: "`script.getRealms` command"
+short-title: getRealms
+slug: Web/WebDriver/Reference/BiDi/Modules/script/getRealms
+page-type: webdriver-command
+browser-compat: webdriver.bidi.script.getRealms
+sidebar: webdriver
+---
+
+The `script.getRealms` [command](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#commands) of the [`script`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script) module returns a list of all [realms](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#realms).
+You can optionally filter the list by [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) or by the type of realm.
+
+## Syntax
+
+```json-nolint
+/* With no parameters */
+{
+  "method": "script.getRealms",
+  "params": {}
+}
+
+/* With optional parameters */
+{
+  "method": "script.getRealms",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "type": "window"
+  }
+}
+```
+
+### Parameters
+
+The `params` field can contain:
+
+- `context` {{optional_inline}}
+  - : A string that contains the ID of the context that has the realms you want.
+    Context IDs are returned by commands such as [`browsingContext.getTree`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/getTree).
+    If not specified, realms of all contexts are returned.
+- `type` {{optional_inline}}
+  - : A string that contains the type of realm you want.
+    It can take one of the following values:
+
+    - `"window"`: A realm whose global object is a {{domxref("Window")}}.
+      This includes sandbox realms.
+    - `"worker"`: A realm whose global object is a {{domxref("WorkerGlobalScope")}} that is not one of the more specific worker global scopes.
+    - `"dedicated-worker"`: A realm whose global object is a {{domxref("DedicatedWorkerGlobalScope")}}.
+    - `"shared-worker"`: A realm whose global object is a {{domxref("SharedWorkerGlobalScope")}}.
+    - `"service-worker"`: A realm whose global object is a {{domxref("ServiceWorkerGlobalScope")}}.
+    - `"worklet"`: A realm whose global object is a {{domxref("WorkletGlobalScope")}} that is not one of the more specific worklet global scopes.
+    - `"audio-worklet"`: A realm whose global object is an {{domxref("AudioWorkletGlobalScope")}}.
+    - `"paint-worklet"`: A realm whose global object is a {{domxref("PaintWorkletGlobalScope")}}.
+
+    If not specified, realms of all types are returned.
+
+### Return value
+
+The `result` object in the response contains the following field:
+
+- `realms`
+  - : An array of realm objects, one for each matching realm, or an empty array if there are no matching realms.
+    The value of the `type` field in each object determines which additional fields are present:
+
+    - `context` {{optional_inline}}
+      - : A string that contains the ID of the context to which the realm belongs.
+        This field is included only when the `type` field value is `"window"`.
+    - `origin`
+      - : A string with the [origin](/en-US/docs/Glossary/Origin) of the realm.
+    - `owners` {{optional_inline}}
+      - : A single-element array that contains the ID of the realm that owns the worker.
+        This field is included only when the `type` field value is `"dedicated-worker"`.
+    - `realm`
+      - : A string that contains the ID of the realm.
+    - `sandbox` {{optional_inline}}
+      - : A string that contains the name of the sandbox realm.
+        This field is included only for a sandbox realm, which is of type `"window"`.
+    - `type`
+      - : A string that indicates the type of the realm.
+        It has one of the same values as the [`type`](#type) parameter.
+
+### Errors
+
+- [`invalid argument`](/en-US/docs/Web/WebDriver/Reference/Errors/InvalidArgument)
+  - : A parameter has an invalid type.
+    This error is also returned when `type` is not one of the recognized realm types.
+- `no such frame`
+  - : No context with the given `context` ID is found.
+
+## Description
+
+The `script.getRealms` command is a way to discover realm IDs, which you can then pass to commands such as [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate), [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction), or [`script.disown`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/disown) instead of a context ID.
+Since worker realms have no associated context ID, referring to a realm directly is the only way to run a script in a worker.
+
+A context can have several realms, so filtering by `context` can return the realm of the active document, any sandbox realms, and any realms of the workers that the document owns.
+The realms of child contexts are not included.
+To get the realms of a child context, call the command with the ID of that context.
+
+Only realms that are ready to run scripts are returned, so a realm that is still initializing does not appear in the result.
+Realm IDs change on each cross-document navigation, so make sure to fetch them again after navigating.
+
+## Examples
+
+### Getting all realms
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new).
+
+Suppose a tab is open at `https://example.com` and the page has started a dedicated worker.
+You also created a sandbox realm named `myAutomationSandbox` earlier using [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate).
+
+Send the following message to get every available realm:
+
+```json
+{
+  "id": 1,
+  "method": "script.getRealms",
+  "params": {}
+}
+```
+
+The browser responds with the three realms as follows:
+
+```json
+{
+  "id": 1,
+  "type": "success",
+  "result": {
+    "realms": [
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "origin": "https://example.com",
+        "realm": "7c37f4c0-abcd-1234-ef56-789012345678",
+        "type": "window"
+      },
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "origin": "https://example.com",
+        "realm": "e4f5a6b7-c8d9-4012-b3c4-d5e6f7a8b9c0",
+        "sandbox": "myAutomationSandbox",
+        "type": "window"
+      },
+      {
+        "origin": "https://example.com",
+        "owners": ["7c37f4c0-abcd-1234-ef56-789012345678"],
+        "realm": "a1b2c3d4-e5f6-4708-9a1b-2c3d4e5f6071",
+        "type": "dedicated-worker"
+      }
+    ]
+  }
+}
+```
+
+### Getting only the window realms of one context
+
+Using the same connection and session as in the previous example, suppose you open a second tab at `https://example.net`.
+The new tab has its own context.
+
+Send the following message to get only the window realms of the first tab, the one at `https://example.com`:
+
+```json
+{
+  "id": 2,
+  "method": "script.getRealms",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "type": "window"
+  }
+}
+```
+
+The browser responds with only the realms that match the specified `context` and `type`.
+The realm of the dedicated worker does not match the `type`, and the realm of the second tab belongs to a different `context`, so both are omitted from the response:
+
+```json
+{
+  "id": 2,
+  "type": "success",
+  "result": {
+    "realms": [
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "origin": "https://example.com",
+        "realm": "7c37f4c0-abcd-1234-ef56-789012345678",
+        "type": "window"
+      },
+      {
+        "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+        "origin": "https://example.com",
+        "realm": "e4f5a6b7-c8d9-4012-b3c4-d5e6f7a8b9c0",
+        "sandbox": "myAutomationSandbox",
+        "type": "window"
+      }
+    ]
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction) command
+- [`script.disown`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/disown) command
+- [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) command
+- [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated) event
+- [`script.realmDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed) event

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/getrealms/index.md
@@ -43,15 +43,15 @@ The `params` field can contain:
 
     - `"window"`: A realm whose global object is a {{domxref("Window")}}.
       This includes sandbox realms.
-    - `"worker"`: A realm whose global object is a {{domxref("WorkerGlobalScope")}} that is not one of the more specific worker global scopes.
+    - `"worker"`: A realm whose global object is a {{domxref("WorkerGlobalScope")}}, but not one of the more specific dedicated, shared, or service worker global scopes.
     - `"dedicated-worker"`: A realm whose global object is a {{domxref("DedicatedWorkerGlobalScope")}}.
     - `"shared-worker"`: A realm whose global object is a {{domxref("SharedWorkerGlobalScope")}}.
     - `"service-worker"`: A realm whose global object is a {{domxref("ServiceWorkerGlobalScope")}}.
-    - `"worklet"`: A realm whose global object is a {{domxref("WorkletGlobalScope")}} that is not one of the more specific worklet global scopes.
+    - `"worklet"`: A realm whose global object is a {{domxref("WorkletGlobalScope")}}, but not one of the more specific audio or paint worklet global scopes.
     - `"audio-worklet"`: A realm whose global object is an {{domxref("AudioWorkletGlobalScope")}}.
     - `"paint-worklet"`: A realm whose global object is a {{domxref("PaintWorkletGlobalScope")}}.
 
-    If not specified, realms of all types are returned.
+    If the `type` field is not specified, realms of all types are returned.
 
 ### Return value
 
@@ -59,7 +59,7 @@ The `result` object in the response contains the following field:
 
 - `realms`
   - : An array of realm objects, one for each matching realm, or an empty array if there are no matching realms.
-    The value of the `type` field in each object determines which additional fields are present:
+    The value of the `type` field in each object determines the other fields that are present:
 
     - `context` {{optional_inline}}
       - : A string that contains the ID of the context to which the realm belongs.

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/index.md
@@ -63,8 +63,8 @@ Realms differ in their access to the DOM, in their isolation from the page's scr
 | Realm                        | Access to DOM | Isolated from the page's scripts | How you identify it                         |
 | ---------------------------- | ------------- | -------------------------------- | ------------------------------------------- |
 | Realm of the active document | Yes           | No                               | Realm ID or context ID                      |
-| Worker or worklet realm      | No            | Yes                              | Realm ID only                               |
 | Sandbox realm                | Yes           | Yes                              | Realm ID, or context ID with a sandbox name |
+| Worker or worklet realm      | No            | Yes                              | Realm ID only                               |
 
 ## Commands
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/index.md
@@ -7,7 +7,62 @@ browser-compat: webdriver.bidi.script
 sidebar: webdriver
 ---
 
-The **`script`** module contains commands and events for executing JavaScript and managing script realms in the browser.
+The **`script`** module contains commands and events for executing JavaScript and managing realms in the browser.
+
+## Realms
+
+JavaScript code runs in an execution environment called a [realm](/en-US/docs/Web/JavaScript/Reference/Execution_model#realms), which has its own global object, such as {{domxref("Window")}} for a document.
+Normally, a document has one realm, but it can have an additional realm for each of the workers (dedicated, shared, or service) it owns.
+
+In WebDriver BiDi, each realm has a unique string identifier called a realm ID, and each context (a tab or an iframe) has at least one realm.
+
+You can identify a realm in one of the following ways:
+
+- By using its realm ID.
+- By using the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) that contains it, since each context has a realm for its active document.
+
+A worker realm has no context ID, so you can identify it only by its realm ID.
+
+Commands such as [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) and [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction) take a `target` parameter that accepts either a realm ID or a context ID.
+When you pass a context ID, the script runs in the realm of the active document of that context.
+
+Each cross-document navigation loads a new document with a new realm, so a realm ID from before the navigation is no longer valid.
+
+### Sandbox realms
+
+In WebDriver BiDi, a sandbox realm is a named realm that you create in a context.
+
+By default, a script that you evaluate in a context runs in the realm of the active document.
+This means that your script can accidentally change the globals that the page relies on, and the page can read or change the variables that your script defines.
+
+A sandbox realm avoids this.
+It has its own global object, which is separate from that of the active document and that of every other sandbox realm of that context.
+Scripts inside it can access the same DOM as the scripts of the page.
+Scripts inside it are not affected by changes that the page makes to built-in objects and DOM APIs.
+The variables defined by scripts inside a sandbox realm are also not visible to the page.
+
+Creating a sandbox realm does not require an explicit step; you only need to pass a sandbox name alongside a context ID.
+The browser creates the sandbox realm the first time you use that name.
+Each combination of a context and a sandbox name has one realm, so the same sandbox name in two contexts gives you two separate realms.
+
+### Comparing realms
+
+The realms that you can target differ in their access to the DOM, in their isolation from the page, and in how you specify them:
+
+| Realm                        | Access to DOM | Isolated from the page's scripts | How you specify it in `target`             |
+| ---------------------------- | ------------- | -------------------------------- | ------------------------------------------ |
+| Realm of the active document | Yes           | No                               | Context ID or realm ID                     |
+| Worker realm                 | No            | Yes                              | Realm ID only                              |
+| Sandbox realm                | Yes           | Yes                              | Context ID with a sandbox name or realm ID |
+
+## Commands
+
+- [`script.getRealms`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms)
+
+## Events
+
+- [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated)
+- [`script.realmDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed)
 
 ## Specifications
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/index.md
@@ -12,16 +12,27 @@ The **`script`** module contains commands and events for executing JavaScript an
 ## Realms
 
 JavaScript code runs in an execution environment called a [realm](/en-US/docs/Web/JavaScript/Reference/Execution_model#realms), which has its own global object, such as {{domxref("Window")}} for a document.
-Normally, a document has one realm, but it can have an additional realm for each of the workers (dedicated, shared, or service) it owns.
+Normally, a document has one realm, but it can have an additional realm for each of the workers and worklets it owns.
 
-In WebDriver BiDi, each realm has a unique string identifier called a realm ID, and each context (a tab or an iframe) has at least one realm.
+In WebDriver BiDi, each realm has a unique string identifier called a realm ID.
+Each context (a tab or an iframe) has at least one realm.
+
+### Types of realms
+
+WebDriver BiDi defines the following realm types:
+
+- A document realm: `"window"`, which also includes sandbox realms
+- A worker realm: `"dedicated-worker"`, `"shared-worker"`, `"service-worker"`, or `"worker"` for any other worker
+- A worklet realm: `"audio-worklet"`, `"paint-worklet"`, or `"worklet"` for any other worklet
+
+### Identifying realms
 
 You can identify a realm in one of the following ways:
 
 - By using its realm ID.
 - By using the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) that contains it, since each context has a realm for its active document.
 
-A worker realm has no context ID, so you can identify it only by its realm ID.
+A worker and a worklet realm have no context ID, so you can identify them only by their realm ID.
 
 Commands such as [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) and [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction) take a `target` parameter that accepts either a realm ID or a context ID.
 When you pass a context ID, the script runs in the realm of the active document of that context.
@@ -45,15 +56,15 @@ Creating a sandbox realm does not require an explicit step; you only need to pas
 The browser creates the sandbox realm the first time you use that name.
 Each combination of a context and a sandbox name has one realm, so the same sandbox name in two contexts gives you two separate realms.
 
-### Comparing realms
+### How realms differ
 
-The realms that you can target differ in their access to the DOM, in their isolation from the page, and in how you specify them:
+Realms differ in their access to the DOM, in their isolation from the page's scripts, and in how you identify them:
 
-| Realm                        | Access to DOM | Isolated from the page's scripts | How you specify it in `target`             |
-| ---------------------------- | ------------- | -------------------------------- | ------------------------------------------ |
-| Realm of the active document | Yes           | No                               | Context ID or realm ID                     |
-| Worker realm                 | No            | Yes                              | Realm ID only                              |
-| Sandbox realm                | Yes           | Yes                              | Context ID with a sandbox name or realm ID |
+| Realm                        | Access to DOM | Isolated from the page's scripts | How you identify it                         |
+| ---------------------------- | ------------- | -------------------------------- | ------------------------------------------- |
+| Realm of the active document | Yes           | No                               | Realm ID or context ID                      |
+| Worker or worklet realm      | No            | Yes                              | Realm ID only                               |
+| Sandbox realm                | Yes           | Yes                              | Realm ID, or context ID with a sandbox name |
 
 ## Commands
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
@@ -25,7 +25,7 @@ The `params` field in the event notification is a realm object with the followin
   - : A string that contains the ID of the realm.
     Pass this value as the `realm` field of the `target` parameter of commands such as [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate).
 - `sandbox` {{optional_inline}}
-  - : A string that contains the name of the sandbox realm.
+  - : A string that contains the name of the [sandbox realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#sandbox_realms).
     This field is included only for a sandbox realm, which is of type `"window"`.
 - `type`
   - : A string that indicates the [type of realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#types_of_realms).

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
@@ -11,7 +11,7 @@ The `script.realmCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
 
 ## Event data
 
-The `params` field in the event notification is a [realm object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms#realms) with the following fields, where the value of the `type` field determines the other fields that are present:
+The `params` field in the event notification is an object with the following fields, where the value of the `type` field determines the other fields that are present:
 
 - `context` {{optional_inline}}
   - : A string that contains the ID of the context to which the realm belongs.
@@ -28,7 +28,7 @@ The `params` field in the event notification is a [realm object](/en-US/docs/Web
   - : A string that contains the name of the sandbox realm.
     This field is included only for a sandbox realm, which is of type `"window"`.
 - `type`
-  - : A string that indicates the type of the realm.
+  - : A string that indicates the [type of realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#types_of_realms).
     It has one of the following values:
 
     - `"window"`: A realm whose global object is a {{domxref("Window")}}.

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
@@ -11,7 +11,7 @@ The `script.realmCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
 
 ## Event data
 
-The `params` field in the event notification is an object with the following fields, where the value of the `type` field determines the other fields that are present:
+The `params` field in the event notification is a realm object with the following fields, where the value of the `type` field determines the other fields that are present:
 
 - `context` {{optional_inline}}
   - : A string that contains the ID of the context to which the realm belongs.

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
@@ -14,7 +14,7 @@ The `script.realmCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modul
 The `params` field in the event notification is a realm object with the following fields, where the value of the `type` field determines the other fields that are present:
 
 - `context` {{optional_inline}}
-  - : A string that contains the ID of the context to which the realm belongs.
+  - : A string that contains the ID of the [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) to which the realm belongs.
     This field is included only when the `type` field value is `"window"`.
 - `origin`
   - : A string with the [origin](/en-US/docs/Glossary/Origin) of the realm.
@@ -30,7 +30,6 @@ The `params` field in the event notification is a realm object with the followin
 - `type`
   - : A string that indicates the [type of realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#types_of_realms).
     It has one of the following values:
-
     - `"window"`: A realm whose global object is a {{domxref("Window")}}.
       This includes sandbox realms.
     - `"worker"`: A realm whose global object is a {{domxref("WorkerGlobalScope")}}, but not one of the more specific dedicated, shared, or service worker global scopes.

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
@@ -1,0 +1,109 @@
+---
+title: "`script.realmCreated` event"
+short-title: realmCreated
+slug: Web/WebDriver/Reference/BiDi/Modules/script/realmCreated
+page-type: webdriver-event
+browser-compat: webdriver.bidi.script.realmCreated_event
+sidebar: webdriver
+---
+
+The `script.realmCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`script`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script) module fires when a new [realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#realms) is created for a window, a worker, or a worklet.
+
+## Event data
+
+The `params` field in the event notification is a [realm object](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms#realms) with the following fields, where the value of the `type` field determines the other fields that are present:
+
+- `context` {{optional_inline}}
+  - : A string that contains the ID of the context to which the realm belongs.
+    This field is included only when the `type` field value is `"window"`.
+- `origin`
+  - : A string with the [origin](/en-US/docs/Glossary/Origin) of the realm.
+- `owners` {{optional_inline}}
+  - : A single-element array that contains the ID of the realm that owns the worker.
+    This field is included only when the `type` field value is `"dedicated-worker"`.
+- `realm`
+  - : A string that contains the ID of the realm.
+    Pass this value as the `realm` field of the `target` parameter of commands such as [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate).
+- `sandbox` {{optional_inline}}
+  - : A string that contains the name of the sandbox realm.
+    This field is included only for a sandbox realm, which is of type `"window"`.
+- `type`
+  - : A string that indicates the type of the realm.
+    It has one of the following values:
+
+    - `"window"`: A realm whose global object is a {{domxref("Window")}}.
+      This includes sandbox realms.
+    - `"worker"`: A realm whose global object is a {{domxref("WorkerGlobalScope")}}, but not one of the more specific dedicated, shared, or service worker global scopes.
+    - `"dedicated-worker"`: A realm whose global object is a {{domxref("DedicatedWorkerGlobalScope")}}.
+    - `"shared-worker"`: A realm whose global object is a {{domxref("SharedWorkerGlobalScope")}}.
+    - `"service-worker"`: A realm whose global object is a {{domxref("ServiceWorkerGlobalScope")}}.
+    - `"worklet"`: A realm whose global object is a {{domxref("WorkletGlobalScope")}}, but not one of the more specific audio or paint worklet global scopes.
+    - `"audio-worklet"`: A realm whose global object is an {{domxref("AudioWorkletGlobalScope")}}.
+    - `"paint-worklet"`: A realm whose global object is a {{domxref("PaintWorkletGlobalScope")}}.
+
+## Description
+
+Together with [`script.realmDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed), use this event to monitor the lifetime of the JavaScript realms of a context and its workers.
+When you [subscribe](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to this event, the browser first sends a `script.realmCreated` event for each realm that already exists and is ready to run scripts, and then sends further events as new realms are created.
+This means you don't need to call [`script.getRealms`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms) to discover the realms that existed before you subscribed.
+
+A cross-document navigation creates a new realm for the document, so you receive a new event with a new realm ID.
+The realm ID from before the navigation is no longer valid.
+
+## Examples
+
+### Receiving an event when a document is loaded
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to `script.realmCreated`.
+
+If any realms already exist when you subscribe, you receive an event for each of them first.
+Then, when a tab loads a document at `https://example.com`, the browser sends the following notification:
+
+```json
+{
+  "type": "event",
+  "method": "script.realmCreated",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "origin": "https://example.com",
+    "realm": "7c37f4c0-abcd-1234-ef56-789012345678",
+    "type": "window"
+  }
+}
+```
+
+### Receiving an event when a worker starts
+
+Using the same connection and session as in the previous example, suppose the page starts a dedicated worker.
+
+The browser sends the following notification, which has no `context` field because a worker realm doesn't belong to a context.
+Instead, `owners` contains the ID of the realm that owns the worker:
+
+```json
+{
+  "type": "event",
+  "method": "script.realmCreated",
+  "params": {
+    "origin": "https://example.com",
+    "owners": ["7c37f4c0-abcd-1234-ef56-789012345678"],
+    "realm": "a1b2c3d4-e5f6-4708-9a1b-2c3d4e5f6071",
+    "type": "dedicated-worker"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`script.callFunction`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/callFunction) command
+- [`script.evaluate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/evaluate) command
+- [`script.getRealms`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms) command
+- [`script.realmDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed) event
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmcreated/index.md
@@ -7,7 +7,7 @@ browser-compat: webdriver.bidi.script.realmCreated_event
 sidebar: webdriver
 ---
 
-The `script.realmCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`script`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script) module fires when a new [realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#realms) is created for a window, a worker, or a worklet.
+The `script.realmCreated` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`script`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script) module fires when a new [realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#realms) is created for a document, a worker, or a worklet.
 
 ## Event data
 
@@ -43,7 +43,8 @@ The `params` field in the event notification is a [realm object](/en-US/docs/Web
 
 ## Description
 
-Together with [`script.realmDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed), use this event to monitor the lifetime of the JavaScript realms of a context and its workers.
+Together with [`script.realmDestroyed`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed), use this event to monitor the lifetime of JavaScript realms.
+
 When you [subscribe](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to this event, the browser first sends a `script.realmCreated` event for each realm that already exists and is ready to run scripts, and then sends further events as new realms are created.
 This means you don't need to call [`script.getRealms`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms) to discover the realms that existed before you subscribed.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmdestroyed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmdestroyed/index.md
@@ -20,7 +20,7 @@ The `params` field in the event notification is an object with the following fie
 
 Together with [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated), use this event to monitor the lifetime of JavaScript realms.
 
-This event fires when a document is unloaded, which happens when its context navigates to a new document or is closed.
+This event fires when a document is unloaded, which happens when its [context](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext#contexts) navigates to a new document or is closed.
 Unloading a document destroys the realm of the document and the realms of its worklets, so the event fires once for each of them.
 The event also fires when a worker reaches the end of its lifecycle or is terminated.
 

--- a/files/en-us/web/webdriver/reference/bidi/modules/script/realmdestroyed/index.md
+++ b/files/en-us/web/webdriver/reference/bidi/modules/script/realmdestroyed/index.md
@@ -1,0 +1,80 @@
+---
+title: "`script.realmDestroyed` event"
+short-title: realmDestroyed
+slug: Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed
+page-type: webdriver-event
+browser-compat: webdriver.bidi.script.realmDestroyed_event
+sidebar: webdriver
+---
+
+The `script.realmDestroyed` [event](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules#events) of the [`script`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script) module fires when the [realm](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script#realms) of a document, a worker, or a worklet is destroyed.
+
+## Event data
+
+The `params` field in the event notification is an object with the following field:
+
+- `realm`
+  - : A string that contains the ID of the realm that was destroyed.
+
+## Description
+
+Together with [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated), use this event to monitor the lifetime of JavaScript realms.
+
+This event fires when a document is unloaded, which happens when its context navigates to a new document or is closed.
+Unloading a document destroys the realm of the document and the realms of its worklets, so the event fires once for each of them.
+The event also fires when a worker reaches the end of its lifecycle or is terminated.
+
+The event contains only the realm ID, so if you need to know the context or worker to which a realm belongs, refer to [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated) or [`script.getRealms`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms).
+A realm ID is no longer valid after this event fires, and you don't need to release the objects of that realm with [`script.disown`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/disown) because they are released together with the realm.
+
+Unlike [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated), this event is never replayed, so it fires only for the realms that are destroyed after you subscribe to this event.
+
+## Examples
+
+### Tracking realms across a navigation
+
+Assume you have a [WebDriver BiDi connection](/en-US/docs/Web/WebDriver/How_to/Create_BiDi_connection) and an [active session](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/new) with a [subscription](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) to both `script.realmDestroyed` and [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated).
+
+Suppose a tab is open at `https://example.com` and you use [`browsingContext.navigate`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/browsingContext/navigate) to navigate the context to `https://example.org`.
+
+The browser first sends the following notification about the destroyed realm of the previous document:
+
+```json
+{
+  "type": "event",
+  "method": "script.realmDestroyed",
+  "params": {
+    "realm": "7c37f4c0-abcd-1234-ef56-789012345678"
+  }
+}
+```
+
+It then sends the following notification about the realm of the new document:
+
+```json
+{
+  "type": "event",
+  "method": "script.realmCreated",
+  "params": {
+    "context": "93ee5bd6-d256-4608-a002-9a8995cc0e5f",
+    "origin": "https://example.org",
+    "realm": "2b8e6d41-0f9a-4c3b-8d7e-1a2b3c4d5e6f",
+    "type": "window"
+  }
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`script.disown`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/disown) command
+- [`script.getRealms`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/getRealms) command
+- [`script.realmCreated`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script/realmCreated) event
+- [`session.subscribe`](/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/session/subscribe) command

--- a/files/sidebars/webdriver.yaml
+++ b/files/sidebars/webdriver.yaml
@@ -112,7 +112,21 @@ sidebar:
       - link: /Web/WebDriver/Reference/BiDi/Modules/permissions
         code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/script
+        details: closed
         code: true
+        children:
+          - type: section
+            link: /Web/WebDriver/Reference/BiDi/Modules/script#commands
+            title: Commands
+          - link: /Web/WebDriver/Reference/BiDi/Modules/script/getRealms
+            code: true
+          - type: section
+            link: /Web/WebDriver/Reference/BiDi/Modules/script#events
+            title: Events
+          - link: /Web/WebDriver/Reference/BiDi/Modules/script/realmCreated
+            code: true
+          - link: /Web/WebDriver/Reference/BiDi/Modules/script/realmDestroyed
+            code: true
       - link: /Web/WebDriver/Reference/BiDi/Modules/session
         details: closed
         code: true


### PR DESCRIPTION
### Description

This PR:

- Adds pages for the following command and events of the [`script` module](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/script):
    - `script.getRealms`
    - `script.realmCreated`
    - `script.realmDestroyed`

- Adds sections to the `script` module landing page to explain realms and sandbox realms in the context of BiDi.
- Makes two passing fixes to [`log.entryadded`](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Reference/BiDi/Modules/log/entryAdded) to update a link and to remove the other.



### Spec links

- https://w3c.github.io/webdriver-bidi/#command-script-getRealms
- https://w3c.github.io/webdriver-bidi/#event-script-realmCreated
- https://w3c.github.io/webdriver-bidi/#event-script-realmDestroyed

### Related issue

Doc issue: mdn/mdn#851