### PR TITLE
Finalize release notes for Firefox 154

### DIFF
--- a/files/en-us/mozilla/firefox/releases/153/index.md
+++ b/files/en-us/mozilla/firefox/releases/153/index.md
@@ -1,8 +1,8 @@
 ---
-title: Firefox 153 release notes for developers (Stable)
-short-title: Firefox 153 (Stable)
+title: Firefox 153 release notes for developers
+short-title: Firefox 153
 slug: Mozilla/Firefox/Releases/153
-page-type: firefox-release-notes-active
+page-type: firefox-release-notes
 sidebar: firefox
 ---
 

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -1,18 +1,13 @@
 ---
-title: Firefox 154 release notes for developers (Beta)
-short-title: Firefox 154 (Beta)
+title: Firefox 154 release notes for developers (Stable)
+short-title: Firefox 154 (Stable)
 slug: Mozilla/Firefox/Releases/154
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
 This article provides information about the changes in Firefox 154 that affect developers.
-Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [August 18, 2026](https://whattrainisitnow.com/release/?version=154).
-
-> [!NOTE]
-> The release notes for this Firefox version are still a work in progress.
-
-<!-- Authors: Please uncomment any headings you are writing notes for -->
+Firefox 154 was released on [August 18, 2026](https://whattrainisitnow.com/release/?version=154).
 
 ## Changes for web developers
 
@@ -21,26 +16,14 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
 - The [JSON Viewer](https://firefox-source-docs.mozilla.org/devtools-user/json_viewer/index.html) now displays a breadcrumb at the bottom of the panel indicating the location of the selected entry within the JSON structure.
   ([Firefox bug 1850288](https://bugzil.la/1850288)).
 
-<!-- ### HTML -->
+### HTML
 
-<!-- No notable changes. -->
-
-<!-- #### Removals -->
-
-<!-- ### MathML -->
-
-<!-- #### Removals -->
-
-<!-- ### SVG -->
-
-<!-- #### Removals -->
+No notable changes.
 
 ### CSS
 
 - The {{cssxref("sibling-count")}} and {{cssxref("sibling-index")}} functions are now supported. The `sibling-count()` function returns the number of sibling elements as well as the element itself. The `sibling-index()` function returns the index number of the element in relation to its siblings. The index starts at `1`, not `0`. ([Firefox bug 2045706](https://bugzil.la/2045706)).
 - The {{cssxref("text-box-edge")}} and {{cssxref("text-box-trim")}} properties and the {{cssxref("text-box")}} shorthand are now supported. These properties make it easier to control text spacing in the block direction, especially when a block contains multiple fonts. The `text-box-edge` property allows you to specify the amount of space to trim from the text element's block container. The `text-box-trim` property allows you to specify which edges to trim: the over edge, the under edge, both, or neither. The `text-box` shorthand combines these two properties. ([Firefox bug 2050141](https://bugzil.la/2050141)).
-
-<!-- #### Removals -->
 
 ### JavaScript
 
@@ -54,19 +37,7 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
   The difference between the methods is that the `chunks()` helper splits the elements from the original iterator into consecutive array chunks, while the `windows()` helper returns an array that is a sliding window over the original iterator (each iteration yields an array that slides forward one element: dropping the first element in the previous iteration and fetching a new element from the original iterator).
   ([Firefox bug 2047997](https://bugzil.la/2047997)).
 
-<!-- #### Removals -->
-
-<!-- ### HTTP -->
-
-<!-- #### Removals -->
-
-<!-- ### Security -->
-
-<!-- #### Removals -->
-
 ### APIs
-
-<!-- #### DOM -->
 
 #### Media, WebRTC, and Web Audio
 
@@ -79,12 +50,6 @@ Firefox 154 is the current [Beta version of Firefox](https://www.firefox.com/en-
   ([Firefox bug 1584318](https://bugzil.la/1584318)).
 - Firefox now reports all WebRTC `certificate` statistics defined in the {{domxref("RTCCertificateStats")}} dictionary, and the following additional WebRTC `transport` statistics defined in the {{domxref("RTCTransportStats")}} dictionary: {{domxref("RTCTransportStats/remoteCertificateId", "remoteCertificateId")}}, {{domxref("RTCTransportStats/localCertificateId", "localCertificateId")}}, {{domxref("RTCTransportStats/packetsSent", "packetsSent")}}, {{domxref("RTCTransportStats/packetsReceived", "packetsReceived")}}, {{domxref("RTCTransportStats/bytesSent", "bytesSent")}}, and {{domxref("RTCTransportStats/bytesReceived", "bytesReceived")}}.
   ([Firefox bug 2019349](https://bugzil.la/2019349) and [Firefox bug 2019333](https://bugzil.la/2019333)).
-
-<!-- #### Removals -->
-
-<!-- ### WebAssembly -->
-
-<!-- #### Removals -->
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 

--- a/files/en-us/mozilla/firefox/releases/156/index.md
+++ b/files/en-us/mozilla/firefox/releases/156/index.md
@@ -1,13 +1,13 @@
 ---
-title: Firefox 155 release notes for developers (Beta)
-short-title: Firefox 155 (Beta)
-slug: Mozilla/Firefox/Releases/155
+title: Firefox 156 release notes for developers (Nightly)
+short-title: Firefox 156 (Nightly)
+slug: Mozilla/Firefox/Releases/156
 page-type: firefox-release-notes-active
 sidebar: firefox
 ---
 
-This article provides information about the changes in Firefox 155 that affect developers.
-Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-US/channel/desktop/#beta) and ships on [September 1, 2026](https://whattrainisitnow.com/release/?version=155).
+This article provides information about the changes in Firefox 156 that affect developers.
+Firefox 156 is the current [Nightly version of Firefox](https://www.firefox.com/en-US/channel/desktop/#nightly) and ships on [September 15, 2026](https://whattrainisitnow.com/release/?version=156).
 
 > [!NOTE]
 > The release notes for this Firefox version are still a work in progress.
@@ -78,6 +78,6 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ## Experimental web features
 
-These features are shipping in Firefox 155 but are disabled by default.
+These features are shipping in Firefox 156 but are disabled by default.
 To experiment with them, search for the appropriate preference on the `about:config` page and set it to `true`.
 You can find more such features on the [Experimental features](/en-US/docs/Mozilla/Firefox/Experimental_features) page.


### PR DESCRIPTION
### Description

Updates pages for Firefox 154 release (August 18, 2026).

- Removed active status from Firefox 153
- Updated Firefox 154 to (Stable)
- Updated Firefox 155 to (Beta)
- Created a new Nightly page for Firefox 156

### Note

It successfully picked up the new schedule from [whattrainisitnow.com](https://whattrainisitnow.com/):

- August 18th
- September 1st
- September 15th