### PR TITLE
Remove invalid `media` attribute from `<meta name="color-scheme">` docs

### DIFF
--- a/files/en-us/web/html/reference/elements/meta/name/color-scheme/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/color-scheme/index.md
@@ -36,10 +36,6 @@ A `<meta name="color-scheme">` element has the following additional attributes:
     - `only light`
       - : Indicates that the document _only_ supports light mode, with a light background and dark foreground colors.
         `only dark` _is invalid_, because forcing a document to render in dark mode when it isn't compatible can result in unreadable content and all major browsers default to light mode if not otherwise configured.
-- `media` {{optional_inline}}
-  - : Any valid media type or query.
-    If provided, the options for the document's color scheme defined in the `content` attribute are suggested to the browser when the media query matches.
-    This is mostly useful for the {{cssxref("@media/prefers-color-scheme", "prefers-color-scheme")}} CSS media feature.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Removes the incorrect `media` attribute entry from the `<meta name="color-scheme">` documentation.

### Motivation

The `media` attribute is only relevant for `<meta name="theme-color">`, as documented on the main `<meta>` page. It was mistakenly also listed as a valid additional attribute for `<meta name="color-scheme">`, likely copied over by mistake in a previous PR. This fix removes the incorrect mention so readers aren't misled into thinking `media` has an effect on `color-scheme`.

### Related issues and pull requests

Fixes #43091