### PR TITLE
FF155 RTCError{Event} also supported on workers

### DIFF
--- a/files/en-us/web/api/rtcerror/errordetail/index.md
+++ b/files/en-us/web/api/rtcerror/errordetail/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCError.errorDetail
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`errorDetail`** read-only property of the {{domxref("RTCError")}} interface is a string indicating the [WebRTC](/en-US/docs/Web/API/WebRTC_API)-specific error code that occurred.
 

--- a/files/en-us/web/api/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.RTCError
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`RTCError`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) describes an error which has occurred while handling RTC operations.
 It's based upon the standard {{domxref("DOMException")}} interface that describes general DOM errors.

--- a/files/en-us/web/api/rtcerror/receivedalert/index.md
+++ b/files/en-us/web/api/rtcerror/receivedalert/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCError.receivedAlert
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`receivedAlert`** read-only property of the {{domxref("RTCError")}} interface specifies the fatal {{Glossary("DTLS")}} error which resulted in an alert being received from the remote peer.
 

--- a/files/en-us/web/api/rtcerror/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/rtcerror/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.RTCError.RTCError
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`RTCError()`** constructor creates and returns a new {{domxref("RTCError")}} object instance.
 

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.md
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCError.sctpCauseCode
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`sctpCauseCode`** read-only property of the {{domxref("RTCError")}} interface provides the {{Glossary("SCTP")}} cause code explaining why the SCTP negotiation failed, if the `RTCError` represents an SCTP error.
 

--- a/files/en-us/web/api/rtcerror/sdplinenumber/index.md
+++ b/files/en-us/web/api/rtcerror/sdplinenumber/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCError.sdpLineNumber
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`sdpLineNumber`** read-only property of the {{domxref("RTCError")}} interface specifies the {{Glossary("SDP")}} message line number where a syntax error occurred.
 

--- a/files/en-us/web/api/rtcerror/sentalert/index.md
+++ b/files/en-us/web/api/rtcerror/sentalert/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCError.sentAlert
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`sentAlert`** read-only property of the {{domxref("RTCError")}} interface specifies the {{Glossary("DTLS")}} alert number sent to the remote peer, if the error represents an outbound DTLS error.
 

--- a/files/en-us/web/api/rtcerrorevent/error/index.md
+++ b/files/en-us/web/api/rtcerrorevent/error/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-property
 browser-compat: api.RTCErrorEvent.error
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`error`** read-only property of the {{domxref("RTCErrorEvent")}} interface contains an {{domxref("RTCError")}} object that describes the {{Glossary("WebRTC")}}-specific details of the error.
 

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -5,7 +5,7 @@ page-type: web-api-interface
 browser-compat: api.RTCErrorEvent
 ---
 
-{{APIRef("WebRTC")}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`RTCErrorEvent`** interface of the [WebRTC API](/en-US/docs/Web/API/WebRTC_API) represents an error event sent to a WebRTC object.
 It inherits from the standard {{domxref("Event")}} interface, adding RTC-specific information describing the error.

--- a/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/rtcerrorevent/index.md
@@ -6,7 +6,7 @@ page-type: web-api-constructor
 browser-compat: api.RTCErrorEvent.RTCErrorEvent
 ---
 
-{{APIRef("WebRTC")}}{{AvailableInWorkers}}
+{{APIRef("WebRTC")}}{{AvailableInWorkers("window_and_dedicated")}}
 
 The **`RTCErrorEvent()`** constructor creates a new {{domxref("RTCErrorEvent")}} object.
 


### PR DESCRIPTION
FF155 adds support for [`RTCErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/RTCErrorEvent) to be fired in dedicated workers (but not other workers) and hence it is exposed on them, along with the property [`RTCError`](https://developer.mozilla.org/en-US/docs/Web/API/RTCError). See https://bugzilla.mozilla.org/show_bug.cgi?id=1814460

This adds the macro to methods.

Note that this is not in the spec yet, but is approved https://github.com/w3c/webrtc-pc/issues/3092

Related docs work can be tracked in #45175