### PR TITLE
FF155 Relnote: RTCError "sctp-failure" detail

### DIFF
--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -50,11 +50,15 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
 
 <!-- #### DOM -->
 
-<!-- #### Media, WebRTC, and Web Audio -->
+#### Media, WebRTC, and Web Audio
+
+- The [`error` event](/en-US/docs/Web/API/RTCDataChannel/error_event) fired at {{domxref("RTCDataChannel")}} may now specify ["sctp-failure"](/en-US/docs/Web/API/RTCError/errorDetail#sctp-failure) in its {{domxref("RTCError.errorDetail", "error.errorDetail")}} property if the transport is closed due to an error.
+  In addition, the event is now exposed on dedicated workers.
+  ([Firefox bug 1814460](https://bugzil.la/1814460)).
 
 <!-- #### Removals -->
 

--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -56,8 +56,8 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### Media, WebRTC, and Web Audio
 
-- The [`error` event](/en-US/docs/Web/API/RTCDataChannel/error_event) fired at {{domxref("RTCDataChannel")}} may now specify ["sctp-failure"](/en-US/docs/Web/API/RTCError/errorDetail#sctp-failure) in its {{domxref("RTCError.errorDetail", "error.errorDetail")}} property if the transport is closed due to an error.
-  In addition, the event is now exposed on dedicated workers.
+- The [`error` event](/en-US/docs/Web/API/RTCDataChannel/error_event) fired on an {{domxref("RTCDataChannel")}} object may now report [`sctp-failure`](/en-US/docs/Web/API/RTCError/errorDetail#sctp-failure) in its {{domxref("RTCError.errorDetail", "error.errorDetail")}} property if the transport is closed due to an error.
+  In addition, {{domxref("RTCError")}} and {{domxref("RTCErrorEvent")}} are now available in dedicated workers (this exposure is not yet in the specification).
   ([Firefox bug 1814460](https://bugzil.la/1814460)).
 
 <!-- #### Removals -->


### PR DESCRIPTION
FF155 supports web rtc error events with the `sctp-error` type fired at a data channel with [`RTCError.errorDetail`](https://developer.mozilla.org/en-US/docs/Web/API/RTCError/errorDetail) set to ["sctp-failure"](https://developer.mozilla.org/en-US/docs/Web/API/RTCError/errorDetail#sctp-failure) in https://bugzilla.mozilla.org/show_bug.cgi?id=1814460.

This adds the release note. Note that [`RTCErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/RTCErrorEvent) and its [`RTCError`](https://developer.mozilla.org/en-US/docs/Web/API/RTCError) property are also supported on dedicated workers so this is mentioned (it is non-standard nowm, but coming to the spec).

Related docs work can be tracked in #45175