### PR TITLE
FF155 Relnote: WebGPU dual-source-blending

### DIFF
--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -52,7 +52,7 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
-- The [`dual-source-blending` GPU feature](/en-US/docs/Web/API/GPUSupportedFeatures#available_features) is now supported.
+- The [`dual-source-blending` GPU feature](/en-US/docs/Web/API/GPUSupportedFeatures#available_features) is now supported on desktop.
   This allows the blend operations `src1`, `one-minus-src1`, `src1-alpha`, and `one-minus-src1-alpha` to be specified in the [`dstFactor`](/en-US/docs/Web/API/GPUDevice/createRenderPipeline#dstfactor) and [`srcFactor`](/en-US/docs/Web/API/GPUDevice/createRenderPipeline#srcfactor) properties of {{domxref("GPUDevice.createRenderPipeline", "createRenderPipeline()")}} and {{domxref("GPUDevice.createRenderPipelineAsync", "createRenderPipelineAsync()")}}.
   ([Firefox bug 1924328](https://bugzil.la/1924328)).
 

--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -52,6 +52,10 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 ### APIs
 
+- The [`dual-source-blending` GPU feature](/en-US/docs/Web/API/GPUSupportedFeatures#available_features) is now supported.
+  This allows the blend operations `src1`, `one-minus-src1`, `src1-alpha`, and `one-minus-src1-alpha` to be specified in the [`dstFactor`](/en-US/docs/Web/API/GPUDevice/createRenderPipeline#dstfactor) and [`srcFactor`](/en-US/docs/Web/API/GPUDevice/createRenderPipeline#srcfactor) properties of {{domxref("GPUDevice.createRenderPipeline", "createRenderPipeline()")}} and {{domxref("GPUDevice.createRenderPipelineAsync", "createRenderPipelineAsync()")}}.
+  ([Firefox bug 1924328](https://bugzil.la/1924328)).
+
 #### DOM
 
 - The {{domxref("SVGAElement")}} interface now implements the [`HyperlinkElementUtils`](https://html.spec.whatwg.org/multipage/links.html#hyperlinkelementutils) mixin. As a result, SVG {{SVGElement("a")}} elements expose the same URL component properties as HTML {{HTMLElement("a")}} elements: {{domxref("SVGAElement.protocol", "protocol")}}, {{domxref("SVGAElement.username", "username")}}, {{domxref("SVGAElement.password", "password")}}, {{domxref("SVGAElement.host", "host")}}, {{domxref("SVGAElement.hostname", "hostname")}}, {{domxref("SVGAElement.port", "port")}}, {{domxref("SVGAElement.pathname", "pathname")}}, {{domxref("SVGAElement.search", "search")}}, and {{domxref("SVGAElement.hash", "hash")}}. The read-only {{domxref("SVGAElement.origin", "origin")}} property is also exposed.


### PR DESCRIPTION
FF155 supports the [dual-source blending](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedFeatures#available_features) feature in https://bugzilla.mozilla.org/show_bug.cgi?id=1924328

This adds the feature for Firefox desktop (FF android doesn't support the parent feature).

Note that I have explained what it allows you to specifically use, rather than what it allows you to do - because that's what the existing docs do, and because I don't know enough about Web GPU to be sure of what AIs tell me. 
According to Gemini this allows you to blend two sources into a destination texture: your source and a per-channel mask. This allows control over the mixing of your source into particular colour channels rather than equally to all channels. Apprarently can be useful for some fonts etc.

Related docs work can be tracked in #45176