### PR TITLE
Add accessibility note for screen reader support to ElementInternals.labels

### DIFF
--- a/files/en-us/web/api/elementinternals/labels/index.md
+++ b/files/en-us/web/api/elementinternals/labels/index.md
@@ -31,6 +31,12 @@ let element = document.getElementById("custom-checkbox");
 console.log(element.internals_.label);
 ```
 
+## Accessibility
+
+While the `labels` property returns the label elements associated with a custom element, screen reader support for these labels varies by browser. In most browsers, the label is announced when the custom element receives focus. However, Safari does not reliably narrate labels associated via `ElementInternals` for form-associated custom elements (see [WebKit bug 259124](https://bugs.webkit.org/show_bug.cgi?id=259124)).
+
+For robust screen reader support across browsers, consider supplementing `ElementInternals` label association with ARIA attributes such as [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label).
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/elementinternals/labels/index.md
+++ b/files/en-us/web/api/elementinternals/labels/index.md
@@ -14,6 +14,18 @@ The **`labels`** read-only property of the {{domxref("ElementInternals")}} inter
 
 A {{domxref("NodeList")}} containing all of the label elements associated with this element.
 
+## Accessibility
+
+Screen reader support for labels associated with a form-associated custom element via `ElementInternals` varies by browser.
+In most browsers, the labels are announced when the custom element receives focus.
+Safari does not narrate labels associated via `ElementInternals` for form-associated custom elements (see [WebKit bug 259124](https://bugs.webkit.org/show_bug.cgi?id=259124)).
+
+For more robust cross-browser support, supplement label association with ARIA in one of two places:
+
+- Consumers of the custom element can add [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) directly to it, the same as they would for a native form control.
+- The custom element itself can set a default accessible name with {{domxref("ElementInternals.ariaLabel")}} or {{domxref("ElementInternals.ariaLabelledByElements")}}.
+  These apply only until a consumer sets `aria-label` or `aria-labelledby` on the element directly, so they act as a fallback rather than overriding a name the consumer chose.
+
 ## Examples
 
 The following example shows a custom checkbox component with a {{HTMLElement("label")}} element linked to it.
@@ -30,12 +42,6 @@ Printing the value of `labels` to the console returns a {{domxref("NodeList")}} 
 let element = document.getElementById("custom-checkbox");
 console.log(element.internals_.label);
 ```
-
-## Accessibility
-
-While the `labels` property returns the label elements associated with a custom element, screen reader support for these labels varies by browser. In most browsers, the label is announced when the custom element receives focus. However, Safari does not reliably narrate labels associated via `ElementInternals` for form-associated custom elements (see [WebKit bug 259124](https://bugs.webkit.org/show_bug.cgi?id=259124)).
-
-For robust screen reader support across browsers, consider supplementing `ElementInternals` label association with ARIA attributes such as [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) or [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label).
 
 ## Specifications
 

--- a/files/en-us/web/api/elementinternals/labels/index.md
+++ b/files/en-us/web/api/elementinternals/labels/index.md
@@ -20,11 +20,10 @@ Screen reader support for labels associated with a form-associated custom elemen
 In most browsers, the labels are announced when the custom element receives focus.
 Safari does not narrate labels associated via `ElementInternals` for form-associated custom elements (see [WebKit bug 259124](https://bugs.webkit.org/show_bug.cgi?id=259124)).
 
-For more robust cross-browser support, supplement label association with ARIA in one of two places:
+For more robust cross-browser support, you can supplement the label association with ARIA labels:
 
-- Consumers of the custom element can add [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) directly to it, the same as they would for a native form control.
-- The custom element itself can set a default accessible name with {{domxref("ElementInternals.ariaLabel")}} or {{domxref("ElementInternals.ariaLabelledByElements")}}.
-  These apply only until a consumer sets `aria-label` or `aria-labelledby` on the element directly, so they act as a fallback rather than overriding a name the consumer chose.
+- Add [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby) when using the element.
+- Custom element authors can set a default accessible name with {{domxref("ElementInternals.ariaLabel")}} or {{domxref("ElementInternals.ariaLabelledByElements")}}.
 
 ## Examples
 


### PR DESCRIPTION
## Description

This adds an Accessibility section to the [ElementInternals.labels](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/labels) page, documenting that screen reader support for labels associated via  varies by browser.

Key points covered:
- In most browsers, the label is announced when the custom element receives focus
- Safari does not reliably narrate labels associated via  for form-associated custom elements (referencing [WebKit bug 259124](https://bugs.webkit.org/show_bug.cgi?id=259124))
- Developers should consider supplementing with ARIA attributes (, ) for robust cross-browser support

Fixes #44395