### PR TITLE
Remove unnecessary markdown escaping in Element/ariaBrailleLabel example

### DIFF
--- a/files/en-us/web/api/element/ariabraillelabel/index.md
+++ b/files/en-us/web/api/element/ariabraillelabel/index.md
@@ -26,11 +26,11 @@ This example shows how to get and set the `ariaBrailleLabel` property.
 
 #### HTML
 
-First we define a button with label text "3 out of 5 stars" and an `aria-braillelabel` attribute with a value of `"\*\*\*"`.
+First we define a button with label text "3 out of 5 stars" and an `aria-braillelabel` attribute with a value of `"***"`.
 This allows a braille display to show "btn \*\*\*" in braille rather than the more verbose "btn gra 3 out of 5 stars".
 
 ```html
-<button id="button" aria-braillelabel="\*\*\*">3 out of 5 stars</button>
+<button id="button" aria-braillelabel="***">3 out of 5 stars</button>
 ```
 
 ```html hidden


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Remove unnecessary markdown escaping in Element/ariaBrailleLabel example.

https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaBrailleLabel#getting_and_setting_ariabraillelabel


### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
