### PR TITLE
FF155 Audio Session API updates

### DIFF
--- a/files/en-us/web/api/audio_session_api/index.md
+++ b/files/en-us/web/api/audio_session_api/index.md
@@ -4,9 +4,7 @@ slug: Web/API/Audio_Session_API
 page-type: web-api-overview
 status:
   - experimental
-browser-compat:
-  - api.AudioSession
-  - api.Navigator.audioSession
+browser-compat: api.AudioSession
 ---
 
 {{DefaultAPISidebar("Audio Session API")}}{{SeeCompatTable}}
@@ -30,10 +28,38 @@ The API supports several audio session types, which specify the type of audio an
 - `"ambient"` — For audio that can mix with other audio sources.
 - `"play-and-record"` — For applications that both play and record audio, such as video conferencing.
 
+#### `auto` type selection
+
+When `type` is set to `"auto"`, the user agent selects a type based on the audio APIs and elements in the page that are outputting audio.
+
+Each audio-producing feature has its own default type:
+
+- an {{domxref("AudioContext")}} defaults to `"ambient"`
+- an {{domxref("HTMLMediaElement")}} (such as `<audio>` or `<video>`) defaults to `"playback"`
+- a microphone {{domxref("MediaStreamTrack")}} obtained via {{domxref("MediaDevices.getUserMedia()", "getUserMedia()")}} defaults to `"play-and-record"`
+
+If several of these are active on the page at once, the automatically-selected type is the highest-priority one present, using the order `"play-and-record"`, `"playback"`, `"transient-solo"`, `"transient"`.
+The type falls back to `"ambient"` if none of them are active.
+For example, a page that is both recording a microphone track and playing a `<video>` resolves to `"play-and-record"`.
+
+Note that `"transient"` and `"transient-solo"` have no default source of their own, so these types must be set explicitly.
+
+### Audio session states
+
+An audio session also has a state, reflecting whether it is currently producing audio, idle, or temporarily suspended by the platform:
+
+- `"active"` — The audio session is playing sound, recording audio, or both (and is not interrupted).
+- `"interrupted"` — The session was active but has been temporarily suspended by the platform, for example because of an incoming phone call or another application taking exclusive control of audio.
+- `"inactive"` — The audio session is not playing or recording audio, and is not currently interrupted. This is the default state.
+
+The session is active while any element or other mechanism in the page is producing or capturing audio, and becomes inactive once all audio sources and sinks have stopped.
+
+The {{domxref("AudioSession.statechange_event", "statechange")}} event fires whenever the state changes, letting a page react to interruptions — for example, by pausing playback that the platform doesn't already pause automatically.
+
 ## Interfaces
 
 - {{domxref("AudioSession")}} {{Experimental_Inline}}
-  - : The main interface for controlling audio session behavior, including setting the audio session type.
+  - : The main interface for controlling audio session behavior, including setting the audio session type and tracking its state.
 
 ### Extensions to other interfaces
 
@@ -46,10 +72,13 @@ The API supports several audio session types, which specify the type of audio an
 
 In a video conferencing application, both playback and recording are required simultaneously; this is something the Audio Session API can help with.
 
-First, we set the audio session type to `"play-and-record"` to inform the platform that this page requires microphone access alongside audio output. On supporting platforms, this may adjust system volume routing (for example, using the earpiece instead of the speaker on mobile devices) and prevent audio from other applications from interrupting the call.
+First, we check that the interface is supported, and if so we set the audio session type to `"play-and-record"`.
+This informs the platform that this page requires microphone access alongside audio output, which in turn may then adjust system volume routing (for example, using the earpiece instead of the speaker on mobile devices) and prevent audio from other applications from interrupting the call.
 
 ```js
-navigator.audioSession.type = "play-and-record";
+if ("audioSession" in navigator) {
+  navigator.audioSession.type = "play-and-record";
+}
 ```
 
 Next, we set up the media streams for the video call as usual. The platform will now handle the audio produced by these streams according to the `"play-and-record"` session type.
@@ -65,6 +94,35 @@ navigator.mediaDevices
   .then((stream) => {
     localVideo.srcObject = stream;
   });
+```
+
+The following code listens for the {{domxref("AudioSession.statechange_event", "statechange")}} event.
+If the session state is `"interrupted"` by the platform, for example due to an incoming phone call, the handler pauses unmuted local and remote video while the interruption lasts (the platform itself will pause and restart any elements that have an audible output).
+
+```js
+// Pause local playback and recording while the platform interrupts the call
+navigator.audioSession.addEventListener("statechange", () => {
+  const interrupted = navigator.audioSession.state === "interrupted";
+
+  // remoteVideo is the audio/video from the remote end.
+  // We pause it on interruption if it was muted (and hence not paused automatically)
+  if (remoteVideo.muted) {
+    if (interrupted) {
+      remoteVideo.pause();
+    } else {
+      remoteVideo.play();
+    }
+  }
+
+  // localVideo is the preview for the local user.
+  // This is typically muted by default,
+  // so the page must pause and resume it explicitly.
+  if (interrupted) {
+    localVideo.pause();
+  } else {
+    localVideo.play();
+  }
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/audiosession/index.md
+++ b/files/en-us/web/api/audiosession/index.md
@@ -9,7 +9,11 @@ browser-compat: api.AudioSession
 
 {{APIRef("Audio Session API")}}{{SeeCompatTable}}
 
-The **`AudioSession`** interface of the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) lets a web page declare the type of audio it is producing — for example music playback, a video call, or a short notification. The platform uses that declaration to decide how the page's audio and audio from other applications and tabs should coexist — whether to pause, duck (lower the volume), or play in parallel.
+The **`AudioSession`** interface of the [Audio Session API](/en-US/docs/Web/API/Audio_Session_API) lets a web page declare the type of audio it is producing — for example music playback, a video call, or a short notification.
+The platform uses the declared type to decide how the page's audio and audio from other applications and tabs should coexist — whether to pause, duck (lower the volume), or play in parallel.
+
+The interface also provides the {{domxref("AudioSession.state", "state")}} property, which indicates if audio is actively playing on the page, is inactive, or has been interrupted, and the {{domxref("AudioSession.statechange_event", "statechange")}} event, which provides notification when the state changes.
+While audible media is automatically paused/resumed by interruptions, state monitoring allows the configuration of behavior that is not automatically controlled.
 
 {{InheritanceDiagram}}
 
@@ -17,12 +21,41 @@ The **`AudioSession`** interface of the [Audio Session API](/en-US/docs/Web/API/
 
 - {{domxref("AudioSession.type")}} {{Experimental_Inline}}
   - : A string representing the type of the audio session. Possible values include `"auto"`, `"playback"`, `"transient"`, `"transient-solo"`, `"ambient"`, and `"play-and-record"`.
+- {{domxref("AudioSession.state")}} {{ReadOnlyInline}} {{Experimental_Inline}}
+  - : A string representing the current state of the audio session. Possible values are `"active"`, `"interrupted"`, and `"inactive"`.
+
+## Events
+
+Listen to these events using {{domxref("EventTarget.addEventListener", "addEventListener()")}} or by assigning an event listener to the `oneventname` property of this interface.
+
+- {{domxref("AudioSession.statechange_event", "statechange")}}
+  - : Fired when the {{domxref("AudioSession.state", "state")}} property changes.
+    Also available through the {{domxref("AudioSession.statechange_event", "onstatechange")}} event handler property.
 
 ## Examples
 
-### Setting the audio session type for a video conferencing app
+### Basic usage
 
-The following example sets the audio session type to `"play-and-record"` for a video conferencing application. On supporting platforms, this signals that the page needs simultaneous playback and recording, which may cause the system to route audio through the correct output (for example, earpiece instead of speaker on mobile devices) and prevent other applications' audio from interrupting the call.
+The following example sets the audio session type to `"playback"` before starting media playback (provided `AudioSession` is supported).
+This signals that the page is playing media such as music or video.
+
+```js
+if ("audioSession" in navigator) {
+  // Set the audio session type for media playback
+  navigator.audioSession.type = "playback";
+}
+
+// Play some audio
+audioElement.play();
+```
+
+### Setting up a video conferencing app
+
+This example sets the audio session type to `"play-and-record"` for a video conferencing application.
+
+First we use {{domxref("Navigator.audioSession")}} to signal that the page needs simultaneous playback and recording.
+This may cause the system to route audio through the correct output (for example, earpiece instead of speaker on mobile devices) and prevent other applications' audio from interrupting the call.
+Then we start playing the remote media and streaming our own video and audio.
 
 ```js
 navigator.audioSession.type = "play-and-record";
@@ -37,6 +70,35 @@ const stream = await navigator.mediaDevices.getUserMedia({
   video: true,
 });
 localVideo.srcObject = stream;
+```
+
+The following code listens for the {{domxref("AudioSession.statechange_event", "statechange")}} event.
+If the session state is `"interrupted"` by the platform, for example due to an incoming phone call, the handler pauses unmuted local and remote video while the interruption lasts (the platform itself will pause and restart any elements that have an audible output).
+
+```js
+// Pause local playback and recording while the platform interrupts the call
+navigator.audioSession.addEventListener("statechange", () => {
+  const interrupted = navigator.audioSession.state === "interrupted";
+
+  // remoteVideo is the audio/video from the remote end.
+  // We pause it on interruption if it was muted (and hence not paused automatically)
+  if (remoteVideo.muted) {
+    if (interrupted) {
+      remoteVideo.pause();
+    } else {
+      remoteVideo.play();
+    }
+  }
+
+  // localVideo is the preview for the local user.
+  // This is typically muted by default,
+  // so the page must pause and resume it explicitly.
+  if (interrupted) {
+    localVideo.pause();
+  } else {
+    localVideo.play();
+  }
+});
 ```
 
 ## Specifications

--- a/files/en-us/web/api/audiosession/state/index.md
+++ b/files/en-us/web/api/audiosession/state/index.md
@@ -1,0 +1,66 @@
+---
+title: "AudioSession: state property"
+short-title: state
+slug: Web/API/AudioSession/state
+page-type: web-api-instance-property
+status:
+  - experimental
+browser-compat: api.AudioSession.state
+---
+
+{{APIRef("Audio Session API")}}{{SeeCompatTable}}
+
+The **`state`** read-only property of the {{domxref("AudioSession")}} interface returns the current state of the audio session.
+
+## Value
+
+A string whose value is one of the following:
+
+- `"active"`
+  - : The audio session is currently playing sound, recording audio, or both.
+- `"interrupted"`
+  - : The audio session was active but has been temporarily suspended by the platform, for example because of an incoming phone call or another application taking exclusive control of audio. The session may return to `"active"` once the interruption ends.
+- `"inactive"`
+  - : The audio session is not playing or recording audio, and is not currently interrupted. This is the default state.
+
+## Description
+
+The platform updates the `state` in response to the page's own audio activity (starting or stopping playback or recording) and to platform-level events, such as another application taking exclusive control of audio or an incoming phone call.
+The {{domxref("AudioSession.statechange_event", "statechange")}} event can be monitored for notifications when the value changes.
+
+The property reflects the state of every audio source and sink that the page has created, including {{htmlelement("audio")}} and {{htmlelement("video")}} elements, {{domxref("AudioContext")}} instances, and microphone {{domxref("MediaStreamTrack")}}s obtained with {{domxref("MediaDevices.getUserMedia()")}}.
+The session becomes `"active"` when any of these is producing or capturing audible sound, and returns to `"inactive"` when all of them are stopped.
+Starting or stopping an individual source doesn't otherwise change the reported state.
+
+When the state becomes `"interrupted"`, because something else has taken exclusive control of audio, the browser automatically pauses playing media elements, suspends `AudioContext`s, and mutes microphone tracks that belong to the session.
+It then automatically resumes them when the state returns to `"active"`.
+Note that this only applies to elements that are producing audible output when the state is interrupted; a muted or silent element is never affected and must be explicitly paused or resumed if needed.
+See the {{domxref("AudioSession.statechange_event", "statechange")}} event page for an example.
+
+The value of `state` doesn't stop you calling {{domxref("HTMLMediaElement.play()")}} or other mechanisms to start audio, but such a call will likely fail if another app is still holding exclusive control of audio.
+In this case the `state` stays `"inactive"` or `"interrupted"`, the method returns without error, but no sound may actually be produced.
+You should instead wait for the {{domxref("AudioSession.statechange_event", "statechange")}} event to report that `state` has returned to `"active"` on its own.
+
+## Examples
+
+### Basic usage
+
+```js
+navigator.audioSession.addEventListener("statechange", () => {
+  statusElement.textContent = `Audio session: ${navigator.audioSession.state}`;
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioSession")}}
+- {{domxref("AudioSession.statechange_event")}}
+- [Audio Session API](/en-US/docs/Web/API/Audio_Session_API)

--- a/files/en-us/web/api/audiosession/statechange_event/index.md
+++ b/files/en-us/web/api/audiosession/statechange_event/index.md
@@ -1,0 +1,96 @@
+---
+title: "AudioSession: statechange event"
+short-title: statechange
+slug: Web/API/AudioSession/statechange_event
+page-type: web-api-event
+status:
+  - experimental
+browser-compat: api.AudioSession.statechange_event
+---
+
+{{APIRef("Audio Session API")}}{{SeeCompatTable}}
+
+A **`statechange`** event fires on an {{domxref("AudioSession")}} when its {{domxref("AudioSession.state", "state")}} property changes.
+
+This event is not cancelable and does not bubble.
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js-nolint
+addEventListener("statechange", (event) => { })
+
+onstatechange = (event) => { }
+```
+
+## Event type
+
+A generic {{domxref("Event")}}.
+
+## Description
+
+The `state` value changes in response to the page's own audio activity, becoming `"active"` when any audio source or sink in the page is active and `"inactive"` when all audio sources and sinks are stopped.
+It can also change to `"interrupted"` in response to a platform-level event such as an incoming phone call or another application taking exclusive control of audio.
+
+When the state changes to or from `"interrupted"`, the browser automatically pauses or resumes audible media elements, suspends or resumes `AudioContext`s, and mutes or unmutes microphone tracks belonging to the session.
+
+The **`statechange`** event allows you to monitor for state changes and perform any operations that aren't handled automatically.
+This includes whether or not to pause muted video, or continue to stream an outgoing {{domxref("MediaStreamTrack")}}.
+
+## Examples
+
+### Handling an interruption in a video call
+
+This example shows how code might handle a `statechange` event during a video call.
+
+`remoteVideo` plays the audio from the other participant, so while it's audible the browser pauses and resumes it automatically.
+If the user has muted the other participant, though, `remoteVideo` isn't audible and the browser leaves it alone.
+
+`localVideo` shows the user's own camera preview (which is muted).
+This and the outgoing microphone track must be paused, resumed, muted, and unmuted by the page itself if needed.
+
+```js
+navigator.audioSession.addEventListener("statechange", () => {
+  const interrupted = navigator.audioSession.state === "interrupted";
+
+  // remoteVideo is the audio/video from the remote end.
+  // We pause it on interruption if it was muted (and hence not paused automatically)
+  if (remoteVideo.muted) {
+    if (interrupted) {
+      remoteVideo.pause();
+    } else {
+      remoteVideo.play();
+    }
+  }
+
+  // localVideo is the preview for the local user.
+  // This is typically muted by default,
+  // so the page must pause and resume it explicitly.
+  if (interrupted) {
+    localVideo.pause();
+  } else {
+    localVideo.play();
+  }
+
+  // Whether an outgoing track is enabled is always up to the page.
+  microphoneTrack.enabled = !interrupted;
+
+  // Control the display of a banner
+  // ... and so on ...
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("AudioSession")}}
+- {{domxref("AudioSession.state")}}
+- [Audio Session API](/en-US/docs/Web/API/Audio_Session_API)

--- a/files/en-us/web/api/audiosession/type/index.md
+++ b/files/en-us/web/api/audiosession/type/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AudioSession.type
 
 {{APIRef("Audio Session API")}}{{SeeCompatTable}}
 
-The **`type`** property of the {{domxref("AudioSession")}} interface returns or sets the type of the audio session.
+The **`type`** property of the {{domxref("AudioSession")}} interface represents the type of the audio session.
 
 The audio session type describes the general nature of a web page's audio output, allowing the platform to determine how web-based audio should interact with other audio playing on the device.
 
@@ -19,7 +19,7 @@ The audio session type describes the general nature of a web page's audio output
 A string representing the audio session type. Possible values are:
 
 - `"auto"`
-  - : The default value. The user agent automatically chooses the best audio session type based on the audio APIs used by the page.
+  - : The default value. The user agent automatically chooses the audio session type based on the audio APIs used by the page, following a fixed priority order — see [`auto` type selection](/en-US/docs/Web/API/Audio_Session_API#auto_type_selection) for details.
 - `"playback"`
   - : Audio for media playback, such as video or music playback, podcasts, etc. This is an exclusive type that will pause other playback audio on the device, but may allow non-playback audio (such as notification sounds) to continue.
 - `"transient"`


### PR DESCRIPTION
FF155 Adds support for the Audio Session API](https://developer.mozilla.org/en-US/docs/Web/API/Audio_Session_API).
This updates the docs to add missing properties and events to track changes in the audio _state_ (matching spec).

Related docs work can be tracked in #45184