### PR TITLE
fix: (Element.getAttributeNode) return value can be null

### DIFF
--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -8,53 +8,26 @@ browser-compat: api.Element.getAttribute
 
 {{APIRef("DOM")}}
 
-The **`getAttribute()`** method of the
-{{domxref("Element")}} interface returns the value of a specified attribute on the
-element.
-
-If the given attribute does not exist, the value returned will be `null`.
+The **`getAttribute()`** method of the {{domxref("Element")}} interface returns the string value of the specified attribute of the specified element. It returns `null` if the element doesn't have an attribute with the given name.
 
 If you need to inspect the {{domxref("Attr")}} node's properties, you can use the {{domxref("Element.getAttributeNode()", "getAttributeNode()")}} method instead.
 
 ## Syntax
 
 ```js-nolint
-getAttribute(attributeName)
+getAttribute(attrName)
 ```
 
 ### Parameters
 
-- `attributeName`
-  - : The name of the attribute whose value you want to get.
+- `attrName`
+  - : A string specifying the name of the attribute. When called on an HTML element in a DOM flagged as an HTML document, the name is normalized to lowercase.
 
 ### Return value
 
-A string containing the value of `attributeName` if the attribute exists, otherwise `null`.
+A string containing the attribute's value, or `null` if the element doesn't have an attribute with the given name.
 
-## Examples
-
-```html
-<!-- example div in an HTML DOC -->
-<div id="div1">Hi Champ!</div>
-```
-
-```js
-const div1 = document.getElementById("div1");
-// <div id="div1">Hi Champ!</div>
-
-const exampleAttr = div1.getAttribute("id");
-// "div1"
-
-const lang = div1.getAttribute("lang");
-// null
-```
-
-## Description
-
-### Lower casing
-
-When called on an HTML element in a DOM flagged as an HTML document,
-`getAttribute()` lower-cases its argument before proceeding.
+## Usage notes
 
 ### Decoded character references in attribute values
 
@@ -74,12 +47,10 @@ Use {{domxref("Node.textContent", "textContent")}} (or another text-safe API) fo
 
 ### Retrieving nonce values
 
-For security reasons, [CSP](/en-US/docs/Web/HTTP/Guides/CSP) nonces from non-script
-sources, such as CSS selectors, and `.getAttribute("nonce")` calls are
-hidden.
+For security reasons, [CSP](/en-US/docs/Web/HTTP/Guides/CSP) nonces from non-script sources, such as CSS selectors and `.getAttribute("nonce")` calls, are hidden.
 
 ```js example-bad
-let nonce = script.getAttribute("nonce");
+const nonce = script.getAttribute("nonce");
 // returns empty string
 ```
 
@@ -87,7 +58,25 @@ Instead of retrieving the nonce from the content attribute, use the
 {{domxref("HTMLElement/nonce", "nonce")}} property:
 
 ```js
-let nonce = script.nonce;
+const nonce = script.nonce;
+```
+
+## Examples
+
+```html
+<!-- example div in an HTML DOC -->
+<div id="div1">Hi Champ!</div>
+```
+
+```js
+const div1 = document.getElementById("div1");
+// <div id="div1">Hi Champ!</div>
+
+const exampleAttr = div1.getAttribute("id");
+// "div1"
+
+const lang = div1.getAttribute("lang");
+// null
 ```
 
 ## Specifications

--- a/files/en-us/web/api/element/getattributenode/index.md
+++ b/files/en-us/web/api/element/getattributenode/index.md
@@ -6,7 +6,7 @@ page-type: web-api-instance-method
 browser-compat: api.Element.getAttributeNode
 ---
 
-{{ APIRef("DOM") }}
+{{APIRef("DOM")}}
 
 The **`getAttributeNode()`** method of the {{domxref("Element")}} interface returns the specified attribute of the specified element, as an {{domxref("Attr")}} node. It returns `null` if the element doesn't have an attribute with the given name.
 
@@ -22,7 +22,7 @@ getAttributeNode(attrName)
 ### Parameters
 
 - `attrName`
-  - : A string containing the name of the attribute. When called on an HTML element in a DOM flagged as an HTML document, the name is normalized to lowercase.
+  - : A string specifying the name of the attribute. When called on an HTML element in a DOM flagged as an HTML document, the name is normalized to lowercase.
 
 ### Return value
 

--- a/files/en-us/web/api/element/getattributenode/index.md
+++ b/files/en-us/web/api/element/getattributenode/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Element.getAttributeNode
 
 {{ APIRef("DOM") }}
 
-Returns the specified attribute of the specified element, as an {{domxref("Attr")}} node.
+The **`getAttributeNode()`** method of the {{domxref("Element")}} interface returns the specified attribute of the specified element, as an {{domxref("Attr")}} node. It returns `null` if the element doesn't have an attribute with the given name.
 
 This method is useful if you need the attribute's [instance properties](/en-US/docs/Web/API/Attr#instance_properties).
 If you only need the attribute's value, you can use the {{domxref("Element.getAttribute()", "getAttribute()")}} method instead.
@@ -22,26 +22,23 @@ getAttributeNode(attrName)
 ### Parameters
 
 - `attrName`
-  - : A string containing the name of the attribute.
+  - : A string containing the name of the attribute. When called on an HTML element in a DOM flagged as an HTML document, the name is normalized to lowercase.
 
 ### Return value
 
-An `Attr` node for the attribute, or `null`.
+An `Attr` node for the attribute, or `null` if the element doesn't have an attribute with the given name.
+
+> [!NOTE]
+> The `Attr` node inherits from `Node`, but is not considered a part of the document tree. Common `Node` attributes like [`parentNode`](/en-US/docs/Web/API/Node/parentNode), [`previousSibling`](/en-US/docs/Web/API/Node/previousSibling), and [`nextSibling`](/en-US/docs/Web/API/Node/nextSibling) are `null` for an `Attr` node. You can, however, get the element to which the attribute belongs with the {{domxref("Attr.ownerElement", "ownerElement")}} property.
 
 ## Examples
 
 ```js
 // html: <div id="top" />
-let t = document.getElementById("top");
-let idAttr = t.getAttributeNode("id");
-alert(idAttr.value === "top");
+const t = document.getElementById("top");
+const idAttr = t.getAttributeNode("id");
+console.log(idAttr.value); // "top"
 ```
-
-## Notes
-
-When called on an HTML element in a DOM flagged as an HTML document, `getAttributeNode` lower-cases its argument before proceeding.
-
-The `Attr` node inherits from `Node`, but is not considered a part of the document tree. Common `Node` attributes like [parentNode](/en-US/docs/Web/API/Node/parentNode), [previousSibling](/en-US/docs/Web/API/Node/previousSibling), and [nextSibling](/en-US/docs/Web/API/Node/nextSibling) are `null` for an `Attr` node. You can, however, get the element to which the attribute belongs with the `ownerElement` property.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/getattributenode/index.md
+++ b/files/en-us/web/api/element/getattributenode/index.md
@@ -26,7 +26,7 @@ getAttributeNode(attrName)
 
 ### Return value
 
-An `Attr` node for the attribute.
+An `Attr` node for the attribute, or `null`.
 
 ## Examples
 

--- a/files/en-us/web/api/element/getattributenodens/index.md
+++ b/files/en-us/web/api/element/getattributenodens/index.md
@@ -8,7 +8,7 @@ browser-compat: api.Element.getAttributeNodeNS
 
 {{ APIRef("DOM") }}
 
-The **`getAttributeNodeNS()`** method of the {{domxref("Element")}} interface returns the namespaced {{domxref("Attr")}} node of an element.
+The **`getAttributeNodeNS()`** method of the {{domxref("Element")}} interface returns the specified attribute in a namespace of the specified element, as an {{domxref("Attr")}} node. It returns `null` if the element doesn't have an attribute with the given name in the namespace.
 
 This method is useful if you need the namespaced attribute's [instance properties](/en-US/docs/Web/API/Attr#instance_properties).
 If you only need the namespaced attribute's value, you can use the {{domxref("Element.getAttributeNS()", "getAttributeNS()")}} method instead.
@@ -24,17 +24,13 @@ getAttributeNodeNS(namespace, nodeName)
 ### Parameters
 
 - `namespace`
-  - : A string specifying the namespace of the attribute.
+  - : A string specifying the namespace of the attribute, or `null` to use the default namespace.
 - `nodeName`
   - : A string specifying the name of the attribute.
 
 ### Return value
 
-The node for specified attribute, or `null`.
-
-## Notes
-
-`getAttributeNodeNS` is more specific than [getAttributeNode](/en-US/docs/Web/API/Element/getAttributeNode) in that it allows you to specify attributes that are part of a particular namespace. The corresponding setter method is [setAttributeNodeNS](/en-US/docs/Web/API/Element/setAttributeNodeNS).
+An `Attr` node for the attribute, or `null` if the element doesn't have an attribute with the given name in the namespace.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/getattributenodens/index.md
+++ b/files/en-us/web/api/element/getattributenodens/index.md
@@ -18,14 +18,14 @@ If you are working with HTML documents and you don't need to specify the request
 ## Syntax
 
 ```js-nolint
-getAttributeNodeNS(namespace, attrName)
+getAttributeNodeNS(namespace, localName)
 ```
 
 ### Parameters
 
 - `namespace`
-  - : A string specifying the namespace of the attribute, or `null` to use the default namespace.
-- `attrName`
+  - : A string specifying the namespace of the attribute, or `null` for no explicit namespace.
+- `localName`
   - : A string specifying the name of the attribute.
 
 ### Return value

--- a/files/en-us/web/api/element/getattributenodens/index.md
+++ b/files/en-us/web/api/element/getattributenodens/index.md
@@ -30,7 +30,7 @@ getAttributeNodeNS(namespace, nodeName)
 
 ### Return value
 
-The node for specified attribute.
+The node for specified attribute, or `null`.
 
 ## Notes
 

--- a/files/en-us/web/api/element/getattributenodens/index.md
+++ b/files/en-us/web/api/element/getattributenodens/index.md
@@ -6,26 +6,26 @@ page-type: web-api-instance-method
 browser-compat: api.Element.getAttributeNodeNS
 ---
 
-{{ APIRef("DOM") }}
+{{APIRef("DOM")}}
 
-The **`getAttributeNodeNS()`** method of the {{domxref("Element")}} interface returns the specified attribute in a namespace of the specified element, as an {{domxref("Attr")}} node. It returns `null` if the element doesn't have an attribute with the given name in the namespace.
+The **`getAttributeNodeNS()`** method of the {{domxref("Element")}} interface returns the specified namespaced attribute of the specified element, as an {{domxref("Attr")}} node. It returns `null` if the element doesn't have an attribute with the given name in the namespace.
 
 This method is useful if you need the namespaced attribute's [instance properties](/en-US/docs/Web/API/Attr#instance_properties).
 If you only need the namespaced attribute's value, you can use the {{domxref("Element.getAttributeNS()", "getAttributeNS()")}} method instead.
 
-If you need the {{domxref("Attr")}} node of an element in HTML documents and the attribute is not namespaced, use the {{domxref("Element.getAttributeNode()", "getAttributeNode()")}} method instead.
+If you are working with HTML documents and you don't need to specify the requested attribute as being part of a specific namespace, use the {{domxref("Element.getAttributeNode()", "getAttributeNode()")}} method instead.
 
 ## Syntax
 
 ```js-nolint
-getAttributeNodeNS(namespace, nodeName)
+getAttributeNodeNS(namespace, attrName)
 ```
 
 ### Parameters
 
 - `namespace`
   - : A string specifying the namespace of the attribute, or `null` to use the default namespace.
-- `nodeName`
+- `attrName`
   - : A string specifying the name of the attribute.
 
 ### Return value

--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -8,37 +8,26 @@ browser-compat: api.Element.getAttributeNS
 
 {{APIRef("DOM")}}
 
-The **`getAttributeNS()`** method of the {{domxref("Element")}}
-interface returns the string value of the attribute with the specified namespace and
-name. If the named attribute does not exist, the value returned will either be
-`null` or `""` (the empty string); see [Notes](#notes) for
-details.
+The **`getAttributeNS()`** method of the {{domxref("Element")}} interface returns the string value of the specified namespaced attribute of the specified element. It returns `null` if the element doesn't have an attribute with the given name in the namespace.
 
 If you are working with HTML documents and you don't need to specify the requested attribute as being part of a specific namespace, use the {{domxref("Element.getAttribute()", "getAttribute()")}} method instead.
 
 ## Syntax
 
 ```js-nolint
-getAttributeNS(namespace, name)
+getAttributeNS(namespace, attrName)
 ```
 
 ### Parameters
 
 - `namespace`
-  - : The namespace in which to look for the specified attribute.
-- `name`
-  - : The name of the attribute to look for.
+  - : A string specifying the namespace of the attribute, or `null` to use the default namespace.
+- `attrName`
+  - : A string specifying the name of the attribute.
 
 ### Return value
 
-The string value of the specified attribute. If the attribute doesn't exist, the result
-is `null`.
-
-> [!NOTE]
-> Earlier versions of the DOM specification had
-> this method described as returning an empty string for non-existent attributes, but it
-> was not typically implemented this way since null makes more sense. The DOM4
-> specification now says this method should return null for non-existent attributes.
+A string containing the attribute's value, or `null` if the element doesn't have an attribute with the given name.
 
 ## Examples
 
@@ -87,21 +76,6 @@ const ns = "http://www.example.com/2014/test";
 const circle = document.getElementById("target");
 console.log(`Attribute value: ${circle.getAttribute("test:foo")}`);
 ```
-
-## Notes
-
-`getAttributeNS()` differs from {{domxref("element.getAttribute()", "getAttribute()")}}
-in that it allows you to further specify the requested attribute as
-being part of a particular namespace, as in the example above, where the attribute is
-part of the fictional "test" namespace.
-
-Prior to the DOM4 specification, this method was specified to return an empty string
-rather than null for non-existent attributes. However, most browsers instead returned
-null. Starting with DOM4, the specification now says to return null. However, some older
-browsers return an empty string. For that reason, you should use
-{{domxref("element.hasAttributeNS()", "hasAttributeNS()")}} to check for an attribute's
-existence prior to calling `getAttributeNS()` if it is possible that the
-requested attribute does not exist on the specified element.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -15,14 +15,14 @@ If you are working with HTML documents and you don't need to specify the request
 ## Syntax
 
 ```js-nolint
-getAttributeNS(namespace, attrName)
+getAttributeNS(namespace, localName)
 ```
 
 ### Parameters
 
 - `namespace`
-  - : A string specifying the namespace of the attribute, or `null` to use the default namespace.
-- `attrName`
+  - : A string specifying the namespace of the attribute, or `null` for no explicit namespace.
+- `localName`
   - : A string specifying the name of the attribute.
 
 ### Return value


### PR DESCRIPTION
### Description

The return value of `Element.getAttributeNode` can be null, if the given attribute name does not exist.

### Motivation

Provide direct and accurate information.

### Additional details

None

### Related issues and pull requests

None