### PR TITLE
Docs: move <details> usage notes out of Try It, fix ::details-content animation claim

### DIFF
--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -83,13 +83,15 @@ A `<details>` widget can be in one of two states. The default _closed_ state dis
 
 When the user clicks on the widget or focuses it then presses the space bar, it "twists" open, revealing its contents. The common use of a triangle which rotates or twists around to represent opening or closing the widget is why these are sometimes called "twisty".
 
-You can use CSS to style the disclosure widget, and you can programmatically open and close the widget by setting/removing its [`open`](#open) attribute.
+You can programmatically open and close the widget by setting or removing its [`open`](#open) attribute.
 
-By default when closed, the widget is only tall enough to display the disclosure triangle and summary. When open, it expands to display the details contained within.
+By default, the element when closed is only tall enough to display the disclosure triangle and summary. When open, it expands to display the details contained within.
 
-To animate the transition between open and closed, use the {{cssxref("::details-content")}} pseudo-element.
+### Styling the `<details>` element
 
-Fully standards-compliant implementations automatically apply the CSS `{{cssxref("display")}}: list-item` to the {{HTMLElement("summary")}} element. You can use this or the {{cssxref("::marker")}} pseudo-element to [customize the disclosure widget](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
+The `<summary>` element is automatically given a {{cssxref("display")} value of {{cssxref("<display-listitem>")}}, enabling you to style the disclosure icon using the {{cssxref("list-style-type")}} and {{cssxref("list-style-position")}} properties or the {{cssxref("::marker")}} pseudo-element. See also [Changing the summary's icon](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
+
+You can style the content of the `<details>` element using the {{cssxref("::details-content")}} pseudo-element.
 
 ## Examples
 

--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -89,7 +89,7 @@ By default, the element when closed is only tall enough to display the disclosur
 
 ### Styling the `<details>` element
 
-The `<summary>` element is automatically given a `display: list-item` value, enabling you to style the disclosure icon using the {{cssxref("list-style-type")}} and {{cssxref("list-style-position")}} properties or the {{cssxref("::marker")}} pseudo-element. See also [Changing the summary's icon](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
+The `<summary>` element is automatically given a `display: list-item` value, enabling you to style the summary's marker using the {{cssxref("list-style-type")}} and {{cssxref("list-style-position")}} properties or the {{cssxref("::marker")}} pseudo-element. See also [Changing the summary's icon](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
 
 You can style the content of the `<details>` element using the {{cssxref("::details-content")}} pseudo-element.
 

--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -79,7 +79,7 @@ details.addEventListener("toggle", (event) => {
 
 ## Usage notes
 
-A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside `<summary>` (or a {{Glossary("user agent")}}-defined default string if no `<summary>`).
+A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside the enclosed `<summary>` element, or a {{Glossary("user agent")}}-defined default string if no `<summary>` element is defined.
 
 When the user clicks on the widget or focuses it then presses the space bar, it "twists" open, revealing its contents. The common use of a triangle which rotates or twists around to represent opening or closing the widget is why these are sometimes called "twisty".
 

--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -43,16 +43,6 @@ details[open] summary {
 }
 ```
 
-A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside `<summary>` (or a {{Glossary("user agent")}}-defined default string if no `<summary>`).
-
-When the user clicks on the widget or focuses it then presses the space bar, it "twists" open, revealing its contents. The common use of a triangle which rotates or twists around to represent opening or closing the widget is why these are sometimes called "twisty".
-
-You can use CSS to style the disclosure widget, and you can programmatically open and close the widget by setting/removing its [`open`](#open) attribute. Unfortunately, at this time, there's no built-in way to animate the transition between open and closed.
-
-By default when closed, the widget is only tall enough to display the disclosure triangle and summary. When open, it expands to display the details contained within.
-
-Fully standards-compliant implementations automatically apply the CSS `{{cssxref("display")}}: list-item` to the {{HTMLElement("summary")}} element. You can use this or the {{cssxref("::marker")}} pseudo-element to [customize the disclosure widget](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
-
 ## Attributes
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -86,6 +76,20 @@ details.addEventListener("toggle", (event) => {
   }
 });
 ```
+
+## Usage notes
+
+A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside `<summary>` (or a {{Glossary("user agent")}}-defined default string if no `<summary>`).
+
+When the user clicks on the widget or focuses it then presses the space bar, it "twists" open, revealing its contents. The common use of a triangle which rotates or twists around to represent opening or closing the widget is why these are sometimes called "twisty".
+
+You can use CSS to style the disclosure widget, and you can programmatically open and close the widget by setting/removing its [`open`](#open) attribute.
+
+By default when closed, the widget is only tall enough to display the disclosure triangle and summary. When open, it expands to display the details contained within.
+
+To animate the transition between open and closed, use the {{cssxref("::details-content")}} pseudo-element.
+
+Fully standards-compliant implementations automatically apply the CSS `{{cssxref("display")}}: list-item` to the {{HTMLElement("summary")}} element. You can use this or the {{cssxref("::marker")}} pseudo-element to [customize the disclosure widget](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
 
 ## Examples
 

--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -89,7 +89,7 @@ By default, the element when closed is only tall enough to display the disclosur
 
 ### Styling the `<details>` element
 
-The `<summary>` element is automatically given a {{cssxref("display")} value of {{cssxref("<display-listitem>")}}, enabling you to style the disclosure icon using the {{cssxref("list-style-type")}} and {{cssxref("list-style-position")}} properties or the {{cssxref("::marker")}} pseudo-element. See also [Changing the summary's icon](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
+The `<summary>` element is automatically given a `display: list-item` value, enabling you to style the disclosure icon using the {{cssxref("list-style-type")}} and {{cssxref("list-style-position")}} properties or the {{cssxref("::marker")}} pseudo-element. See also [Changing the summary's icon](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
 
 You can style the content of the `<details>` element using the {{cssxref("::details-content")}} pseudo-element.
 


### PR DESCRIPTION
### Description
Moves the descriptive prose about the `<details>` disclosure widget out of the "Try it" interactive-example block and into a new "Usage notes" section, and corrects the outdated claim that there's no built-in way to animate the open/closed transition.

### Motivation
The "Try it" section should only contain the interactive demo, not explanatory prose — the surrounding text was left over from before MDN content moved to GitHub and predates that convention. Separately, the text stated there's "no built-in way to animate the transition between open and closed," which is no longer true: `::details-content` supports this and has been Baseline since September 2025. This PR relocates the prose into a new "Usage notes" section (placed after "Events" and before "Examples") and updates the animation claim to point readers to `::details-content`.

### Additional details
- [`::details-content` on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::details-content)
- Baseline status: widely available since September 2025

### Related issues and pull requests
Fixes #42226
From https://github.com/mdn/content/issues/42226#issuecomment-5288349011