### PR TITLE
Clarify that setting an image's src starts the image request immediately

### DIFF
--- a/files/en-us/web/api/htmlimageelement/src/index.md
+++ b/files/en-us/web/api/htmlimageelement/src/index.md
@@ -10,7 +10,8 @@ browser-compat: api.HTMLImageElement.src
 
 The **`src`** property of the {{domxref("HTMLImageElement")}} interface specifies the image to display in the {{HTMLElement("img")}} element. It reflects the `<img>` element's [`src`](/en-US/docs/Web/HTML/Reference/Elements/img#src) content attribute.
 
-Setting the `src` property starts the browser's request for the specified image resource right away, even if the `<img>` element has not yet been added to the document.
+Setting `src` property triggers scheduling of a task to fetch the specified resource; the element does not need to be inserted into the active document first.
+Unless loading is set to `lazy`, the image will be fetched almost immediately (if lazy loading is specified the request is deferred until the element is near the viewport: which can't happen until the element is inserted).
 
 ## Value
 

--- a/files/en-us/web/api/htmlimageelement/src/index.md
+++ b/files/en-us/web/api/htmlimageelement/src/index.md
@@ -10,6 +10,8 @@ browser-compat: api.HTMLImageElement.src
 
 The **`src`** property of the {{domxref("HTMLImageElement")}} interface specifies the image to display in the {{HTMLElement("img")}} element. It reflects the `<img>` element's [`src`](/en-US/docs/Web/HTML/Reference/Elements/img#src) content attribute.
 
+Setting the `src` property starts the browser's request for the specified image resource right away, even if the `<img>` element has not yet been added to the document.
+
 ## Value
 
 A string. For more information about the syntax of the `src` attribute, see the HTML [`<img>`](/en-US/docs/Web/HTML/Reference/Elements/img#src) reference.


### PR DESCRIPTION
### Description

Setting the `src` property of an `HTMLImageElement` starts loading the image immediately, even if the element has not yet been added to the document. This sentence is now included in the `src` property description.

### Motivation

Make the timing of the image request explicit for readers, matching how the property actually behaves.

### Additional details

### Related issues and pull requests

Fixes #26560