### PR TITLE
Document the periodic-background-sync permission for PeriodicSyncManager.register()

### DIFF
--- a/files/en-us/web/api/periodicsyncmanager/register/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.md
@@ -38,11 +38,11 @@ Returns a {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if there is no active {{domxref('ServiceWorker')}} present.
+  - : Thrown if there is no active {{domxref('ServiceWorker')}} present.
 - `NotAllowedError` {{domxref("DOMException")}}
-  - : Returned if permission for background periodic sync is not granted. The required permission name is `periodic-background-sync`. In Chromium-based browsers, this permission is only granted to sites that have been installed as an app (or installed as a [PWA](/en-US/docs/Web/Progressive_web_apps)); regular web pages cannot obtain it.
+  - : Thrown if the `periodic-background-sync` permission is not granted.
 - `InvalidAccessError` {{domxref("DOMException")}}
-  - : Returned if the active window is not the main window (not of `auxiliary` or `top-level` type).
+  - : Thrown if the active window is not the main window (not of `auxiliary` or `top-level` type).
 
 ## Examples
 

--- a/files/en-us/web/api/periodicsyncmanager/register/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.md
@@ -40,7 +40,7 @@ Returns a {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Returned if there is no active {{domxref('ServiceWorker')}} present.
 - `NotAllowedError` {{domxref("DOMException")}}
-  - : Returned if permission for background periodic sync is not granted.
+  - : Returned if permission for background periodic sync is not granted. The required permission name is `periodic-background-sync`. In Chromium-based browsers, this permission is only granted to sites that have been installed as an app (or installed as a [PWA](/en-US/docs/Web/Progressive_web_apps)); regular web pages cannot obtain it.
 - `InvalidAccessError` {{domxref("DOMException")}}
   - : Returned if the active window is not the main window (not of `auxiliary` or `top-level` type).
 


### PR DESCRIPTION
### Description

Clarifies the `NotAllowedError` exception of `PeriodicSyncManager.register()`: the required permission is `periodic-background-sync`, and in Chromium-based browsers it is only granted to sites installed as an app (PWA).

### Motivation

The register() page now explains how and when the permission needed for periodic background sync is granted.

### Additional details

### Related issues and pull requests

Partially addresses #33692