### PR TITLE
Fix max string length math

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -34,14 +34,17 @@ The language specification requires strings to have a maximum length of 2<sup>53
 - In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
 - In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
 
-If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the visible encoding always becomes UTF-16. The length of the string may be different from the size of the source file. The actual space used by a string is subject to JavaScript engine optimizations, and most engines will store in a smaller Latin-1 encoding when possible, since it uses half the memory.
+> [!NOTE]
+> All memory sizes above assume strings are stored in UTF-16 encoding in memory, which may be an overestimate. The actual space used by a string is subject to JavaScript engine optimizations, and most engines will store in a smaller Latin-1 encoding when possible, since it uses half the memory.
+
+If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the encoding and thus memory size may also change.
 
 ```js
 const str1 = "a".repeat(2 ** 29 - 24); // Success
 const str2 = "a".repeat(2 ** 29 - 23); // RangeError: Invalid string length
 
 const buffer = new Uint8Array(2 ** 29 - 24).fill("a".codePointAt(0)); // This buffer is 512MiB in size
-const str = new TextDecoder().decode(buffer); // This string is 1GiB in size unless optimized.
+const str = new TextDecoder().decode(buffer); // This string is 1GiB in size unless optimized
 ```
 
 For an empty string, `length` is 0.

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -35,9 +35,9 @@ The language specification requires strings to have a maximum length of 2<sup>53
 - In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
 
 > [!NOTE]
-> All memory sizes above assume strings are stored in UTF-16 encoding in memory, which may be an overestimate. The actual space used by a string is subject to JavaScript engine optimizations, and most engines will store in a smaller Latin-1 encoding when possible, since it uses half the memory.
+> All memory sizes above assume strings are stored in UTF-16 encoding in memory, which may be an overestimate. The actual space used by a string is subject to JavaScript engine optimizations, and all major engines use a more compact internal representation, such as one-byte storage, for strings containing only Latin-1 characters.
 
-If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the encoding and thus memory size may also change.
+If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the encoding always becomes UTF-16. The size of the string may be different from the size of the source file.
 
 ```js
 const str1 = "a".repeat(2 ** 29 - 24); // Success

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -30,18 +30,18 @@ This property returns the number of code units in the string. JavaScript uses [U
 
 The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TiB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
 
-- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~512MiB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~256MiB).
-- In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~1GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~256MiB).
-- In Safari, the maximum length is 2<sup>31</sup> - 1 (\~2GiB).
+- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~1GiB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~512MiB).
+- In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
+- In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
 
-If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the encoding always becomes UTF-16. The size of the string may be different from the size of the source file.
+If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the visible encoding always becomes UTF-16. The length of the string may be different from the size of the source file. The actual space used by a string is subject to JavaScript engine optimizations, and most engines will store in a smaller Latin-1 encoding when possible, since it uses half the memory.
 
 ```js
 const str1 = "a".repeat(2 ** 29 - 24); // Success
 const str2 = "a".repeat(2 ** 29 - 23); // RangeError: Invalid string length
 
 const buffer = new Uint8Array(2 ** 29 - 24).fill("a".codePointAt(0)); // This buffer is 512MiB in size
-const str = new TextDecoder().decode(buffer); // This string is 1GiB in size
+const str = new TextDecoder().decode(buffer); // This string is 1GiB in size unless optimized.
 ```
 
 For an empty string, `length` is 0.

--- a/files/en-us/web/javascript/reference/global_objects/string/length/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/length/index.md
@@ -30,9 +30,9 @@ This property returns the number of code units in the string. JavaScript uses [U
 
 The language specification requires strings to have a maximum length of 2<sup>53</sup> - 1 elements, which is the upper limit for [precise integers](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER). However, a string with this length needs 16384TiB of storage, which cannot fit in any reasonable device's memory, so implementations tend to lower the threshold, which allows the string's length to be conveniently stored in a 32-bit integer.
 
-- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~1GiB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~512MiB).
-- In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~2GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~512MiB).
-- In Safari, the maximum length is 2<sup>31</sup> - 1 (\~4GiB).
+- In V8 (used by Chrome and Node), the maximum length is 2<sup>29</sup> - 24 (\~512MiB). On 32-bit systems, the maximum length is 2<sup>28</sup> - 16 (\~256MiB).
+- In Firefox, the maximum length is 2<sup>30</sup> - 2 (\~1GiB). Before Firefox 65, the maximum length was 2<sup>28</sup> - 1 (\~256MiB).
+- In Safari, the maximum length is 2<sup>31</sup> - 1 (\~2GiB).
 
 If you are working with large strings in other encodings (such as UTF-8 files or blobs), note that when you load the data into a JS string, the encoding always becomes UTF-16. The size of the string may be different from the size of the source file.
 


### PR DESCRIPTION
### Description

The parenthetical values describing maximum string lengths on different browser are incorrect.

### Motivation

Fixing incorrect information.

### Additional details

I only know about max string lengths in Firefox, but the calculations for what is written here were clearly incorrect.

It said "the maximum length is 2^29 - 24 (~1GiB)". 2^29 is not 1GiB, it's half that. Same for all the rest of the parentheticals; they're all twice the actual values.

(I did confirm V8's max string length on 64-bit Chromium. `"x".repeat(2**29-23)` fails with "RangeError: Invalid string length". `"x".repeat(2**29-24)` succeeds though it takes a little while for the console to think about it.)
