### PR TITLE
Add overflow: clip guidance and recommend auto over scroll

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
@@ -35,19 +35,19 @@ Overflow is what happens when there is too much content to fit inside an element
 
 ## What is overflow?
 
-Everything in CSS is a box. You can constrain the size of these boxes by assigning values such as {{cssxref("width")}} and {{cssxref("height")}}. **Overflow happens when there is too much content to fit in a box.** CSS provides various tools to manage overflow. As you go further with CSS layout and writing CSS, you will encounter more overflow situations.
+Everything in CSS is a box. You can constrain the size of these boxes by setting values for properties such as {{cssxref("width")}} and {{cssxref("height")}}. **Overflow happens when there is too much content to fit in a box.** CSS provides various tools to manage overflow. As you go further with CSS layout and writing CSS, you will encounter more overflow situations.
 
 ## CSS tries to avoid "data loss"
 
-Let's consider two examples that demonstrate the default behavior of CSS when overflow occurs.
+Let's consider two examples that demonstrate default CSS overflow behavior.
 
-The first example features a box that has been restricted by setting a `height`. The box's content exceeds the available space, therefore it overflows the box and falls into the paragraph below.
+The first example features a box that has been restricted by setting a `height`. The box's content exceeds the available space; therefore, it overflows the box and falls into the paragraph below.
 
 ```html live-sample___block-overflow
 <div class="box">
   This box has a height and a width. This means that if there is too much
   content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to hidden then any overflow will not be visible.
+  situation. If overflow is set to hidden, then any overflow will not be visible.
 </div>
 
 <p>This content is outside of the box.</p>
@@ -63,7 +63,7 @@ The first example features a box that has been restricted by setting a `height`.
 
 {{EmbedLiveSample("block-overflow", "", "200px")}}
 
-The second example features a word in a box. The box has been made too small for the word and so it breaks out of the box.
+The second example features a word in a box. The box size is set too small for the word, therefore the word breaks out of the box.
 
 ```html live-sample___inline-overflow
 <div class="word">Overflow</div>
@@ -79,32 +79,32 @@ The second example features a word in a box. The box has been made too small for
 
 {{EmbedLiveSample("inline-overflow")}}
 
-You might wonder why CSS works in such a messy way, displaying content outside of its intended container. Why not hide overflowing content? Why not scale the size of the container to fit all the content?
+You might wonder why CSS works in such a messy way, displaying content outside its intended container. Why not hide overflowing content? Why not scale the container size to fit all the content?
 
-Wherever possible, CSS does not hide content. This would cause data loss. The problem with data loss is that you, or visitors to your website, may not notice. If the submit button on a form disappears and no one can complete the form, this could be a big problem! Instead, CSS overflows in visible ways. You are more likely to see there is a problem. At worst, a site visitor will let you know that content is overlapping.
+Wherever possible, CSS does not hide content. This would cause data loss. The problem with data loss is that you, or visitors to your website, may not notice. If the submit button on a form disappears and no one can complete the form, this could be a big problem! Instead, CSS overflows in visible ways. You are more likely to notice a problem. At worst, a site visitor will let you know that content is overlapping.
 
 If you restrict a box with a `width` or a `height`, CSS trusts you to know what you are doing. CSS assumes that you are managing the potential for overflow. In general, restricting the block dimension is problematic when the box contains text. There may be more text than you expected when designing the site, or the text may be larger (for example, if the user has increased their font size).
 
 ## The overflow property
 
-The {{cssxref("overflow")}} property allows you to specify how the browser should handle overflowing content. The default value of the {{cssxref("&lt;overflow&gt;")}} value type is `visible`. With this default setting, you can see content when it overflows.
+The {{cssxref("overflow")}} property allows you to specify how the browser should handle overflowing content. Its default value is `visible`, which means you can see content when it overflows.
 
-The following two `overflow` values cover most situations:
+The following two `overflow` values provide the behavior you will need to fix the majority of overflow problems:
 
 - `overflow: clip` cuts the overflowing content off, so it is never seen.
-- `overflow: auto` lets the user scroll the box to read the content that does not fit.
+- `overflow: auto` displays scrollbars only when needed, allowing the user to scroll boxes to read overflowing content.
 
-The next two sections look at how to use these. After that, we will look at other `overflow` values and explain how to control the x and y axes' overflow separately.
+The next two sections look at how to use these values. After that, we will look at other `overflow` values and explain how to control the x and y axes' overflow separately.
 
 ## Hiding overflowing content
 
-To cut content off when it overflows, set `overflow: clip`. Anything that does not fit is clipped at the edge of the box, and there is no way for the user to reach it. This means some content becomes invisible, so only do this when hiding it won't cause problems.
+To cut content off when it overflows, set `overflow: clip`. Anything that doesn't fit is clipped at the edge of the box, and cannot be reached. This means some content becomes invisible, so only do this when hiding it won't cause problems.
 
 ```html live-sample___clip
 <div class="box">
   This box has a height and a width. This means that if there is too much
   content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to clip then any overflow will not be visible.
+  situation. If overflow is set to clip, then any overflow will not be visible.
 </div>
 
 <p>This content is outside of the box.</p>
@@ -121,14 +121,14 @@ To cut content off when it overflows, set `overflow: clip`. Anything that does n
 
 {{EmbedLiveSample("clip", "", "200px")}}
 
-Try editing the above example to set the `overflow` value to `visible`, then back to `clip`, to see what the effect is.
+Try editing this example to set `overflow` to `visible`, then back to `clip`, to see the effect.
 
 > [!NOTE]
-> By default, `clip` cuts content off at the box's border edge. The {{cssxref("overflow-clip-margin")}} property moves that clip edge outwards, letting a specified amount of the overflow stay visible before the rest is clipped.
+> By default, `clip` cuts content off at the box's border edge. The {{cssxref("overflow-clip-margin")}} property moves that clip edge outwards, letting a specified amount of the overflowing content stay visible before the rest is clipped.
 
 ## Scrolling overflowing content
 
-Instead, perhaps you would like to allow your users to scroll the content to read it all. Setting `overflow: auto` makes the box scrollable, and browsers with visible scrollbars display a scrollbar only when there is actually too much content to fit.
+Instead, perhaps you want users to scroll the content to read it all. Setting `overflow: auto` makes the box scrollable, and browsers with visible scrollbars display a scrollbar only when there is actually too much content to fit.
 
 In the example below, remove content from the `<div>` until it no longer overflows. You should see the scrollbar disappear:
 
@@ -136,7 +136,7 @@ In the example below, remove content from the `<div>` until it no longer overflo
 <div class="box">
   This box has a height and a width. This means that if there is too much
   content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to auto then scrollbars appear only when needed.
+  situation. If overflow is set to auto, then scrollbars appear only when needed.
 </div>
 
 <p>This content is outside of the box.</p>
@@ -159,9 +159,9 @@ In the example below, remove content from the `<div>` until it no longer overflo
 
 ## Controlling overflow on each axis
 
-Specifying a single keyword for the `overflow` property value sets the overflow behavior for a container's x _and_ y axes. In the example above, if you set `overflow` to `scroll` (which sets scrollbars to [always appear](#always_displaying_scrollbars) regardless of whether the content overflows), you'll see scrollbars on both axes. To control the axes separately, use the {{cssxref("overflow-x")}} and {{cssxref("overflow-y")}} properties. Try setting `overflow-y: auto` in the example above.
+Specifying a single keyword for the `overflow` property value sets the overflow behavior for a container's x _and_ y axes. In the previous example, if you set `overflow` to `scroll` (which sets scrollbars to [always appear](#always_displaying_scrollbars) regardless of whether the content overflows), you'll see scrollbars on both axes. To control the axes separately, use the {{cssxref("overflow-x")}} and {{cssxref("overflow-y")}} properties. Try setting `overflow-y: auto` in the example.
 
-You can also enable scrolling along the x-axis with `overflow-x`, as shown in the next example, although this is not recommended for accommodating long words! If you have a long word in a small box, consider using the {{cssxref("word-break")}} or {{cssxref("overflow-wrap")}} properties to break the word over multiple lines. In addition, some of the methods discussed in [Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing) may help you create boxes that scale better with varying amounts of content.
+The next example demonstrates enabling scrolling along the x-axis with `overflow-x`, although this is not recommended for accommodating long words! If you have a long word in a small box, consider using the {{cssxref("word-break")}} or {{cssxref("overflow-wrap")}} properties to break the word over multiple lines. In addition, some of the methods discussed in [Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing) may help you create boxes that scale better with varying amounts of content.
 
 ```html live-sample___scroll-x
 <div class="word">Overflow</div>
@@ -179,7 +179,7 @@ You can also enable scrolling along the x-axis with `overflow-x`, as shown in th
 {{EmbedLiveSample("scroll-x")}}
 
 > [!NOTE]
-> You can specify x- and y-axis overflow using the `overflow` property, passing two values. If two keywords are specified, the first applies to `overflow-x` and the second applies to `overflow-y`. Otherwise, both `overflow-x` and `overflow-y` are set to the same value. For example, `overflow: clip auto` would set `overflow-x` to `clip` and `overflow-y` to `auto`.
+> You can also specify x- and y-axis overflow separately by passing two keyword values to the `overflow` property: the first applies to `overflow-x` and the second applies to `overflow-y`. For example, `overflow: clip auto` would set `overflow-x` to `clip` and `overflow-y` to `auto`.
 
 `clip` is the only value you can combine with `visible` on the other axis. If you set one axis to a scrolling value (`auto`, `scroll`, or `hidden`) and the other to `visible`, the `visible` value computes to `auto` instead, because a box cannot scroll on one axis while letting content spill out of the other. So `overflow: clip visible` clips horizontally and lets content overflow vertically, whereas `overflow: hidden visible` behaves as `overflow: hidden auto`.
 
@@ -187,7 +187,7 @@ You can also enable scrolling along the x-axis with `overflow-x`, as shown in th
 
 Setting `overflow: scroll` makes the box scrollable like `overflow: auto` does, except that browsers with visible scrollbars display them at all times, even when the content doesn't overflow.
 
-The main reason to use `scroll` is layout consistency: because the scrollbar is always there, the content does not shift when the amount of content changes. However, in such a case, combining `overflow: auto` with a {{cssxref("scrollbar-gutter")}} value of `stable` is usually a better fit, as it reserves the space without forcing a scrollbar to be drawn.
+The main reason to use `scroll` is layout consistency: the scrollbar is always there; therefore, the content doesn't shift when the amount of content changes between overflowing and not overflowing. However, in such a case, combining `overflow: auto` with a {{cssxref("scrollbar-gutter")}} value of `stable` is usually a better fit, as it reserves the space without forcing a scrollbar to be drawn.
 
 ## The hidden value
 
@@ -197,15 +197,15 @@ You should use the `clip` value most of the time; `hidden` is only required if y
 
 ## Unwanted overflow in web design
 
-Modern layout methods (which you'll meet later in the [CSS layout](/en-US/docs/Learn_web_development/Core/CSS_layout) module) manage overflow. They largely work without assumptions or dependencies for how much content there will be on a web page.
+Modern layout methods (which you'll meet later in the [CSS layout](/en-US/docs/Learn_web_development/Core/CSS_layout) module) manage overflow. They largely work without assumptions or dependencies on how much content there will be on a web page.
 
-This was not always the norm. In the past, some sites were built with fixed-height containers to align box bottoms. These boxes may otherwise have had no relationship to each other. This was fragile. If you encounter a box where content is overlaying other content, you will now recognize that overflow may well be the cause of this. Ideally, you will refactor the layout to not rely on fixed-height containers.
+This was not always the norm. In the past, some sites were built with fixed-height containers to align box bottoms. These boxes may otherwise have had no relationship to each other. This was fragile. If you encounter a box where content is overlaying other content, you will now recognize that overflow may be the cause. Ideally, you should refactor the layout to avoid fixed-height containers.
 
-When developing a site, always keep overflow in mind. Test designs with large and small amounts of content. Increase and decrease font sizes by at least two increments. Ensure your CSS is robust. Changing overflow values to hide content or to add scrollbars is reserved for a few select use cases (for example, where you intend to have a scrolling box).
+When developing a site, always keep overflow in mind. Test designs with large and small amounts of content. Increase and decrease font sizes by at least two increments. Ensure your CSS is robust. Changing overflow values to hide content or add scrollbars is reserved for a few select use cases (for example, when you want your scrolling box to always display scrollbars).
 
 ## Summary
 
-This lesson introduced the concept of overflow. You should understand that default CSS avoids making overflowing content invisible. You have discovered that you can manage potential overflow, and also, that you should test work to make sure it does not accidentally cause problematic overflow.
+This lesson introduced the concept of overflow. By default, CSS avoids making overflowing content invisible. You can manage potential overflow, and you should test your work to make sure it doesn't accidentally cause problematic overflow.
 
 In the next article, we'll give you some tests that you can use to check how well you've understood and retained the information we've provided on overflow.
 

--- a/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
@@ -137,7 +137,8 @@ In the example below, remove content from the `<div>` until it no longer overflo
 <div class="box">
   This box has a height and a width. This means that if there is too much
   content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to auto, then scrollbars appear only when needed.
+  situation. If overflow is set to auto, then scrollbars appear only when
+  needed.
 </div>
 
 <p>This content is outside of the box.</p>

--- a/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
@@ -47,7 +47,8 @@ The first example features a box that has been restricted by setting a `height`.
 <div class="box">
   This box has a height and a width. This means that if there is too much
   content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to hidden, then any overflow will not be visible.
+  situation. If overflow is set to hidden, then any overflow will not be
+  visible.
 </div>
 
 <p>This content is outside of the box.</p>

--- a/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
@@ -87,16 +87,16 @@ If you restrict a box with a `width` or a `height`, CSS trusts you to know what 
 
 ## The overflow property
 
-The {{cssxref("overflow")}} property allows you to specify how the browser should handle overflowing content. The default value of the {{cssxref("&lt;overflow&gt;")}} value type is `visible`. With this default setting, one can see content when it overflows.
+The {{cssxref("overflow")}} property allows you to specify how the browser should handle overflowing content. The default value of the {{cssxref("&lt;overflow&gt;")}} value type is `visible`. With this default setting, you can see content when it overflows.
 
-Two values cover most situations:
+The following two `overflow` values cover most situations:
 
 - `overflow: clip` cuts the overflowing content off, so it is never seen.
 - `overflow: auto` lets the user scroll the box to read the content that does not fit.
 
-The sections below look at each of these, then at the other values and at controlling each axis separately.
+The next two sections look at how to use these. After that, we will look at other `overflow` values and explain how to control the x and y axes' overflow separately.
 
-### Hiding overflowing content
+## Hiding overflowing content
 
 To cut content off when it overflows, set `overflow: clip`. Anything that does not fit is clipped at the edge of the box, and there is no way for the user to reach it. This means some content becomes invisible, so only do this when hiding it won't cause problems.
 
@@ -123,13 +123,14 @@ To cut content off when it overflows, set `overflow: clip`. Anything that does n
 
 Try editing the above example to set the `overflow` value to `visible`, then back to `clip`, to see what the effect is.
 
-By default, `clip` cuts content off at the box's border edge. The {{cssxref("overflow-clip-margin")}} property moves that clip edge outwards, letting a specified amount of the overflow stay visible before the rest is clipped.
+> [!NOTE]
+> By default, `clip` cuts content off at the box's border edge. The {{cssxref("overflow-clip-margin")}} property moves that clip edge outwards, letting a specified amount of the overflow stay visible before the rest is clipped.
 
-### Scrolling overflowing content
+## Scrolling overflowing content
 
 Instead, perhaps you would like to allow your users to scroll the content to read it all. Setting `overflow: auto` makes the box scrollable, and browsers with visible scrollbars display a scrollbar only when there is actually too much content to fit.
 
-In the example below, remove content until it fits into the box. You should see the scrollbars disappear:
+In the example below, remove content from the `<div>` until it no longer overflows. You should see the scrollbar disappear:
 
 ```html live-sample___auto
 <div class="box">
@@ -154,13 +155,13 @@ In the example below, remove content until it fits into the box. You should see 
 
 > [!NOTE]
 > Scrollbar visibility depends on the operating system.
-> You may have to change your browser settings to always show scroll bars in order for the scroll bars to always show in the following examples.
+> You may have to change your browser settings to always show scrollbars for them to display in the following examples.
 
-### Controlling overflow on each axis
+## Controlling overflow on each axis
 
-In the example above, we only need to scroll on the `y` axis, however we get a scroll container on both axes. To control the axes separately, use the {{cssxref("overflow-x")}} and {{cssxref("overflow-y")}} properties. Try setting `overflow-y: auto` in the example above.
+Specifying a single keyword for the `overflow` property value sets the overflow behavior for a container's x _and_ y axes. In the example above, if you set `overflow` to `scroll` (which sets scrollbars to [always appear](#always_displaying_scrollbars) regardless of whether the content overflows), you'll see scrollbars on both axes. To control the axes separately, use the {{cssxref("overflow-x")}} and {{cssxref("overflow-y")}} properties. Try setting `overflow-y: auto` in the example above.
 
-You can also enable scrolling along the x-axis with `overflow-x`, although this is not a recommended way to accommodate long words! If you have a long word in a small box, consider using the {{cssxref("word-break")}} or {{cssxref("overflow-wrap")}} properties. In addition, some of the methods discussed in [Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing) may help you create boxes that scale better with varying amounts of content.
+You can also enable scrolling along the x-axis with `overflow-x`, as shown in the next example, although this is not recommended for accommodating long words! If you have a long word in a small box, consider using the {{cssxref("word-break")}} or {{cssxref("overflow-wrap")}} properties to break the word over multiple lines. In addition, some of the methods discussed in [Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing) may help you create boxes that scale better with varying amounts of content.
 
 ```html live-sample___scroll-x
 <div class="word">Overflow</div>
@@ -182,38 +183,17 @@ You can also enable scrolling along the x-axis with `overflow-x`, although this 
 
 `clip` is the only value you can combine with `visible` on the other axis. If you set one axis to a scrolling value (`auto`, `scroll`, or `hidden`) and the other to `visible`, the `visible` value computes to `auto` instead, because a box cannot scroll on one axis while letting content spill out of the other. So `overflow: clip visible` clips horizontally and lets content overflow vertically, whereas `overflow: hidden visible` behaves as `overflow: hidden auto`.
 
-### Always displaying scrollbars
+## Always displaying scrollbars
 
-Setting `overflow: scroll` makes the box scrollable like `auto` does, but browsers with visible scrollbars display them at all times, even when there is not enough content to overflow.
+Setting `overflow: scroll` makes the box scrollable like `overflow: auto` does, except that browsers with visible scrollbars display them at all times, even when the content doesn't overflow.
 
-The main reason to reach for `scroll` is layout consistency: because the scrollbar is always there, the content does not shift when the amount of content changes. If that is all you need, {{cssxref("scrollbar-gutter")}} with a value of `stable` is usually a better fit, as it reserves the space without forcing a scrollbar to be drawn.
+The main reason to use `scroll` is layout consistency: because the scrollbar is always there, the content does not shift when the amount of content changes. However, in such a case, combining `overflow: auto` with a {{cssxref("scrollbar-gutter")}} value of `stable` is usually a better fit, as it reserves the space without forcing a scrollbar to be drawn.
 
-Edit the following example to remove some content from the `box` `<div>`. Notice how the scrollbars remain, even if there is no need for scrolling:
+## The hidden value
 
-```html live-sample___scroll
-<div class="box">
-  This box has a height and a width. This means that if there is too much
-  content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to scroll then scrollbars are always shown.
-</div>
+You will often meet `overflow: hidden` in existing code. Like `clip`, it cuts the overflowing content off and doesn't display scrollbars. Unlike `clip`, it still turns the box into a scroll container, and the content can be scrolled using other means, for example using [JavaScript](/en-US/docs/Learn_web_development/Core/Scripting) or by tabbing to a focusable item further down the content such as a [link element](/en-US/docs/Learn_web_development/Core/Structuring_content/Creating_links).
 
-<p>This content is outside of the box.</p>
-```
-
-```css live-sample___scroll
-.box {
-  border: 1px solid #333333;
-  width: 250px;
-  height: 100px;
-  overflow: scroll;
-}
-```
-
-{{EmbedLiveSample("scroll", "", "200px")}}
-
-### The hidden value
-
-You will often meet `overflow: hidden` in existing code. Like `clip`, it cuts the overflowing content off. Unlike `clip`, it still makes the box a scroll container: the content can be scrolled programmatically, and the browser can scroll the box when something inside it receives focus. Use `clip` when you want the content genuinely cut off, and reach for `hidden` only when you need that scrollable behavior.
+You should use the `clip` value most of the time; `hidden` is only required if you need the scrollable behavior described above.
 
 ## Unwanted overflow in web design
 

--- a/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
@@ -173,7 +173,7 @@ As with `scroll`, you get a scrollbar in the scrolling dimension whether or not 
 
 ### Only displaying scrollbars when needed
 
-If you only want scrollbars to appear when there is more content than can fit in the box, use `overflow: auto`. This allows the browser to determine if it should display scrollbars.
+If you only want scrollbars to appear when there is more content than can fit in the box, use `overflow: auto`. This allows the browser to determine if it should display scrollbars, so scrollbars appear only when they are actually needed. For most boxes that need to scroll, `auto` is a better choice than `scroll`, which always shows scrollbars even when there is nothing to scroll.
 
 In the example below, remove content until it fits into the box. You should see the scrollbars disappear:
 
@@ -197,6 +197,15 @@ In the example below, remove content until it fits into the box. You should see 
 ```
 
 {{EmbedLiveSample("auto", "", "200px")}}
+
+### Clipping overflowing content
+
+If you want to cut off overflowing content without creating a scrollable area, you can use `overflow: clip`. Unlike `overflow: hidden`, `clip` does not create a scroll container, and it lets you clip on one axis while keeping the other axis as `visible`. For example, `overflow-x: clip; overflow-y: visible` clips horizontally but lets content overflow vertically. With `overflow: hidden`, the visible axis would instead become `hidden` too.
+
+By default, `clip` cuts content off at the box's border edge, leaving no way to access the clipped content. You can adjust where the clipping starts using the {{cssxref("overflow-clip-margin")}} property.
+
+> [!NOTE]
+> `overflow: clip` is newer than the other values. Check the [browser compatibility](/en-US/docs/Web/CSS/Reference/Properties/overflow#browser_compatibility) for `overflow` before relying on it.
 
 ## Unwanted overflow in web design
 

--- a/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/overflow/index.md
@@ -89,91 +89,45 @@ If you restrict a box with a `width` or a `height`, CSS trusts you to know what 
 
 The {{cssxref("overflow")}} property allows you to specify how the browser should handle overflowing content. The default value of the {{cssxref("&lt;overflow&gt;")}} value type is `visible`. With this default setting, one can see content when it overflows.
 
+Two values cover most situations:
+
+- `overflow: clip` cuts the overflowing content off, so it is never seen.
+- `overflow: auto` lets the user scroll the box to read the content that does not fit.
+
+The sections below look at each of these, then at the other values and at controlling each axis separately.
+
 ### Hiding overflowing content
 
-To hide content when it overflows, you can set `overflow: hidden`. This does exactly what it says: it hides overflow. Beware that this can make some content invisible. You should only do this if hiding content won't cause problems.
+To cut content off when it overflows, set `overflow: clip`. Anything that does not fit is clipped at the edge of the box, and there is no way for the user to reach it. This means some content becomes invisible, so only do this when hiding it won't cause problems.
 
-```html live-sample___hidden
+```html live-sample___clip
 <div class="box">
   This box has a height and a width. This means that if there is too much
   content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to hidden then any overflow will not be visible.
+  situation. If overflow is set to clip then any overflow will not be visible.
 </div>
 
 <p>This content is outside of the box.</p>
 ```
 
-```css live-sample___hidden
+```css live-sample___clip
 .box {
   border: 1px solid #333333;
   width: 250px;
   height: 100px;
-  overflow: hidden;
+  overflow: clip;
 }
 ```
 
-{{EmbedLiveSample("hidden", "", "200px")}}
+{{EmbedLiveSample("clip", "", "200px")}}
 
-Try editing the above example to set the `overflow` value to `visible`, then back to `hidden`, to see what the effect is.
+Try editing the above example to set the `overflow` value to `visible`, then back to `clip`, to see what the effect is.
+
+By default, `clip` cuts content off at the box's border edge. The {{cssxref("overflow-clip-margin")}} property moves that clip edge outwards, letting a specified amount of the overflow stay visible before the rest is clipped.
 
 ### Scrolling overflowing content
 
-Instead, perhaps you would like to allow your users to scroll the content to read it all? When you set `overflow: scroll` on overflowing content, browsers with visible scrollbars will always display them—even if there is not enough content to overflow. This offers the advantage of keeping the layout consistent, instead of scrollbars appearing or disappearing, depending upon the amount of content in the container.
-
-Let's see this in action. Edit the following example to remove some content from the `box` `<div>`. Notice how the scrollbars remain, even if there is no need for scrolling:
-
-```html live-sample___scroll
-<div class="box">
-  This box has a height and a width. This means that if there is too much
-  content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to hidden then any overflow will not be visible.
-</div>
-
-<p>This content is outside of the box.</p>
-```
-
-```css live-sample___scroll
-.box {
-  border: 1px solid #333333;
-  width: 250px;
-  height: 100px;
-  overflow: scroll;
-}
-```
-
-{{EmbedLiveSample("scroll", "", "200px")}}
-
-> [!NOTE]
-> Scrollbar visibility depends on the operating system.
-> You may have to change your browser settings to always show scroll bars in order for the scroll bars to always show in the following examples.
-
-In the example above, we only need to scroll on the `y` axis, however we get scrollbars on both axes. To just scroll on the `y` axis, you could use the {{cssxref("overflow-y")}} property, setting `overflow-y: scroll`. Try setting this property in the example above.
-
-You can also enable scrolling along the x-axis by using {{cssxref("overflow-x")}}, although this is not a recommended way to accommodate long words! If you have a long word in a small box, consider using the {{cssxref("word-break")}} or {{cssxref("overflow-wrap")}} properties. In addition, some of the methods discussed in [Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing) may help you create boxes that scale better with varying amounts of content.
-
-```html live-sample___scroll-x
-<div class="word">Overflow</div>
-```
-
-```css live-sample___scroll-x
-.word {
-  border: 5px solid #333333;
-  width: 100px;
-  font-size: 250%;
-  overflow-x: scroll;
-}
-```
-
-{{EmbedLiveSample("scroll-x")}}
-
-As with `scroll`, you get a scrollbar in the scrolling dimension whether or not there is enough content to cause a scrollbar.
-
-> [!NOTE]
-> You can specify x- and y-axis scrolling using the `overflow` property, passing two values. If two keywords are specified, the first applies to `overflow-x` and the second applies to `overflow-y`. Otherwise, both `overflow-x` and `overflow-y` are set to the same value. For example, `overflow: scroll hidden` would set `overflow-x` to `scroll` and `overflow-y` to `hidden`.
-
-### Only displaying scrollbars when needed
-
-If you only want scrollbars to appear when there is more content than can fit in the box, use `overflow: auto`. This allows the browser to determine if it should display scrollbars, so scrollbars appear only when they are actually needed. For most boxes that need to scroll, `auto` is a better choice than `scroll`, which always shows scrollbars even when there is nothing to scroll.
+Instead, perhaps you would like to allow your users to scroll the content to read it all. Setting `overflow: auto` makes the box scrollable, and browsers with visible scrollbars display a scrollbar only when there is actually too much content to fit.
 
 In the example below, remove content until it fits into the box. You should see the scrollbars disappear:
 
@@ -181,7 +135,7 @@ In the example below, remove content until it fits into the box. You should see 
 <div class="box">
   This box has a height and a width. This means that if there is too much
   content to be displayed within the assigned height, there will be an overflow
-  situation. If overflow is set to hidden then any overflow will not be visible.
+  situation. If overflow is set to auto then scrollbars appear only when needed.
 </div>
 
 <p>This content is outside of the box.</p>
@@ -198,14 +152,68 @@ In the example below, remove content until it fits into the box. You should see 
 
 {{EmbedLiveSample("auto", "", "200px")}}
 
-### Clipping overflowing content
+> [!NOTE]
+> Scrollbar visibility depends on the operating system.
+> You may have to change your browser settings to always show scroll bars in order for the scroll bars to always show in the following examples.
 
-If you want to cut off overflowing content without creating a scrollable area, you can use `overflow: clip`. Unlike `overflow: hidden`, `clip` does not create a scroll container, and it lets you clip on one axis while keeping the other axis as `visible`. For example, `overflow-x: clip; overflow-y: visible` clips horizontally but lets content overflow vertically. With `overflow: hidden`, the visible axis would instead become `hidden` too.
+### Controlling overflow on each axis
 
-By default, `clip` cuts content off at the box's border edge, leaving no way to access the clipped content. You can adjust where the clipping starts using the {{cssxref("overflow-clip-margin")}} property.
+In the example above, we only need to scroll on the `y` axis, however we get a scroll container on both axes. To control the axes separately, use the {{cssxref("overflow-x")}} and {{cssxref("overflow-y")}} properties. Try setting `overflow-y: auto` in the example above.
+
+You can also enable scrolling along the x-axis with `overflow-x`, although this is not a recommended way to accommodate long words! If you have a long word in a small box, consider using the {{cssxref("word-break")}} or {{cssxref("overflow-wrap")}} properties. In addition, some of the methods discussed in [Sizing items in CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Sizing) may help you create boxes that scale better with varying amounts of content.
+
+```html live-sample___scroll-x
+<div class="word">Overflow</div>
+```
+
+```css live-sample___scroll-x
+.word {
+  border: 5px solid #333333;
+  width: 100px;
+  font-size: 250%;
+  overflow-x: auto;
+}
+```
+
+{{EmbedLiveSample("scroll-x")}}
 
 > [!NOTE]
-> `overflow: clip` is newer than the other values. Check the [browser compatibility](/en-US/docs/Web/CSS/Reference/Properties/overflow#browser_compatibility) for `overflow` before relying on it.
+> You can specify x- and y-axis overflow using the `overflow` property, passing two values. If two keywords are specified, the first applies to `overflow-x` and the second applies to `overflow-y`. Otherwise, both `overflow-x` and `overflow-y` are set to the same value. For example, `overflow: clip auto` would set `overflow-x` to `clip` and `overflow-y` to `auto`.
+
+`clip` is the only value you can combine with `visible` on the other axis. If you set one axis to a scrolling value (`auto`, `scroll`, or `hidden`) and the other to `visible`, the `visible` value computes to `auto` instead, because a box cannot scroll on one axis while letting content spill out of the other. So `overflow: clip visible` clips horizontally and lets content overflow vertically, whereas `overflow: hidden visible` behaves as `overflow: hidden auto`.
+
+### Always displaying scrollbars
+
+Setting `overflow: scroll` makes the box scrollable like `auto` does, but browsers with visible scrollbars display them at all times, even when there is not enough content to overflow.
+
+The main reason to reach for `scroll` is layout consistency: because the scrollbar is always there, the content does not shift when the amount of content changes. If that is all you need, {{cssxref("scrollbar-gutter")}} with a value of `stable` is usually a better fit, as it reserves the space without forcing a scrollbar to be drawn.
+
+Edit the following example to remove some content from the `box` `<div>`. Notice how the scrollbars remain, even if there is no need for scrolling:
+
+```html live-sample___scroll
+<div class="box">
+  This box has a height and a width. This means that if there is too much
+  content to be displayed within the assigned height, there will be an overflow
+  situation. If overflow is set to scroll then scrollbars are always shown.
+</div>
+
+<p>This content is outside of the box.</p>
+```
+
+```css live-sample___scroll
+.box {
+  border: 1px solid #333333;
+  width: 250px;
+  height: 100px;
+  overflow: scroll;
+}
+```
+
+{{EmbedLiveSample("scroll", "", "200px")}}
+
+### The hidden value
+
+You will often meet `overflow: hidden` in existing code. Like `clip`, it cuts the overflowing content off. Unlike `clip`, it still makes the box a scroll container: the content can be scrolled programmatically, and the browser can scroll the box when something inside it receives focus. Use `clip` when you want the content genuinely cut off, and reach for `hidden` only when you need that scrollable behavior.
 
 ## Unwanted overflow in web design
 


### PR DESCRIPTION
### Description

Updates the "Overflowing content" guide:
- recommends `overflow: auto` over `scroll` for boxes that need to scroll, since `auto` shows scrollbars only when needed;
- adds a "Clipping overflowing content" section explaining `overflow: clip`, how it differs from `hidden` (no scroll container, per-axis clipping with `visible`) and `overflow-clip-margin`.

### Motivation

The guide previously omitted `clip` entirely and gave `auto` only a brief mention. `clip` and `auto` are the values many developers should reach for in these cases.

### Additional details

### Related issues and pull requests

Fixes #32173