### PR TITLE
Fix history.go() link on :target page

### DIFF
--- a/files/en-us/web/css/reference/selectors/_colon_target/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_target/index.md
@@ -40,7 +40,7 @@ The following element would be selected by a `:target` selector when the current
 
 When an HTML document loads, the browser sets its target element. The element is identified using the URL fragment identifier. Without the URL fragment identifier, the document has no target element. The `:target` pseudo-class allows styling the document's target element. The element could be focused, highlighted, animated, etc.
 
-The target element is set at document load and [`history.back()`](/en-US/docs/Web/API/History/back), [`history.forward()`](/en-US/docs/Web/API/History/forward), and [`history.go()`](/en-US/docs/Web/API/History/forward) method calls. But it is _not_ changed when [`history.pushState()`](/en-US/docs/Web/API/History/pushState) and [`history.replaceState()`](/en-US/docs/Web/API/History/replaceState) methods are called.
+The target element is set at document load and [`history.back()`](/en-US/docs/Web/API/History/back), [`history.forward()`](/en-US/docs/Web/API/History/forward), and [`history.go()`](/en-US/docs/Web/API/History/go) method calls. But it is _not_ changed when [`history.pushState()`](/en-US/docs/Web/API/History/pushState) and [`history.replaceState()`](/en-US/docs/Web/API/History/replaceState) methods are called.
 
 > [!NOTE]
 > Due to [a possible bug in the CSS specification](https://discourse.wicg.io/t/target-css-does-not-work-because-shadowroot-does-not-set-a-target-element/2070/), `:target` doesn't work within a [web component](/en-US/docs/Web/API/Web_components) because the [shadow root](/en-US/docs/Web/API/ShadowRoot) doesn't pass the target element down to the shadow tree.


### PR DESCRIPTION
### Description

Fixes the `history.go()` link on the `:target` selector reference page, which pointed to the `history.forward()` docs instead of its own.

### Motivation

The link led readers to the wrong API reference page, making it harder to find the correct `history.go()` documentation.

### Additional details

Single-line link fix; verified by confirming `/en-US/docs/Web/API/History/go` corresponds to the existing `files/en-us/web/api/history/go/` content directory. No build was needed to verify a link href correction.

### Related issues and pull requests

Fixes #45223
