### PR TITLE
fix(css): correct invalid media query syntax in @custom-media example

### DIFF
--- a/files/en-us/web/css/reference/at-rules/@custom-media/index.md
+++ b/files/en-us/web/css/reference/at-rules/@custom-media/index.md
@@ -80,20 +80,20 @@ This alias only matches when the viewport is within the specified width range.
 
 #### Using the `or` operator
 
-The logical `or` operator (or its comma alias) creates a media query that matches if any of the listed conditions are `true`.
+The logical `or` operator (or its comma alias, when combining media types) creates a media query that matches if any of the listed conditions are `true`.
 
 ```css
-@custom-media --screen-or-print-1 screen, print;
-@custom-media --screen-or-print-2 screen or print;
+@custom-media --screen-or-print screen, print;
+@custom-media --narrow-or-tall (width < 600px) or (height > 800px);
 
-@media (--screen-or-print-1) {
+@media (--screen-or-print) {
 }
 
-@media (--screen-or-print-2) {
+@media (--narrow-or-tall) {
 }
 ```
 
-The two aliases are identical. They are activated for both screen and print environments.
+The `--screen-or-print` alias uses a comma to match either the `screen` or `print` media type. The `--narrow-or-tall` alias uses the `or` keyword to combine two media features, matching when the viewport is narrower than 600px, taller than 800px, or both.
 
 ## Formal syntax
 


### PR DESCRIPTION
### Description

Replace the invalid `screen or print` custom media query example on the `@custom-media` reference page with a valid example that actually demonstrates the `or` keyword.

### Motivation

`screen or print` is not valid media-query syntax. Per the [Media Queries Level 4 grammar](https://drafts.csswg.org/mediaqueries/#typedef-media-query), the `or` keyword combines parenthesized `<media-in-parens>` conditions (media features), not bare `<media-type>` keywords like `screen` and `print` — those can only be combined with a comma. Simply swapping in a comma would leave two examples showing the exact same syntax, so per the issue discussion the second example was replaced with `(width < 600px) or (height > 800px)`, a valid demonstration of the `or` keyword combining media features, matching the style of the `and` example directly above it.

### Additional details

https://drafts.csswg.org/mediaqueries/#typedef-media-query

### Related issues and pull requests

Fixes #45126
