### PR TITLE
ci(dependabot): exclude @mdn packages from cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      exclude:
+        - "@mdn/*"
     open-pull-requests-limit: 10
     labels:
       - "automated pr"


### PR DESCRIPTION
Part of https://github.com/mdn/fred/issues/1770