### PR TITLE
Link to SVG <a> element from SVGAElement pages

### DIFF
--- a/files/en-us/web/api/svgaelement/hash/index.md
+++ b/files/en-us/web/api/svgaelement/hash/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/host/index.md
+++ b/files/en-us/web/api/svgaelement/host/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/hostname/index.md
+++ b/files/en-us/web/api/svgaelement/hostname/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/origin/index.md
+++ b/files/en-us/web/api/svgaelement/origin/index.md
@@ -24,4 +24,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/password/index.md
+++ b/files/en-us/web/api/svgaelement/password/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/pathname/index.md
+++ b/files/en-us/web/api/svgaelement/pathname/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/port/index.md
+++ b/files/en-us/web/api/svgaelement/port/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/protocol/index.md
+++ b/files/en-us/web/api/svgaelement/protocol/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/search/index.md
+++ b/files/en-us/web/api/svgaelement/search/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element

--- a/files/en-us/web/api/svgaelement/username/index.md
+++ b/files/en-us/web/api/svgaelement/username/index.md
@@ -26,4 +26,4 @@ A string.
 
 ## See also
 
-- SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+- SVG {{SVGElement("a")}} element


### PR DESCRIPTION
### Description

```diff
- - SVG [`<a>`](/en-US/docs/Web/HTML/Reference/Elements/a) element
+ - SVG {{SVGElement("a")}} element
```

### Motivation

Part of the fill the gaps project

- https://github.com/mdn/mdn/issues/852