### PR TITLE
Add SVG*List interface changes to Firefox 155 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -50,9 +50,13 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### APIs -->
+### APIs
 
-<!-- #### DOM -->
+#### DOM
+
+- The {{domxref("SVGNumberList")}}, {{domxref("SVGPointList")}}, {{domxref("SVGStringList")}}, and {{domxref("SVGTransformList")}} interfaces now support indexed setters, so an item in the list can be replaced using bracket notation, such as `transformList[0] = newTransform`, instead of calling {{domxref("SVGTransformList.replaceItem", "replaceItem()")}}.
+  The {{domxref("SVGLengthList")}} interface already supported this.
+  ([Firefox bug 2059426](https://bugzil.la/2059426)).
 
 <!-- #### Media, WebRTC, and Web Audio -->
 

--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -55,7 +55,7 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 #### DOM
 
 - The {{domxref("SVGNumberList")}}, {{domxref("SVGPointList")}}, {{domxref("SVGStringList")}}, and {{domxref("SVGTransformList")}} interfaces now support indexed setters. This means you can replace an item in the list using bracket notation, such as `transformList[0] = newTransform`, instead of calling {{domxref("SVGTransformList.replaceItem", "replaceItem()")}}.
-  The {{domxref("SVGLengthList")}} interface already supported this.
+  The {{domxref("SVGLengthList")}} interface already supports indexed setters.
   ([Firefox bug 2059426](https://bugzil.la/2059426)).
 
 <!-- #### Media, WebRTC, and Web Audio -->

--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -54,7 +54,7 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 #### DOM
 
-- The {{domxref("SVGNumberList")}}, {{domxref("SVGPointList")}}, {{domxref("SVGStringList")}}, and {{domxref("SVGTransformList")}} interfaces now support indexed setters, so an item in the list can be replaced using bracket notation, such as `transformList[0] = newTransform`, instead of calling {{domxref("SVGTransformList.replaceItem", "replaceItem()")}}.
+- The {{domxref("SVGNumberList")}}, {{domxref("SVGPointList")}}, {{domxref("SVGStringList")}}, and {{domxref("SVGTransformList")}} interfaces now support indexed setters. This means you can replace an item in the list using bracket notation, such as `transformList[0] = newTransform`, instead of calling {{domxref("SVGTransformList.replaceItem", "replaceItem()")}}.
   The {{domxref("SVGLengthList")}} interface already supported this.
   ([Firefox bug 2059426](https://bugzil.la/2059426)).
 


### PR DESCRIPTION
### Description

- Adds `SVG*List` interface changes

### Related issues and pull requests

- https://github.com/mdn/content/issues/45189