### PR TITLE
Fix description for percentage basis for text-decoration-inset in Firefox 154 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -437,7 +437,7 @@ The {{cssxref("line-clamp")}} CSS property now works without the `-webkit-` vend
 
 ### Percentage values for `text-decoration-inset`
 
-The {{cssxref("text-decoration-inset")}} CSS property now supports percentages as values. The percentage value specifies the size of the inset as a percentage of the {{cssxref("font-size")}}. ([Firefox bug 2044602](https://bugzil.la/2044602)).
+The {{cssxref("text-decoration-inset")}} CSS property now supports percentages as values. The percentage value specifies the size of the inset as a percentage of the inline size of the decorating box or of each individual box fragment, depending on the value of {{cssxref("box-decoration-break")}}. ([Firefox bug 2044602](https://bugzil.la/2044602)).
 
 | Release channel   | Version added | Enabled by default? |
 | ----------------- | ------------- | ------------------- |

--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -83,7 +83,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 
 - **Percentage values for `text-decoration-inset`**: `layout.css.text-decoration-inset-percentage.enabled`
 
-  The {{cssxref("text-decoration-inset")}} CSS property now supports percentages as values. The percentage value specifies the size of the inset as a percentage of the {{cssxref("font-size")}}. ([Firefox bug 2044602](https://bugzil.la/2044602)).
+  The {{cssxref("text-decoration-inset")}} CSS property now supports percentages as values. The percentage value specifies the size of the inset as a percentage of the inline size of the decorating box or of each individual box fragment, depending on the value of {{cssxref("box-decoration-break")}}. ([Firefox bug 2044602](https://bugzil.la/2044602)).
 
 - **Calculating a value based upon `progress()`**: `layout.css.progress-function.enabled`
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Corrects the description for percentage basis for `text-decoration-inset` — from `font-size` to inline size — on the Firefox 154 release notes and experimental features pages.

### Motivation

Both pages state that percentages resolve against the `font-size`. They don't. Per [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-inset), percentages refer to the inline size of the decorating box, or of each individual box fragment, depending on the value of `box-decoration-break`.

As written, a reader would expect `10%` on 20px text to inset the decoration by 2px, when it actually resolves against the inline size of the box — a substantially different result.

### Additional details

This matches the Gecko implementation in [bug 2044602](https://bugzil.la/2044602), which resolves the percentage against the total inline size of the decorating box for `box-decoration-break: slice`, or each fragment individually for `clone`.

The wording follows the spec's `Percentages:` definition, and the underlying CSSWG resolution is [csswg-drafts#8403](https://github.com/w3c/csswg-drafts/issues/8403).

The same sentence appears on both pages (added in #45027), so both are updated.

### Related issues and pull requests

Fixes #45254
Relates to #44840
