### PR TITLE
Move `activeTab`permission information to a new concept page

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
@@ -32,10 +32,10 @@ It's also possible to include `activeTab` in [`optional_permissions`](/en-US/doc
 The browser grants `activeTab` when the user interacts with the extension. These interactions are known as [user actions](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions) and include the user:
 
 - clicking the extension's [toolbar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions).
-- selecting an extension's context menu item.
-- activating a keyboard shortcut defined by the extension with the {{WebExtAPIRef("commands")}} API.
-- clicking a button on a page bundled with the extension.
-- clicking an extension suggestion in the address bar (omnibox) (from Firefox 142).
+- selecting an extension's context menu item, which triggers the {{WebExtAPIRef("menus.onClicked")}} event.
+- activating a keyboard shortcut defined by the extension with the {{WebExtAPIRef("commands")}} API, which triggers the {{WebExtAPIRef("commands.onCommand")}} event.
+- clicking a button on a page bundled with the extension, which triggers a DOM [`click`](/en-US/docs/Web/API/Element/click_event) event handled by the page's script.
+- clicking an extension suggestion in the address bar (omnibox), which triggers the {{WebExtAPIRef("omnibox.onInputEntered")}} event (from Firefox 142).
 
 Usually, the tab granted `activeTab` is the active tab. There is one exception: an extension can use the {{WebExtAPIRef("menus")}} API to create a menu item that displays when the user context-clicks a tab in the tab strip. If the user selects this menu item, `activeTab` is granted for the tab clicked, even if it isn't the active tab.
 
@@ -100,6 +100,100 @@ browser.action.onClicked.addListener((tab) => {
 ```
 
 The same click also makes the privileged tab properties readable, so `tab.url` and `tab.title` hold real values rather than being `undefined`.
+
+### Further examples
+
+These further examples showing the use of declare the `activeTab` permission are available in the repository of example extensions at <https://github.com/mdn/webextensions-examples>. :
+
+<table>
+  <thead>
+    <tr>
+      <th>Example</th>
+      <th>How <code>activeTab</code> is used</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/webextensions-examples/apply-css/"
+          >apply-css</a
+        >
+      </td>
+      <td>
+        A page action click grants access to inject or remove CSS on the active
+        tab ({{WebExtAPIRef("tabs.insertCSS()")}} and {{WebExtAPIRef("tabs.removeCSS()")}}).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/webextensions-examples/beastify/"
+          >beastify</a
+        >
+      </td>
+      <td>
+        A browser action click grants access for
+        {{WebExtAPIRef("scripting.executeScript()")}} and {{WebExtAPIRef("scripting.insertCSS()")}}
+        on the active tab.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a
+          href="https://github.com/mdn/webextensions-examples/context-menu-copy-link-with-types/"
+          >context-menu-copy-link-with-types</a
+        >
+      </td>
+      <td>
+        A context menu click on a link unlocks the page so the link can be
+        copied to the clipboard.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/webextensions-examples/export-helpers/"
+          >export-helpers</a
+        >
+      </td>
+      <td>
+        Grants access to the active tab to demo
+        <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts/cloneInto"
+          ><code>cloneInto()</code></a
+        > and export helpers with page scripts.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/webextensions-examples/history-deleter/"
+          >history-deleter</a
+        >
+      </td>
+      <td>
+        Reads the active tab's URL to determine the domain whose history is to
+        be deleted.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/mdn/webextensions-examples/menu-demo/"
+          >menu-demo</a
+        >
+      </td>
+      <td>A menu item click unlock the active tab for the menu manipulation demo.</td>
+    </tr>
+    <tr>
+      <td>
+        <a
+          href="https://github.com/mdn/webextensions-examples/menu-remove-element/"
+          >menu-remove-element</a
+        >
+      </td>
+      <td>
+        A menu item click unlocks page access to inject a script that removes
+        the element under the cursor.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
@@ -114,7 +114,7 @@ These further examples showing the use of declare the `activeTab` permission are
   <tbody>
     <tr>
       <td>
-        <a href="https://github.com/mdn/webextensions-examples/apply-css/"
+        <a href="https://github.com/mdn/webextensions-examples/tree/main/apply-css/"
           >apply-css</a
         >
       </td>
@@ -125,7 +125,7 @@ These further examples showing the use of declare the `activeTab` permission are
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/webextensions-examples/beastify/"
+        <a href="https://github.com/mdn/webextensions-examples/tree/main/beastify/"
           >beastify</a
         >
       </td>
@@ -138,7 +138,7 @@ These further examples showing the use of declare the `activeTab` permission are
     <tr>
       <td>
         <a
-          href="https://github.com/mdn/webextensions-examples/context-menu-copy-link-with-types/"
+          href="https://github.com/mdn/webextensions-examples/tree/main/context-menu-copy-link-with-types/"
           >context-menu-copy-link-with-types</a
         >
       </td>
@@ -149,7 +149,7 @@ These further examples showing the use of declare the `activeTab` permission are
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/webextensions-examples/history-deleter/"
+        <a href="https://github.com/mdn/webextensions-examples/tree/main/history-deleter/"
           >history-deleter</a
         >
       </td>
@@ -160,7 +160,7 @@ These further examples showing the use of declare the `activeTab` permission are
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/webextensions-examples/menu-demo/"
+        <a href="https://github.com/mdn/webextensions-examples/tree/main/menu-demo/"
           >menu-demo</a
         >
       </td>
@@ -169,7 +169,7 @@ These further examples showing the use of declare the `activeTab` permission are
     <tr>
       <td>
         <a
-          href="https://github.com/mdn/webextensions-examples/menu-remove-element/"
+          href="https://github.com/mdn/webextensions-examples/tree/main/menu-remove-element/"
           >menu-remove-element</a
         >
       </td>
@@ -200,7 +200,7 @@ Firefox, Safari, and Chromium-based browsers, including Chrome and Edge, support
 | Capability                                                                          | Chrome                               | Firefox                                               | Safari         |
 | ----------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- | -------------- |
 | Programmatic script and stylesheet injection                                        | Yes                                  | Yes                                                   | Yes            |
-| Sensitive {{WebExtAPIRef("tabs.Tab")}} properties (`url`, `title`, `favIconUrl`)   | Yes                                  | Yes                                                   | Yes            |
+| Sensitive {{WebExtAPIRef("tabs.Tab")}} properties (`url`, `title`, `favIconUrl`)    | Yes                                  | Yes                                                   | Yes            |
 | {{WebExtAPIRef("tabs.captureVisibleTab()")}}                                        | Yes                                  | From Firefox 126                                      | Yes            |
 | Intercepting the tab's network requests with the {{WebExtAPIRef("webRequest")}} API | Yes, for the tab's main frame origin | No ([Firefox bug 1617479](https://bugzil.la/1617479)) | Not documented |
 

--- a/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
@@ -1,0 +1,145 @@
+---
+title: activeTab permission
+short-title: activeTab permission
+slug: Mozilla/Add-ons/WebExtensions/activeTab_permission
+page-type: guide
+sidebar: addonsidebar
+---
+
+The `activeTab` permission gives an extension temporary access to the tab a user is working in. It is granted in response to an explicit [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions), such as clicking the extension's toolbar button. Access is limited to that tab and lasts until the user navigates elsewhere.
+
+Its purpose is to enable extensions to fulfill the common use case of "do something to the current page when the user asks", without the extension needing broad privileges. For example, consider an extension that wants to run a script in the current page when the user clicks its toolbar button. Without `activeTab`, the extension would have to request the host permission `<all_urls>`, which gives it far more power than it needs: the ability to execute scripts in _any tab_, at _any time_, rather than in the active tab only and only in response to a user action.
+
+Because `activeTab` provides limited access, browsers don't display a permission warning when the user installs the extension.
+
+## Request the activeTab permission
+
+Your extension requests `activeTab` using the [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) manifest key:
+
+```json
+"permissions": ["activeTab"]
+```
+
+`activeTab` is an [API permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions), not a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). So, it's requested using the `permissions` key in all manifest versions. Unlike host permissions, it isn't moved to [`host_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) in Manifest V3 and later.
+
+It's also possible to include `activeTab` in [`optional_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) and request it at runtime using {{WebExtAPIRef("permissions.request()")}}. It's one of the permissions granted silently, without a user prompt.
+
+> [!NOTE]
+> `activeTab` grants privileges for a tab. It doesn't, by itself, grant access to an API. For example, to inject a script, your extension needs the `"scripting"` permission to use the {{WebExtAPIRef("scripting")}} API.
+
+## How activeTab is granted
+
+The browser grants `activeTab` when the user interacts with the extension. These interactions are known as [user actions](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions) and include the user:
+
+- clicking the extension's [toolbar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions).
+- selecting an extension's context menu item.
+- activating a keyboard shortcut defined by the extension with the {{WebExtAPIRef("commands")}} API.
+- clicking a button on a page bundled with the extension.
+- clicking an extension suggestion in the address bar (omnibox) (from Firefox 142).
+
+Usually, the tab granted `activeTab` is the active tab. There is one exception: an extension can use the {{WebExtAPIRef("menus")}} API to create a menu item that displays when the user context-clicks a tab in the tab strip. If the user selects this menu item, `activeTab` is granted for the tab clicked, even if it isn't the active tab.
+
+## What activeTab grants
+
+While `activeTab` is granted for a tab, the extension can:
+
+- Inject JavaScript or CSS into the tab, using the {{WebExtAPIRef("scripting")}} API (or {{WebExtAPIRef("tabs.executeScript()")}} and {{WebExtAPIRef("tabs.insertCSS()")}} in Manifest V2). See [Loading content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#loading_content_scripts).
+- Read the privileged properties of the tab's {{WebExtAPIRef("tabs.Tab")}} object: `url`, `title`, and `favIconUrl`. Otherwise, these properties require the `"tabs"` permission or a matching host permission.
+- Capture the tab's contents with {{WebExtAPIRef("tabs.captureVisibleTab()")}} (from Firefox 126). With `activeTab`, this method can also capture sensitive pages that are otherwise restricted, such as browser UI pages and other extensions' pages.
+- Read the rules matched for the tab with {{WebExtAPIRef("declarativeNetRequest.getMatchedRules()")}}, without the `"declarativeNetRequestFeedback"` permission.
+
+## Scope of the access
+
+`activeTab` grants scripting access to the top-level page in the tab and to same-origin frames within it. Running scripts or modifying styles inside [cross-origin](/en-US/docs/Web/Security/Defenses/Same-origin_policy#cross-origin_network_access) frames requires additional [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions).
+
+The [restrictions and limitations](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#permissions_restrictions_and_limitations) that apply to particular sites and URI schemes also apply to `activeTab`. Some special pages don't allow script injection, including reader view, view-source, the PDF viewer, and other built-in browser UI pages.
+
+## When the access ends
+
+The extension can only access the tab, or the data, that existed when the user interaction occurred. When the tab navigates away, the extension loses permission to access it. This means that the extension must complete its work with the tab, or capture the data it needs, during the granted period. If the extension needs access again, the user must repeat the user action.
+
+The point at which access ends varies by browser [browser_compatibility](#browser_compatibility).
+
+## Example
+
+This extension injects a script into the current page when the user clicks its toolbar button. It needs no host permissions.
+
+manifest.json:
+
+```json
+{
+  "manifest_version": 3,
+  "name": "Heading highlighter",
+  "version": "1.0",
+  "permissions": ["activeTab", "scripting"],
+  "action": {
+    "default_title": "Highlight headings"
+  },
+  "background": {
+    "scripts": ["background.js"]
+  }
+}
+```
+
+background.js:
+
+```js
+function highlightHeadings() {
+  for (const heading of document.querySelectorAll("h1, h2, h3")) {
+    heading.style.backgroundColor = "yellow";
+  }
+}
+
+browser.action.onClicked.addListener((tab) => {
+  // activeTab is granted for `tab` because the user clicked the toolbar button.
+  browser.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: highlightHeadings,
+  });
+});
+```
+
+The same click also makes the privileged tab properties readable, so `tab.url` and `tab.title` hold real values rather than being `undefined`.
+
+## Browser compatibility
+
+Firefox, Safari, and Chromium-based browsers, including Chrome and Edge, support `activeTab`. However, when it's granted, what it enables, and when it's revoked vary.
+
+### Actions that grant activeTab
+
+| User action                                     | Chrome                                                                              | Firefox          | Safari                                                                              |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------- |
+| Clicking the extension's toolbar button         | Yes                                                                                 | Yes              | Yes                                                                                 |
+| Selecting the extension's context menu item     | Yes                                                                                 | Yes              | Yes                                                                                 |
+| Activating the extension's keyboard shortcut    | Yes                                                                                 | From Firefox 63  | Yes                                                                                 |
+| Clicking a button on an extension's own page    | Yes                                                                                 | Yes              | Yes                                                                                 |
+| Accepting an address bar (omnibox) suggestion   | Yes                                                                                 | From Firefox 142 | No, Safari doesn't support the {{WebExtAPIRef("omnibox")}} API                      |
+| Selecting a menu item on a tab in the tab strip | No, Chrome doesn't support the `tab` value of {{WebExtAPIRef("menus.ContextType")}} | From Firefox 63  | No, Safari doesn't support the `tab` value of {{WebExtAPIRef("menus.ContextType")}} |
+
+### Capabilities granted
+
+| Capability                                                                          | Chrome                               | Firefox                                               | Safari         |
+| ----------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- | -------------- |
+| Programmatic script and stylesheet injection                                        | Yes                                  | Yes                                                   | Yes            |
+| Privileged {{WebExtAPIRef("tabs.Tab")}} properties (`url`, `title`, `favIconUrl`)   | Yes                                  | Yes                                                   | Yes            |
+| {{WebExtAPIRef("tabs.captureVisibleTab()")}}                                        | Yes                                  | From Firefox 126                                      | Yes            |
+| Intercepting the tab's network requests with the {{WebExtAPIRef("webRequest")}} API | Yes, for the tab's main frame origin | No ([Firefox bug 1617479](https://bugzil.la/1617479)) | Not documented |
+
+### When access is revoked
+
+- **Chrome and Safari**: access lasts while the tab stays on the same site. It's revoked when the user navigates the tab to a different origin, or closes the tab. Reloading the page or navigating within the same origin doesn't revoke the access.
+- **Firefox**: access is revoked when the tab navigates, including on a reload or a same-origin navigation. So, the user must repeat the user action after each navigation.
+
+### Other differences
+
+- **Permission prompts**: Firefox and Chrome grant an extension's requested host permissions on installation, so `activeTab` avoids an install-time warning. Safari, by contrast, defaults host permissions to "ask", and prompts the user the first time the extension tries to access a site, offering **Allow for One Day** or **Always Allow**. Using `activeTab` avoids this prompt, as Safari treats the user's interaction with the extension as the grant.
+- **Manifest V2 and V3**: `activeTab` works the same way in both manifest versions in all browsers. In Manifest V3, the {{WebExtAPIRef("scripting")}} API replaces {{WebExtAPIRef("tabs.executeScript()")}} and {{WebExtAPIRef("tabs.insertCSS()")}}, and the `"scripting"` permission is needed alongside `activeTab`.
+
+## See also
+
+- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) manifest key
+- [`optional_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) manifest key
+- [User actions](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions)
+- [Content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)
+- [Request the right permissions](https://extensionworkshop.com/documentation/develop/request-the-right-permissions/) on Extension Workshop
+- [The "activeTab" permission](https://developer.chrome.com/docs/extensions/develop/concepts/activeTab) in the Chrome extensions documentation

--- a/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
@@ -143,7 +143,7 @@ These further examples showing the use of declare the `activeTab` permission are
         >
       </td>
       <td>
-        A context menu click on a link unlocks the page so the link can be
+        A context menu click on a link unlocks access to the page so the link can be
         copied to the clipboard.
       </td>
     </tr>
@@ -197,22 +197,40 @@ Firefox, Safari, and Chromium-based browsers, including Chrome and Edge, support
 
 ### Capabilities granted
 
-| Capability                                                                          | Chrome                               | Firefox                                               | Safari         |
-| ----------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- | -------------- |
-| Programmatic script and stylesheet injection                                        | Yes                                  | Yes                                                   | Yes            |
-| Sensitive {{WebExtAPIRef("tabs.Tab")}} properties (`url`, `title`, `favIconUrl`)    | Yes                                  | Yes                                                   | Yes            |
-| {{WebExtAPIRef("tabs.captureVisibleTab()")}}                                        | Yes                                  | From Firefox 126                                      | Yes            |
-| Intercepting the tab's network requests with the {{WebExtAPIRef("webRequest")}} API | Yes, for the tab's main frame origin | No ([Firefox bug 1617479](https://bugzil.la/1617479)) | Not documented |
+| Capability                                                                                                                         | Chrome                               | Firefox                                               | Safari  |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- | ------- |
+| Programmatic script and stylesheet injection                                                                                       | Yes                                  | Yes                                                   | Yes     |
+| Sensitive {{WebExtAPIRef("tabs.Tab")}} properties (`url`, `title`, `favIconUrl`)                                                   | Yes                                  | Yes                                                   | Yes     |
+| {{WebExtAPIRef("tabs.captureVisibleTab()")}}                                                                                       | Yes                                  | From Firefox 126                                      | Yes     |
+| Intercepting the tab's network requests with the {{WebExtAPIRef("webRequest")}} and {{WebExtAPIRef("declarativeNetRequest")}} APIs | Yes, for the tab's main frame origin | No ([Firefox bug 1617479](https://bugzil.la/1617479)) | Unknown |
+
+Also, the access browsers grant with `activeTab` differs:
+
+- Firefox and Safari grant access to the active tab only.
+- Chrome grants the host permissions derived from the tab's URL.
+
+Chrome's logic can provide more access than Firefox's, for example:
+
+- Another tab with the same origin can be scripted in Chrome, but not in Firefox.
+- An extension script (such as a background script or a popup's script) can make a cross-origin request to the tab's URL in Chrome, but not in Firefox.
+- The {{WebExtAPIRef("cookies")}} API requires host permissions to access cookies for specific domains. Chrome allows this with `activeTab`, while Firefox doesn't.
+
+This list isn't exhaustive.
 
 ### When access is revoked
 
-- **Chrome and Safari**: access lasts while the tab stays on the same site. It's revoked when the user navigates the tab to a different origin, or closes the tab. Reloading the page or navigating within the same origin doesn't revoke the access.
-- **Firefox**: access is revoked when the tab navigates, including on a reload or a same-origin navigation. So, the user must repeat the user action after each navigation.
+In all browsers, closing the tab revokes access. However, same-document navigations, such as a fragment (hash) change or a {{DOMxRef("History.pushState()")}} call, don't: the document and its origin are unchanged, so access is preserved.
+
+For navigations that load a new document, the behavior differs:
+
+- **Chrome**: access persists while the tab stays on the same origin, including across reloads. It's revoked when the tab navigates to a different origin.
+- **Safari**: access persists while the tab stays on the same host, including across reloads. It's revoked when the tab navigates to a different host.
+- **Firefox**: access is tied to the document that was in the tab when the user action occurred. Loading a new document, including on a reload or a same-origin navigation, ends the access, and the user must repeat the user action. If that document returns from the [back/forward cache](/en-US/docs/Glossary/bfcache), its access is restored.
 
 ### Other differences
 
 - **Permission prompts**: Firefox and Chrome grant an extension's requested host permissions on installation, so `activeTab` avoids an install-time warning. Safari, by contrast, defaults host permissions to "ask", and prompts the user the first time the extension tries to access a site, offering **Allow for One Day** or **Always Allow**. Using `activeTab` avoids this prompt, as Safari treats the user's interaction with the extension as the grant.
-- **Manifest V2 and V3**: `activeTab` works the same way in both manifest versions in all browsers. In Manifest V3, the {{WebExtAPIRef("scripting")}} API replaces {{WebExtAPIRef("tabs.executeScript()")}} and {{WebExtAPIRef("tabs.insertCSS()")}}, and the `"scripting"` permission is needed alongside `activeTab`.
+- **Manifest V2 and V3**: `activeTab` works the same way in both manifest versions in all browsers except that in Firefox Manifest V3 `activeTab` doesn't enable {{WebExtAPIRef("scripting.executeScript")}} in an iframe with a different origin (see [Bug 1839200](https://bugzil.la/1839200#c3)). In Manifest V3, the {{WebExtAPIRef("scripting")}} API replaces {{WebExtAPIRef("tabs.executeScript()")}} and {{WebExtAPIRef("tabs.insertCSS()")}}, and the `"scripting"` permission is needed alongside `activeTab`.
 
 ## See also
 

--- a/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
@@ -20,7 +20,7 @@ Your extension requests `activeTab` using the [`permissions`](/en-US/docs/Mozill
 "permissions": ["activeTab"]
 ```
 
-`activeTab` is an [API permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions), not a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). So, it's requested using the `permissions` key in all manifest versions. Unlike host permissions, it isn't moved to [`host_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) in Manifest V3 and later.
+`activeTab` is an [API permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions), not a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions).
 
 It's also possible to include `activeTab` in [`optional_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) and request it at runtime using {{WebExtAPIRef("permissions.request()")}}. It's one of the permissions granted silently, without a user prompt.
 
@@ -34,7 +34,6 @@ The browser grants `activeTab` when the user interacts with the extension. These
 - clicking the extension's [toolbar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions).
 - selecting an extension's context menu item, which triggers the {{WebExtAPIRef("menus.onClicked")}} event.
 - activating a keyboard shortcut defined by the extension with the {{WebExtAPIRef("commands")}} API, which triggers the {{WebExtAPIRef("commands.onCommand")}} event.
-- clicking a button on a page bundled with the extension, which triggers a DOM [`click`](/en-US/docs/Web/API/Element/click_event) event handled by the page's script.
 - clicking an extension suggestion in the address bar (omnibox), which triggers the {{WebExtAPIRef("omnibox.onInputEntered")}} event (from Firefox 142).
 
 Usually, the tab granted `activeTab` is the active tab. There is one exception: an extension can use the {{WebExtAPIRef("menus")}} API to create a menu item that displays when the user context-clicks a tab in the tab strip. If the user selects this menu item, `activeTab` is granted for the tab clicked, even if it isn't the active tab.
@@ -45,7 +44,7 @@ While `activeTab` is granted for a tab, the extension can:
 
 - Inject JavaScript or CSS into the tab, using the {{WebExtAPIRef("scripting")}} API (or {{WebExtAPIRef("tabs.executeScript()")}} and {{WebExtAPIRef("tabs.insertCSS()")}} in Manifest V2). See [Loading content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#loading_content_scripts).
 - Read the privileged properties of the tab's {{WebExtAPIRef("tabs.Tab")}} object: `url`, `title`, and `favIconUrl`. Otherwise, these properties require the `"tabs"` permission or a matching host permission.
-- Capture the tab's contents with {{WebExtAPIRef("tabs.captureVisibleTab()")}} (from Firefox 126). With `activeTab`, this method can also capture sensitive pages that are otherwise restricted, such as browser UI pages and other extensions' pages.
+- Capture the tab's contents with {{WebExtAPIRef("tabs.captureVisibleTab()")}} (from Firefox 126).
 - Read the rules matched for the tab with {{WebExtAPIRef("declarativeNetRequest.getMatchedRules()")}}, without the `"declarativeNetRequestFeedback"` permission.
 
 ## Scope of the access
@@ -150,19 +149,6 @@ These further examples showing the use of declare the `activeTab` permission are
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/mdn/webextensions-examples/export-helpers/"
-          >export-helpers</a
-        >
-      </td>
-      <td>
-        Grants access to the active tab to demo
-        <a href="/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts/cloneInto"
-          ><code>cloneInto()</code></a
-        > and export helpers with page scripts.
-      </td>
-    </tr>
-    <tr>
-      <td>
         <a href="https://github.com/mdn/webextensions-examples/history-deleter/"
           >history-deleter</a
         >
@@ -206,7 +192,6 @@ Firefox, Safari, and Chromium-based browsers, including Chrome and Edge, support
 | Clicking the extension's toolbar button         | Yes             | Yes              | Yes                                                                                 |
 | Selecting the extension's context menu item     | Yes             | Yes              | Yes                                                                                 |
 | Activating the extension's keyboard shortcut    | Yes             | From Firefox 63  | Yes                                                                                 |
-| Clicking a button on an extension's own page    | Yes             | Yes              | Yes                                                                                 |
 | Accepting an address bar (omnibox) suggestion   | Yes             | From Firefox 142 | No, Safari doesn't support the {{WebExtAPIRef("omnibox")}} API                      |
 | Selecting a menu item on a tab in the tab strip | From Chrome 150 | From Firefox 63  | No, Safari doesn't support the `tab` value of {{WebExtAPIRef("menus.ContextType")}} |
 
@@ -215,7 +200,7 @@ Firefox, Safari, and Chromium-based browsers, including Chrome and Edge, support
 | Capability                                                                          | Chrome                               | Firefox                                               | Safari         |
 | ----------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- | -------------- |
 | Programmatic script and stylesheet injection                                        | Yes                                  | Yes                                                   | Yes            |
-| Privileged {{WebExtAPIRef("tabs.Tab")}} properties (`url`, `title`, `favIconUrl`)   | Yes                                  | Yes                                                   | Yes            |
+| Sensitive {{WebExtAPIRef("tabs.Tab")}} properties (`url`, `title`, `favIconUrl`)   | Yes                                  | Yes                                                   | Yes            |
 | {{WebExtAPIRef("tabs.captureVisibleTab()")}}                                        | Yes                                  | From Firefox 126                                      | Yes            |
 | Intercepting the tab's network requests with the {{WebExtAPIRef("webRequest")}} API | Yes, for the tab's main frame origin | No ([Firefox bug 1617479](https://bugzil.la/1617479)) | Not documented |
 

--- a/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
@@ -107,13 +107,13 @@ Firefox, Safari, and Chromium-based browsers, including Chrome and Edge, support
 
 ### Actions that grant activeTab
 
-| User action                                     | Chrome                                                                              | Firefox          | Safari                                                                              |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------- |
-| Clicking the extension's toolbar button         | Yes                                                                                 | Yes              | Yes                                                                                 |
-| Selecting the extension's context menu item     | Yes                                                                                 | Yes              | Yes                                                                                 |
-| Activating the extension's keyboard shortcut    | Yes                                                                                 | From Firefox 63  | Yes                                                                                 |
-| Clicking a button on an extension's own page    | Yes                                                                                 | Yes              | Yes                                                                                 |
-| Accepting an address bar (omnibox) suggestion   | Yes                                                                                 | From Firefox 142 | No, Safari doesn't support the {{WebExtAPIRef("omnibox")}} API                      |
+| User action                                     | Chrome          | Firefox          | Safari                                                                              |
+| ----------------------------------------------- | --------------- | ---------------- | ----------------------------------------------------------------------------------- |
+| Clicking the extension's toolbar button         | Yes             | Yes              | Yes                                                                                 |
+| Selecting the extension's context menu item     | Yes             | Yes              | Yes                                                                                 |
+| Activating the extension's keyboard shortcut    | Yes             | From Firefox 63  | Yes                                                                                 |
+| Clicking a button on an extension's own page    | Yes             | Yes              | Yes                                                                                 |
+| Accepting an address bar (omnibox) suggestion   | Yes             | From Firefox 142 | No, Safari doesn't support the {{WebExtAPIRef("omnibox")}} API                      |
 | Selecting a menu item on a tab in the tab strip | From Chrome 150 | From Firefox 63  | No, Safari doesn't support the `tab` value of {{WebExtAPIRef("menus.ContextType")}} |
 
 ### Capabilities granted

--- a/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/activetab_permission/index.md
@@ -114,7 +114,7 @@ Firefox, Safari, and Chromium-based browsers, including Chrome and Edge, support
 | Activating the extension's keyboard shortcut    | Yes                                                                                 | From Firefox 63  | Yes                                                                                 |
 | Clicking a button on an extension's own page    | Yes                                                                                 | Yes              | Yes                                                                                 |
 | Accepting an address bar (omnibox) suggestion   | Yes                                                                                 | From Firefox 142 | No, Safari doesn't support the {{WebExtAPIRef("omnibox")}} API                      |
-| Selecting a menu item on a tab in the tab strip | No, Chrome doesn't support the `tab` value of {{WebExtAPIRef("menus.ContextType")}} | From Firefox 63  | No, Safari doesn't support the `tab` value of {{WebExtAPIRef("menus.ContextType")}} |
+| Selecting a menu item on a tab in the tab strip | From Chrome 150 | From Firefox 63  | No, Safari doesn't support the `tab` value of {{WebExtAPIRef("menus.ContextType")}} |
 
 ### Capabilities granted
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/oncommand/index.md
@@ -10,6 +10,8 @@ Fired when a command is executed using its associated keyboard shortcut.
 
 The listener is passed the command's name. This matches the name given to the command in its [manifest.json entry](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands).
 
+If the extension has the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission), activating a command's keyboard shortcut is a user action that grants it temporary access to the active tab.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.declarativeNetRequest.getMatchedRules
 sidebar: addonsidebar
 ---
 
-Returns all the rules matched for the extension. Callers can filter the list of matched rules by specifying a `filter`. This method is only available to extensions with the `"declarativeNetRequestFeedback"` permission or that have the `"activeTab"` permission granted for the `tabId` specified in `filter`. Rules not associated with an active document that were matched more than five minutes ago are not returned.
+Returns all the rules matched for the extension. Callers can filter the list of matched rules by specifying a `filter`. This method is only available to extensions with the `"declarativeNetRequestFeedback"` permission or have the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission granted for the `tabId` specified in `filter`. Rules not associated with an active document that were matched more than five minutes ago are not returned.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/declarativenetrequest/getmatchedrules/index.md
@@ -6,7 +6,7 @@ browser-compat: webextensions.api.declarativeNetRequest.getMatchedRules
 sidebar: addonsidebar
 ---
 
-Returns all the rules matched for the extension. Callers can filter the list of matched rules by specifying a `filter`. This method is only available to extensions with the `"declarativeNetRequestFeedback"` permission or have the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission granted for the `tabId` specified in `filter`. Rules not associated with an active document that were matched more than five minutes ago are not returned.
+Returns all the rules matched for the extension. Callers can filter the list of matched rules by specifying a `filter`. This method is only available to extensions with the `"declarativeNetRequestFeedback"` permission or have the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) granted for the `tabId` specified in `filter`. Rules not associated with an active document that were matched more than five minutes ago are not returned.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -42,7 +42,7 @@ Values of this type are strings. The item is displayed when the given context ap
 - `tab`
   - : Applies when the user context-clicks on a tab (specifically, this refers to the tab-strip or other user interface element enabling the user to switch from one browser tab to another, not to the page itself).
 
-    Clicking the menu item on a tab grants the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission for the tab clicked, even if that isn't the active tab.
+    Clicking the menu item on a tab grants the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) for the tab clicked, even if that isn't the active tab.
 
 - `tools_menu`
   - : The item will be added to the browser's tools menu. Note that this is only available if you access `ContextType` through the `menus` namespace. It is not available if you access it through the `contextMenus` namespace.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -42,7 +42,7 @@ Values of this type are strings. The item is displayed when the given context ap
 - `tab`
   - : Applies when the user context-clicks on a tab (specifically, this refers to the tab-strip or other user interface element enabling the user to switch from one browser tab to another, not to the page itself).
 
-    In Firefox, clicking the menu item on a tab grants the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission for the tab clicked, even if that isn't the active tab.
+    Clicking the menu item on a tab grants the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission for the tab clicked, even if that isn't the active tab.
 
 - `tools_menu`
   - : The item will be added to the browser's tools menu. Note that this is only available if you access `ContextType` through the `menus` namespace. It is not available if you access it through the `contextMenus` namespace.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/contexttype/index.md
@@ -42,7 +42,7 @@ Values of this type are strings. The item is displayed when the given context ap
 - `tab`
   - : Applies when the user context-clicks on a tab (specifically, this refers to the tab-strip or other user interface element enabling the user to switch from one browser tab to another, not to the page itself).
 
-    From Firefox 63, clicking the menu item on a tab grants the [activeTab](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission) permission for the tab clicked, even if that isn't the currently active tab.
+    In Firefox, clicking the menu item on a tab grants the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission for the tab clicked, even if that isn't the active tab.
 
 - `tools_menu`
   - : The item will be added to the browser's tools menu. Note that this is only available if you access `ContextType` through the `menus` namespace. It is not available if you access it through the `contextMenus` namespace.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -137,7 +137,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 });
 ```
 
-This example adds two radio items, which you can use to choose whether to apply a green or a blue border to the page. Note that this example will need the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+This example adds two radio items you can use to apply a green or blue border to the page. This example needs the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 ```js
 function onCreated() {

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -137,7 +137,7 @@ browser.menus.onClicked.addListener((info, tab) => {
 });
 ```
 
-This example adds two radio items you can use to apply a green or blue border to the page. This example needs the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+This example adds two radio items you can use to apply a green or blue border to the page. This example needs the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 ```js
 function onCreated() {

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclicked/index.md
@@ -10,6 +10,8 @@ Fired when a menu item is clicked.
 
 For compatibility with other browsers, Firefox makes this event available via the `contextMenus` namespace as well as the `menus` namespace.
 
+If the extension has the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission), selecting a menu item is a user action that grants it temporary access to the tab where the click occurred.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/omnibox/oninputentered/index.md
@@ -13,6 +13,8 @@ Use this event to handle the user's selection, generally by opening the correspo
 - the user's selection
 - an {{WebExtAPIRef("omnibox.OnInputEnteredDisposition")}}: use this to determine whether to open the new page in the current tab, in a new foreground tab, or in a new background tab.
 
+If the extension has the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission), selecting a suggestion is a user action that grants it temporary access to the active tab (in Firefox, from Firefox 142).
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -11,7 +11,7 @@ Injects a script into a target context. The script is run at `document_idle` by 
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Safari and Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission). Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
 
 In Firefox and Safari, partial lack of host permissions can result in a successful execution (with the partial results in the resolved promise). In Chrome, any missing permission prevents any execution from happening (see [Issue 1325114](https://crbug.com/1325114)).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -11,7 +11,7 @@ Injects a script into a target context. The script is run at `document_idle` by 
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Safari and Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
 
 In Firefox and Safari, partial lack of host permissions can result in a successful execution (with the partial results in the resolved promise). In Chrome, any missing permission prevents any execution from happening (see [Issue 1325114](https://crbug.com/1325114)).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
@@ -11,7 +11,7 @@ Returns all the content scripts registered with {{WebExtAPIRef("scripting.regist
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/getregisteredcontentscripts/index.md
@@ -11,7 +11,7 @@ Returns all the content scripts registered with {{WebExtAPIRef("scripting.regist
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
@@ -16,7 +16,7 @@ Inserts JavaScript and CSS into websites. This API offers two approaches to inse
 
 This API requires the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the target in the tab into which JavaScript or CSS is injected.
 
-Alternatively, you can get permission temporarily in the active tab and only in response to an explicit user action, by asking for the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. However, the `"scripting"` permission is still required.
+Alternatively, you can get permission temporarily in the active tab and only in response to an explicit user action, by asking for the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission). However, the `"scripting"` permission is still required.
 
 ## Types
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/index.md
@@ -16,7 +16,7 @@ Inserts JavaScript and CSS into websites. This API offers two approaches to inse
 
 This API requires the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the target in the tab into which JavaScript or CSS is injected.
 
-Alternatively, you can get permission temporarily in the active tab and only in response to an explicit user action, by asking for the [`"activeTab"` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). However, the `"scripting"` permission is still required.
+Alternatively, you can get permission temporarily in the active tab and only in response to an explicit user action, by asking for the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. However, the `"scripting"` permission is still required.
 
 ## Types
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
@@ -11,7 +11,7 @@ Injects CSS into a page.
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Safari and Firefox 102+, this method is also available in Manifest V2.
 
-To use this API, you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To use this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 You can only inject CSS into pages whose URL can be expressed using a [match pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns): meaning its scheme must be one of "http", "https", or "file". This means you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
@@ -11,7 +11,7 @@ Injects CSS into a page.
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Safari and Firefox 102+, this method is also available in Manifest V2.
 
-To use this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+To use this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the target's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 You can only inject CSS into pages whose URL can be expressed using a [match pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns): meaning its scheme must be one of "http", "https", or "file". This means you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -11,7 +11,7 @@ Registers one or more content scripts.
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To call this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+To call this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registercontentscripts/index.md
@@ -11,7 +11,7 @@ Registers one or more content scripts.
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To call this API, you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To call this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
@@ -11,7 +11,7 @@ Removes a CSS stylesheet injected by a call to {{WebExtAPIRef("scripting.insertC
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Safari and Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
@@ -11,7 +11,7 @@ Removes a CSS stylesheet injected by a call to {{WebExtAPIRef("scripting.insertC
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Safari and Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
@@ -11,7 +11,7 @@ Unregisters one or more content scripts.
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
@@ -11,7 +11,7 @@ Unregisters one or more content scripts.
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+To use this API you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) and permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
@@ -11,7 +11,7 @@ Updates registered content scripts. If there are errors during script parsing an
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To call this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+To call this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/updatecontentscripts/index.md
@@ -11,7 +11,7 @@ Updates registered content scripts. If there are errors during script parsing an
 > [!NOTE]
 > This method is available in Manifest V3 or higher in Chrome and Firefox 101. In Firefox 102+, this method is also available in Manifest V2.
 
-To call this API, you must have the `"scripting"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To call this API, you must have the `scripting` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions). To run the injected script, the extension must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -6,12 +6,12 @@ browser-compat: webextensions.api.tabs.captureVisibleTab
 sidebar: addonsidebar
 ---
 
-Creates a data URL encoding the image of an area of the active tab in the specified window. You must have the `<all_urls>` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+Creates a data URL encoding the image of an area of the active tab in the specified window. You must have the `<all_urls>` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 > [!NOTE]
 > In Firefox 125 and earlier, this method was only available with the `<all_urls>` permission.
 
-In addition to sites that extensions can normally access, this method allows extensions to capture sensitive sites that are otherwise restricted, including browser UI pages and other extensions' pages. These sensitive sites can only be captured with the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. Chrome also permits file URLs to be captured when the extension has been granted file access.
+In addition to sites that extensions can normally access, this method allows extensions to capture sensitive sites that are otherwise restricted, including browser UI pages and other extensions' pages. These sensitive sites can only be captured with the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission). Chrome also permits file URLs to be captured when the extension has been granted file access.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -6,12 +6,12 @@ browser-compat: webextensions.api.tabs.captureVisibleTab
 sidebar: addonsidebar
 ---
 
-Creates a data URL encoding the image of an area of the active tab in the specified window. You must have the `<all_urls>` or `activeTab` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
+Creates a data URL encoding the image of an area of the active tab in the specified window. You must have the `<all_urls>` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 > [!NOTE]
 > In Firefox 125 and earlier, this method was only available with the `<all_urls>` permission.
 
-In addition to sites that extensions can normally access, this method allows extensions to capture sensitive sites that are otherwise restricted, including browser UI pages and other extensions' pages. These sensitive sites can only be captured with the `activeTab` permission. Chrome also permits file URLs to be captured when the extension has been granted file access.
+In addition to sites that extensions can normally access, this method allows extensions to capture sensitive sites that are otherwise restricted, including browser UI pages and other extensions' pages. These sensitive sites can only be captured with the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. Chrome also permits file URLs to be captured when the extension has been granted file access.
 
 This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -13,7 +13,7 @@ Injects JavaScript code into a page.
 
 You can inject code into pages whose URL you can express using a [match pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). To do so, its scheme must be one of: `http`, `https`, or `file`.
 
-You must have permission for the page's URL either explicitly, as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions), or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
+You must have permission for the page's URL either explicitly, as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions), or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission). Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
 
 Extensions cannot run content scripts in [extension pages](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages). If an extension wants to run code in an extension page dynamically, it can include a script in the document. This script contains the code to run and registers a {{WebExtAPIRef("runtime.onMessage")}} listener that implements a way to execute the code. The extension can then send a message to the listener to trigger the code's execution.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/executescript/index.md
@@ -13,7 +13,7 @@ Injects JavaScript code into a page.
 
 You can inject code into pages whose URL you can express using a [match pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). To do so, its scheme must be one of: `http`, `https`, or `file`.
 
-You must have the permission for the page's URL either explicitly, as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions), or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
+You must have permission for the page's URL either explicitly, as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions), or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. Note that some special pages do not allow this permission, including reader view, view-source, PDF viewer, and other built-in browser UI pages.
 
 Extensions cannot run content scripts in [extension pages](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages). If an extension wants to run code in an extension page dynamically, it can include a script in the document. This script contains the code to run and registers a {{WebExtAPIRef("runtime.onMessage")}} listener that implements a way to execute the code. The extension can then send a message to the listener to trigger the code's execution.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -20,7 +20,7 @@ You can use most of this API without any special permission. However:
 
 - To use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}}, you must have the [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the tab
 
-Alternatively, you can get these permissions temporarily for the active tab in response to an explicit user action by asking for the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+Alternatively, you can get these permissions temporarily for the active tab in response to an explicit user action by asking for the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a single tab only within a browser session. If the browser is restarted, then it can and will reuse tab `id`s. To associate information with a tab across browser restarts, use {{WebExtAPIRef("sessions.setTabValue()")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -20,7 +20,7 @@ You can use most of this API without any special permission. However:
 
 - To use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}}, you must have the [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the tab
 
-Alternatively, you can get these permissions temporarily, only for the currently active tab and only in response to an explicit user action, by asking for the [`"activeTab"` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+Alternatively, you can get these permissions temporarily for the active tab in response to an explicit user action by asking for the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 Many tab operations use a Tab `id`. Tab `id`s are guaranteed to be unique to a single tab only within a browser session. If the browser is restarted, then it can and will reuse tab `id`s. To associate information with a tab across browser restarts, use {{WebExtAPIRef("sessions.setTabValue()")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -11,7 +11,7 @@ Injects CSS into a page.
 > [!NOTE]
 > When using Manifest V3 or higher, use {{WebExtAPIRef("scripting.insertCSS()")}} and {{WebExtAPIRef("scripting.removeCSS()")}} to insert and remove CSS.
 
-To use this method, you must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+To use this method, you must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 You can only inject CSS into pages whose URL can be expressed using a [match pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns): meaning, its scheme must be one of "http", "https", or "file". This means that you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -11,7 +11,7 @@ Injects CSS into a page.
 > [!NOTE]
 > When using Manifest V3 or higher, use {{WebExtAPIRef("scripting.insertCSS()")}} and {{WebExtAPIRef("scripting.removeCSS()")}} to insert and remove CSS.
 
-To use this API you must have the permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions), or using the [activeTab permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+To use this method, you must have permission for the page's URL, either explicitly as a [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) or using the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 You can only inject CSS into pages whose URL can be expressed using a [match pattern](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns): meaning, its scheme must be one of "http", "https", or "file". This means that you can't inject CSS into any of the browser's built-in pages, such as about:debugging, about:addons, or the page that opens when you open a new empty tab.
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -80,7 +80,7 @@ When calling `tabs.remove()`:
 
 - **In Firefox:**
   - Requests can be redirected only if their original URL uses the `http:` or `https:` scheme.
-  - The [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission does not allow for intercepting network requests in the current tab. (See [bug 1617479](https://bugzil.la/1617479))
+  - The [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) does not allow for intercepting network requests in the current tab. (See [bug 1617479](https://bugzil.la/1617479))
   - Events are not fired for system requests (for example, extension upgrades or search bar suggestions).
     - **From Firefox 57 onwards:** Firefox makes an exception for extensions that need to intercept {{WebExtAPIRef("webRequest.onAuthRequired")}} for proxy authorization. See the documentation for {{WebExtAPIRef("webRequest.onAuthRequired")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/chrome_incompatibilities/index.md
@@ -80,7 +80,7 @@ When calling `tabs.remove()`:
 
 - **In Firefox:**
   - Requests can be redirected only if their original URL uses the `http:` or `https:` scheme.
-  - The `activeTab` permission does not allow for intercepting network requests in the current tab. (See [bug 1617479](https://bugzil.la/1617479))
+  - The [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission does not allow for intercepting network requests in the current tab. (See [bug 1617479](https://bugzil.la/1617479))
   - Events are not fired for system requests (for example, extension upgrades or search bar suggestions).
     - **From Firefox 57 onwards:** Firefox makes an exception for extensions that need to intercept {{WebExtAPIRef("webRequest.onAuthRequired")}} for proxy authorization. See the documentation for {{WebExtAPIRef("webRequest.onAuthRequired")}}.
 

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -40,13 +40,13 @@ However, the {{WebExtAPIRef("scripting.registerContentScripts()")}} API provides
 
 Registered content scripts are only executed if the extension is granted [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the domain.
 
-To inject scripts programmatically, the extension needs either the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission) or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). The `scripting` permission is required to use methods from the {{WebExtAPIRef("scripting")}} API.
+To inject scripts programmatically, the extension needs either the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). The `scripting` permission is required to use methods from the {{WebExtAPIRef("scripting")}} API.
 
 On installation, an extension can request host permissions for hosts in its `matches` lists of the `content_scripts` manifest key. Users can opt in or out of host permissions after installing the extension.
 
 ### Restricted domains
 
-Both [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) and the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission) have exceptions for some domains. Content scripts are blocked from executing on these domains, for example, to protect the user from an extension escalating privileges through special pages.
+Both [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) and the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission have exceptions for some domains. Content scripts are blocked from executing on these domains, for example, to protect the user from an extension escalating privileges through special pages.
 
 In Firefox, this includes these domains:
 

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -40,13 +40,13 @@ However, the {{WebExtAPIRef("scripting.registerContentScripts()")}} API provides
 
 Registered content scripts are only executed if the extension is granted [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the domain.
 
-To inject scripts programmatically, the extension needs either the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). The `scripting` permission is required to use methods from the {{WebExtAPIRef("scripting")}} API.
+To inject scripts programmatically, the extension needs either the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions). The `scripting` permission is required to use methods from the {{WebExtAPIRef("scripting")}} API.
 
 On installation, an extension can request host permissions for hosts in its `matches` lists of the `content_scripts` manifest key. Users can opt in or out of host permissions after installing the extension.
 
 ### Restricted domains
 
-Both [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) and the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission have exceptions for some domains. Content scripts are blocked from executing on these domains, for example, to protect the user from an extension escalating privileges through special pages.
+Both [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) and the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) have exceptions for some domains. Content scripts are blocked from executing on these domains, for example, to protect the user from an extension escalating privileges through special pages.
 
 In Firefox, this includes these domains:
 

--- a/files/en-us/mozilla/add-ons/webextensions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/index.md
@@ -32,6 +32,7 @@ Get detailed information on the concepts that underpin extensions.
 - [Overview of the JavaScript API](/en-US/docs/Mozilla/Add-ons/WebExtensions/API)
 - [Content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts)
 - [Background scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts)
+- [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission)
 - [Match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns)
 - [Working with files](/en-US/docs/Mozilla/Add-ons/WebExtensions/Working_with_files)
 - [Internationalization](/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization)

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/optional_permissions/index.md
@@ -54,7 +54,7 @@ These are the same as the host permissions you can specify in the [`permissions`
 
 The optional API permissions are:
 
-- `activeTab`
+- [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission)
 - `background`
 - `bookmarks`
 - `browserSettings`

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -43,7 +43,7 @@ The key can contain three kinds of permissions:
 
 - host permissions (Manifest V2 only, host permissions are specified in the [`host_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) manifest key for Manifest V3 or higher.)
 - API permissions
-- the `activeTab` permission
+- the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission
 
 ## Host permissions
 
@@ -143,31 +143,9 @@ In most cases, the permission grants access to the API only, with these exceptio
 
 ## activeTab permission
 
-If an extension has the `"activeTab"` permission, when a user interacts with the extension, the extension is granted extra privileges for the active tab only.
+When a user interacts with an extension that has the `activeTab` permission, the extension is granted extra privileges for the tab where the interaction occurred. This lets an extension act on the current page when the user asks, without requesting broad [host permissions](#host_permissions).
 
-These interactions are known as [user actions](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions) and include the user:
-
-- clicking the extension's [toolbar button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) or [page action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions).
-- selecting an extension's context menu item.
-- activating a keyboard shortcut defined by the extension (from Firefox 63).
-- clicking a button on a page bundled with the extension.
-- clicking an extension suggestion in the address bar (omnibox) (from Firefox 142).
-
-The extra privileges are:
-
-- The ability to inject JavaScript or CSS into the tab programmatically (see [Loading content scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#loading_content_scripts)).
-- Access to the privileged parts of the tabs API for the current tab: `Tab.url`, `Tab.title`, and `Tab.faviconUrl`.
-
-The intent of this permission is to enable extensions to fulfill a common use case without granting them overly powerful permissions. Many extensions want to "do something to the current page when the user asks".
-
-For example, consider an extension that wants to run a script in the current page when the user clicks a browser action. If the `activeTab` permission did not exist, the extension would need to ask for the host permission `<all_urls>`. But this gives the extension more power than it needs: it can now execute scripts in _any tab_, _any time_ it likes, instead of just the active tab and only in response to a user action.
-
-> [!NOTE]
-> Your extension can only access the tab or data that existed when the user interaction occurred (e.g., a click). When the active tab navigates away (e.g., due to page load finishing or another event), the extension no longer has permission to access the tab.
-
-The `activeTab` permission enables scripting access to the top-level tab's page and same-origin frames. Running scripts or modifying styles inside [cross-origin](/en-US/docs/Web/Security/Defenses/Same-origin_policy#cross-origin_network_access) frames may require additional [host permissions](#host_permissions). Of course, [restrictions and limitations](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#permissions_restrictions_and_limitations) related to particular sites and URI schemes are applied as well.
-
-Usually, the tab that's granted `activeTab` is the active tab, with one exception. An extension can create a menu item using the {{webextAPIref("menus")}} API that displays when the user context-clicks a tab. That is, a menu on an element in the tabstrip that lets the user switch between tabs. If the user clicks this menu, then the `activeTab` permission is granted for the tab the user clicked, even if it's not the active tab (as of Firefox 63, [Firefox bug 1446956](https://bugzil.la/1446956)).
+For details of how the permission is granted, what it enables, when the access ends, and how behavior differs among browsers, see the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission page.
 
 ## Clipboard access
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/permissions/index.md
@@ -43,7 +43,7 @@ The key can contain three kinds of permissions:
 
 - host permissions (Manifest V2 only, host permissions are specified in the [`host_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) manifest key for Manifest V3 or higher.)
 - API permissions
-- the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission
+- the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission)
 
 ## Host permissions
 
@@ -145,7 +145,7 @@ In most cases, the permission grants access to the API only, with these exceptio
 
 When a user interacts with an extension that has the `activeTab` permission, the extension is granted extra privileges for the tab where the interaction occurred. This lets an extension act on the current page when the user asks, without requesting broad [host permissions](#host_permissions).
 
-For details of how the permission is granted, what it enables, when the access ends, and how behavior differs among browsers, see the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission page.
+For details of how the permission is granted, what it enables, when the access ends, and how behavior differs among browsers, see the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) page.
 
 ## Clipboard access
 

--- a/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -83,7 +83,7 @@ First, update "manifest.json" so it has the following contents:
 
 Here, we've removed the `content_scripts` key, and added two new keys:
 
-- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions): To inject scripts into pages, we need permissions for the page we're modifying. The [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission lets us do this temporarily for the active tab. We also need the `contextMenus` permission to add context menu items.
+- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions): To inject scripts into pages, we need permissions for the page we're modifying. The [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) lets us do this temporarily for the active tab. We also need the `contextMenus` permission to add context menu items.
 - [`background`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background): We're using this to load a persistent ["background script"](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts) called `background.js`, in which we'll set up the context menu and inject the content script.
 
 Let's create this file. Create a new file called `background.js` in the `modify-page` directory, and give it the following contents:

--- a/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/modify_a_web_page/index.md
@@ -83,7 +83,7 @@ First, update "manifest.json" so it has the following contents:
 
 Here, we've removed the `content_scripts` key, and added two new keys:
 
-- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions): To inject scripts into pages we need permissions for the page we're modifying. The [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission) is a way to get this temporarily for the currently active tab. We also need the `contextMenus` permission to be able to add context menu items.
+- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions): To inject scripts into pages, we need permissions for the page we're modifying. The [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission lets us do this temporarily for the active tab. We also need the `contextMenus` permission to add context menu items.
 - [`background`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background): We're using this to load a persistent ["background script"](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts) called `background.js`, in which we'll set up the context menu and inject the content script.
 
 Let's create this file. Create a new file called `background.js` in the `modify-page` directory, and give it the following contents:

--- a/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
@@ -31,7 +31,7 @@ function handleClick() {
 browser.browserAction.onClicked.addListener(handleClick);
 ```
 
-In addition to enabling the APIs, these actions also enable the [`"activeTab"` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). This permission grants extra privileges for the tab visible when the user action takes place.
+In addition to enabling the APIs, these actions also enable the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. This permission grants extra privileges for the tab visible when the user action takes place.
 
 User interactions in normal web pages aren't treated as user actions. For example, consider a button on a normal web page that uses a content script. This content script added a click handler for the button that sends a message to the extension's background page. When a user clicks the button, the background page message handler is not considered to be handling a user action.
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_actions/index.md
@@ -31,7 +31,7 @@ function handleClick() {
 browser.browserAction.onClicked.addListener(handleClick);
 ```
 
-In addition to enabling the APIs, these actions also enable the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. This permission grants extra privileges for the tab visible when the user action takes place.
+In addition to enabling the APIs, these actions also enable the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission). This permission grants extra privileges for the tab visible when the user action takes place.
 
 User interactions in normal web pages aren't treated as user actions. For example, consider a button on a normal web page that uses a content script. This content script added a click handler for the button that sends a message to the extension's background page. When a user clicks the button, the background page message handler is not considered to be handling a user action.
 

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -37,12 +37,12 @@ The following is how you might request `"tabs"` permission in your extension's m
 ],
 ```
 
-This request gives you use of all Tabs API feature on all website your user visits. There is also an alternative approach for requesting permissions to use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}} where you don't need host permission, in the form of [`"activeTab"`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission). This permission provides the same rights as `"tabs"` with `<all_urls>`, but with two restrictions:
+This request gives you use of all Tabs API feature on all website your user visits. There is also an alternative approach for requesting permissions to use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}} where you don't need host permission, in the form of the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. This permission provides the same rights as `"tabs"` with `<all_urls>`, but with two restrictions:
 
 - the user must interact with the extension through its browser or page action, context menu, or shortcut key.
 - it only grants permission within the active tab.
 
-The benefit of this approach is the user won't get a permissions warning saying your extension can "Access your data for all websites". This is because `<all_urls>` permission gives an extension the ability to execute scripts in any tab, any time it likes, whereas [`"activeTab"`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission) is limited to allowing the extension to perform a user requested action in the current tab.
+The benefit of this approach is the user won't get a permissions warning saying your extension can "Access your data for all websites". This is because `<all_urls>` permission gives an extension the ability to execute scripts in any tab, any time it likes, whereas the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission is limited to allowing the extension to perform a user requested action in the current tab.
 
 ## Discovering more about tabs and their properties
 

--- a/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/working_with_the_tabs_api/index.md
@@ -37,12 +37,12 @@ The following is how you might request `"tabs"` permission in your extension's m
 ],
 ```
 
-This request gives you use of all Tabs API feature on all website your user visits. There is also an alternative approach for requesting permissions to use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}} where you don't need host permission, in the form of the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission. This permission provides the same rights as `"tabs"` with `<all_urls>`, but with two restrictions:
+This request gives you use of all Tabs API feature on all website your user visits. There is also an alternative approach for requesting permissions to use {{WebExtAPIRef("tabs.executeScript()")}} or {{WebExtAPIRef("tabs.insertCSS()")}} where you don't need host permission, in the form of the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission). This permission provides the same rights as `"tabs"` with `<all_urls>`, but with two restrictions:
 
 - the user must interact with the extension through its browser or page action, context menu, or shortcut key.
 - it only grants permission within the active tab.
 
-The benefit of this approach is the user won't get a permissions warning saying your extension can "Access your data for all websites". This is because `<all_urls>` permission gives an extension the ability to execute scripts in any tab, any time it likes, whereas the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission is limited to allowing the extension to perform a user requested action in the current tab.
+The benefit of this approach is the user won't get a permissions warning saying your extension can "Access your data for all websites". This is because `<all_urls>` permission gives an extension the ability to execute scripts in any tab, any time it likes, whereas the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) is limited to allowing the extension to perform a user requested action in the current tab.
 
 ## Discovering more about tabs and their properties
 

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -98,7 +98,7 @@ Now create a file called "manifest.json", and give it this content:
   - The `gecko` property provides addons.mozilla.org and Firefox with extra configuration information about the extension:
   - [`id`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#id) defines a unique identifier for the extension. This ID is needed before an extension can be published on addons.mozilla.org (AMO).
   - [`data_collection_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#data_collection_permissions) provides information on whether the extension collects and transmits personally identifiable information. This example doesn't collect or transmit any data.
-- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) lists permissions the extension needs. In this example, the extension asks for the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) lists permissions the extension needs. In this example, the extension asks for the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 - [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) specifies the toolbar button. You supply three pieces of information here, all of which are optional:
   - `default_icon` points to the button's icon.
   - `default_title` provides text for a tooltip displayed for the action button.

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -98,7 +98,7 @@ Now create a file called "manifest.json", and give it this content:
   - The `gecko` property provides addons.mozilla.org and Firefox with extra configuration information about the extension:
   - [`id`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#id) defines a unique identifier for the extension. This ID is needed before an extension can be published on addons.mozilla.org (AMO).
   - [`data_collection_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#data_collection_permissions) provides information on whether the extension collects and transmits personally identifiable information. This example doesn't collect or transmit any data.
-- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) lists permissions the extension needs. In this example, the extension asks for the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
+- [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) lists permissions the extension needs. In this example, the extension asks for the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 - [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) specifies the toolbar button. You supply three pieces of information here, all of which are optional:
   - `default_icon` points to the button's icon.
   - `default_title` provides text for a tooltip displayed for the action button.

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -79,7 +79,7 @@ No notable changes.
 - The {{WebExtAPIRef("runtime.MessageSender")}} type now includes the `origin` property. This enables message or connection requests to see the page or frame that opened the connection. This is useful for identifying if the origin can be trusted if it isn't apparent from the URL ([Firefox bug 1787379](https://bugzil.la/1787379)).
 - The `"webRequestAuthProvider"` permission is now supported. This provides compatibility with Chrome for requesting permission for {{WebExtAPIRef("webRequest.onAuthRequired")}} in Manifest V3 ([Firefox bug 1820569](https://bugzil.la/1820569)).
 - The [`options_page` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page) is provided as an alias of the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key. This has been provided to offer extensions better compatibility with Chrome ([Firefox bug 1816960](https://bugzil.la/1816960)).
-- The {{WebExtAPIRef("tabs.captureVisibleTab")}} method is now also enabled by the `activeTab` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions), providing compatibility with Chrome and Safari ([Firefox bug 1784920](https://bugzil.la/1784920)).
+- The {{WebExtAPIRef("tabs.captureVisibleTab")}} method is now also enabled by the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission, providing compatibility with Chrome and Safari ([Firefox bug 1784920](https://bugzil.la/1784920)).
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/126/index.md
+++ b/files/en-us/mozilla/firefox/releases/126/index.md
@@ -79,7 +79,7 @@ No notable changes.
 - The {{WebExtAPIRef("runtime.MessageSender")}} type now includes the `origin` property. This enables message or connection requests to see the page or frame that opened the connection. This is useful for identifying if the origin can be trusted if it isn't apparent from the URL ([Firefox bug 1787379](https://bugzil.la/1787379)).
 - The `"webRequestAuthProvider"` permission is now supported. This provides compatibility with Chrome for requesting permission for {{WebExtAPIRef("webRequest.onAuthRequired")}} in Manifest V3 ([Firefox bug 1820569](https://bugzil.la/1820569)).
 - The [`options_page` manifest key](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page) is provided as an alias of the [`options_ui`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) key. This has been provided to offer extensions better compatibility with Chrome ([Firefox bug 1816960](https://bugzil.la/1816960)).
-- The {{WebExtAPIRef("tabs.captureVisibleTab")}} method is now also enabled by the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission, providing compatibility with Chrome and Safari ([Firefox bug 1784920](https://bugzil.la/1784920)).
+- The {{WebExtAPIRef("tabs.captureVisibleTab")}} method is now also enabled by the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission), providing compatibility with Chrome and Safari ([Firefox bug 1784920](https://bugzil.la/1784920)).
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -52,7 +52,7 @@ No notable changes.
 ## Changes for add-on developers
 
 - Addition of {{WebExtAPIRef("storage.StorageArea.getKeys()")}}. This method returns an array containing all of the keys in a storage area. It's available for all storage areas, that is {{WebExtAPIRef("storage.sync", "sync")}}, {{WebExtAPIRef("storage.local", "local")}}, {{WebExtAPIRef("storage.session", "session")}}, and {{WebExtAPIRef("storage.managed", "managed")}}. ([Firefox bug 1910669](https://bugzil.la/1910669))
-- User selection of an extension suggestion in the address bar (omnibox), an action that fires {{WebExtAPIRef("omnibox.onInputEntered")}}, is now considered a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions). In addition to enabling the APIs that require a user action, selecting an extension suggestion in the address bar also grants the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
+- User selection of an extension suggestion in the address bar (omnibox), an action that fires {{WebExtAPIRef("omnibox.onInputEntered")}}, is now considered a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions). In addition to enabling the APIs that require a user action, selecting an extension suggestion in the address bar also grants the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission).
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/143/index.md
+++ b/files/en-us/mozilla/firefox/releases/143/index.md
@@ -52,7 +52,7 @@ No notable changes.
 ## Changes for add-on developers
 
 - Addition of {{WebExtAPIRef("storage.StorageArea.getKeys()")}}. This method returns an array containing all of the keys in a storage area. It's available for all storage areas, that is {{WebExtAPIRef("storage.sync", "sync")}}, {{WebExtAPIRef("storage.local", "local")}}, {{WebExtAPIRef("storage.session", "session")}}, and {{WebExtAPIRef("storage.managed", "managed")}}. ([Firefox bug 1910669](https://bugzil.la/1910669))
-- User selection of an extension suggestion in the address bar (omnibox), an action that fires {{WebExtAPIRef("omnibox.onInputEntered")}}, is now considered a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions). In addition to enabling the APIs that require a user action, selecting an extension suggestion in the address bar also grants the `"activeTab"` permission.
+- User selection of an extension suggestion in the address bar (omnibox), an action that fires {{WebExtAPIRef("omnibox.onInputEntered")}}, is now considered a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions). In addition to enabling the APIs that require a user action, selecting an extension suggestion in the address bar also grants the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission.
 
 ## Experimental web features
 

--- a/files/en-us/mozilla/firefox/releases/63/index.md
+++ b/files/en-us/mozilla/firefox/releases/63/index.md
@@ -200,7 +200,7 @@ _No changes._
 - {{WebExtAPIRef("menus.create()")}} now enables you to create invisible menu items, and {{WebExtAPIRef("menus.update()")}} enables you to toggle menu item visibility ([Firefox bug 1482529](https://bugzil.la/1482529)).
 - Items created using the {{WebExtAPIRef("menus")}} API now support access keys ([Firefox bug 1320462](https://bugzil.la/1320462)).
 - The `targetUrlPatterns` parameter of {{WebExtApiRef("menus.create()")}} and {{WebExtApiRef("menus.update()")}} now supports any URL scheme, even those that are usually not allowed in a match pattern ([Firefox bug 1280370](https://bugzil.la/1280370)).
-- When a tab context menu item is clicked, the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission is now granted for that tab, even if that's not the currently active tab ([Firefox bug 1446956](https://bugzil.la/1446956)).
+- When a tab context menu item is clicked, the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) is now granted for that tab, even if that's not the currently active tab ([Firefox bug 1446956](https://bugzil.la/1446956)).
 
 #### Other
 

--- a/files/en-us/mozilla/firefox/releases/63/index.md
+++ b/files/en-us/mozilla/firefox/releases/63/index.md
@@ -200,7 +200,7 @@ _No changes._
 - {{WebExtAPIRef("menus.create()")}} now enables you to create invisible menu items, and {{WebExtAPIRef("menus.update()")}} enables you to toggle menu item visibility ([Firefox bug 1482529](https://bugzil.la/1482529)).
 - Items created using the {{WebExtAPIRef("menus")}} API now support access keys ([Firefox bug 1320462](https://bugzil.la/1320462)).
 - The `targetUrlPatterns` parameter of {{WebExtApiRef("menus.create()")}} and {{WebExtApiRef("menus.update()")}} now supports any URL scheme, even those that are usually not allowed in a match pattern ([Firefox bug 1280370](https://bugzil.la/1280370)).
-- When a tab context menu item is clicked, the ["activeTab" permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission) is now granted for that tab, even if that's not the currently active tab ([Firefox bug 1446956](https://bugzil.la/1446956)).
+- When a tab context menu item is clicked, the [`activeTab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/activeTab_permission) permission is now granted for that tab, even if that's not the currently active tab ([Firefox bug 1446956](https://bugzil.la/1446956)).
 
 #### Other
 

--- a/files/sidebars/addonsidebar.yaml
+++ b/files/sidebars/addonsidebar.yaml
@@ -18,6 +18,7 @@ sidebar:
       - /Mozilla/Add-ons/WebExtensions/API
       - /Mozilla/Add-ons/WebExtensions/Content_scripts
       - /Mozilla/Add-ons/WebExtensions/Background_scripts
+      - /Mozilla/Add-ons/WebExtensions/activeTab_permission
       - /Mozilla/Add-ons/WebExtensions/Match_patterns
       - /Mozilla/Add-ons/WebExtensions/Working_with_files
       - /Mozilla/Add-ons/WebExtensions/Internationalization


### PR DESCRIPTION
### Description

This change moves all information about the `activeTab` permission to a new concepts page (placed after the content and background script articles). It also adds an example illustrating how to use `activeTab`. All references to `activeTab` should now link back to the concept page.

### Motivation

This change increases the visibility of information about `activeTab`, given its significance to web extension development.

### Additional details

- The extension example's manifest doesn't include the `browser_specific_settings.gecko` add-on ID and `data_collection_permissions`.
- The Firefox 63 change to enable `activeTab` when activating a context menu item from the tab bar is no longer mentioned in the body text (given the change occurred 8 years ago); however, it is detailed in the tables identifying differences between the browsers.
- We don't seem to be certain whether permission names should be enclosed quotes or not. As the quotes are part of the manifest structure, I've removed them in these changes.

### Related issues and pull requests

Fiyes #40942