### PR TITLE
Fullscreen API - tidy overview and guide

### DIFF
--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -124,7 +124,7 @@ The user has to interact with the page or a UI element in order for this feature
 
 Fullscreen mode is controlled by the [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) directive {{HTTPHeader("Permissions-Policy/fullscreen","fullscreen")}}.
 
-The default allowlist for `screen-wake-lock` is `self`.
+The default allowlist for `fullscreen` is `self`.
 This allows fullscreen usage in same-origin nested frames but prevents them in third-party content.
 Third party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third party origin.
 

--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -11,6 +11,7 @@ This article demonstrates how to use the [Fullscreen API](/en-US/docs/Web/API/Fu
 ## Activating fullscreen mode
 
 Given an element that you'd like to present in fullscreen mode (such as a {{HTMLElement("video")}}, for example), you can present it in fullscreen mode by calling its {{DOMxRef("Element.requestFullscreen", "requestFullscreen()")}} method.
+The user has to interact with the page or a UI element in order for this feature to work (it requires [Transient user activation](/en-US/docs/Web/Security/Defenses/User_activation))
 
 Let's consider this {{HTMLElement("video")}} element:
 
@@ -47,11 +48,96 @@ It's not guaranteed that you'll be able to switch into fullscreen mode. For exam
 > [!NOTE]
 > Fullscreen requests need to be called from within an event handler or otherwise they will be denied.
 
+## Browser keyboard locking
+
+Some applications want to use use keys or key-combinations that the are normally handled by the browser or the underlying OS.
+For example, a game might want to use the <kbd>Esc</kbd> key to invoke a menu instead of exiting fullscreen mode.
+
+Keyboard locking mode allows you exit fullscreen mode using a long-press of the normal exit key (usually <kbd>Esc</kbd>), and intercept and handle other keys you might not otherwise be able to, including the normal exit key!
+
+The HTML below shows a video element we might want to display full screen.
+
+```html
+<p>
+  The video element below shows a time-lapse of a flower blooming. You can
+  toggle fullscreen on and off using <kbd>Enter</kbd> or
+  <kbd>Shift+F</kbd> (uppercase "F"). The embedded document needs to have
+  <a
+    href="https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event">
+    focus
+  </a>
+  for the example to work.
+</p>
+
+<video controls loop src="/shared-assets/videos/flower.mp4" width="420"></video>
+```
+
+```css hidden
+body {
+  font-family:
+    "Benton Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  margin: 2em;
+}
+
+video::backdrop {
+  background-color: #444488;
+}
+button {
+  display: block;
+}
+kbd {
+  border: 2px solid #cdcdcd;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 0 #cdcdcd;
+  font-size: 0.825rem;
+  padding: 0.25rem;
+}
+```
+
+The following code adds an `click` event handler for the video element that calls `requestFullscreen({ keyboardLock: "browser" }))` if <kbd>Enter</kbd> or <kbd>Shift+F</kbd> are pressed when not in fullscreen mode.
+Setting the [`options.keyboardLock`](#keyboardlock) to `"browser"` is what activates keyboard lock.
+When we're in fullscreen mode we check if the <kbd>Escape</kbd> key was pressed and call `event.preventDefault()` to disable the default action (which would be to exit fullscreen mode).
+
+```js
+const video = document.querySelector("video");
+document.addEventListener("keydown", (event) => {
+  // Check if we're in fullscreen mode
+  if (document.fullscreenElement) {
+    // Cancel exiting via the Escape key
+    if (event.key === "Escape") {
+      event.preventDefault();
+      // Do whatever else you might want to do when escape is pressed
+    }
+  } else if (event.key === "Enter" || event.key === "F") {
+    // Open full screen if Enter or F is pressed and not already fullscreen.
+    // Note that "F" is case-sensitive (uppercase).
+    video.requestFullscreen({ keyboardLock: "browser" }).catch((err) => {
+      console.error(`Error enabling fullscreen: ${err.message}`);
+    });
+  }
+});
+```
+
+You can see this in operation below.
+Select the frame and press <kbd>Shift+F</kbd>.
+When the page displays full frame, note the temporary notification at the top of the page that explains how to exit full screen mode.
+
+On [browsers that support the `keyboardLock` option](/en-US/docs/Web/API/Element/requestFullscreen#browser_compatibility) you will need a long-press to exit full screen mode.
+On other browsers you will be able to exit with the normal key.
+
+{{embedlivesample("Browser keyboard locking", , "400", "", "", "", "fullscreen")}}
+
 ## Getting out of full screen mode
 
-The user always has the ability to exit fullscreen mode of their own accord; see [Things your users want to know](#things_your_users_want_to_know). You can also do so programmatically by calling the {{DOMxRef("Document.exitFullscreen()")}} method.
+Browers provide a mechanism for users to manually exit fullscreen mode, and the method is displayed in a transient notification when fullscreen mode is entered.
+This method is commonly the <kbd>Esc</kbd> key (or a long-press of the <kbd>Esc</kbd> when in [browser keyboard lock mode](/en-US/docs/Web/API/Element/requestFullscreen#keyboard_locking)).
 
-If there are multiple elements in fullscreen mode, calling `exitFullscreen()` only exits the topmost element, revealing the next element below it. Pressing <kbd>Esc</kbd> or <kbd>F11</kbd> exits all fullscreen elements.
+A browser may support other keys or key-combinations for exiting fullscreen mode, such as <kbd>F11</kbd> or <kbd>Alt+Tab</kbd>.
+It can also exit fullscreen mode for any other reason it chooses, such as when navigating to another page, changing tabs, or switching to another application.
+
+You can programmatically exit fullscreen mode by calling the {{DOMxRef("Document.exitFullscreen()")}} method.
+If there are multiple elements in fullscreen mode, calling `exitFullscreen()` only exits the topmost element, revealing the next element below it.
+Pressing the browser-specific exit key that was shown in the notifiction when entering fullscreen mode (usually <kbd>Esc</kbd>) exits all fullscreen elements.
 
 ## Other information
 
@@ -66,25 +152,11 @@ The {{DOMxRef("Document")}} provides some additional information that can be use
 
 Some mobile browsers while in fullscreen mode ignore viewport meta-tag settings and block user scaling; for example: a "pinch to zoom" gesture may not work on a page presented in fullscreen mode — even if, when not in fullscreen mode, the page can be scaled using pinch to zoom.
 
-## Things your users want to know
-
-You'll want to be sure to let your users know that they can press the <kbd>Esc</kbd> key (or <kbd>F11</kbd>) to exit fullscreen mode.
-
-In addition, navigating to another page, changing tabs, or switching to another application (using, for example, <kbd>Alt</kbd>-<kbd>Tab</kbd>) while in fullscreen mode exits fullscreen mode as well.
-
 ## Example
 
 The [mdn/dom-examples GitHub repo](https://github.com/mdn/) has a complete example of the Fullscreen API.
 
 [Run the example](https://mdn.github.io/dom-examples/fullscreen-api/index.html) and [browse the source code](https://github.com/mdn/dom-examples/tree/main/fullscreen-api).
-
-## Specifications
-
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/fullscreen_api/index.md
+++ b/files/en-us/web/api/fullscreen_api/index.md
@@ -2,16 +2,13 @@
 title: Fullscreen API
 slug: Web/API/Fullscreen_API
 page-type: web-api-overview
-browser-compat:
-  - api.Document.fullscreenElement
-  - api.Document.fullscreenEnabled
-  - api.Document.exitFullscreen
-  - api.Element.requestFullscreen
+browser-compat: api.Element.requestFullscreen
 ---
 
 {{DefaultAPISidebar("Fullscreen API")}}
 
-The **Fullscreen API** adds methods to present a specific {{DOMxRef("Element")}} (and its descendants) in fullscreen mode, and to exit fullscreen mode once it is no longer needed. This makes it possible to present desired content—such as an online game—using the user's entire screen, removing all browser user interface elements and other applications from the screen until fullscreen mode is shut off.
+The **Fullscreen API** adds methods to present a specific {{DOMxRef("Element")}} (and its descendants) in fullscreen mode, and to exit fullscreen mode once it is no longer needed.
+This makes it possible to present desired content—such as an online game—using the user's entire screen, removing all browser user interface elements and other applications from the screen until fullscreen mode is shut off.
 
 See the article [Guide to the Fullscreen API](/en-US/docs/Web/API/Fullscreen_API/Guide) for details on how to use the API.
 
@@ -36,9 +33,11 @@ The Fullscreen API adds methods to the {{DOMxRef("Document")}} and {{DOMxRef("El
 ## Instance properties
 
 - {{DOMxRef("Document.fullscreenElement")}} / {{DOMxRef("ShadowRoot.fullscreenElement")}}
-  - : The `fullscreenElement` property tells you the {{DOMxRef("Element")}} that's currently being displayed in fullscreen mode on the DOM (or shadow DOM). If this is `null`, the document (or shadow DOM) is not in fullscreen mode.
+  - : The `fullscreenElement` property tells you the {{DOMxRef("Element")}} that's currently being displayed in fullscreen mode on the DOM (or shadow DOM).
+    If this is `null`, the document (or shadow DOM) is not in fullscreen mode.
 - {{DOMxRef("Document.fullscreenEnabled")}}
-  - : The `fullscreenEnabled` property tells you whether or not it is possible to engage fullscreen mode. This is `false` if fullscreen mode is not available for any reason (such as the `"fullscreen"` feature not being allowed, or fullscreen mode not being supported).
+  - : The `fullscreenEnabled` property tells you whether or not it is possible to engage fullscreen mode.
+    This is `false` if fullscreen mode is not available for any reason (such as the `"fullscreen"` feature not being allowed, or fullscreen mode not being supported).
 
 ### Obsolete properties
 
@@ -55,16 +54,27 @@ The Fullscreen API adds methods to the {{DOMxRef("Document")}} and {{DOMxRef("El
 - {{domxref("Element/fullscreenerror_event", "fullscreenerror")}}
   - : Sent to an `Element` if an error occurs while attempting to switch it into or out of fullscreen mode.
 
-## Controlling access
+## Security considerations
 
-The availability of fullscreen mode can be controlled using a [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy). The fullscreen mode feature is identified by the string `"fullscreen"`, with a default allowlist value of `"self"`, meaning that fullscreen mode is permitted in top-level document contexts, as well as to nested browsing contexts loaded from the same origin as the top-most document.
+[Transient user activation](/en-US/docs/Web/Security/Defenses/User_activation) is required to enter fullscreen mode (the user has to interact with the page or a UI element in order for this feature to work).
 
-## Usage notes
+Fullscreen mode is controlled by the [Permissions-Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) directive {{HTTPHeader("Permissions-Policy/fullscreen","fullscreen")}}.
 
-Users can choose to exit fullscreen mode by pressing the <kbd>ESC</kbd> (or <kbd>F11</kbd>) key, rather than waiting for the site or app to programmatically do so. Make sure you provide, somewhere in your user interface, appropriate user interface elements that inform the user that this option is available to them.
+The default allowlist for `fullscreen` is `self`.
+This allows fullscreen usage in same-origin nested frames but prevents it in third-party content.
+Third-party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission to a particular third-party origin.
 
-> [!NOTE]
-> Navigating to another page, changing tabs, or switching to another application using any application switcher (or <kbd>Alt</kbd>-<kbd>Tab</kbd>) will likewise exit fullscreen mode.
+```http
+Permissions-Policy: fullscreen=(self "https://b.example.com")
+```
+
+Then the `allow="fullscreen"` attribute must be added to the frame container element for sources from that origin:
+
+```html
+<iframe src="https://b.example.com" allow="fullscreen"></iframe>
+```
+
+The [Permissions API](/en-US/docs/Web/API/Permissions_API) `fullscreen` permission can be used to test whether access to use the mode is `granted`, `denied` or `prompt` (requires user acknowledgement of a prompt).
 
 ## Examples
 


### PR DESCRIPTION
This updates the Fullsceen API overview and guide.

The overview 
- had a controlling access section which I have replaced with a "Security considertations" section (more complete, and used in far more places).
- Had incorrect usage notes - that inferred you had to implement user notification about exiting, when this is handled on browsers for you.

The guide had similar information, but also omitted information about transient activation and didn't mention keyboard lock, and was incorrect about keys that can exit.

The truth is that `Escape` works everywhere, but even that isn't in the spec. Any other mechanisms that exit the fullscreen are also up to the browser. SO this is now clear that it's esc, and may be all these other things.

Fixes https://github.com/mdn/content/issues/37810