### PR TITLE
FF155 Relnote: Promise.allKeyed() and Promise.allSettledKeyed() 

### DIFF
--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -36,9 +36,12 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### JavaScript -->
+### JavaScript
 
-<!-- No notable changes. -->
+- The {{jsxref("Promise.allKeyed()")}} and {{jsxref("Promise.allSettledKeyed()")}} static methods are now supported.
+  These behave like {{jsxref("Promise.all()")}} and {{jsxref("Promise.allSettled()")}}, respectively, but take an object of promises instead of an iterable, and fulfill with an object that has results in matching properties.
+  This allows you to associate results with semantically meaningful keys, instead of relying on array ordering.
+  ([Firefox bug 2057270](https://bugzil.la/2057270)).
 
 <!-- #### Removals -->
 


### PR DESCRIPTION
FF155 supports Promise.allKeyed() and Promise.allSettledKeyed() in https://bugzilla.mozilla.org/show_bug.cgi?id=2057270.

This adds a release note.

Related docs work can be tracked in #45186
