### PR TITLE
lint and format .yaml files as well as .yml

### DIFF
--- a/.github/workflows/pr-check_yml.yml
+++ b/.github/workflows/pr-check_yml.yml
@@ -8,7 +8,9 @@ on:
       - package.json
       - package-lock.json
       - "*.yml"
+      - "*.yaml"
       - "**/*.yml"
+      - "**/*.yaml"
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}
@@ -33,5 +35,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lint markdown files
+      - name: Lint yml files
         run: npm run lint:yml

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fix:json": "prettier --write --cache \"**/*.json(c)?\"",
     "fix:md": "markdownlint-cli2 --fix \"**/*.md\" && prettier --write --cache \"**/*.md\"",
     "fix:pre-commit": "lefthook run pre-commit",
-    "fix:yml": "prettier --write --cache \"**/*.yml\"",
+    "fix:yml": "prettier --write --cache \"**/*.{yml,yaml}\"",
     "lint:fm": "node scripts/front-matter_linter.js",
     "lint:js": "prettier -c \"**/*.(m)?js\"",
     "lint:json": "prettier -c \"**/*.json(c)?\"",
@@ -43,7 +43,7 @@
     "lint:typos": "cspell --no-progress --gitignore --config .vscode/cspell.json \"**/*.md\"",
     "lint:typos-group-by-file": "cspell --no-progress --gitignore --quiet --reporter cspell-group-by-file-reporter --config .vscode/cspell.json \"**/*.md\"",
     "lint:typos-words-only": "cspell --no-progress --gitignore --words-only --unique --config .vscode/cspell.json \"**/*.md\"",
-    "lint:yml": "prettier -c \"**/*.yml\"",
+    "lint:yml": "prettier -c \"**/*.{yml,yaml}\"",
     "start": "npm run --silent info:fred && npm run up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files NODE_ENV=production FRED_PLAYGROUND_LOCAL=true FRED_PLAYGROUND_PORT=5043 FRED_PORT=5042 FRED_WRITER_MODE=true fred server",
     "test": "node --test",
     "up-to-date-check": "node scripts/up-to-date-check.js"


### PR DESCRIPTION
@pepelsbey as requested yesterday - renaming these files would require a multi-step migration in rari (first accept `yml` *and* `yaml`, then accept only `yml`) - so fixing the problem, `yaml` wasn't caught by the lint/format steps.