### PR TITLE
Remove duplicated navigation menu

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
@@ -6,7 +6,6 @@ page-type: learn-module-chapter
 sidebar: learnsidebar
 ---
 
-{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Sessions", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Authentication", "Learn_web_development/Extensions/Server-side/Django/Testing", "Learn_web_development/Extensions/Server-side/Django")}}
 
 In this tutorial, we'll show you how to work with HTML Forms in Django, and, in particular, the easiest way to write forms to create, update, and delete model instances. As part of this demonstration, we'll extend the [LocalLibrary](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) website so that librarians can renew books, and create, update, and delete authors using our own forms (rather than using the admin application).


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

There is a copy of the navigation menu, with the 'Previous' link leading to the 'Sessions' chapter. I've removed this copy, leaving only the correct one, which leads to the 'Authentication' chapter on clicking 'Previous'.

### Motivation

This helps readers know which menu is the right one to navigate with, and avoids confusion as to whether this is an error in their browser rendering or with the page itself.