### PR TITLE
Modernize DOM guide (3): new XML namespaces guide, fix issues in namespace properties

### DIFF
--- a/files/en-us/web/api/attr/localname/index.md
+++ b/files/en-us/web/api/attr/localname/index.md
@@ -8,59 +8,60 @@ browser-compat: api.Attr.localName
 
 {{APIRef("DOM")}}
 
-The read-only **`localName`** property of the {{domxref("Attr")}} interface returns the _local part_ of the _qualified name_ of an attribute, that is the name of the attribute, stripped from any namespace in front of it. For example, if the qualified name is `xml:lang`, the returned local name is `lang`, if the element supports that namespace.
-
-The local name is always in lower case, whatever case at the attribute creation.
+The **`localName`** read-only property of the {{domxref("Attr")}} interface returns the [local name](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an attribute, which is the attribute name with the namespace prefix removed, if any.
 
 > [!NOTE]
-> HTML only supports a fixed set of namespaces on SVG and MathML elements. These are `xml` (for the `xml:lang` attribute), `xlink` (for the `xlink:href`, `xlink:show`, `xlink:target` and `xlink:title` attributes) and `xpath`.
+> Attributes in HTML documents are case-normalized by the parser and namespace-unaware methods like {{domxref("document.createAttribute()")}}. This property returns the internally-stored name, which is usually lowercase (camel case for certain SVG/MathML attributes).
 >
-> That means that the local name of an attribute of an HTML element is always be equal to its qualified name: Colons are treated as regular characters. In XML, like in SVG or MathML, the colon denotes the end of the prefix and what is before is the namespace; the local name may be different from the qualified name.
+> The HTML parser special-cases several prefixed attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns:xlink`. For all other attributes, the prefix is simply seen as a part of the local name.
 
 ## Value
 
-A string representing the local part of the attribute's qualified name.
+A string.
 
-## Example
+## Examples
 
-The following example displays the local name of the first attribute of the two first elements, when we click on the appropriate button. The {{SVGElement("svg")}} element is XML and supports namespaces leading to the local name (`lang`) to be different from the qualified name `xml:lang`. The {{HTMLElement("label")}} element is HTML, that doesn't support namespaces, leading to a local name and the qualified name to be both `xml:lang`.
+### Reading the localName
 
-### HTML
-
-```html
-<svg xml:lang="en-US" class="struct" height="1" width="1">Click me</svg>
-<label xml:lang="en-US" class="struct"></label>
-
-<p>
-  <button>Show value for &lt;svg&gt;</button>
-  <button>Show value for &lt;label&gt;</button>
-</p>
-
-<p>
-  Local part of the attribute <code>xml:lang</code>:
-  <output id="result">None.</output>
-</p>
-```
-
-### JavaScript
+We use {{domxref("DOMParser")}} to create an XML document.
 
 ```js
-const elements = document.querySelectorAll(".struct");
-const buttons = document.querySelectorAll("button");
-const outputEl = document.querySelector("#result");
-
-let i = 0;
-for (const button of buttons) {
-  const element = elements[i];
-  button.addEventListener("click", () => {
-    const attribute = element.attributes[0];
-    outputEl.value = attribute.localName;
-  });
-  i++;
-}
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns:mdn="https://developer.mozilla.org/" mdn:status="ready" />`,
+  "application/xml",
+);
+const status = doc.querySelector("parent").getAttributeNode("mdn:status");
+console.log(status.localName); // status
 ```
 
-{{ EmbedLiveSample('Example','100%',100) }}
+### Local names in HTML documents
+
+[The HTML syntax supports namespaces only for a fixed set of attributes on SVG and MathML elements](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#namespace_syntax_in_html). For other attributes, a colon is part of the local name rather than a namespace separator.
+
+```html
+<svg xml:lang="en-US" mdn:status="ready"></svg>
+```
+
+```js
+const svg = document.querySelector("svg");
+
+console.log(svg.getAttributeNode("xml:lang").localName); // lang
+console.log(svg.getAttributeNode("mdn:status").localName); // mdn:status
+```
+
+However, this is only a parser restriction; you can create prefixed attributes using [`document.createAttributeNS()`](/en-US/docs/Web/API/Document/createAttributeNS) or [`element.setAttributeNS()`](/en-US/docs/Web/API/Element/setAttributeNS) and attach them to the HTML DOM without problems. These methods do not normalize internal casing even when the namespace is HTML.
+
+```js
+const status = document.createAttributeNS(
+  "http://www.w3.org/1999/xhtml",
+  "Mdn:Status",
+);
+document.body.setAttributeNode(status);
+
+console.log(status.name); // Mdn:Status
+console.log(status.prefix); // Mdn
+console.log(status.localName); // Status
+```
 
 ## Specifications
 
@@ -72,5 +73,8 @@ for (const button of buttons) {
 
 ## See also
 
-- The properties {{domxref("Attr.name")}}, returning the qualified name of the attribute, and {{domxref("Attr.prefix")}}, the namespace prefix.
-- The {{domxref("Element.localName()")}} property, returning the local name of an {{domxref("Element")}}.
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
+- {{domxref("Attr.name")}}
+- {{domxref("Attr.namespaceURI")}}
+- {{domxref("Attr.prefix")}}
+- {{domxref("Element.localName")}}

--- a/files/en-us/web/api/attr/name/index.md
+++ b/files/en-us/web/api/attr/name/index.md
@@ -8,54 +8,56 @@ browser-compat: api.Attr.name
 
 {{APIRef("DOM")}}
 
-The read-only **`name`** property of the {{domxref("Attr")}} interface returns the _qualified name_ of an attribute, that is the name of the attribute, with the namespace prefix, if any, in front of it. For example, if the local name is `lang` and the namespace prefix is `xml`, the returned qualified name is `xml:lang`.
+The **`name`** read-only property of the {{domxref("Attr")}} interface returns the [qualified name](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an attribute. It is the attribute's local name by itself when the attribute has no prefix, or the prefix and local name separated by a colon when it does.
 
-The qualified name is always in lower case, whatever case at the attribute creation.
+> [!NOTE]
+> Attributes in HTML documents are case-normalized by the parser and namespace-unaware methods like {{domxref("document.createAttribute()")}}. This property returns the internally-stored name, which is usually lowercase (camel case for certain SVG/MathML attributes).
 
 ## Value
 
-A string representing the attribute's qualified name.
+A string.
 
-## Example
+## Examples
 
-The following example displays the qualified name of the first attribute of the two first elements, when we click on the appropriate button.
+### Reading the name
 
-### HTML
-
-```html
-<svg xml:lang="en-US" class="struct" height="1" width="1">Click me</svg>
-<label xml:lang="en-US" class="struct"></label>
-
-<p>
-  <button>Show value for &lt;svg&gt;</button>
-  <button>Show value for &lt;label&gt;</button>
-</p>
-
-<p>
-  Qualified name of the attribute <code>xml:lang</code>:
-  <output id="result">None.</output>
-</p>
-```
-
-### JavaScript
+We use {{domxref("DOMParser")}} to create an XML document.
 
 ```js
-const elements = document.querySelectorAll(".struct");
-const buttons = document.querySelectorAll("button");
-const outputEl = document.querySelector("#result");
-
-let i = 0;
-for (const button of buttons) {
-  const element = elements[i];
-  button.addEventListener("click", () => {
-    const attribute = element.attributes[0];
-    outputEl.value = attribute.name;
-  });
-  i++;
-}
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns:mdn="https://developer.mozilla.org/" mdn:status="ready" />`,
+  "application/xml",
+);
+const status = doc.querySelector("parent").getAttributeNode("mdn:status");
+console.log(status.name); // mdn:status
 ```
 
-{{ EmbedLiveSample('Example','100%',100) }}
+### Attribute names in HTML documents
+
+Unlike {{domxref("Element.tagName", "tagName")}}, `name` does not convert the qualified name to uppercase. The HTML parser normalizes attribute names according to the HTML parsing rules, including the fixed adjustments it makes for attributes on SVG and MathML elements.
+
+```xml
+<svg viewbox="0 0 100 100" xml:lang="en-US"></svg>
+```
+
+```js
+const svg = document.querySelector("svg");
+
+console.log(svg.getAttributeNode("viewBox").name); // viewBox
+console.log(svg.getAttributeNode("xml:lang").name); // xml:lang
+```
+
+Attributes created with [`document.createAttributeNS()`](/en-US/docs/Web/API/Document/createAttributeNS) preserve the supplied qualified name and casing, even when attached to an HTML DOM.
+
+```js
+const status = document.createAttributeNS(
+  "https://developer.mozilla.org/",
+  "Mdn:Status",
+);
+document.querySelector("svg").setAttributeNode(status);
+
+console.log(status.name); // Mdn:Status
+```
 
 ## Specifications
 
@@ -67,5 +69,8 @@ for (const button of buttons) {
 
 ## See also
 
-- The properties {{domxref("Attr.localName")}}, returning the local part of the qualified name of the attribute, and {{domxref("Attr.prefix")}}, the namespace prefix.
-- The {{domxref("Element.tagName()")}} property, returning the qualified name of an {{domxref("Element")}}.
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
+- {{domxref("Attr.localName")}}
+- {{domxref("Attr.namespaceURI")}}
+- {{domxref("Attr.prefix")}}
+- {{domxref("Element.tagName")}}

--- a/files/en-us/web/api/attr/namespaceuri/index.md
+++ b/files/en-us/web/api/attr/namespaceuri/index.md
@@ -8,66 +8,57 @@ browser-compat: api.Attr.namespaceURI
 
 {{APIRef("DOM")}}
 
-The read-only **`namespaceURI`** property of the {{domxref("Attr")}} interface returns the namespace URI of the attribute,
-or `null` if the element is not in a namespace.
+The **`namespaceURI`** read-only property of the {{domxref("Attr")}} interface returns the [namespace URI](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an attribute, or `null` if the attribute is not in a namespace.
 
-The namespace URI is set at the {{domxref("Attr")}} creation and cannot be changed.
-An attribute with a namespace can be created using {{domxref("Element.setAttributeNS()")}}.
+The namespace URI of an attribute is frozen at the attribute's creation time, either set by the parser or by the [`document.createAttributeNS()`](/en-US/docs/Web/API/Document/createAttributeNS) or {{domxref("Element.setAttributeNS()")}} method. Reading this property does not involve dynamic lookup in the document tree.
 
 > [!NOTE]
 > An attribute does not inherit its namespace from the element it is attached to.
 > If an attribute is not explicitly given a namespace, it has no namespace.
 
-The browser does not handle or enforce namespace validation per se. It is up to the JavaScript
-application to do any necessary validation. Note, too, that the namespace prefix, once it
-is associated with a particular attribute node, cannot be changed.
-
 ## Value
 
-A string containing the URI of the namespace, or `null` if the attribute is not in a namespace.
+A string or `null`.
 
-## Example
+## Examples
 
-The following example shows the result for a prefixed attribute on an HTML element and on an SVG element.
-As HTML doesn't handle namespaces, it will always return `null` in that case.
-In the case of the SVG element, it will return the URI of the XML namespace, `http://www.w3.org/XML/1998/namespace`.
+### Reading the namespaceURI
 
-### HTML
-
-```html
-<svg xml:lang="en-US" class="struct" height="1" width="1">Click me</svg>
-<label xml:lang="en-US" class="struct"></label>
-
-<p>
-  <button>Show value for &lt;svg&gt;</button>
-  <button>Show value for &lt;label&gt;</button>
-</p>
-
-<p>
-  Namespace URI of the attribute <code>xml:lang</code>:
-  <output id="result">None.</output>
-</p>
-```
-
-### JavaScript
+We use {{domxref("DOMParser")}} to create an XML document.
 
 ```js
-const elements = document.querySelectorAll(".struct");
-const buttons = document.querySelectorAll("button");
-const outputEl = document.querySelector("#result");
-
-let i = 0;
-for (const button of buttons) {
-  const element = elements[i];
-  button.addEventListener("click", () => {
-    const attribute = element.attributes[0];
-    outputEl.value = attribute.namespaceURI;
-  });
-  i++;
-}
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns:mdn="https://developer.mozilla.org/" mdn:status="ready" />`,
+  "application/xml",
+);
+const status = doc.querySelector("parent").getAttributeNode("mdn:status");
+console.log(status.namespaceURI); // https://developer.mozilla.org/
 ```
 
-{{ EmbedLiveSample('Example','100%',100) }}
+### Namespace URIs in HTML documents
+
+[The HTML syntax supports namespaces only for a fixed set of attributes on SVG and MathML elements](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#namespace_syntax_in_html). For other attributes, a colon is part of the local name rather than a namespace separator.
+
+```html
+<svg xml:lang="en-US" mdn:status="ready"></svg>
+```
+
+```js
+const svg = document.querySelector("svg");
+
+console.log(svg.getAttributeNode("xml:lang").namespaceURI);
+// http://www.w3.org/XML/1998/namespace
+console.log(svg.getAttributeNode("mdn:status").namespaceURI); // null
+```
+
+However, this is only a parser restriction; you can create arbitrarily namespaced attributes using [`document.createAttributeNS()`](/en-US/docs/Web/API/Document/createAttributeNS) and attach them to the HTML DOM without problems.
+
+```js
+const attr = document.createAttributeNS("https://example.com/", "mdn:status");
+document.body.setAttributeNode(attr);
+
+console.log(attr.namespaceURI); // https://example.com/
+```
 
 ## Specifications
 
@@ -79,6 +70,7 @@ for (const button of buttons) {
 
 ## See also
 
-- The properties {{domxref("Attr.name")}}, returning the qualified name of the attribute, {{domxref("Attr.localName")}}, the local part of the name, and {{domxref("Attr.prefix")}}, the namespace prefix.
-- The {{domxref("Element.namespaceURI")}} property, equivalent to this one but for an {{domxref("Element")}}.
-- The {{domxref("Element.setAttributeNS()")}} method, creating an attribute with a given namespace.
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
+- {{domxref("Attr.localName")}}
+- {{domxref("Attr.prefix")}}
+- {{domxref("Element.namespaceURI")}}

--- a/files/en-us/web/api/attr/prefix/index.md
+++ b/files/en-us/web/api/attr/prefix/index.md
@@ -8,57 +8,58 @@ browser-compat: api.Attr.prefix
 
 {{APIRef("DOM")}}
 
-The read-only **`prefix`** property of the {{domxref("Attr")}} returns the namespace prefix of the attribute, or `null` if no prefix is specified.
-
-The prefix is always in lower case, whatever case is used at the attribute creation.
+The **`prefix`** read-only property of the {{domxref("Attr")}} interface returns the [namespace prefix](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an attribute, or `null` if no prefix is specified.
 
 > [!NOTE]
-> Only XML supports namespaces. HTML does not. That means that the prefix of an attribute of an HTML element will always be `null`.
-
-Also, only the `xml` (for the `xml:lang` attribute), `xlink` (for the `xlink:href`, `xlink:show`, `xlink:target` and `xlink:title` attributes) and `xpath` namespaces are supported, and only on SVG and MathML elements.
+> The HTML parser special-cases several prefixed attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns:xlink`. For all other attributes, the prefix is simply seen as a part of the local name.
 
 ## Value
 
-A string containing the prefix of the namespace the attribute belongs too. If none, it returns `null`.
+A string or `null`.
 
-## Example
+## Examples
 
-### HTML
+### Reading the prefix
 
-```html
-<svg xml:lang="en-US" class="struct" height="1" width="1">Click me</svg>
-<label xml:lang="en-US" class="struct"></label>
-
-<p>
-  <button>Show value for &lt;svg&gt;</button>
-  <button>Show value for &lt;label&gt;</button>
-</p>
-
-<p>
-  Prefix of the attribute <code>xml:lang</code>:
-  <output id="result">None.</output>
-</p>
-```
-
-### JavaScript
+We use {{domxref("DOMParser")}} to create an XML document.
 
 ```js
-const elements = document.querySelectorAll(".struct");
-const buttons = document.querySelectorAll("button");
-const outputEl = document.querySelector("#result");
-
-let i = 0;
-for (const button of buttons) {
-  const element = elements[i];
-  button.addEventListener("click", () => {
-    const attribute = element.attributes[0];
-    outputEl.value = attribute.prefix;
-  });
-  i++;
-}
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns:mdn="https://developer.mozilla.org/" mdn:status="ready" />`,
+  "application/xml",
+);
+const status = doc.querySelector("parent").getAttributeNode("mdn:status");
+console.log(status.prefix); // mdn
 ```
 
-{{ EmbedLiveSample('Example','100%',100) }}
+### Namespace prefixes in HTML documents
+
+[The HTML syntax supports prefixes only for a fixed set of attributes on SVG and MathML elements](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#namespace_syntax_in_html). For other attributes, a colon is part of the local name rather than a namespace separator.
+
+```html
+<svg xml:lang="en-US" mdn:status="ready"></svg>
+```
+
+```js
+const svg = document.querySelector("svg");
+
+console.log(svg.getAttributeNode("xml:lang").prefix); // xml
+console.log(svg.getAttributeNode("mdn:status").prefix); // null
+```
+
+However, this is only a parser restriction; you can create prefixed attributes using [`document.createAttributeNS()`](/en-US/docs/Web/API/Document/createAttributeNS) or [`element.setAttributeNS()`](/en-US/docs/Web/API/Element/setAttributeNS) and attach them to the HTML DOM without problems. These methods do not normalize internal casing even when the namespace is HTML.
+
+```js
+const status = document.createAttributeNS(
+  "http://www.w3.org/1999/xhtml",
+  "Mdn:Status",
+);
+document.body.setAttributeNode(status);
+
+console.log(status.name); // Mdn:Status
+console.log(status.prefix); // Mdn
+console.log(status.localName); // Status
+```
 
 ## Specifications
 
@@ -70,5 +71,8 @@ for (const button of buttons) {
 
 ## See also
 
-- The properties {{domxref("Attr.name")}}, returning the qualified name of the attribute, and {{domxref("Attr.localName")}}, its local name.
-- The {{domxref("Element.prefix()")}} property, returning the namespace prefix of an {{domxref("Element")}}.
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
+- {{domxref("Attr.name")}}
+- {{domxref("Attr.namespaceURI")}}
+- {{domxref("Attr.localName")}}
+- {{domxref("Element.prefix")}}

--- a/files/en-us/web/api/document_object_model/anatomy_of_the_dom/index.md
+++ b/files/en-us/web/api/document_object_model/anatomy_of_the_dom/index.md
@@ -64,7 +64,7 @@ The `DocumentType` node is always a leaf node. The `Element` node is where most 
 
 All nodes that can have children ({{domxref("Document")}}, {{domxref("DocumentFragment")}}, and {{domxref("Element")}}) allow two types of children: {{domxref("Comment")}} and {{domxref("ProcessingInstruction")}} nodes. These nodes are always leaf nodes.
 
-Each element, in addition to having child nodes, can also have attributes, represented as {{domxref("Attr")}} nodes. `Attr` extend the `Node` interface, but they are not part of the main tree structure, because they are not the child of any node and their parent node is `null`. Instead, they are stored in a separate named node map, accessible via the {{domxref("Element/attributes", "attributes")}} property of the `Element` node.
+Each element, in addition to having child nodes, can also have attributes, represented as {{domxref("Attr")}} nodes. `Attr` extend the `Node` interface, but they are not part of the main tree structure, because they are not the child of any node and their parent node is `null`. Instead, they are stored in a separate map keyed by their names ([namespace plus local name](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces), to be exact), accessible via the {{domxref("Element/attributes", "attributes")}} property of the `Element` node.
 
 The `Node` interface defines a {{domxref("Node/nodeType", "nodeType")}} property that indicates the type of the node. To summarize, we introduced the following node types:
 
@@ -126,7 +126,7 @@ An `Element` in the document looks like this:
 <p class="note" id="intro">This is a paragraph.</p>
 ```
 
-In addition to the contents, there are two parts you can specify: the tag name and the attributes. The tag name corresponds to the {{domxref("Element/tagName", "tagName")}} property of the `Element` node, which is `"P"` in this case (note that it is always in uppercase for HTML elements). The attributes correspond to the `Attr` nodes stored in the {{domxref("Element/attributes", "attributes")}} property of the `Element` node. We will discuss attributes in more detail in the [Element and its attributes](#element_and_its_attributes) section.
+In addition to the contents, there are two parts you can specify: the tag name and the attributes. The tag name corresponds to the {{domxref("Element/tagName", "tagName")}} property of the `Element` node, which is `"P"` in this case (note that it is always in uppercase for HTML elements). The attributes correspond to the `Attr` nodes stored in the {{domxref("Element/attributes", "attributes")}} property of the `Element` node. We will discuss attributes in more detail in the [Element and its attributes](#element_and_its_attributes) section. We'll also take another look at the tag name and the attributes in the [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces) guide.
 
 The `Element` node does not hold any data itself, so its `nodeValue` is always `null`. Its `textContent` is the concatenation of all its text node descendants in tree order, which is `"This is a paragraph."` in this case. For the following element:
 
@@ -175,7 +175,7 @@ For the following element:
 <p class="note" id="intro">This is a paragraph.</p>
 ```
 
-The `<p>` element has two attributes, represented by two `Attr` nodes. Each attribute consists of a name and a value, corresponding to the {{domxref("Attr/name", "name")}} and {{domxref("Attr/value", "value")}} properties. The first attribute has `"class"` as `name` and `"note"` as `value`, while the second attribute has `"id"` as `name` and `"intro"` as `value`.
+The `<p>` element has two attributes, represented by two `Attr` nodes. Each attribute consists of a name and a value, corresponding to the {{domxref("Attr/name", "name")}} and {{domxref("Attr/value", "value")}} properties. The first attribute has `"class"` as `name` and `"note"` as `value`, while the second attribute has `"id"` as `name` and `"intro"` as `value`. We'll take another look at the attribute name in the [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces) guide.
 
 ## Element and its attributes
 

--- a/files/en-us/web/api/document_object_model/anatomy_of_the_dom/index.md
+++ b/files/en-us/web/api/document_object_model/anatomy_of_the_dom/index.md
@@ -216,7 +216,7 @@ The `isEqualNode()` method compares two nodes structurally. Two nodes are consid
 - For `Document`, there is no data, so only the child nodes need to be compared.
 - For `DocumentType`, the `name`, `publicId`, and `systemId` properties need to be compared.
 - For `Element`, the `tagName` (more accurately, the `namespaceURI`, `prefix`, and `localName`; we will introduce these in the [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces) guide) and the attributes need to be compared.
-- For `Attr`, the `name` (more accurately, the `namespaceURI`, `prefix`, and `localName`; we will introduce these in the [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces) guide) and `value` properties need to be compared.
+- For `Attr`, the `name` (more accurately, the `namespaceURI` and `localName`, but not `prefix`; we will introduce these in the [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces) guide) and `value` properties need to be compared.
 - For all `CharacterData` nodes (`Text`, `CDATASection`, `Comment`, and `ProcessingInstruction`), the `data` property needs to be compared. For `ProcessingInstruction`, the `target` property also needs to be compared.
 
 The `a.compareDocumentPosition(b)` method compares two nodes by tree order. It returns a bitmask indicating their relative positions. The possible cases are:

--- a/files/en-us/web/api/document_object_model/xml_namespaces/index.md
+++ b/files/en-us/web/api/document_object_model/xml_namespaces/index.md
@@ -8,39 +8,45 @@ page-type: guide
 
 **XML namespace** is a standardized mechanism that allows identifiers (element or attribute names) defined by different specifications with different semantics to coexist in the same XML document without ambiguity.
 
-In the [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM) guide, we introduced the basic data associated with [`Element`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#element) and [`Attr`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#attr) nodes, which include the {{domxref("Element.tagName", "tagName")}} and {{domxref("Attr.name", "name")}} properties. These properties return the _qualified name_. In the DOM, there are actually four properties that pertain to the element or attribute's name:
+In the [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM) guide, we introduced the basic data associated with [`Element`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#element) and [`Attr`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#attr) nodes, which include the {{domxref("Element.tagName", "tagName")}} and {{domxref("Attr.name", "name")}} properties. These properties return the _qualified name_. In the DOM, elements and attributes actually keep three properties that identify their names:
 
-- The **namespace** is a namespace URI or `null`. It's returned by the {{domxref("Element.namespaceURI")}} or {{domxref("Attr.namespaceURI")}} property.
-- The **local name** identifies the element or attribute within that namespace. It's returned by the {{domxref("Element.localName")}} or {{domxref("Attr.localName")}} property.
-- The **namespace prefix** is a short name that is bound to the namespace URI in the current XML namespace context. It's returned by the {{domxref("Element.prefix")}} or {{domxref("Attr.prefix")}} property.
-- The **qualified name** is the local name by itself when there is no prefix, or the prefix and local name joined by a colon when there is one. It's returned by the {{domxref("Element.tagName")}} (but uppercased if in HTML) or {{domxref("Attr.name")}} property.
+- The **namespace** is a string or `null`. We will also refer to it as the _namespace URI_ or _namespace identifier_. It's returned by the {{domxref("Element.namespaceURI")}} or {{domxref("Attr.namespaceURI")}} property.
 
-The namespace URI is an identifier. Although it often looks like a web address, it does not have to identify a resource that can be retrieved from the web. Applications compare the strings; no requests are ever sent to the URI. However, by convention, the URI points to a domain that the standard body controls to avoid collisions.
+  > [!NOTE]
+  > Although the namespace uses the URI format, it does not have to identify a resource that can be retrieved from the web. Applications compare the strings; no requests are ever sent. However, by convention, the URI points to a domain that the standard body controls to avoid collisions.
+
+- The **local name** is a string identifying the element or attribute within that namespace. It's returned by the {{domxref("Element.localName")}} or {{domxref("Attr.localName")}} property.
+- The **namespace prefix** is a string or `null`. If specified, it explicitly sets a namespace during parse time (see [The namespace prefix](#the_namespace_prefix)). It's returned by the {{domxref("Element.prefix")}} or {{domxref("Attr.prefix")}} property.
+
+The **qualified name** is not a primitive property; it's the local name by itself when there is no prefix, or the prefix and local name joined by a colon when there is one. It's returned by the {{domxref("Element.tagName")}} (but uppercased if in HTML) or {{domxref("Attr.name")}} property.
 
 Several XML languages are relevant to the web, and each defines elements and attributes in their namespace. [HTML](/en-US/docs/Web/HTML) (although it also has its own syntax) uses `http://www.w3.org/1999/xhtml`, [SVG](/en-US/docs/Web/SVG) uses `http://www.w3.org/2000/svg`, and [MathML](/en-US/docs/Web/MathML) uses `http://www.w3.org/1998/Math/MathML`. The {{Glossary("XLink")}} namespace `http://www.w3.org/1999/xlink` is now deprecated for web purposes. XML also defines two reserved namespaces, `xml` and `xmlns`, for features such as `xml:lang` and for namespace declarations themselves. This guide explains how these namespaces are represented and manipulated through the DOM.
 
+## XML namespace syntax
+
 > [!WARNING]
-> **XML namespace declarations are very restricted in HTML documents.** This guide mainly applies to XML documents, with occasional references to HTML behavior (see [Namespaces in HTML](#namespaces_in_html)).
+> **The XML namespace syntax is very restricted in HTML.** This section mainly applies to XML documents; see [Namespace syntax in HTML](#namespace_syntax_in_html) for how they differ.
 
-## XML element and attribute names
-
-### The default namespace
-
-In XML, if an element name does not have an explicit [namespace prefix](#the_namespace_prefix), its namespace is defined by the closest `xmlns` attribute (either on the element itself or on the closest ancestor element). If there's no such `xmlns` declaration, the namespace is `null` (the `null` namespace functions just like any other namespace). The namespace established by the `xmlns` declaration (or its lack thereof) is the _default namespace_.
+To create XML documents, we'll use the following utility function, which is a [template tag](/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) that invokes the {{domxref("DOMParser")}} on the template string.
 
 ```js
-// The utility function for creating XML documents
 const xml = (strings, ...values) =>
   new DOMParser().parseFromString(
     String.raw({ raw: strings }, ...values),
     "application/xml",
   );
+```
 
+### The default namespace
+
+In XML, if an element name does not have an explicit [namespace prefix](#the_namespace_prefix), it belongs to its _default namespace_. The default namespace is the `null` namespace by default. The `xmlns` attribute sets the default namespace for the containing element as well as all of its descendants (unless it gets overridden in a subtree).
+
+```js
 // No xmlns declaration -> namespace is null
 const doc = xml`<parent></parent>`;
 console.log(doc.querySelector("parent").namespaceURI); // null
 
-// The xmlns attribute applies to the element itself and nested elements
+// The xmlns attribute applies to the element itself and all descendants
 const doc2 = xml`<parent xmlns="https://developer.mozilla.org/">
   <child><grandchild></grandchild></child>
 </parent>`;
@@ -49,7 +55,7 @@ console.log(doc2.querySelector("child").namespaceURI); // https://developer.mozi
 console.log(doc2.querySelector("grandchild").namespaceURI); // https://developer.mozilla.org/
 ```
 
-For all APIs that deal with namespace identifiers, the empty string is equivalent to `null`. So for example, you can set `xmlns=""` to reset to the null namespace.
+The descendant may specify another `xmlns` attribute, which sets a different default namespace in its subtree (much like JavaScript variable scopes). For all purposes of namespace URIs, the empty string is equivalent to `null`. So for example, you can set `xmlns=""` to reset to the null namespace.
 
 ```js
 const doc = xml`<parent xmlns="https://developer.mozilla.org/">
@@ -96,7 +102,7 @@ console.log(xmlLangAttr.namespaceURI); // http://www.w3.org/XML/1998/namespace
 console.log(xmlLangAttr.prefix); // xml
 ```
 
-New namespace prefix identifiers can be declared with the `xmlns:prefix="namespace URI"` attribute. This creates a new namespace prefix called `prefix` which resolves to the namespace `"namespace URI"`. Now this prefix can be used in the element and all descendant elements that don't override it.
+New namespace prefix identifiers can be declared with the `xmlns:prefix="namespace URI"` attribute. This creates a new namespace prefix called `prefix` which resolves to the namespace `"namespace URI"`. Now this prefix can be used in the element and all its descendants.
 
 ```js
 const doc = xml`<parent mdn:foo="bar" xmlns:mdn="https://developer.mozilla.org/"></parent>`;
@@ -111,7 +117,7 @@ console.log(doc2.querySelector("child").namespaceURI);
 ```
 
 > [!NOTE]
-> The [CSS type selector](/en-US/docs/Web/CSS/Reference/Selectors/Type_selectors) selects by the local name (the part after `:`), so we write `child` instead of `mdn:child` in the selector above. To use the [namespace separator](/en-US/docs/Web/CSS/Reference/Selectors/Namespace_separator) syntax, the namespace identifier must be declared separately in CSS via [`@namespace`](/en-US/docs/Web/CSS/Reference/At-rules/@namespace), which is not possible with {{domxref("Document.querySelector()")}}.
+> The [CSS type selector](/en-US/docs/Web/CSS/Reference/Selectors/Type_selectors) selects by the local name (the part after `:`), so we write `child` instead of `mdn:child` in the selector above. See [Querying namespaced elements](#querying_namespaced_elements).
 
 When the `prefix` is `null`, the qualified name of the element/attribute is just the `localName`; when the `prefix` is not null, the qualified name is `prefix:localName` (basically, what you actually wrote in the source code).
 
@@ -123,10 +129,11 @@ console.log(fooAttr.localName); // foo
 console.log(fooAttr.name); // mdn:foo
 ```
 
-There is no mechanism for rebinding the `xmlns` or `xml` prefix. Attempting to do so raises a parser error. It is also a parser error to use namespace names that begin with, case-insensitively, `xml`, or to define any custom prefix that binds to the XML or XMLNS namespace.
+The parser enforces the following invariants:
 
-> [!NOTE]
-> Some browsers may be lenient in their XML parser and simply ignore these attributes.
+- The `xmlns` and `xml` prefixes cannot be rebound.
+- The XML and XMLNS namespaces cannot be bound to a custom prefix.
+- The prefix must be defined in scope.
 
 ```js example-bad
 xml`<element xmlns:xmlns="https://developer.mozilla.org/" />`;
@@ -134,27 +141,24 @@ xml`<element xmlns:xmlns="https://developer.mozilla.org/" />`;
 
 xml`<element xmlns:mdn="http://www.w3.org/XML/1998/namespace" />`;
 // XML Parsing Error: prefix must not be bound to one of the reserved namespace names
+
+xml`<element mdn:href="Document.querySelector()" />`;
+// XML Parsing Error: prefix not bound to a namespace
 ```
 
-All other prefix identifiers can be freely associated. This means you can have two prefixes that map to the same namespace URI, or the same prefix mapping to different namespace URIs in different parts of the document.
-
-```js
-const doc = xml`<mdn:parent xmlns:mdn="a">
-  <mdn:child xmlns:mdn="b"></mdn:child>
-</mdn:parent>`;
-console.log(doc.querySelector("parent").namespaceURI); // a
-console.log(doc.querySelector("child").namespaceURI); // b
-```
+All other prefix identifiers can be freely associated. This means you can have two prefixes that map to the same namespace URI, or the same prefix mapping to different namespace URIs in different parts of the document. During parse time, it's guaranteed that for any element, each prefix maps unambiguously to one namespace URI; this is not enforced [during runtime updating](#building_and_updating_namespaced_nodes).
 
 > [!NOTE]
 > Note that the default namespace and the namespace prefix are parsing-time concepts. At runtime, programmatically adding/updating the `xmlns` attributes do not change the namespaces of existing elements.
+>
+> The prefix has almost no runtime significance, apart from a few non-namespaced methods that accept qualified names. All namespaced DOM methods take explicit namespace URIs paired with local names, because that is the only unambiguous way to identify elements and attributes.
 
-## Namespaces in HTML
+## Namespace syntax in HTML
 
-Once again, everything mentioned to this point only work in XML (which is why we've used the `xml` utility function that calls {{domxref("DOMParser")}}). In an HTML document parsed from `text/html`, by default all elements are HTML elements and belong to the HTML namespace `http://www.w3.org/1999/xhtml`. The HTML parser recognizes the {{SVGElement("svg")}} and the {{MathMLElement("math")}} elements, which put them and almost all their descendants into the SVG `http://www.w3.org/2000/svg` and MathML `http://www.w3.org/1998/Math/MathML` namespaces (unless escape hatches like {{SVGElement("foreignObject")}} are used). The following do not work:
+Once again, the [XML namespace syntax](#xml_namespace_syntax) section only applies to XML (which is why we've used the `xml` utility function that calls {{domxref("DOMParser")}}). In an HTML document parsed from `text/html`, by default all elements are HTML elements and belong to the HTML namespace `http://www.w3.org/1999/xhtml`. The HTML parser recognizes the {{SVGElement("svg")}} and the {{MathMLElement("math")}} elements, which put them and all their descendants into the SVG `http://www.w3.org/2000/svg` and MathML `http://www.w3.org/1998/Math/MathML` namespaces (unless escape hatches like {{SVGElement("foreignObject")}} are used). The following do not work:
 
 - The `xmlns` attribute has absolutely no effect. If specified on HTML elements, its value must be `"http://www.w3.org/1999/xhtml"`.
-- The namespace prefix syntax does not exist and the prefix is simply seen as a part of the local name. The parser special-cases several attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns`, `xmlns:xlink`. These have hard-coded namespace associations and are the only ones for which the namespace URI is not one of HTML, SVG, or MathML. None of them are necessary on the modern web because the SVG and MathML specs have defined their own alternatives where appropriate.
+- The namespace prefix syntax does not exist and the prefix is simply seen as a part of the local name. The parser special-cases several attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns`, `xmlns:xlink`. These have hard-coded namespace associations and are the only ones for which the namespace URI is not one of HTML, SVG, or MathML. None of them is necessary on the modern web because the SVG and MathML specs have defined their own alternatives where appropriate.
 
 For example:
 
@@ -189,6 +193,8 @@ console.log(
   doc.querySelector("svg").getAttributeNode("xlink:href").namespaceURI,
 ); // http://www.w3.org/1999/xlink
 ```
+
+However, this is only to say that the _syntax_ of namespaces is very limited in HTML. DOM nodes in all contexts store and process namespaces in the same way, so all programmatic APIs introduced from this point on do not vary in behavior in HTML or XML, except in very certain places.
 
 ## Looking up the prefix-namespace association
 
@@ -241,52 +247,147 @@ console.log(parent.lookupPrefix("http://www.w3.org/2000/xmlns/")); // null
 console.log(parent.lookupPrefix("http://www.w3.org/XML/1998/namespace")); // null
 ```
 
-{{domxref("Node.isDefaultNamespace()")}} takes a namespace and returns whether it's the default. `node.isDefaultNamespace(namespace)` (when `namespace` is not the empty string) is equivalent to `node.lookupNamespaceURI(null) === namespace`.
-
-In HTML documents, these methods exist, but again `xmlns` attributes have no effect. Lookup can still use a node's stored namespace and prefix, the reserved `xml` and `xmlns` mappings, and namespaced nodes created from script (see below).
+{{domxref("Node.isDefaultNamespace()")}} takes a namespace and returns whether it's the default for the relevant element. `node.isDefaultNamespace(namespace)` (when `namespace` is not the empty string) is equivalent to `node.lookupNamespaceURI(null) === namespace`.
 
 > [!NOTE]
 > In HTML documents, Firefox returns `null` as the default namespace URI for all elements, while Chrome and Safari return the default namespaces that would be produced by the HTML parser (HTML, SVG, MathML).
 
-## Creating namespaced nodes and documents
+Note that the information you look up has no real significance (other than for usage with {{domxref("XPathEvaluator.createExpression()")}}), because newly created elements and attributes don't consult this mapping, and it does not even reflect the information used as parse time—the results are affected by runtime attribute updates.
 
-- **In HTML documents:** The namespace-aware creation APIs work fully from script and can create nodes in any namespace. `createElement()` normally creates an HTML element, while `createElementNS()` is required for SVG, MathML, or arbitrary namespaced elements created outside the parser's built-in foreign-content handling. `DOMImplementation.createDocument()` creates a separate XML document rather than changing the current HTML document.
-- {{domxref("Document/createElementNS", "Document.createElementNS()")}} for creating an element from a namespace URI and qualified name.
-- {{domxref("Document/createAttributeNS", "Document.createAttributeNS()")}} for creating a detached attribute from a namespace URI and qualified name.
-- {{domxref("DOMImplementation/createDocument", "DOMImplementation.createDocument()")}} for creating an `XMLDocument` with an optional namespaced document element and doctype; how the root namespace determines the document's content type.
-- How a qualified name is split at `:` into prefix and local name by namespace-aware creation and attribute APIs.
-- Name validation and the `InvalidCharacterError` exception for invalid namespace prefixes, element local names, and attribute local names.
-- Namespace validation and the `NamespaceError` exception: a prefix requires a namespace; `xml` must use the XML namespace; and `xmlns` and the XMLNS namespace must be used together.
-- {{domxref("Document/createElement", "Document.createElement()")}} as a contrast: it creates HTML-namespace elements in HTML and XHTML documents, and null-namespace elements in other documents.
-- {{domxref("Document/createAttribute", "Document.createAttribute()")}} as a contrast: it always creates an attribute with a null namespace.
-- Why the namespace, rather than the prefix, selects the resulting element interface, such as an SVG interface for an element in the SVG namespace.
+## Building and updating namespaced nodes
 
-## Finding namespaced elements
+Most nodes do not have associated namespaces, so their creation/updating methods mentioned in [Building and updating the DOM tree](/en-US/docs/Web/API/Document_Object_Model/Building_and_updating_the_DOM_tree) remain unchanged. Only elements and attributes need another look.
 
-- **In HTML documents:** Both `getElementsByTagNameNS()` methods work for HTML elements and for foreign SVG, MathML, or script-created namespaced elements. Searches use the stored namespace URI and local name, not an `xmlns` declaration written on an HTML element. DOM selector APIs cannot be given namespace-prefix mappings.
-- {{domxref("Document/getElementsByTagNameNS", "Document.getElementsByTagNameNS()")}} for matching descendant elements by namespace and local name.
-- {{domxref("Element/getElementsByTagNameNS", "Element.getElementsByTagNameNS()")}} for the same search within an element.
-- The `"*"` wildcard for either or both arguments and the empty-string-to-`null` rule for the namespace argument.
-- The live `HTMLCollection` returned by the `getElementsByTagNameNS()` methods.
-- {{domxref("Document/getElementsByTagName", "Document.getElementsByTagName()")}} and {{domxref("Element/getElementsByTagName", "Element.getElementsByTagName()")}} as qualified-name searches, including their HTML-document case behavior.
-- How {{domxref("Document/getElementById", "Document.getElementById()")}} and {{domxref("Element/getElementsByClassName", "Element.getElementsByClassName()")}} use the DOM's null-namespace `id` and `class` attribute concepts on elements in any namespace.
-- How {{domxref("HTMLCollection/namedItem", "HTMLCollection.namedItem()")}} uses an element's DOM ID regardless of its namespace, but only uses the null-namespace `name` attribute for elements in the HTML namespace.
-- Why prefixes in selector strings are not a substitute: the DOM selector APIs do not support namespace prefixes.
+If elements or attributes are in the wrong namespace, they will not receive their intended semantics and usually become invalid because they don't exist in the default namespace. In HTML documents, if you create SVG and MathML elements in the HTML namespace, they will not render. In the example below, the `<svg>` and `<circle>` elements are seen as HTML elements and are therefore non-conforming.
 
-## Working with namespaced attributes
+```js example-bad
+const svg = document.createElement("svg");
+svg.setAttribute("width", "200");
+svg.setAttribute("height", "120");
 
-- **In HTML documents:** Namespace-aware attribute methods work fully from script. However, ordinary attributes parsed on HTML elements—including names containing `:` and `xmlns`—have a null namespace. In SVG and MathML foreign content, the HTML parser assigns namespaces only to its fixed list of attributes such as `xlink:href`, `xml:lang`, `xmlns`, and `xmlns:xlink`.
-- Attributes are unique on an element by namespace and local name, not by prefix or qualified name.
-- {{domxref("Element/getAttributeNS", "Element.getAttributeNS()")}}, {{domxref("Element/setAttributeNS", "Element.setAttributeNS()")}}, {{domxref("Element/hasAttributeNS", "Element.hasAttributeNS()")}}, and {{domxref("Element/removeAttributeNS", "Element.removeAttributeNS()")}}.
-- {{domxref("Element/getAttributeNodeNS", "Element.getAttributeNodeNS()")}} and {{domxref("Element/setAttributeNodeNS", "Element.setAttributeNodeNS()")}} when an `Attr` node is needed.
-- {{domxref("NamedNodeMap/getNamedItemNS", "NamedNodeMap.getNamedItemNS()")}}, {{domxref("NamedNodeMap/setNamedItemNS", "NamedNodeMap.setNamedItemNS()")}}, and {{domxref("NamedNodeMap/removeNamedItemNS", "NamedNodeMap.removeNamedItemNS()")}} through {{domxref("Element/attributes", "Element.attributes")}}.
-- The empty-string-to-`null` rule for namespace arguments to namespace-aware attribute lookup and removal methods.
-- Why namespace-aware lookup, presence, and removal methods take a local name, while `setAttributeNS()` takes a qualified name so it can establish a prefix.
-- Prefix replacement: `setAttributeNS()` identifies an existing attribute by namespace and local name, then updates its value without changing its existing prefix.
-- The qualified-name methods {{domxref("Element/getAttribute", "getAttribute()")}}, {{domxref("Element/setAttribute", "setAttribute()")}}, {{domxref("Element/hasAttribute", "hasAttribute()")}}, {{domxref("Element/removeAttribute", "removeAttribute()")}}, {{domxref("Element/toggleAttribute", "toggleAttribute()")}}, and {{domxref("Element/getAttributeNode", "getAttributeNode()")}} as contrasts to their namespace-aware counterparts.
-- How {{domxref("Element/getAttributeNames", "Element.getAttributeNames()")}} returns qualified names and can contain duplicates when attributes with different namespaces share a qualified name.
-- How `setAttributeNode()` and `NamedNodeMap.setNamedItem()` replace attributes by namespace and local name despite their non-`NS` names, and how {{domxref("Element/removeAttributeNode", "Element.removeAttributeNode()")}} removes a particular `Attr` object.
-- Namespace behavior of {{domxref("Element/id", "id")}}, {{domxref("Element/className", "className")}}, {{domxref("Element/classList", "classList")}}, and {{domxref("Element/slot", "slot")}}: their DOM concepts use null-namespace attributes even on elements outside the HTML namespace.
+const circle = document.createElement("circle");
+circle.setAttribute("cx", "100");
+circle.setAttribute("cy", "60");
+circle.setAttribute("r", "40");
+circle.setAttribute("fill", "skyblue");
+
+svg.appendChild(circle);
+document.body.appendChild(svg);
+```
+
+By default, the {{domxref("Document.createElement()")}} method creates elements in the HTML namespace if the document is an HTML document (including XHTML), and creates elements in the `null` namespace otherwise. As mentioned previously, the `xmlns` and `xmlns:prefix` attributes are parse-time concepts. They do not rebind the namespace at runtime. Therefore, the following is wrong for creating namespaced elements:
+
+```js example-bad
+const doc = xml`<parent xmlns="https://developer.mozilla.org/" />`;
+const child = doc.createElement("child"); // Note: this element is created without a namespace!
+child.setAttribute("xmlns", "https://example.com/");
+doc.querySelector("parent").appendChild(child);
+console.log(child.namespaceURI); // null
+```
+
+Furthermore, the name you pass to `createElement` is a _local name_, which means any colon in the name is treated as a part of the name instead of as a namespace prefix.
+
+```js example-bad
+const doc = xml`<parent xmlns:mdn="https://developer.mozilla.org/" />`;
+const child = doc.createElement("mdn:child"); // Not a namespace prefix
+doc.querySelector("parent").appendChild(child);
+console.log(child.namespaceURI); // null
+console.log(child.localName); // mdn:child
+```
+
+In order to specify the parts other than local name—namely, the namespace URI and namespace prefix—you must use the {{domxref("Document.createElementNS()")}} method instead. Instead of a local name, it takes two parts: the namespace URI and the _qualified name_. The qualified name is composed from the namespace prefix and the local name, so the method can extract those two parts as necessary.
+
+```js example-good
+const doc = new Document();
+const child = doc.createElementNS("https://example.com/", "child");
+console.log(child.namespaceURI); // https://example.com/
+console.log(child.prefix); // null
+console.log(child.localName); // child
+
+const child2 = doc.createElementNS(
+  "https://developer.mozilla.org/",
+  "mdn:child",
+);
+console.log(child2.namespaceURI); // https://developer.mozilla.org/
+console.log(child2.prefix); // mdn
+console.log(child2.localName); // child
+```
+
+The idea is the same for attributes. {{domxref("Document.createAttribute()")}} always takes a local name and creates an `Attr` node in the `null` namespace. Most attributes parsed from XML source code live in the `null` namespace anyway (if there's no explicit prefix), but if you do want to use an explicit namespace, you should use {{domxref("Document.createAttributeNS()")}} instead.
+
+Note that the prefix, after parsing, has no significance and does not need to be declared with `xmlns:`. It is just a piece of data stored inside the node. For example, above we used the `mdn:` prefix without ever declaring it with `xmlns:mdn`. The namespaced creation methods like `createElementNS` and `createAttributeNS` do enforce certain invariants.
+
+- If a prefix exists, then the namespace cannot be `null`. (In other words, you can't create prefixed elements/attributes in the `null` namespace.)
+- If the prefix is `xml`, then the namespace must be the XML namespace `http://www.w3.org/XML/1998/namespace`.
+- The prefix is `xmlns` or the qualified name is `xmlns`, if and only if the namespace is the XMLNS namespace `http://www.w3.org/2000/xmlns/`.
+
+Apart from these (and that you cannot use certain characters), anything is permitted regarding what prefix and namespace you specify. You can achieve other things that are impossible in XML source code, like having the same prefix map to different namespace URIs in the same scope. However, it is recommended that you keep the prefix consistent with how it would be written in the XML source code. This avoids bugs and ensures that your DOM can be serialized if needed.
+
+In [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#element_and_its_attributes), we introduced that attributes associated with an element are stored in the {{domxref("Element/attributes", "attributes")}} {{domxref("NamedNodeMap")}}. This map is keyed by the attributes' namespace and local name—not by the qualified name. It is possible, although extremely rare in practice (because it can't happen when parsed from XML source code), for two attributes to have the same qualified names but different namespaces.
+
+```js
+const doc = xml`<parent />`;
+const parent = doc.querySelector("parent");
+parent.setAttributeNS("https://example.com/", "foo", "bar");
+parent.setAttributeNS("https://example.org/", "foo", "baz");
+console.log(parent.attributes.length); // 2
+console.log(parent.getAttribute("foo")); // bar
+console.log(parent.getAttributeNames()); // ['foo', 'foo']
+```
+
+There are two types of methods that read or modify this `attributes` map.
+
+The first type takes existing `Attr` nodes: {{domxref("Element.setAttributeNode()")}}, {{domxref("Element.removeAttributeNode()")}}, and {{domxref("NamedNodeMap.setNamedItem()")}}. Because the `Attr` node already contains all namespace information, these methods are already namespace-aware. They either have no namespaced counterpart (no `Element.removeAttributeNodeNS()`) or the namespaced counterpart is exactly equivalent ({{domxref("Element.setAttributeNodeNS()")}} and {{domxref("NamedNodeMap.setNamedItemNS()")}}) and serves no particular purpose.
+
+The second type takes qualified names: {{domxref("Element.getAttributeNode()")}}, {{domxref("Element.hasAttribute()")}}, {{domxref("Element.getAttribute()")}}, {{domxref("Element.setAttribute()")}}, {{domxref("Element.removeAttribute()")}}, {{domxref("NamedNodeMap.getNamedItem()")}} and {{domxref("NamedNodeMap.removeNamedItem()")}}. As shown above, qualified names are unreliable for unique identification. To precisely identify namespaced attributes, use the namespaced counterparts, which take a namespace URI and a local name. The {{domxref("Element/setAttributeNS", "setAttributeNS()")}} method takes a _qualified name_ instead of a local name, allowing you to specify the prefix for the new attribute as well. If the attribute already exists with a different prefix, the initial one is kept.
+
+```js
+const a = document.createElementNS("http://www.w3.org/2000/svg", "a");
+a.setAttributeNS(
+  "http://www.w3.org/1999/xlink",
+  "xlink:href",
+  "https://developer.mozilla.org",
+);
+svg.appendChild(a);
+```
+
+## Querying namespaced elements
+
+The {{domxref("Document.querySelector()")}} method and its likes use [CSS selectors](/en-US/docs/Web/CSS/Guides/Selectors). The [CSS type selector](/en-US/docs/Web/CSS/Reference/Selectors/Type_selectors) selects by elements' local name. To explicitly select a certain namespace, you must use the [namespace separator](/en-US/docs/Web/CSS/Reference/Selectors/Namespace_separator) syntax, which requires declaring the namespace identifier separately via [`@namespace`](/en-US/docs/Web/CSS/Reference/At-rules/@namespace) (CSS does not consider the namespace prefix in DOM). This is not possible with `document.querySelector()`. Therefore, for example, there's no way to select only HTML {{HTMLElement("a")}} elements but not SVG {{SVGElement("a")}} elements using `querySelectorAll()`. The same goes for [attribute selectors](/en-US/docs/Web/CSS/Reference/Selectors/Attribute_selectors).
+
+The {{domxref("Document.getElementsByTagName()")}} takes a qualified name, so it can distinguish, for example, `<a />` and `<mdn:a />`, but only if the elements have explicit prefixes. But as mentioned towards the end of [XML namespace syntax](#xml_namespace_syntax), prefixes and qualified names are unreliable for identification purposes. HTML almost never contains prefixes; in XML, explicit prefixes are also rarer than using `xmlns` to switch default namespaces. To query by the actual namespace, use {{domxref("Document.getElementsByTagNameNS()")}} instead, which takes a namespace and a local name. You can also pass `*` for either argument (to not filter for namespace or local name).
+
+```js
+const doc1 = xml`<parent><a href="foo" /><mdn:a href="bar" /></parent>`;
+console.log(doc1.getElementsByTagName("a").length); // 1
+console.log(doc1.getElementsByTagName("mdn:a").length); // 1
+
+const doc2 = xml`<parent><a href="foo" /><a href="bar" xmlns="http://www.w3.org/1999/xhtml" /></parent>`;
+console.log(doc2.getElementsByTagName("a").length); // 2
+console.log(doc2.getElementsByTagNameNS(null, "a").length); // 1
+console.log(
+  doc2.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "a").length,
+); // 1
+```
+
+The element's {{domxref("Element/id", "id")}} and {{domxref("Element/className", "className")}} only reflect the attributes in the `null` namespace with local name `id` and `class`. This behavior thus affects [class selectors](/en-US/docs/Web/CSS/Reference/Selectors/Class_selectors), [ID selectors](/en-US/docs/Web/CSS/Reference/Selectors/ID_selectors), {{domxref("Document.getElementsByClassName()")}}, {{domxref("Document.getElementById()")}}, etc.
+
+```js
+const doc = new Document();
+const parent = doc.createElement("parent");
+doc.append(parent);
+
+const child1 = doc.createElement("child");
+// namespace=null, prefix=null
+child1.setAttributeNS(null, "class", "foo");
+const child2 = doc.createElement("child");
+// namespace=MDN, prefix=null
+child2.setAttributeNS("https://developer.mozilla.org/", "class", "foo");
+
+parent.append(child1, child2);
+console.log(doc.querySelectorAll(".foo").length); // 1
+console.log(doc.getElementsByClassName("foo").length); // 1
+```
 
 ## Namespaces across other DOM operations
 
@@ -307,8 +408,11 @@ In HTML documents, these methods exist, but again `xmlns` attributes have no eff
 
 ## Summary
 
-- **In HTML documents:** Use the HTML parser's built-in HTML, SVG, and MathML namespace handling for markup; use the namespace-aware DOM APIs for other namespaces; use an XML MIME type when namespace declarations and arbitrary prefixes must be interpreted from source markup.
-- Namespace identity is the namespace URI/local-name pair; prefixes only provide qualified-name syntax and in-scope bindings.
-- Inspect names with `namespaceURI`, `prefix`, and `localName`; use `tagName`, `name`, and `nodeName` when the qualified name is required.
-- Create, find, and update namespaced elements and attributes with the namespace-aware DOM methods.
-- Resolve declarations with the `Node` namespace lookup methods, and account for namespace identity when comparing, cloning, importing, adopting, and observing nodes.
+This guide provides an augment to the previous guides: [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM), [Selection and traversal](/en-US/docs/Web/API/Document_Object_Model/Selection_and_traversal_on_the_DOM_tree), and [Building and updating](/en-US/docs/Web/API/Document_Object_Model/Building_and_updating_the_DOM_tree). We've systematically covered how methods working with element and attributes need to be switched to be namespace-aware if necessary.
+
+- Element and attribute nodes maintain three properties: namespace ({{domxref("Element.namespaceURI")}}/{{domxref("Attr.namespaceURI")}}), local name ({{domxref("Element.localName")}}/{{domxref("Attr.localName")}}), and namespace prefix ({{domxref("Element.prefix")}} or {{domxref("Attr.prefix")}}). The qualified name ({{domxref("Element.tagName")}}/{{domxref("Attr.name")}}) is derived from the namespace prefix and the local name.
+- Namespaces in XML are declared using the `xmlns="..."` (for default) and `xmlns:prefix="..."` syntax. Elements and attributes can specify an explicit namespace using the `<prefix:local-name />` or `prefix:local-name="..."` syntax.
+- The namespace syntax in HTML is basically non-existent; the HTML parser takes care of assigning namespaces.
+- The {{domxref("Node.lookupNamespaceURI()")}}, {{domxref("Node.lookupPrefix()")}}, and {{domxref("Node.isDefaultNamespace()")}} methods can be used to look up the prefix-namespace association.
+- The DOM methods mentioned in [Building and updating the DOM tree](/en-US/docs/Web/API/Document_Object_Model/Building_and_updating_the_DOM_tree) do not take namespace URIs; they take either local names or qualified names. Use the versions suffixed with `NS` when dealing with element and attribute names.
+- The `querySelector` methods cannot select by namespaces due to the lack of `@namespace` declarations. {{domxref("Document.getElementsByTagNameNS()")}} is the only `NS`-suffixed selection method.

--- a/files/en-us/web/api/document_object_model/xml_namespaces/index.md
+++ b/files/en-us/web/api/document_object_model/xml_namespaces/index.md
@@ -8,6 +8,10 @@ page-type: guide
 
 **XML namespace** is a standardized mechanism that allows identifiers (element or attribute names) defined by different specifications with different semantics to coexist in the same XML document without ambiguity.
 
+Several XML languages are relevant to the web, and each defines elements and attributes in their namespace. [HTML](/en-US/docs/Web/HTML) (although it also has its own syntax) uses `http://www.w3.org/1999/xhtml`, [SVG](/en-US/docs/Web/SVG) uses `http://www.w3.org/2000/svg`, and [MathML](/en-US/docs/Web/MathML) uses `http://www.w3.org/1998/Math/MathML`. The {{Glossary("XLink")}} namespace `http://www.w3.org/1999/xlink` is now deprecated for web purposes. XML also defines two reserved namespaces, `xml` and `xmlns`, for features such as `xml:lang` and for namespace declarations themselves. This guide explains how these namespaces are represented and manipulated through the DOM.
+
+## Element and attribute names in the DOM
+
 In the [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM) guide, we introduced the basic data associated with [`Element`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#element) and [`Attr`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#attr) nodes, which include the {{domxref("Element.tagName", "tagName")}} and {{domxref("Attr.name", "name")}} properties. These properties return the _qualified name_. In the DOM, elements and attributes actually keep three properties that identify their names:
 
 - The **namespace** is a string or `null`. We will also refer to it as the _namespace URI_ or _namespace identifier_. It's returned by the {{domxref("Element.namespaceURI")}} or {{domxref("Attr.namespaceURI")}} property.
@@ -19,8 +23,6 @@ In the [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of
 - The **namespace prefix** is a string or `null`. If specified, it explicitly sets a namespace during parse time (see [The namespace prefix](#the_namespace_prefix)). It's returned by the {{domxref("Element.prefix")}} or {{domxref("Attr.prefix")}} property.
 
 The **qualified name** is not a primitive property; it's the local name by itself when there is no prefix, or the prefix and local name joined by a colon when there is one. It's returned by the {{domxref("Element.tagName")}} (but uppercased if in HTML) or {{domxref("Attr.name")}} property.
-
-Several XML languages are relevant to the web, and each defines elements and attributes in their namespace. [HTML](/en-US/docs/Web/HTML) (although it also has its own syntax) uses `http://www.w3.org/1999/xhtml`, [SVG](/en-US/docs/Web/SVG) uses `http://www.w3.org/2000/svg`, and [MathML](/en-US/docs/Web/MathML) uses `http://www.w3.org/1998/Math/MathML`. The {{Glossary("XLink")}} namespace `http://www.w3.org/1999/xlink` is now deprecated for web purposes. XML also defines two reserved namespaces, `xml` and `xmlns`, for features such as `xml:lang` and for namespace declarations themselves. This guide explains how these namespaces are represented and manipulated through the DOM.
 
 ## XML namespace syntax
 
@@ -396,20 +398,79 @@ console.log(doc.getElementsByClassName("foo").length); // 1
 
 ## Namespaces across other DOM operations
 
-- **In HTML documents:** Equality, cloning, importing, adopting, and mutation records use the stored namespace fields exactly as they do in XML documents. The main limitation comes earlier, during HTML parsing: most parsed attributes have a null namespace unless they are among the parser's recognized foreign attributes.
-- {{domxref("Node/isEqualNode", "Node.isEqualNode()")}} compares element namespaces, prefixes, and local names, and compares attribute namespaces and local names; attribute prefixes do not affect attribute equality.
-- {{domxref("Node/cloneNode", "Node.cloneNode()")}} and {{domxref("Document/importNode", "Document.importNode()")}} preserve the namespace, prefix, and local name of elements and attributes.
-- {{domxref("Document/adoptNode", "Document.adoptNode()")}} changes a node's document without recomputing its namespace information.
-- {{domxref("MutationRecord/attributeName", "MutationRecord.attributeName")}} reports the changed attribute's local name, while {{domxref("MutationRecord/attributeNamespace", "MutationRecord.attributeNamespace")}} reports its namespace.
-- {{domxref("MutationObserver/observe", "MutationObserver.observe()")}} attribute filters contain local names only and do not match attributes whose namespace is non-null.
+Namespace data is stored on each element and attribute, so most DOM operations use or copy that data directly. They do not consult the node's current `xmlns` declarations or attempt to resolve its prefix again.
+
+The {{domxref("Node.cloneNode()")}} and {{domxref("Document.importNode()")}} methods copy the namespace URI, prefix, and local name of every copied element and attribute. {{domxref("Document.adoptNode()")}} moves a node to another document without copying it, but likewise leaves its namespace information unchanged. Therefore, importing or adopting an SVG element into an HTML document does not turn it into an HTML element; it remains in the SVG namespace.
+
+The {{domxref("Node.isEqualNode()")}} method considers the namespace URI, prefix, and local name when comparing elements. Consequently, two otherwise identical elements with different prefixes are not equal, even if the prefixes are associated with the same namespace. For attributes, it compares the namespace URI, local name, and value, but not the prefix.
+
+```js
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const circle1 = document.createElementNS(SVG_NS, "svg:circle");
+const circle2 = document.createElementNS(SVG_NS, "s:circle");
+console.log(circle1.isEqualNode(circle2)); // false
+
+const attr1 = document.createAttributeNS(SVG_NS, "svg:fill");
+const attr2 = document.createAttributeNS(SVG_NS, "s:fill");
+attr1.value = "blue";
+attr2.value = "blue";
+console.log(attr1.isEqualNode(attr2)); // true
+```
+
+Attribute [mutation records](/en-US/docs/Web/API/MutationRecord) separate the two parts needed to identify a namespaced attribute: {{domxref("MutationRecord/attributeName", "attributeName")}} is the local name and {{domxref("MutationRecord/attributeNamespace", "attributeNamespace")}} is the namespace URI.
+
+```js
+const SVG_NS = "http://www.w3.org/2000/svg";
+const EXAMPLE_NS = "https://example.com/attributes";
+const circle = document.createElementNS(SVG_NS, "circle");
+
+const observer = new MutationObserver(([record]) => {
+  console.log(record.attributeName); // status
+  console.log(record.attributeNamespace); // https://example.com/attributes
+});
+observer.observe(circle, { attributes: true });
+
+circle.setAttributeNS(EXAMPLE_NS, "example:status", "ready");
+```
+
+The strings in the `attributeFilter` option of {{domxref("MutationObserver/observe", "observe()")}} are local names, but the filter only matches attributes in the `null` namespace. There is no way to include a namespace URI in the filter. For example, observing the `circle` above with `{ attributes: true, attributeFilter: ["status"] }` would not report the change to `example:status`. To observe namespaced attributes selectively, observe all attribute changes and inspect each record's `attributeName` and `attributeNamespace` in the callback.
 
 ## Namespaces in XPath and XSLT
 
-- **In HTML documents:** The XPath APIs are available and namespace resolvers can address HTML, SVG, MathML, and script-created namespaces. The XSLT APIs are also exposed in supporting browsers, but their namespace parameters identify XSLT variables or parameters and do not make `xmlns` declarations functional in HTML markup.
-- The `XPathNSResolver` callback and its `lookupNamespaceURI()` method for resolving prefixes used in XPath expressions.
-- The optional namespace resolver accepted by {{domxref("XPathEvaluator/createExpression", "XPathEvaluator.createExpression()")}} and {{domxref("XPathEvaluator/evaluate", "XPathEvaluator.evaluate()")}}, including a `Node` as a resolver.
-- {{domxref("XPathEvaluator/createNSResolver", "XPathEvaluator.createNSResolver()")}} as a legacy method that returns the supplied node unchanged.
-- {{domxref("XSLTProcessor/setParameter", "XSLTProcessor.setParameter()")}}, {{domxref("XSLTProcessor/getParameter", "XSLTProcessor.getParameter()")}}, and {{domxref("XSLTProcessor/removeParameter", "XSLTProcessor.removeParameter()")}} identify stylesheet parameters by namespace URI and local name.
+XPath expressions use prefixes to refer to namespaces, but like CSS, the expression does not automatically inherit the prefix declarations from the document that it queries. Instead, {{domxref("XPathEvaluator/createExpression", "XPathEvaluator.createExpression()")}} and {{domxref("XPathEvaluator/evaluate", "XPathEvaluator.evaluate()")}} accept a _namespace resolver_. The resolver is called with each prefix used in the expression and returns the corresponding namespace URI, or `null` if it cannot resolve the prefix. It can be a function or an object implementing the `XPathNSResolver` interface's `lookupNamespaceURI()` method.
+
+The prefixes in the XPath expression are arbitrary. They only need to be understood by the resolver; they do not need to match the prefixes used in the document. In the following example, the `vector` prefix selects elements in the SVG namespace even though the SVG markup does not use that prefix:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="40" />
+</svg>
+```
+
+```js
+const resolver = (prefix) => {
+  if (prefix === "vector") {
+    return "http://www.w3.org/2000/svg";
+  }
+  return null;
+};
+
+const result = document.evaluate(
+  "//vector:circle",
+  document,
+  resolver,
+  XPathResult.FIRST_ORDERED_NODE_TYPE,
+  null,
+);
+console.log(result.singleNodeValue); // The SVG circle element
+```
+
+The treatment of unprefixed element names differs between HTML and XML documents. In an HTML document, an unprefixed element test uses the HTML namespace. For example, `//a` selects HTML `<a>` elements but not SVG `<a>` elements. Other namespaces, including SVG and MathML, require a prefix and a resolver as shown above. In an XML document, an unprefixed element test uses the `null` namespace, so resolvers are necessary even if if the XML source uses only a default `xmlns` declaration. Unprefixed attribute tests use the `null` namespace in both kinds of document, matching the way unprefixed attributes are normally represented in the DOM.
+
+Instead of a custom resolver, you can pass a {{domxref("Node")}}. Its {{domxref("Node/lookupNamespaceURI", "lookupNamespaceURI()")}} method resolves the prefixes, using the node's current prefix-namespace associations described in [Looking up the prefix-namespace association](#looking_up_the_prefix-namespace_association). This is convenient when the expression uses prefixes declared in an XML document, but it also inherits the limitations of those lookup methods. In particular, it reflects the current DOM rather than necessarily reflecting what the parser used.
+
+Namespaces also appear in the {{domxref("XSLTProcessor")}} parameter methods. {{domxref("XSLTProcessor/setParameter", "setParameter()")}}, {{domxref("XSLTProcessor/getParameter", "getParameter()")}}, and {{domxref("XSLTProcessor/removeParameter", "removeParameter()")}} take a namespace URI and local name to identify an XSLT parameter.
 
 ## Summary
 
@@ -421,3 +482,4 @@ This guide provides an augment to the previous guides: [Anatomy of the DOM](/en-
 - The {{domxref("Node.lookupNamespaceURI()")}}, {{domxref("Node.lookupPrefix()")}}, and {{domxref("Node.isDefaultNamespace()")}} methods can be used to look up the prefix-namespace association.
 - The DOM methods mentioned in [Building and updating the DOM tree](/en-US/docs/Web/API/Document_Object_Model/Building_and_updating_the_DOM_tree) do not take namespace URIs; they take either local names or qualified names. Use the versions suffixed with `NS` when dealing with element and attribute names.
 - The `querySelector` methods cannot select by namespaces due to the lack of `@namespace` declarations. {{domxref("Document.getElementsByTagNameNS()")}} is the only `NS`-suffixed selection method.
+- When using XPath, you need to use namespace prefixes to refer to namespaced elements, which requires passing a namespace resolver. All nodes are namespace resolvers thanks to its `lookupNamespaceURI` method.

--- a/files/en-us/web/api/document_object_model/xml_namespaces/index.md
+++ b/files/en-us/web/api/document_object_model/xml_namespaces/index.md
@@ -160,7 +160,9 @@ All other prefix identifiers can be freely associated. This means you can have t
 Once again, the [XML namespace syntax](#xml_namespace_syntax) section only applies to XML (which is why we've used the `xml` utility function that calls {{domxref("DOMParser")}}). In an HTML document parsed from `text/html`, by default all elements are HTML elements and belong to the HTML namespace `http://www.w3.org/1999/xhtml`. The HTML parser recognizes the {{SVGElement("svg")}} and the {{MathMLElement("math")}} elements, which put them and all their descendants into the SVG `http://www.w3.org/2000/svg` and MathML `http://www.w3.org/1998/Math/MathML` namespaces (unless escape hatches like {{SVGElement("foreignObject")}} are used). The following do not work:
 
 - The `xmlns` attribute has absolutely no effect. If specified on HTML elements, its value must be `"http://www.w3.org/1999/xhtml"`.
-- The namespace prefix syntax does not exist and the prefix is simply seen as a part of the local name. The parser special-cases several attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns`, `xmlns:xlink`. These have hard-coded namespace associations and are the only ones for which the namespace URI is not `null`. None of them is necessary in modern HTML documents because the SVG and MathML specs have defined their own alternatives where appropriate.
+- The namespace prefix syntax does not exist and the prefix is simply seen as a part of the local name.
+
+The parser special-cases several attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns`, `xmlns:xlink`. These have hard-coded namespace associations and are the only ones for which the namespace URI is not `null`. None of them is necessary in modern HTML documents because the SVG and MathML specs have defined their own alternatives where appropriate.
 
 For example:
 

--- a/files/en-us/web/api/document_object_model/xml_namespaces/index.md
+++ b/files/en-us/web/api/document_object_model/xml_namespaces/index.md
@@ -8,152 +8,245 @@ page-type: guide
 
 **XML namespace** is a standardized mechanism that allows identifiers (element or attribute names) defined by different specifications with different semantics to coexist in the same XML document without ambiguity.
 
-Several XML languages are relevant to the web. [HTML](/en-US/docs/Web/HTML) (although it also has its own syntax) uses `http://www.w3.org/1999/xhtml`, [SVG](/en-US/docs/Web/SVG) uses `http://www.w3.org/2000/svg`, and [MathML](/en-US/docs/Web/MathML) uses `http://www.w3.org/1998/Math/MathML`. XML also defines reserved namespaces for features such as `xml:lang` and for namespace declarations themselves. This guide explains how these namespaces are represented and manipulated through the DOM.
+In the [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM) guide, we introduced the basic data associated with [`Element`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#element) and [`Attr`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#attr) nodes, which include the {{domxref("Element.tagName", "tagName")}} and {{domxref("Attr.name", "name")}} properties. These properties return the _qualified name_. In the DOM, there are actually four properties that pertain to the element or attribute's name:
 
-a HTML
+- The **namespace** is a namespace URI or `null`. It's returned by the {{domxref("Element.namespaceURI")}} or {{domxref("Attr.namespaceURI")}} property.
+- The **local name** identifies the element or attribute within that namespace. It's returned by the {{domxref("Element.localName")}} or {{domxref("Attr.localName")}} property.
+- The **namespace prefix** is a short name that is bound to the namespace URI in the current XML namespace context. It's returned by the {{domxref("Element.prefix")}} or {{domxref("Attr.prefix")}} property.
+- The **qualified name** is the local name by itself when there is no prefix, or the prefix and local name joined by a colon when there is one. It's returned by the {{domxref("Element.tagName")}} (but uppercased if in HTML) or {{domxref("Attr.name")}} property.
+
+The namespace URI is an identifier. Although it often looks like a web address, it does not have to identify a resource that can be retrieved from the web. Applications compare the strings; no requests are ever sent to the URI. However, by convention, the URI points to a domain that the standard body controls to avoid collisions.
+
+Several XML languages are relevant to the web, and each defines elements and attributes in their namespace. [HTML](/en-US/docs/Web/HTML) (although it also has its own syntax) uses `http://www.w3.org/1999/xhtml`, [SVG](/en-US/docs/Web/SVG) uses `http://www.w3.org/2000/svg`, and [MathML](/en-US/docs/Web/MathML) uses `http://www.w3.org/1998/Math/MathML`. The {{Glossary("XLink")}} namespace `http://www.w3.org/1999/xlink` is now deprecated for web purposes. XML also defines two reserved namespaces, `xml` and `xmlns`, for features such as `xml:lang` and for namespace declarations themselves. This guide explains how these namespaces are represented and manipulated through the DOM.
 
 > [!WARNING]
-> **XML namespace declarations are very restricted in HTML documents.** When markup is parsed as `text/html`, `xmlns` attributes do not bind prefixes or change an element's namespace, and the namespace prefix syntax usually does not work. This guide mainly applies to XML documents, with occasional references to HTML behavior.
+> **XML namespace declarations are very restricted in HTML documents.** This guide mainly applies to XML documents, with occasional references to HTML behavior (see [Namespaces in HTML](#namespaces_in_html)).
 
-## Element and attribute names
+## XML element and attribute names
 
-In the [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM) guide, we introduced the basic data associated with [`Element`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#element) and [`Attr`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#attr) nodes, which include the {{domxref("Element.tagName", "tagName")}} and {{domxref("Attr.name", "name")}} properties.
+### The default namespace
 
-- **In HTML documents:** Namespace declarations in markup do not work as they do in XML. The HTML parser chooses the HTML, SVG, or MathML namespace from HTML parsing rules rather than from author-defined prefix bindings; arbitrary XML namespace declarations require an XML document.
-- Why namespaces let XML vocabularies such as HTML, SVG, and MathML use the same local names without collisions.
-- A namespace is identified by a namespace URI string; the URI is an identifier and does not need to be retrievable.
-- The difference between a namespace, a namespace prefix, a local name, and a qualified name (`prefix:localName`).
-- Prefixes are aliases, not namespace identities: different prefixes can bind to the same namespace, and the same prefix can bind to different namespaces in different scopes.
-- The difference between a null namespace and a default namespace, including the normalization of an empty namespace string to `null` in DOM APIs.
-- Namespace declaration attributes: `xmlns` for the default namespace and `xmlns:prefix` for a prefixed binding.
-- The reserved `xml` prefix and XML namespace (`http://www.w3.org/XML/1998/namespace`), and the reserved `xmlns` name and XMLNS namespace (`http://www.w3.org/2000/xmlns/`).
-- The standard HTML (`http://www.w3.org/1999/xhtml`), SVG (`http://www.w3.org/2000/svg`), and MathML (`http://www.w3.org/1998/Math/MathML`) namespace URIs.
+In XML, if an element name does not have an explicit [namespace prefix](#the_namespace_prefix), its namespace is defined by the closest `xmlns` attribute (either on the element itself or on the closest ancestor element). If there's no such `xmlns` declaration, the namespace is `null` (the `null` namespace functions just like any other namespace). The namespace established by the `xmlns` declaration (or its lack thereof) is the _default namespace_.
 
-XML namespaces make it possible to use elements and attributes from different XML vocabularies in the same document without name collisions. A namespace is identified by a **namespace URI**, such as `http://www.w3.org/2000/svg` for SVG.
+```js
+// The utility function for creating XML documents
+const xml = (strings, ...values) =>
+  new DOMParser().parseFromString(
+    String.raw({ raw: strings }, ...values),
+    "application/xml",
+  );
 
-The namespace URI is an identifier. Although it often looks like a web address, it does not have to identify a resource that can be retrieved from the web. Applications compare the URI strings; they do not fetch the addresses to determine what the namespaces mean.
+// No xmlns declaration -> namespace is null
+const doc = xml`<parent></parent>`;
+console.log(doc.querySelector("parent").namespaceURI); // null
 
-For example, this SVG document contains two elements named `title`. One belongs to SVG, while the other belongs to an application-specific metadata vocabulary:
-
-```xml
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:meta="https://example.com/metadata">
-  <title>An SVG title</title>
-  <meta:title>A metadata title</meta:title>
-</svg>
+// The xmlns attribute applies to the element itself and nested elements
+const doc2 = xml`<parent xmlns="https://developer.mozilla.org/">
+  <child><grandchild></grandchild></child>
+</parent>`;
+console.log(doc2.querySelector("parent").namespaceURI); // https://developer.mozilla.org/
+console.log(doc2.querySelector("child").namespaceURI); // https://developer.mozilla.org/
+console.log(doc2.querySelector("grandchild").namespaceURI); // https://developer.mozilla.org/
 ```
 
-The two elements have the same **local name**, `title`, but different namespace URIs. Their namespace/local-name pairs therefore identify different kinds of elements.
+For all APIs that deal with namespace identifiers, the empty string is equivalent to `null`. So for example, you can set `xmlns=""` to reset to the null namespace.
 
-### Namespaces in HTML
-
-Namespace declarations in markup only have their XML meaning when the document is parsed as XML, such as when SVG is served as `image/svg+xml` or XHTML is served as `application/xhtml+xml`.
-
-When a document is parsed as `text/html`, an `xmlns` attribute does not select a namespace, declare an arbitrary prefix, or change how descendants are parsed. Instead, the HTML parser assigns namespaces using fixed rules:
-
-- Most elements are placed in the HTML namespace.
-- A `<svg>` element and its foreign-content descendants are placed in the SVG namespace.
-- A `<math>` element and its foreign-content descendants are placed in the MathML namespace.
-- A fixed set of attributes in SVG and MathML content, such as `xml:lang` and `xlink:href`, are assigned to their predefined namespaces.
-
-For example, a `<svg>` element embedded in an HTML document is placed in the SVG namespace because its local name is `svg`, not because of an `xmlns` attribute. Adding another `xmlns` value would not change the namespace chosen by the HTML parser.
-
-Namespace-aware DOM APIs are not subject to this parsing restriction. Scripts running in an HTML document can use methods such as {{domxref("Document/createElementNS", "createElementNS()")}} and {{domxref("Element/setAttributeNS", "setAttributeNS()")}} to create elements and attributes in any namespace. However, if arbitrary namespace declarations need to be interpreted directly from source markup, the document must use XML syntax and an XML MIME type.
-
-### Local names, prefixes, and qualified names
-
-A namespaced element or attribute has several related parts:
-
-- Its **namespace** is a namespace URI or `null`.
-- Its **local name** identifies the element or attribute within that namespace.
-- Its **namespace prefix** is a short name that is bound to the namespace URI in the current XML namespace context. A prefix is optional.
-- Its **qualified name** is the local name by itself when there is no prefix, or the prefix and local name joined by a colon when there is one.
-
-In the preceding example, the two `title` elements have the following names:
-
-| Markup         | Namespace URI                  | Prefix | Local name | Qualified name |
-| -------------- | ------------------------------ | ------ | ---------- | -------------- |
-| `<title>`      | `http://www.w3.org/2000/svg`   | `null` | `title`    | `title`        |
-| `<meta:title>` | `https://example.com/metadata` | `meta` | `title`    | `meta:title`   |
-
-The namespace and local name determine the identity of a name. The prefix does not. Multiple prefixes can be bound to the same namespace URI, so these two elements have the same namespace and local name despite having different qualified names:
-
-```xml
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:a="https://example.com/metadata"
-  xmlns:b="https://example.com/metadata">
-  <a:title>First title</a:title>
-  <b:title>Second title</b:title>
-</svg>
+```js
+const doc = xml`<parent xmlns="https://developer.mozilla.org/">
+  <child xmlns="">
+    <grandchild></grandchild>
+  </child>
+</parent>`;
+console.log(doc.querySelector("parent").namespaceURI); // https://developer.mozilla.org/
+console.log(doc.querySelector("child").namespaceURI); // null
+console.log(doc.querySelector("grandchild").namespaceURI); // null
 ```
 
-Conversely, a prefix can be rebound to a different namespace URI in a nested scope. Code must not assume that a particular prefix always identifies the same namespace. It should use the namespace URI and local name when comparing or locating namespaced nodes.
+Attributes do not use the default namespace; unprefixed attributes always use the `null` namespace. The only exception is the `xmlns` attribute itself, which uses the XMLNS namespace, `http://www.w3.org/2000/xmlns/`.
 
-### Default and null namespaces
-
-A declaration written as `xmlns="namespace URI"` defines the **default namespace** for its element and, unless overridden, its descendant elements. In the first example, the default namespace declaration places the unprefixed `svg` and `title` element names in the SVG namespace.
-
-A default namespace is an in-scope namespace binding. It is different from the **null namespace**, which means that a DOM element or attribute has no namespace at all. DOM namespace APIs represent the null namespace with `null`. For the namespace arguments accepted by most namespace-aware DOM methods, the empty string is treated as `null` as well.
-
-The default namespace applies to unprefixed element names, but it does not apply to unprefixed attribute names. Consider the attributes on this SVG element:
-
-```xml
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:meta="https://example.com/metadata"
-  viewBox="0 0 100 100"
-  meta:viewBox="overview"
-  xml:lang="en"></svg>
+```js
+const doc = xml`<parent xmlns="https://developer.mozilla.org/" foo="bar">
+  <child foo="bar"></child>
+</parent>`;
+console.log(doc.querySelector("parent").getAttributeNode("foo").namespaceURI);
+// null
+console.log(doc.querySelector("parent").getAttributeNode("xmlns").namespaceURI);
+// http://www.w3.org/2000/xmlns/
+console.log(doc.querySelector("child").getAttributeNode("foo").namespaceURI);
+// null
 ```
 
-The `svg` element is in the SVG namespace. Its unprefixed `viewBox` attribute is in the null namespace, while `meta:viewBox` is in the metadata namespace. The two attributes can coexist because an attribute is identified by its namespace URI and local name, not by its local name alone. The `xml:lang` attribute is in the reserved XML namespace.
+In all examples above, because we've never used the namespace prefix syntax, the `prefix` property is always `null`, even when there is a non-null `namespaceURI`.
 
-### Namespace declaration attributes
+### The namespace prefix
 
-XML provides two forms of namespace declaration:
+The namespace prefix syntax allows a specific element to use a non-default namespace or a specific attribute to use a non-null namespace. The syntax is `prefix:name`, where `prefix` is the _namespace prefix_ and `name` is the _local name_.
 
-- `xmlns="namespace URI"` binds the default namespace.
-- `xmlns:prefix="namespace URI"` binds `prefix` to the namespace URI.
+By default, only two valid namespace prefix identifiers exist: `xmlns` and `xml`.
 
-Namespace declarations are themselves represented as attributes in the XMLNS namespace, `http://www.w3.org/2000/xmlns/`. A default declaration has the local name `xmlns` and no prefix. A prefixed declaration has the prefix `xmlns` and uses the declared prefix as its local name. For example, `xmlns:meta` has the prefix `xmlns` and the local name `meta`.
-
-Again, this description applies to XML parsing. On an HTML element parsed from `text/html`, an `xmlns` attribute is placed in the null namespace and has no namespace-declaration effect. The HTML parser recognizes `xmlns` and `xmlns:xlink` as namespaced attributes only in its SVG and MathML foreign-content handling, and even there the parser—not the declaration's value—determines the namespace of elements.
-
-### Reserved namespaces and common namespace URIs
-
-The `xml` and `xmlns` prefixes have predefined meanings:
-
+- `xmlns` is bound to the XMLNS namespace, `http://www.w3.org/2000/xmlns/`, and is reserved for namespace declaration attributes.
 - `xml` is bound to the XML namespace, `http://www.w3.org/XML/1998/namespace`. It is used by attributes such as `xml:lang` and `xml:space`.
-- `xmlns` is associated with the XMLNS namespace, `http://www.w3.org/2000/xmlns/`, and is reserved for namespace declaration attributes.
 
-Namespace-aware DOM creation and attribute methods enforce these relationships. For example, they reject a qualified name with the `xml` prefix if the supplied namespace is not the XML namespace, and reject invalid combinations of `xmlns` and the XMLNS namespace.
+For example, the following uses the `lang` attribute from the `xml` namespace:
 
-The namespace URIs most commonly encountered in web documents are:
+```js
+const doc = xml`<element xml:lang="en-US" />`;
+const xmlLangAttr = doc.querySelector("element").getAttributeNode("xml:lang");
+console.log(xmlLangAttr.namespaceURI); // http://www.w3.org/XML/1998/namespace
+console.log(xmlLangAttr.prefix); // xml
+```
 
-| Vocabulary | Namespace URI                          |
-| ---------- | -------------------------------------- |
-| HTML       | `http://www.w3.org/1999/xhtml`         |
-| SVG        | `http://www.w3.org/2000/svg`           |
-| MathML     | `http://www.w3.org/1998/Math/MathML`   |
-| XML        | `http://www.w3.org/XML/1998/namespace` |
-| XMLNS      | `http://www.w3.org/2000/xmlns/`        |
+New namespace prefix identifiers can be declared with the `xmlns:prefix="namespace URI"` attribute. This creates a new namespace prefix called `prefix` which resolves to the namespace `"namespace URI"`. Now this prefix can be used in the element and all descendant elements that don't override it.
 
-These strings must be written exactly. Namespace URI comparison is case-sensitive, and a trailing slash or other spelling difference identifies a different namespace.
+```js
+const doc = xml`<parent mdn:foo="bar" xmlns:mdn="https://developer.mozilla.org/"></parent>`;
+console.log(
+  doc.querySelector("parent").getAttributeNode("mdn:foo").namespaceURI,
+);
+// https://developer.mozilla.org/
 
-## How the DOM represents namespaced names
+const doc2 = xml`<parent xmlns:mdn="https://developer.mozilla.org/"><mdn:child /></parent>`;
+console.log(doc2.querySelector("child").namespaceURI);
+// https://developer.mozilla.org/
+```
 
-- **In HTML documents:** Parsed HTML elements are in the HTML namespace with a null prefix; parsed `<svg>` and `<math>` subtrees use the SVG and MathML namespaces. A colon in an HTML element or ordinary HTML attribute name is treated as a literal character, not as a namespace separator; only the parser's fixed foreign-content cases produce prefixed namespaced attributes.
-- Elements and attributes store a namespace, namespace prefix, and local name separately; their namespace and prefix can be `null`.
-- {{domxref("Element/namespaceURI", "Element.namespaceURI")}}, {{domxref("Element/prefix", "Element.prefix")}}, and {{domxref("Element/localName", "Element.localName")}}.
-- {{domxref("Attr/namespaceURI", "Attr.namespaceURI")}}, {{domxref("Attr/prefix", "Attr.prefix")}}, and {{domxref("Attr/localName", "Attr.localName")}}.
-- How qualified names are derived from a prefix and local name, and how {{domxref("Element/tagName", "Element.tagName")}}, {{domxref("Attr/name", "Attr.name")}}, and {{domxref("Node/nodeName", "Node.nodeName")}} expose qualified names.
-- Qualified names are returned in uppercase for HTML elements in HTML documents, versus case-sensitive names in XML documents and for non-HTML namespaces.
-- An element's expanded name as the namespace/local-name pair; the prefix is syntax and is not part of namespace identity.
-- An attribute's expanded name as the namespace/local-name pair; one element can therefore contain attributes with the same qualified name but different namespaces.
-- Namespace declarations determine which namespace the XML parser assigns to a name, but changing a declaration later does not change an existing node's stored `namespaceURI`, `prefix`, or `localName`.
-- Default namespaces apply to element names, while unprefixed attributes have no namespace.
+> [!NOTE]
+> The [CSS type selector](/en-US/docs/Web/CSS/Reference/Selectors/Type_selectors) selects by the local name (the part after `:`), so we write `child` instead of `mdn:child` in the selector above. To use the [namespace separator](/en-US/docs/Web/CSS/Reference/Selectors/Namespace_separator) syntax, the namespace identifier must be declared separately in CSS via [`@namespace`](/en-US/docs/Web/CSS/Reference/At-rules/@namespace), which is not possible with {{domxref("Document.querySelector()")}}.
+
+When the `prefix` is `null`, the qualified name of the element/attribute is just the `localName`; when the `prefix` is not null, the qualified name is `prefix:localName` (basically, what you actually wrote in the source code).
+
+```js
+const doc = xml`<parent mdn:foo="bar" xmlns:mdn="https://developer.mozilla.org/"></parent>`;
+const fooAttr = doc.querySelector("parent").getAttributeNode("mdn:foo");
+console.log(fooAttr.prefix); // mdn
+console.log(fooAttr.localName); // foo
+console.log(fooAttr.name); // mdn:foo
+```
+
+There is no mechanism for rebinding the `xmlns` or `xml` prefix. Attempting to do so raises a parser error. It is also a parser error to use namespace names that begin with, case-insensitively, `xml`, or to define any custom prefix that binds to the XML or XMLNS namespace.
+
+> [!NOTE]
+> Some browsers may be lenient in their XML parser and simply ignore these attributes.
+
+```js example-bad
+xml`<element xmlns:xmlns="https://developer.mozilla.org/" />`;
+// XML Parsing Error: reserved prefix (xmlns) must not be declared or undeclared
+
+xml`<element xmlns:mdn="http://www.w3.org/XML/1998/namespace" />`;
+// XML Parsing Error: prefix must not be bound to one of the reserved namespace names
+```
+
+All other prefix identifiers can be freely associated. This means you can have two prefixes that map to the same namespace URI, or the same prefix mapping to different namespace URIs in different parts of the document.
+
+```js
+const doc = xml`<mdn:parent xmlns:mdn="a">
+  <mdn:child xmlns:mdn="b"></mdn:child>
+</mdn:parent>`;
+console.log(doc.querySelector("parent").namespaceURI); // a
+console.log(doc.querySelector("child").namespaceURI); // b
+```
+
+> [!NOTE]
+> Note that the default namespace and the namespace prefix are parsing-time concepts. At runtime, programmatically adding/updating the `xmlns` attributes do not change the namespaces of existing elements.
+
+## Namespaces in HTML
+
+Once again, everything mentioned to this point only work in XML (which is why we've used the `xml` utility function that calls {{domxref("DOMParser")}}). In an HTML document parsed from `text/html`, by default all elements are HTML elements and belong to the HTML namespace `http://www.w3.org/1999/xhtml`. The HTML parser recognizes the {{SVGElement("svg")}} and the {{MathMLElement("math")}} elements, which put them and almost all their descendants into the SVG `http://www.w3.org/2000/svg` and MathML `http://www.w3.org/1998/Math/MathML` namespaces (unless escape hatches like {{SVGElement("foreignObject")}} are used). The following do not work:
+
+- The `xmlns` attribute has absolutely no effect. If specified on HTML elements, its value must be `"http://www.w3.org/1999/xhtml"`.
+- The namespace prefix syntax does not exist and the prefix is simply seen as a part of the local name. The parser special-cases several attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns`, `xmlns:xlink`. These have hard-coded namespace associations and are the only ones for which the namespace URI is not one of HTML, SVG, or MathML. None of them are necessary on the modern web because the SVG and MathML specs have defined their own alternatives where appropriate.
+
+For example:
+
+```js
+// The utility function for creating HTML documents
+const html = (strings, ...values) =>
+  new DOMParser().parseFromString(
+    String.raw({ raw: strings }, ...values),
+    "text/html",
+  );
+
+const doc = html`<html>
+  <body xmlns:xlink="foo">
+    <svg xmlns:xlink="foo" xlink:href="bar"></svg>
+    <math></math>
+  </body>
+</html>`;
+console.log(doc.querySelector("body").namespaceURI); // http://www.w3.org/1999/xhtml
+console.log(doc.querySelector("svg").namespaceURI); // http://www.w3.org/2000/svg
+console.log(doc.querySelector("math").namespaceURI); // http://www.w3.org/1998/Math/MathML
+
+// xmlns:xlink seen as a normal attribute (and is non-conforming)
+console.log(
+  doc.querySelector("body").getAttributeNode("xmlns:xlink").namespaceURI,
+); // null
+// xmlns:xlink recognized but has no effect
+console.log(
+  doc.querySelector("svg").getAttributeNode("xmlns:xlink").namespaceURI,
+); // http://www.w3.org/2000/xmlns/
+// xlink:href always binds the XLink namespace despite xmlns:xlink
+console.log(
+  doc.querySelector("svg").getAttributeNode("xlink:href").namespaceURI,
+); // http://www.w3.org/1999/xlink
+```
+
+## Looking up the prefix-namespace association
+
+Each element in the document has a bi-directional association between prefix identifiers and namespace URIs. It either inherits the association from its parent or declares itself via its `xmlns="..."` and `xmlns:prefix="..."` attributes. You can lookup this association on any node, which uses the node's relevant element:
+
+- When called on {{domxref("Attr")}} nodes, its {{domxref("Attr.ownerElement", "ownerElement")}} is searched.
+- When called on {{domxref("Document")}} nodes, its {{domxref("Document.documentElement", "documentElement")}} is searched.
+- Other types of non-element nodes search their {{domxref("Node.parentElement", "parentElement")}}.
+
+`null` is always returned if there is no relevant element for the node.
+
+{{domxref("Node.lookupNamespaceURI()")}} takes a prefix and returns the corresponding namespace URI; `null` or `""` requests the default namespace (which, once again, is `null` by default and also `null` when reset with `xmlns=""`). The reserved prefixes `xml` and `xmlns` always resolve to the XML and XMLNS namespaces, or otherwise `null` is returned if no association is found.
+
+```js
+const doc = xml`<parent xmlns="default namespace" xmlns:mdn="https://developer.mozilla.org/"></parent>`;
+const parent = doc.querySelector("parent");
+console.log(parent.lookupNamespaceURI("mdn")); // https://developer.mozilla.org/
+console.log(parent.lookupNamespaceURI("xmlns")); // http://www.w3.org/2000/xmlns/
+console.log(parent.lookupNamespaceURI("xlink")); // null
+console.log(parent.lookupNamespaceURI(null)); // default namespace
+```
+
+{{domxref("Node.lookupPrefix()")}} performs the reverse: takes a namespace URI and returns a prefix. If the namespace URI is `null` or `""`, `null` is returned. If there are multiple prefixes that bind to the same namespace URI, then the prefix used or declared by the nearest element is returned (and the first declaration is preferred among all declarations on the same element).
+
+```js
+const doc = xml`<parent
+  xmlns:mdn="https://developer.mozilla.org/"
+  xmlns:mdn2="https://developer.mozilla.org/">
+  <mdn2:child></mdn2:child>
+</parent>`;
+const child = doc.querySelector("child");
+console.log(child.lookupPrefix("https://developer.mozilla.org/")); // mdn2
+// child itself uses the mdn2 prefix, so mdn2 is preferred
+
+const parent = doc.querySelector("parent");
+console.log(parent.lookupPrefix("https://developer.mozilla.org/")); // mdn
+// parent declares both prefixes, so the first one is preferred
+```
+
+> [!NOTE]
+> The above disambiguation mechanism matches the specification but may not match all browsers' behavior.
+
+`Node.lookupPrefix()` does not special-case the XML/XMLNS namespaces. Because these namespaces cannot be bound to custom prefixes, they will always return `null`. It also doesn't consider `xmlns` attributes.
+
+```js
+const doc = xml`<parent xmlns="https://developer.mozilla.org/"></parent>`;
+const parent = doc.querySelector("parent");
+console.log(parent.lookupPrefix("https://developer.mozilla.org/")); // null
+console.log(parent.lookupPrefix("http://www.w3.org/2000/xmlns/")); // null
+console.log(parent.lookupPrefix("http://www.w3.org/XML/1998/namespace")); // null
+```
+
+{{domxref("Node.isDefaultNamespace()")}} takes a namespace and returns whether it's the default. `node.isDefaultNamespace(namespace)` (when `namespace` is not the empty string) is equivalent to `node.lookupNamespaceURI(null) === namespace`.
+
+In HTML documents, these methods exist, but again `xmlns` attributes have no effect. Lookup can still use a node's stored namespace and prefix, the reserved `xml` and `xmlns` mappings, and namespaced nodes created from script (see below).
+
+> [!NOTE]
+> In HTML documents, Firefox returns `null` as the default namespace URI for all elements, while Chrome and Safari return the default namespaces that would be produced by the HTML parser (HTML, SVG, MathML).
 
 ## Creating namespaced nodes and documents
 
@@ -194,17 +287,6 @@ These strings must be written exactly. Namespace URI comparison is case-sensitiv
 - How {{domxref("Element/getAttributeNames", "Element.getAttributeNames()")}} returns qualified names and can contain duplicates when attributes with different namespaces share a qualified name.
 - How `setAttributeNode()` and `NamedNodeMap.setNamedItem()` replace attributes by namespace and local name despite their non-`NS` names, and how {{domxref("Element/removeAttributeNode", "Element.removeAttributeNode()")}} removes a particular `Attr` object.
 - Namespace behavior of {{domxref("Element/id", "id")}}, {{domxref("Element/className", "className")}}, {{domxref("Element/classList", "classList")}}, and {{domxref("Element/slot", "slot")}}: their DOM concepts use null-namespace attributes even on elements outside the HTML namespace.
-
-## Resolving prefixes and namespace declarations
-
-- **In HTML documents:** These methods exist, but arbitrary `xmlns` attributes on HTML elements do not participate in lookup because the HTML parser puts them in the null namespace. Lookup can still use a node's stored namespace and prefix, the reserved `xml` and `xmlns` mappings, recognized declarations on parsed SVG or MathML foreign content, and namespaced nodes created from script.
-- {{domxref("Node/lookupNamespaceURI", "Node.lookupNamespaceURI()")}} for resolving a prefix in a node's namespace context; `null` or `""` requests the default namespace.
-- {{domxref("Node/lookupPrefix", "Node.lookupPrefix()")}} for finding an in-scope prefix for a namespace URI; the result is not necessarily unique.
-- {{domxref("Node/isDefaultNamespace", "Node.isDefaultNamespace()")}} and its equivalence to comparing a namespace with `lookupNamespaceURI(null)`.
-- How lookup uses an element's own name, namespace declaration attributes, and then ancestor elements.
-- The implicit mappings returned for the reserved `xml` and `xmlns` prefixes.
-- How lookup starts from a document's document element, an attribute's owner element, or another node's parent element; `DocumentType` and `DocumentFragment` have no namespace context.
-- Clearing the default namespace with an empty namespace declaration and the resulting `null` lookup result.
 
 ## Namespaces across other DOM operations
 

--- a/files/en-us/web/api/document_object_model/xml_namespaces/index.md
+++ b/files/en-us/web/api/document_object_model/xml_namespaces/index.md
@@ -151,14 +151,14 @@ All other prefix identifiers can be freely associated. This means you can have t
 > [!NOTE]
 > Note that the default namespace and the namespace prefix are parsing-time concepts. At runtime, programmatically adding/updating the `xmlns` attributes do not change the namespaces of existing elements.
 >
-> The prefix has almost no runtime significance, apart from a few non-namespaced methods that accept qualified names. All namespaced DOM methods take explicit namespace URIs paired with local names, because that is the only unambiguous way to identify elements and attributes.
+> All namespaced DOM methods take explicit namespace URIs paired with local names, because that is the only unambiguous way to identify elements and attributes. The prefix has about as much semantic significance as the element's text content; it participates in node equality, XML serialization, and a few methods that take qualified names.
 
 ## Namespace syntax in HTML
 
 Once again, the [XML namespace syntax](#xml_namespace_syntax) section only applies to XML (which is why we've used the `xml` utility function that calls {{domxref("DOMParser")}}). In an HTML document parsed from `text/html`, by default all elements are HTML elements and belong to the HTML namespace `http://www.w3.org/1999/xhtml`. The HTML parser recognizes the {{SVGElement("svg")}} and the {{MathMLElement("math")}} elements, which put them and all their descendants into the SVG `http://www.w3.org/2000/svg` and MathML `http://www.w3.org/1998/Math/MathML` namespaces (unless escape hatches like {{SVGElement("foreignObject")}} are used). The following do not work:
 
 - The `xmlns` attribute has absolutely no effect. If specified on HTML elements, its value must be `"http://www.w3.org/1999/xhtml"`.
-- The namespace prefix syntax does not exist and the prefix is simply seen as a part of the local name. The parser special-cases several attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns`, `xmlns:xlink`. These have hard-coded namespace associations and are the only ones for which the namespace URI is not one of HTML, SVG, or MathML. None of them is necessary on the modern web because the SVG and MathML specs have defined their own alternatives where appropriate.
+- The namespace prefix syntax does not exist and the prefix is simply seen as a part of the local name. The parser special-cases several attribute names, but only on SVG and MathML elements: `xlink:actuate`, `xlink:arcrole`, `xlink:href`, `xlink:role`, `xlink:show`, `xlink:title`, `xlink:type`, `xml:lang`, `xml:space`, `xmlns`, `xmlns:xlink`. These have hard-coded namespace associations and are the only ones for which the namespace URI is not `null`. None of them is necessary in modern HTML documents because the SVG and MathML specs have defined their own alternatives where appropriate.
 
 For example:
 
@@ -198,7 +198,7 @@ However, this is only to say that the _syntax_ of namespaces is very limited in 
 
 ## Looking up the prefix-namespace association
 
-Each element in the document has a bi-directional association between prefix identifiers and namespace URIs. It either inherits the association from its parent or declares itself via its `xmlns="..."` and `xmlns:prefix="..."` attributes. You can lookup this association on any node, which uses the node's relevant element:
+Each element in the document has a many-to-one association between prefix identifiers and namespace URIs. It either inherits the association from its parent, declares itself via `xmlns="..."` and `xmlns:prefix="..."` attributes, or gets it from the its own `namespaceURI` and `prefix`. You can lookup this association on any node, which uses the node's relevant element:
 
 - When called on {{domxref("Attr")}} nodes, its {{domxref("Attr.ownerElement", "ownerElement")}} is searched.
 - When called on {{domxref("Document")}} nodes, its {{domxref("Document.documentElement", "documentElement")}} is searched.
@@ -216,6 +216,9 @@ console.log(parent.lookupNamespaceURI("xmlns")); // http://www.w3.org/2000/xmlns
 console.log(parent.lookupNamespaceURI("xlink")); // null
 console.log(parent.lookupNamespaceURI(null)); // default namespace
 ```
+
+> [!NOTE]
+> Firefox has a bug where it does not consult the element's own `namespaceURI` when querying the default namespace on an unprefixed element.
 
 {{domxref("Node.lookupPrefix()")}} performs the reverse: takes a namespace URI and returns a prefix. If the namespace URI is `null` or `""`, `null` is returned. If there are multiple prefixes that bind to the same namespace URI, then the prefix used or declared by the nearest element is returned (and the first declaration is preferred among all declarations on the same element).
 
@@ -237,7 +240,7 @@ console.log(parent.lookupPrefix("https://developer.mozilla.org/")); // mdn
 > [!NOTE]
 > The above disambiguation mechanism matches the specification but may not match all browsers' behavior.
 
-`Node.lookupPrefix()` does not special-case the XML/XMLNS namespaces. Because these namespaces cannot be bound to custom prefixes, they will always return `null`. It also doesn't consider `xmlns` attributes.
+`Node.lookupPrefix()` does not special-case the XML/XMLNS namespaces. Unless explicitly declared, they will return `null`. It also doesn't consider `xmlns="..."` attributes.
 
 ```js
 const doc = xml`<parent xmlns="https://developer.mozilla.org/"></parent>`;
@@ -248,9 +251,6 @@ console.log(parent.lookupPrefix("http://www.w3.org/XML/1998/namespace")); // nul
 ```
 
 {{domxref("Node.isDefaultNamespace()")}} takes a namespace and returns whether it's the default for the relevant element. `node.isDefaultNamespace(namespace)` (when `namespace` is not the empty string) is equivalent to `node.lookupNamespaceURI(null) === namespace`.
-
-> [!NOTE]
-> In HTML documents, Firefox returns `null` as the default namespace URI for all elements, while Chrome and Safari return the default namespaces that would be produced by the HTML parser (HTML, SVG, MathML).
 
 Note that the information you look up has no real significance (other than for usage with {{domxref("XPathEvaluator.createExpression()")}}), because newly created elements and attributes don't consult this mapping, and it does not even reflect the information used as parse time—the results are affected by runtime attribute updates.
 
@@ -348,7 +348,6 @@ a.setAttributeNS(
   "xlink:href",
   "https://developer.mozilla.org",
 );
-svg.appendChild(a);
 ```
 
 ## Querying namespaced elements
@@ -358,11 +357,17 @@ The {{domxref("Document.querySelector()")}} method and its likes use [CSS select
 The {{domxref("Document.getElementsByTagName()")}} takes a qualified name, so it can distinguish, for example, `<a />` and `<mdn:a />`, but only if the elements have explicit prefixes. But as mentioned towards the end of [XML namespace syntax](#xml_namespace_syntax), prefixes and qualified names are unreliable for identification purposes. HTML almost never contains prefixes; in XML, explicit prefixes are also rarer than using `xmlns` to switch default namespaces. To query by the actual namespace, use {{domxref("Document.getElementsByTagNameNS()")}} instead, which takes a namespace and a local name. You can also pass `*` for either argument (to not filter for namespace or local name).
 
 ```js
-const doc1 = xml`<parent><a href="foo" /><mdn:a href="bar" /></parent>`;
+const doc1 = xml`<parent xmlns:mdn="https://developer.mozilla.org">
+  <a href="foo" />
+  <mdn:a href="bar" />
+</parent>`;
 console.log(doc1.getElementsByTagName("a").length); // 1
 console.log(doc1.getElementsByTagName("mdn:a").length); // 1
 
-const doc2 = xml`<parent><a href="foo" /><a href="bar" xmlns="http://www.w3.org/1999/xhtml" /></parent>`;
+const doc2 = xml`<parent>
+  <a href="foo" />
+  <a href="bar" xmlns="http://www.w3.org/1999/xhtml" />
+</parent>`;
 console.log(doc2.getElementsByTagName("a").length); // 2
 console.log(doc2.getElementsByTagNameNS(null, "a").length); // 1
 console.log(

--- a/files/en-us/web/api/document_object_model/xml_namespaces/index.md
+++ b/files/en-us/web/api/document_object_model/xml_namespaces/index.md
@@ -1,0 +1,232 @@
+---
+title: XML namespaces
+slug: Web/API/Document_Object_Model/XML_namespaces
+page-type: guide
+---
+
+{{DefaultAPISidebar("DOM")}}
+
+**XML namespace** is a standardized mechanism that allows identifiers (element or attribute names) defined by different specifications with different semantics to coexist in the same XML document without ambiguity.
+
+Several XML languages are relevant to the web. [HTML](/en-US/docs/Web/HTML) (although it also has its own syntax) uses `http://www.w3.org/1999/xhtml`, [SVG](/en-US/docs/Web/SVG) uses `http://www.w3.org/2000/svg`, and [MathML](/en-US/docs/Web/MathML) uses `http://www.w3.org/1998/Math/MathML`. XML also defines reserved namespaces for features such as `xml:lang` and for namespace declarations themselves. This guide explains how these namespaces are represented and manipulated through the DOM.
+
+a HTML
+
+> [!WARNING]
+> **XML namespace declarations are very restricted in HTML documents.** When markup is parsed as `text/html`, `xmlns` attributes do not bind prefixes or change an element's namespace, and the namespace prefix syntax usually does not work. This guide mainly applies to XML documents, with occasional references to HTML behavior.
+
+## Element and attribute names
+
+In the [Anatomy of the DOM](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM) guide, we introduced the basic data associated with [`Element`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#element) and [`Attr`](/en-US/docs/Web/API/Document_Object_Model/Anatomy_of_the_DOM#attr) nodes, which include the {{domxref("Element.tagName", "tagName")}} and {{domxref("Attr.name", "name")}} properties.
+
+- **In HTML documents:** Namespace declarations in markup do not work as they do in XML. The HTML parser chooses the HTML, SVG, or MathML namespace from HTML parsing rules rather than from author-defined prefix bindings; arbitrary XML namespace declarations require an XML document.
+- Why namespaces let XML vocabularies such as HTML, SVG, and MathML use the same local names without collisions.
+- A namespace is identified by a namespace URI string; the URI is an identifier and does not need to be retrievable.
+- The difference between a namespace, a namespace prefix, a local name, and a qualified name (`prefix:localName`).
+- Prefixes are aliases, not namespace identities: different prefixes can bind to the same namespace, and the same prefix can bind to different namespaces in different scopes.
+- The difference between a null namespace and a default namespace, including the normalization of an empty namespace string to `null` in DOM APIs.
+- Namespace declaration attributes: `xmlns` for the default namespace and `xmlns:prefix` for a prefixed binding.
+- The reserved `xml` prefix and XML namespace (`http://www.w3.org/XML/1998/namespace`), and the reserved `xmlns` name and XMLNS namespace (`http://www.w3.org/2000/xmlns/`).
+- The standard HTML (`http://www.w3.org/1999/xhtml`), SVG (`http://www.w3.org/2000/svg`), and MathML (`http://www.w3.org/1998/Math/MathML`) namespace URIs.
+
+XML namespaces make it possible to use elements and attributes from different XML vocabularies in the same document without name collisions. A namespace is identified by a **namespace URI**, such as `http://www.w3.org/2000/svg` for SVG.
+
+The namespace URI is an identifier. Although it often looks like a web address, it does not have to identify a resource that can be retrieved from the web. Applications compare the URI strings; they do not fetch the addresses to determine what the namespaces mean.
+
+For example, this SVG document contains two elements named `title`. One belongs to SVG, while the other belongs to an application-specific metadata vocabulary:
+
+```xml
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:meta="https://example.com/metadata">
+  <title>An SVG title</title>
+  <meta:title>A metadata title</meta:title>
+</svg>
+```
+
+The two elements have the same **local name**, `title`, but different namespace URIs. Their namespace/local-name pairs therefore identify different kinds of elements.
+
+### Namespaces in HTML
+
+Namespace declarations in markup only have their XML meaning when the document is parsed as XML, such as when SVG is served as `image/svg+xml` or XHTML is served as `application/xhtml+xml`.
+
+When a document is parsed as `text/html`, an `xmlns` attribute does not select a namespace, declare an arbitrary prefix, or change how descendants are parsed. Instead, the HTML parser assigns namespaces using fixed rules:
+
+- Most elements are placed in the HTML namespace.
+- A `<svg>` element and its foreign-content descendants are placed in the SVG namespace.
+- A `<math>` element and its foreign-content descendants are placed in the MathML namespace.
+- A fixed set of attributes in SVG and MathML content, such as `xml:lang` and `xlink:href`, are assigned to their predefined namespaces.
+
+For example, a `<svg>` element embedded in an HTML document is placed in the SVG namespace because its local name is `svg`, not because of an `xmlns` attribute. Adding another `xmlns` value would not change the namespace chosen by the HTML parser.
+
+Namespace-aware DOM APIs are not subject to this parsing restriction. Scripts running in an HTML document can use methods such as {{domxref("Document/createElementNS", "createElementNS()")}} and {{domxref("Element/setAttributeNS", "setAttributeNS()")}} to create elements and attributes in any namespace. However, if arbitrary namespace declarations need to be interpreted directly from source markup, the document must use XML syntax and an XML MIME type.
+
+### Local names, prefixes, and qualified names
+
+A namespaced element or attribute has several related parts:
+
+- Its **namespace** is a namespace URI or `null`.
+- Its **local name** identifies the element or attribute within that namespace.
+- Its **namespace prefix** is a short name that is bound to the namespace URI in the current XML namespace context. A prefix is optional.
+- Its **qualified name** is the local name by itself when there is no prefix, or the prefix and local name joined by a colon when there is one.
+
+In the preceding example, the two `title` elements have the following names:
+
+| Markup         | Namespace URI                  | Prefix | Local name | Qualified name |
+| -------------- | ------------------------------ | ------ | ---------- | -------------- |
+| `<title>`      | `http://www.w3.org/2000/svg`   | `null` | `title`    | `title`        |
+| `<meta:title>` | `https://example.com/metadata` | `meta` | `title`    | `meta:title`   |
+
+The namespace and local name determine the identity of a name. The prefix does not. Multiple prefixes can be bound to the same namespace URI, so these two elements have the same namespace and local name despite having different qualified names:
+
+```xml
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:a="https://example.com/metadata"
+  xmlns:b="https://example.com/metadata">
+  <a:title>First title</a:title>
+  <b:title>Second title</b:title>
+</svg>
+```
+
+Conversely, a prefix can be rebound to a different namespace URI in a nested scope. Code must not assume that a particular prefix always identifies the same namespace. It should use the namespace URI and local name when comparing or locating namespaced nodes.
+
+### Default and null namespaces
+
+A declaration written as `xmlns="namespace URI"` defines the **default namespace** for its element and, unless overridden, its descendant elements. In the first example, the default namespace declaration places the unprefixed `svg` and `title` element names in the SVG namespace.
+
+A default namespace is an in-scope namespace binding. It is different from the **null namespace**, which means that a DOM element or attribute has no namespace at all. DOM namespace APIs represent the null namespace with `null`. For the namespace arguments accepted by most namespace-aware DOM methods, the empty string is treated as `null` as well.
+
+The default namespace applies to unprefixed element names, but it does not apply to unprefixed attribute names. Consider the attributes on this SVG element:
+
+```xml
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:meta="https://example.com/metadata"
+  viewBox="0 0 100 100"
+  meta:viewBox="overview"
+  xml:lang="en"></svg>
+```
+
+The `svg` element is in the SVG namespace. Its unprefixed `viewBox` attribute is in the null namespace, while `meta:viewBox` is in the metadata namespace. The two attributes can coexist because an attribute is identified by its namespace URI and local name, not by its local name alone. The `xml:lang` attribute is in the reserved XML namespace.
+
+### Namespace declaration attributes
+
+XML provides two forms of namespace declaration:
+
+- `xmlns="namespace URI"` binds the default namespace.
+- `xmlns:prefix="namespace URI"` binds `prefix` to the namespace URI.
+
+Namespace declarations are themselves represented as attributes in the XMLNS namespace, `http://www.w3.org/2000/xmlns/`. A default declaration has the local name `xmlns` and no prefix. A prefixed declaration has the prefix `xmlns` and uses the declared prefix as its local name. For example, `xmlns:meta` has the prefix `xmlns` and the local name `meta`.
+
+Again, this description applies to XML parsing. On an HTML element parsed from `text/html`, an `xmlns` attribute is placed in the null namespace and has no namespace-declaration effect. The HTML parser recognizes `xmlns` and `xmlns:xlink` as namespaced attributes only in its SVG and MathML foreign-content handling, and even there the parser—not the declaration's value—determines the namespace of elements.
+
+### Reserved namespaces and common namespace URIs
+
+The `xml` and `xmlns` prefixes have predefined meanings:
+
+- `xml` is bound to the XML namespace, `http://www.w3.org/XML/1998/namespace`. It is used by attributes such as `xml:lang` and `xml:space`.
+- `xmlns` is associated with the XMLNS namespace, `http://www.w3.org/2000/xmlns/`, and is reserved for namespace declaration attributes.
+
+Namespace-aware DOM creation and attribute methods enforce these relationships. For example, they reject a qualified name with the `xml` prefix if the supplied namespace is not the XML namespace, and reject invalid combinations of `xmlns` and the XMLNS namespace.
+
+The namespace URIs most commonly encountered in web documents are:
+
+| Vocabulary | Namespace URI                          |
+| ---------- | -------------------------------------- |
+| HTML       | `http://www.w3.org/1999/xhtml`         |
+| SVG        | `http://www.w3.org/2000/svg`           |
+| MathML     | `http://www.w3.org/1998/Math/MathML`   |
+| XML        | `http://www.w3.org/XML/1998/namespace` |
+| XMLNS      | `http://www.w3.org/2000/xmlns/`        |
+
+These strings must be written exactly. Namespace URI comparison is case-sensitive, and a trailing slash or other spelling difference identifies a different namespace.
+
+## How the DOM represents namespaced names
+
+- **In HTML documents:** Parsed HTML elements are in the HTML namespace with a null prefix; parsed `<svg>` and `<math>` subtrees use the SVG and MathML namespaces. A colon in an HTML element or ordinary HTML attribute name is treated as a literal character, not as a namespace separator; only the parser's fixed foreign-content cases produce prefixed namespaced attributes.
+- Elements and attributes store a namespace, namespace prefix, and local name separately; their namespace and prefix can be `null`.
+- {{domxref("Element/namespaceURI", "Element.namespaceURI")}}, {{domxref("Element/prefix", "Element.prefix")}}, and {{domxref("Element/localName", "Element.localName")}}.
+- {{domxref("Attr/namespaceURI", "Attr.namespaceURI")}}, {{domxref("Attr/prefix", "Attr.prefix")}}, and {{domxref("Attr/localName", "Attr.localName")}}.
+- How qualified names are derived from a prefix and local name, and how {{domxref("Element/tagName", "Element.tagName")}}, {{domxref("Attr/name", "Attr.name")}}, and {{domxref("Node/nodeName", "Node.nodeName")}} expose qualified names.
+- Qualified names are returned in uppercase for HTML elements in HTML documents, versus case-sensitive names in XML documents and for non-HTML namespaces.
+- An element's expanded name as the namespace/local-name pair; the prefix is syntax and is not part of namespace identity.
+- An attribute's expanded name as the namespace/local-name pair; one element can therefore contain attributes with the same qualified name but different namespaces.
+- Namespace declarations determine which namespace the XML parser assigns to a name, but changing a declaration later does not change an existing node's stored `namespaceURI`, `prefix`, or `localName`.
+- Default namespaces apply to element names, while unprefixed attributes have no namespace.
+
+## Creating namespaced nodes and documents
+
+- **In HTML documents:** The namespace-aware creation APIs work fully from script and can create nodes in any namespace. `createElement()` normally creates an HTML element, while `createElementNS()` is required for SVG, MathML, or arbitrary namespaced elements created outside the parser's built-in foreign-content handling. `DOMImplementation.createDocument()` creates a separate XML document rather than changing the current HTML document.
+- {{domxref("Document/createElementNS", "Document.createElementNS()")}} for creating an element from a namespace URI and qualified name.
+- {{domxref("Document/createAttributeNS", "Document.createAttributeNS()")}} for creating a detached attribute from a namespace URI and qualified name.
+- {{domxref("DOMImplementation/createDocument", "DOMImplementation.createDocument()")}} for creating an `XMLDocument` with an optional namespaced document element and doctype; how the root namespace determines the document's content type.
+- How a qualified name is split at `:` into prefix and local name by namespace-aware creation and attribute APIs.
+- Name validation and the `InvalidCharacterError` exception for invalid namespace prefixes, element local names, and attribute local names.
+- Namespace validation and the `NamespaceError` exception: a prefix requires a namespace; `xml` must use the XML namespace; and `xmlns` and the XMLNS namespace must be used together.
+- {{domxref("Document/createElement", "Document.createElement()")}} as a contrast: it creates HTML-namespace elements in HTML and XHTML documents, and null-namespace elements in other documents.
+- {{domxref("Document/createAttribute", "Document.createAttribute()")}} as a contrast: it always creates an attribute with a null namespace.
+- Why the namespace, rather than the prefix, selects the resulting element interface, such as an SVG interface for an element in the SVG namespace.
+
+## Finding namespaced elements
+
+- **In HTML documents:** Both `getElementsByTagNameNS()` methods work for HTML elements and for foreign SVG, MathML, or script-created namespaced elements. Searches use the stored namespace URI and local name, not an `xmlns` declaration written on an HTML element. DOM selector APIs cannot be given namespace-prefix mappings.
+- {{domxref("Document/getElementsByTagNameNS", "Document.getElementsByTagNameNS()")}} for matching descendant elements by namespace and local name.
+- {{domxref("Element/getElementsByTagNameNS", "Element.getElementsByTagNameNS()")}} for the same search within an element.
+- The `"*"` wildcard for either or both arguments and the empty-string-to-`null` rule for the namespace argument.
+- The live `HTMLCollection` returned by the `getElementsByTagNameNS()` methods.
+- {{domxref("Document/getElementsByTagName", "Document.getElementsByTagName()")}} and {{domxref("Element/getElementsByTagName", "Element.getElementsByTagName()")}} as qualified-name searches, including their HTML-document case behavior.
+- How {{domxref("Document/getElementById", "Document.getElementById()")}} and {{domxref("Element/getElementsByClassName", "Element.getElementsByClassName()")}} use the DOM's null-namespace `id` and `class` attribute concepts on elements in any namespace.
+- How {{domxref("HTMLCollection/namedItem", "HTMLCollection.namedItem()")}} uses an element's DOM ID regardless of its namespace, but only uses the null-namespace `name` attribute for elements in the HTML namespace.
+- Why prefixes in selector strings are not a substitute: the DOM selector APIs do not support namespace prefixes.
+
+## Working with namespaced attributes
+
+- **In HTML documents:** Namespace-aware attribute methods work fully from script. However, ordinary attributes parsed on HTML elements—including names containing `:` and `xmlns`—have a null namespace. In SVG and MathML foreign content, the HTML parser assigns namespaces only to its fixed list of attributes such as `xlink:href`, `xml:lang`, `xmlns`, and `xmlns:xlink`.
+- Attributes are unique on an element by namespace and local name, not by prefix or qualified name.
+- {{domxref("Element/getAttributeNS", "Element.getAttributeNS()")}}, {{domxref("Element/setAttributeNS", "Element.setAttributeNS()")}}, {{domxref("Element/hasAttributeNS", "Element.hasAttributeNS()")}}, and {{domxref("Element/removeAttributeNS", "Element.removeAttributeNS()")}}.
+- {{domxref("Element/getAttributeNodeNS", "Element.getAttributeNodeNS()")}} and {{domxref("Element/setAttributeNodeNS", "Element.setAttributeNodeNS()")}} when an `Attr` node is needed.
+- {{domxref("NamedNodeMap/getNamedItemNS", "NamedNodeMap.getNamedItemNS()")}}, {{domxref("NamedNodeMap/setNamedItemNS", "NamedNodeMap.setNamedItemNS()")}}, and {{domxref("NamedNodeMap/removeNamedItemNS", "NamedNodeMap.removeNamedItemNS()")}} through {{domxref("Element/attributes", "Element.attributes")}}.
+- The empty-string-to-`null` rule for namespace arguments to namespace-aware attribute lookup and removal methods.
+- Why namespace-aware lookup, presence, and removal methods take a local name, while `setAttributeNS()` takes a qualified name so it can establish a prefix.
+- Prefix replacement: `setAttributeNS()` identifies an existing attribute by namespace and local name, then updates its value without changing its existing prefix.
+- The qualified-name methods {{domxref("Element/getAttribute", "getAttribute()")}}, {{domxref("Element/setAttribute", "setAttribute()")}}, {{domxref("Element/hasAttribute", "hasAttribute()")}}, {{domxref("Element/removeAttribute", "removeAttribute()")}}, {{domxref("Element/toggleAttribute", "toggleAttribute()")}}, and {{domxref("Element/getAttributeNode", "getAttributeNode()")}} as contrasts to their namespace-aware counterparts.
+- How {{domxref("Element/getAttributeNames", "Element.getAttributeNames()")}} returns qualified names and can contain duplicates when attributes with different namespaces share a qualified name.
+- How `setAttributeNode()` and `NamedNodeMap.setNamedItem()` replace attributes by namespace and local name despite their non-`NS` names, and how {{domxref("Element/removeAttributeNode", "Element.removeAttributeNode()")}} removes a particular `Attr` object.
+- Namespace behavior of {{domxref("Element/id", "id")}}, {{domxref("Element/className", "className")}}, {{domxref("Element/classList", "classList")}}, and {{domxref("Element/slot", "slot")}}: their DOM concepts use null-namespace attributes even on elements outside the HTML namespace.
+
+## Resolving prefixes and namespace declarations
+
+- **In HTML documents:** These methods exist, but arbitrary `xmlns` attributes on HTML elements do not participate in lookup because the HTML parser puts them in the null namespace. Lookup can still use a node's stored namespace and prefix, the reserved `xml` and `xmlns` mappings, recognized declarations on parsed SVG or MathML foreign content, and namespaced nodes created from script.
+- {{domxref("Node/lookupNamespaceURI", "Node.lookupNamespaceURI()")}} for resolving a prefix in a node's namespace context; `null` or `""` requests the default namespace.
+- {{domxref("Node/lookupPrefix", "Node.lookupPrefix()")}} for finding an in-scope prefix for a namespace URI; the result is not necessarily unique.
+- {{domxref("Node/isDefaultNamespace", "Node.isDefaultNamespace()")}} and its equivalence to comparing a namespace with `lookupNamespaceURI(null)`.
+- How lookup uses an element's own name, namespace declaration attributes, and then ancestor elements.
+- The implicit mappings returned for the reserved `xml` and `xmlns` prefixes.
+- How lookup starts from a document's document element, an attribute's owner element, or another node's parent element; `DocumentType` and `DocumentFragment` have no namespace context.
+- Clearing the default namespace with an empty namespace declaration and the resulting `null` lookup result.
+
+## Namespaces across other DOM operations
+
+- **In HTML documents:** Equality, cloning, importing, adopting, and mutation records use the stored namespace fields exactly as they do in XML documents. The main limitation comes earlier, during HTML parsing: most parsed attributes have a null namespace unless they are among the parser's recognized foreign attributes.
+- {{domxref("Node/isEqualNode", "Node.isEqualNode()")}} compares element namespaces, prefixes, and local names, and compares attribute namespaces and local names; attribute prefixes do not affect attribute equality.
+- {{domxref("Node/cloneNode", "Node.cloneNode()")}} and {{domxref("Document/importNode", "Document.importNode()")}} preserve the namespace, prefix, and local name of elements and attributes.
+- {{domxref("Document/adoptNode", "Document.adoptNode()")}} changes a node's document without recomputing its namespace information.
+- {{domxref("MutationRecord/attributeName", "MutationRecord.attributeName")}} reports the changed attribute's local name, while {{domxref("MutationRecord/attributeNamespace", "MutationRecord.attributeNamespace")}} reports its namespace.
+- {{domxref("MutationObserver/observe", "MutationObserver.observe()")}} attribute filters contain local names only and do not match attributes whose namespace is non-null.
+
+## Namespaces in XPath and XSLT
+
+- **In HTML documents:** The XPath APIs are available and namespace resolvers can address HTML, SVG, MathML, and script-created namespaces. The XSLT APIs are also exposed in supporting browsers, but their namespace parameters identify XSLT variables or parameters and do not make `xmlns` declarations functional in HTML markup.
+- The `XPathNSResolver` callback and its `lookupNamespaceURI()` method for resolving prefixes used in XPath expressions.
+- The optional namespace resolver accepted by {{domxref("XPathEvaluator/createExpression", "XPathEvaluator.createExpression()")}} and {{domxref("XPathEvaluator/evaluate", "XPathEvaluator.evaluate()")}}, including a `Node` as a resolver.
+- {{domxref("XPathEvaluator/createNSResolver", "XPathEvaluator.createNSResolver()")}} as a legacy method that returns the supplied node unchanged.
+- {{domxref("XSLTProcessor/setParameter", "XSLTProcessor.setParameter()")}}, {{domxref("XSLTProcessor/getParameter", "XSLTProcessor.getParameter()")}}, and {{domxref("XSLTProcessor/removeParameter", "XSLTProcessor.removeParameter()")}} identify stylesheet parameters by namespace URI and local name.
+
+## Summary
+
+- **In HTML documents:** Use the HTML parser's built-in HTML, SVG, and MathML namespace handling for markup; use the namespace-aware DOM APIs for other namespaces; use an XML MIME type when namespace declarations and arbitrary prefixes must be interpreted from source markup.
+- Namespace identity is the namespace URI/local-name pair; prefixes only provide qualified-name syntax and in-scope bindings.
+- Inspect names with `namespaceURI`, `prefix`, and `localName`; use `tagName`, `name`, and `nodeName` when the qualified name is required.
+- Create, find, and update namespaced elements and attributes with the namespace-aware DOM methods.
+- Resolve declarations with the `Node` namespace lookup methods, and account for namespace identity when comparing, cloning, importing, adopting, and observing nodes.

--- a/files/en-us/web/api/element/localname/index.md
+++ b/files/en-us/web/api/element/localname/index.md
@@ -8,63 +8,60 @@ browser-compat: api.Element.localName
 
 {{APIRef("DOM")}}
 
-The **`Element.localName`** read-only property returns the
-local part of the qualified name of an element.
+The **`localName`** read-only property of the {{domxref("Element")}} interface returns the [local name](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an element, which is the tag name with the namespace prefix removed, if any.
+
+> [!NOTE]
+> HTML elements in HTML documents are case-normalized by the parser and namespace-unaware methods like {{domxref("document.createElement()")}}. This property returns the internally-stored lowercase name, but {{domxref("element.tagName", "tagName")}} converts the name to uppercase.
 
 ## Value
 
-A string representing the local part of the element's qualified name.
+A string.
 
 ## Examples
 
-(Must be served with XML content type, such as `text/xml` or
-`application/xhtml+xml`.)
+### Reading the localName
 
-```xml
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:svg="http://www.w3.org/2000/svg">
-<head>
-  <script><![CDATA[
-function test() {
-  const text = document.getElementById("text");
-  const circle = document.getElementById("circle");
+We use {{domxref("DOMParser")}} to create an XML document.
 
-  text.value = `<svg:circle> has:
-localName = "${circle.localName}"
-namespaceURI = "${circle.namespaceURI}"`;
-}
-  ]]></script>
-</head>
-<body onload="test()">
-  <svg:svg version="1.1"
-    width="100px" height="100px"
-    viewBox="0 0 100 100">
-    <svg:circle cx="50" cy="50" r="30" fill="#aaaaaa" id="circle"/>
-  </svg:svg>
-  <textarea id="text" rows="4" cols="55"/>
-</body>
-</html>
+```js
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns:mdn="https://developer.mozilla.org/"><mdn:child /></parent>`,
+  "application/xml",
+);
+const child = doc.querySelector("child");
+console.log(child.localName); // child
 ```
 
-## Notes
+### Local names in HTML documents
 
-The local name of a node is that part of the node's qualified name that comes after the
-colon. Qualified names are typically used in XML as part of the namespace(s) of the
-particular XML documents. For example, in the qualified name
-`comm:partners`, `partners` is the local name and
-`comm` is the prefix:
+[The HTML syntax does not support namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#namespace_syntax_in_html), so the `localName` is always the tag name in lowercase when created by the parser.
 
-```xml
-<comm:business id="soda_shop" type="brick_n_mortar" xmlns:comm="http://example.com/comm">
-  <comm:partners>
-    <comm:partner id="1001">Tony's Syrup Warehouse
-    </comm:partner>
-  </comm:partner>
-</comm:business>
+```html-nolint
+<div></div>
+<BLOCKQUOTE></BLOCKQUOTE>
 ```
 
-> [!NOTE]
-> While the property returns the case of the internal DOM storage, which is lower case, note that {{domxref("element.tagName","tagName")}} property returns upper case for HTML elements in HTML DOMs.
+```js
+const div = document.querySelector("div");
+const blockquote = document.querySelector("blockquote");
+
+console.log(div.localName); // div
+console.log(blockquote.localName); // blockquote
+```
+
+However, this is only a parser restriction; you can create prefixed elements using [`document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) and attach them to the HTML DOM without problems. This method does not normalize internal casing even when the namespace is HTML.
+
+```js
+const elem = document.createElementNS(
+  "http://www.w3.org/1999/xhtml",
+  "Mdn:Child",
+);
+document.body.append(elem);
+
+console.log(elem.tagName); // MDN:CHILD
+console.log(elem.prefix); // Mdn
+console.log(elem.localName); // Child
+```
 
 ## Specifications
 
@@ -76,6 +73,7 @@ particular XML documents. For example, in the qualified name
 
 ## See also
 
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
 - {{domxref("Element.tagName")}}
 - {{domxref("Element.namespaceURI")}}
 - {{domxref("Element.prefix")}}

--- a/files/en-us/web/api/element/namespaceuri/index.md
+++ b/files/en-us/web/api/element/namespaceuri/index.md
@@ -8,35 +8,61 @@ browser-compat: api.Element.namespaceURI
 
 {{APIRef("DOM")}}
 
-The **`Element.namespaceURI`** read-only property returns the namespace URI of the element, or `null` if the element is not in a namespace.
+The **`namespaceURI`** read-only property of the {{domxref("Element")}} interface returns the [namespace URI](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an element, or `null` if the element is not in a namespace.
+
+The namespace URI of a node is frozen at the node creation time, either set by the parser or by the [`document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method. Reading this property does not involve dynamic lookup in the document tree.
 
 ## Value
 
-A string, or `null`.
+A string or `null`.
 
 ## Examples
 
-In this snippet, an element is being examined for its {{domxref("Element.localName", "localName")}} and its `namespaceURI`. If the `namespaceURI` returns the XUL namespace and the `localName` returns "browser", then the node is understood to be a XUL `<browser/>`.
+### Reading the namespaceURI
+
+We use {{domxref("DOMParser")}} to create an XML document.
 
 ```js
-if (
-  element.localName === "browser" &&
-  element.namespaceURI ===
-    "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-) {
-  // this is a XUL browser
-}
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns="https://example.com/"><child /></parent>`,
+  "application/xml",
+);
+const child = doc.querySelector("child");
+console.log(child.namespaceURI); // https://example.com/
 ```
 
-## Notes
+### Namespace URIs in HTML documents
 
-This is not a computed value that is the result of a namespace lookup based on an examination of the namespace declarations in scope. The namespace URI of a node is frozen at the node creation time.
+[The HTML syntax does not support namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#namespace_syntax_in_html), but the parser assigns the HTML, SVG, and MathML namespaces to different elements.
 
-The namespace URI for HTML elements in HTML documents is [`http://www.w3.org/1999/xhtml`](https://www.w3.org/1999/xhtml/) as in XHTML.
+```html
+<div>An HTML element</div>
+<svg>
+  <text x="0" y="15">An SVG element</text>
+</svg>
+<math>
+  <mtext>A MathML element</mtext>
+</math>
+```
 
-You can create an element with the specified `namespaceURI` using the [`document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) method.
+```js
+const htmlEl = document.querySelector("div");
+const svgEl = document.querySelector("text");
+const mathmlEl = document.querySelector("mtext");
 
-The DOM does not handle or enforce namespace validation per se. It is up to the DOM application to do any validation necessary. Also note that the namespace prefix, once it is associated with a particular element, cannot be changed.
+console.log(htmlEl.namespaceURI); // http://www.w3.org/1999/xhtml
+console.log(svgEl.namespaceURI); // http://www.w3.org/2000/svg
+console.log(mathmlEl.namespaceURI); // http://www.w3.org/1998/Math/MathML
+```
+
+However, this is only a parser restriction; you can create arbitrarily namespaced elements using [`document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) and attach them to the HTML DOM without problems.
+
+```js
+const elem = document.createElementNS("https://example.com/", "child");
+document.body.append(elem);
+
+console.log(elem.namespaceURI); // https://example.com/
+```
 
 ## Specifications
 
@@ -48,6 +74,7 @@ The DOM does not handle or enforce namespace validation per se. It is up to the 
 
 ## See also
 
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
 - {{domxref("Element.localName")}}
 - {{domxref("Element.prefix")}}
 - {{domxref("Attr.namespaceURI")}}

--- a/files/en-us/web/api/element/prefix/index.md
+++ b/files/en-us/web/api/element/prefix/index.md
@@ -8,9 +8,7 @@ browser-compat: api.Element.prefix
 
 {{APIRef("DOM")}}
 
-The **`Element.prefix`** read-only property returns the
-namespace prefix of the specified element, or `null` if no prefix is
-specified.
+The **`prefix`** read-only property of the {{domxref("Element")}} interface returns the [namespace prefix](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an element, or `null` if no prefix is specified.
 
 ## Value
 
@@ -18,16 +16,46 @@ A string or `null`.
 
 ## Examples
 
-The following logs "x" to the console.
+### Reading the prefix
 
-```xml
-<x:div onclick="console.log(this.prefix)"/>
+We use {{domxref("DOMParser")}} to create an XML document.
+
+```js
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns:mdn="https://developer.mozilla.org/"><mdn:child /></parent>`,
+  "application/xml",
+);
+const child = doc.querySelector("child");
+console.log(child.prefix); // mdn
 ```
 
-## Notes
+### Namespace prefixes in HTML documents
 
-This will only work when a namespace-aware parser is used, i.e., when a document is
-served with an XML MIME type. This will not work for HTML documents.
+[The HTML syntax does not support namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#namespace_syntax_in_html), so the `prefix` is always `null` when created by the parser.
+
+```html
+<div></div>
+```
+
+```js
+const div = document.querySelector("div");
+
+console.log(div.prefix); // null
+```
+
+However, this is only a parser restriction; you can create prefixed elements using [`document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) and attach them to the HTML DOM without problems. This method does not normalize internal casing even when the namespace is HTML.
+
+```js
+const elem = document.createElementNS(
+  "http://www.w3.org/1999/xhtml",
+  "Mdn:Child",
+);
+document.body.append(elem);
+
+console.log(elem.tagName); // MDN:CHILD
+console.log(elem.prefix); // Mdn
+console.log(elem.localName); // Child
+```
 
 ## Specifications
 
@@ -39,6 +67,8 @@ served with an XML MIME type. This will not work for HTML documents.
 
 ## See also
 
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
+- {{domxref("Element.tagName")}}
 - {{domxref("Element.namespaceURI")}}
 - {{domxref("Element.localName")}}
 - {{domxref("Attr.prefix")}}

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -6,53 +6,65 @@ page-type: web-api-instance-property
 browser-compat: api.Element.tagName
 ---
 
-{{ApiRef("DOM")}}
+{{APIRef("DOM")}}
 
-The **`tagName`** read-only property
-of the {{domxref("Element")}} interface returns the tag name of the element on which
-it's called.
+The **`tagName`** read-only property of the {{domxref("Element")}} interface returns the [qualified name](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces#element_and_attribute_names_in_the_dom) of an element. It is the element's local name by itself when the element has no prefix, or the prefix and local name separated by a colon when it does.
 
-For example, if the element is an {{HTMLElement("img")}}, its
-`tagName` property is `IMG` (for HTML documents; it may be cased
-differently for XML/XHTML documents). Note: You can use the {{domxref("Element.localName", "localName")}} property
-to access the Element's local name — which for the case in the example is `img` (lowercase).
+For {{domxref("Element")}} objects, the value of `tagName` is the same as the value of the {{domxref("Node.nodeName", "nodeName")}} property the element object inherits from {{domxref("Node")}}.
 
 ## Value
 
-A string indicating the element's tag name. This string's capitalization depends on the
-document type:
+A string.
 
-- For DOM trees which represent HTML documents, the returned tag name is always in the
-  canonical upper-case form. For example, `tagName` called on a
-  {{HTMLElement("div")}} element returns `"DIV"`.
-- The tag names of elements in an XML DOM tree are returned in the same case in which
-  they're written in the original XML file. If an XML document includes a tag
-  `"<SomeTag>"`, then the `tagName` property's value is
-  `"SomeTag"`.
-
-For {{domxref("Element")}} objects, the value of `tagName` is the same as
-the value of the {{domxref("Node.nodeName", "nodeName")}} property the element object
-inherits from {{domxref("Node")}}.
+For an HTML element in an HTML document, `tagName` returns the qualified name in uppercase. Use {{domxref("Element.localName", "localName")}} to obtain the internally-stored name without this uppercase conversion.
 
 ## Examples
 
-### HTML
+### Reading the tagName
 
-```html
-<span id="born">When I was born…</span>
-```
-
-### JavaScript
+We use {{domxref("DOMParser")}} to create an XML document.
 
 ```js
-const span = document.getElementById("born");
-console.log(span.tagName);
+const doc = new DOMParser().parseFromString(
+  `<parent xmlns:mdn="https://developer.mozilla.org/"><mdn:child /></parent>`,
+  "application/xml",
+);
+const child = doc.querySelector("child");
+console.log(child.tagName); // mdn:child
 ```
 
-In XHTML (or any other XML format), the original case will be maintained, so
-`"span"` would be output in case the original tag name was created lowercase.
-In HTML, `"SPAN"` would be output instead regardless of the case used while
-creating the original document.
+### Tag names in HTML documents
+
+In an HTML document, `tagName` converts the qualified names of elements in the HTML namespace to uppercase. Elements in other namespaces, such as SVG, preserve the internally-stored casing.
+
+```xml
+<svg>
+  <linearGradient id="gradient"></linearGradient>
+</svg>
+```
+
+```js
+console.log(document.body.tagName); // BODY
+
+const gradient = document.querySelector("#gradient");
+console.log(gradient.tagName); // linearGradient
+```
+
+This distinction also applies to elements created programmatically. An element in the HTML namespace has an uppercase `tagName`, while an element in the SVG namespace does not:
+
+```js
+const htmlElement = document.createElementNS(
+  "http://www.w3.org/1999/xhtml",
+  "Mdn:Child",
+);
+const svgElement = document.createElementNS(
+  "http://www.w3.org/2000/svg",
+  "Mdn:Child",
+);
+
+console.log(htmlElement.tagName); // MDN:CHILD
+console.log(svgElement.tagName); // Mdn:Child
+```
 
 ## Specifications
 
@@ -64,4 +76,8 @@ creating the original document.
 
 ## See also
 
+- [XML namespaces](/en-US/docs/Web/API/Document_Object_Model/XML_namespaces)
 - {{domxref("Element.localName")}}
+- {{domxref("Element.namespaceURI")}}
+- {{domxref("Element.prefix")}}
+- {{domxref("Attr.name")}}

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -469,8 +469,8 @@
         "/docs/Web/API/Document_Object_Model/Reflected_attributes",
         "/docs/Web/API/Document_Object_Model/Selection_and_traversal_on_the_DOM_tree",
         "/docs/Web/API/Document_Object_Model/Building_and_updating_the_DOM_tree",
-        "/docs/Web/API/Document_Object_Model/Events",
-        "/docs/Web/API/Document_Object_Model/XML_namespaces"
+        "/docs/Web/API/Document_Object_Model/XML_namespaces",
+        "/docs/Web/API/Document_Object_Model/Events"
       ],
       "interfaces": [
         "AbortController",

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -469,7 +469,8 @@
         "/docs/Web/API/Document_Object_Model/Reflected_attributes",
         "/docs/Web/API/Document_Object_Model/Selection_and_traversal_on_the_DOM_tree",
         "/docs/Web/API/Document_Object_Model/Building_and_updating_the_DOM_tree",
-        "/docs/Web/API/Document_Object_Model/Events"
+        "/docs/Web/API/Document_Object_Model/Events",
+        "/docs/Web/API/Document_Object_Model/XML_namespaces"
       ],
       "interfaces": [
         "AbortController",


### PR DESCRIPTION
This is long-overdue continuation of https://github.com/mdn/content/pull/41569. This time, I've added an XML namespaces guide (which fixes two broken links in the "Anatomy of the DOM" guide I wrote last time!). It explains the namespace syntax, what's actually lacking in HTML (just the syntax, not the runtime behavior), and summarizes all APIs that interact with namespaces.

I've also fixed the property pages `localName`, `prefix`, `namespaceURI`, and `name`/`tagName` for `Element` and `Attr`, paying extra attention about when and where HTML performs case normalization, and where the namespace syntax does not work. The examples are now modern (no quirky XHTML markup) and directly runnable.