### PR TITLE
typo: block and index flow

### DIFF
--- a/files/en-us/web/css/guides/display/block_and_inline_layout/index.md
+++ b/files/en-us/web/css/guides/display/block_and_inline_layout/index.md
@@ -27,7 +27,7 @@ Block elements in a horizontal writing mode such as English, lay out vertically,
 
 ![Inline direction is horizontal. Block direction is vertical.](mdn-horizontal.png)
 
-In a vertical writing mode then would lay out horizontally.
+In a vertical writing mode they would lay out horizontally.
 
 ![Inline direction is vertical. Block direction is horizontal.](mdn-vertical.png)
 


### PR DESCRIPTION

### Description

This pull request deals with a minor potential typographical error.

### Motivation

I glanced at this "Block and inline layout in normal flow" article on 8/21/2026, and noticed a possible minor typographical error.  Regarding the textual line in question, I suppose the sentence's subject is supposed to be "they".  In the current version, the subject is more vague or unclear.  Maybe you could alternatively rewrite the subject as "the block elements", and that would be potentially helpfully redundant.  My knowledge of CSS is questionable.  So, please also double check the technical accuracy after deciding any change in the verbiage.

### Additional details

[link to the MDN webpage](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Display/Block_and_inline_layout)

I didn't read 100% of the webpage's textual content.  So, this pull request does not claim to address every possible issue with this webpage.

For minor textual changes, etc, maybe an easier editing workflow is:  create and merge your own pull request with the same change, and close the external pull request.  Via this option, there could be reduced chaos relating to having more strangers' names and comments in the git history.


