### PR TITLE
html: add examples for the dir global attribute

### DIFF
--- a/files/en-us/web/html/reference/elements/bdi/index.md
+++ b/files/en-us/web/html/reference/elements/bdi/index.md
@@ -37,6 +37,14 @@ bdi {
 }
 ```
 
+## Attributes
+
+This element only includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
+
+If the [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir) attribute is unspecified, the element still behaves as if `dir="auto"` is specified.
+
+## Usage notes
+
 Bidirectional text is text that may contain both sequences of characters that are arranged left-to-right (LTR) and sequences of characters that are arranged right-to-left (RTL), such as an Arabic quotation embedded in an English string. Browsers implement the [Unicode Bidirectional Algorithm](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics) to handle this. In this algorithm, characters are given an implicit directionality: for example, Latin characters are treated as LTR while Arabic characters are treated as RTL. Some other characters (such as spaces and some punctuation) are treated as neutral and are assigned directionality based on that of their surrounding characters.
 
 Usually, the bidirectional algorithm will do the right thing without the author having to provide any special markup but, occasionally, the algorithm needs help. That's where `<bdi>` comes in.
@@ -62,11 +70,7 @@ If you know the directionality of `EMBEDDED-TEXT` in advance, you can fix this p
 
 Though the same visual effect can be achieved using the CSS rule {{cssxref("unicode-bidi", "unicode-bidi: isolate")}} on a {{HTMLElement("span")}} or another text-formatting element, HTML authors should not use this approach because it is not semantic and browsers are allowed to ignore CSS styling.
 
-Embedding the characters in `<span dir="auto">` has the same effect as using `<bdi>`, but its semantics are less clear.
-
-## Attributes
-
-Like all other HTML elements, this element supports the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes), except that the [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir) attribute behaves differently than normal: it defaults to `auto`, meaning its value is never inherited from the parent element. This means that unless you specify a value of either `rtl` or `ltr` for `dir`, the {{Glossary("user agent")}} will determine the correct directionality to use based on the contents of the `<bdi>`.
+If a semantic element such as {{HTMLElement("cite")}} is appropriate, prefer using `<cite dir="auto">` instead of `<bdi>`. If no semantic element is appropriate and the intended direction is `auto` (infer from content), `<bdi>` is shorter than `<span dir="auto">` and conveys the author intent better. When specifying explicit directionalities such as `ltr`, `<bdi dir="ltr">` and `<span dir="ltr">` are exactly equivalent.
 
 ## Examples
 

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -7,7 +7,7 @@ browser-compat: html.global_attributes.dir
 sidebar: htmlsidebar
 ---
 
-The **`dir`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that indicates the directionality of the element's text.
+The **`dir`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is an [enumerated](/en-US/docs/Glossary/Enumerated) attribute that sets the element's _base text direction_ and directionally isolates its contents from surrounding text.
 
 {{InteractiveExample("HTML Demo: dir", "tabbed-standard")}}
 
@@ -19,40 +19,56 @@ The **`dir`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attribute
 
 <hr />
 
-<p>هذه الفقرة باللغة العربية ولكن بشكل خاطئ من اليسار إلى اليمين.</p>
-<p dir="auto">
+<p lang="ar">هذه الفقرة باللغة العربية ولكن بشكل خاطئ من اليسار إلى اليمين.</p>
+<p lang="ar" dir="auto">
   هذه الفقرة باللغة العربية ، لذا يجب الانتقال من اليمين إلى اليسار.
 </p>
 ```
 
+## Values
+
 It can have the following values:
 
-- `ltr`, which means _left to right_ and is to be used for languages that are written from the left to the right (like English);
-- `rtl`, which means _right to left_ and is to be used for languages that are written from the right to the left (like Arabic);
-- `auto`, which lets the user agent decide. It uses a basic algorithm as it parses the characters inside the element until it finds a character with a strong directionality, then applies that directionality to the whole element.
+- `ltr`, which sets a _left-to-right_ base direction;
+- `rtl`, which sets a _right-to-left_ base direction;
+- `auto`, which lets the user agent determine the base direction from the text, generally using the first character with a strong directionality (skipping `<bdi>`, `<script>`, `<style>`, `<textarea>`, and elements with valid `dir` attributes). For {{HTMLElement("textarea")}} and {{HTMLElement("pre")}}, the rendering direction is determined separately for each paragraph of text.
 
 > [!NOTE]
 > The `auto` value should be used for data with an unknown directionality, like data coming from user input or external data.
+>
+> If the [`dirname`](/en-US/docs/Web/HTML/Reference/Attributes/dirname) attribute is used when users submit input, it may be possible to render the data with a specified directionality instead of relying on automatic detection.
 
-If unspecified, the value is [inherited](#inheritance) from the parent element.
+If unspecified or invalid, the direction is generally [inherited](#inheritance) from the parent element. Omitting `dir` does not enable automatic direction detection.
+
+### Inheritance
+
+If an element has no `dir` attribute, it generally inherits the direction of its [parent element](/en-US/docs/Web/API/Node/parentElement). If no ancestor sets a direction, the default is left-to-right.
+
+There are exceptions:
+
+- A {{HTMLElement("bdi")}} element determines its direction from its content, as if `dir="auto"` were set.
+- An [`<input type="tel">`](/en-US/docs/Web/HTML/Reference/Elements/input/tel) element uses left-to-right direction.
+
+## Usage notes
+
+The base direction is used by the Unicode Bidirectional Algorithm ([BiDi](/en-US/docs/Glossary/BiDi)). While characters strongly typed as LTR or RTL (such as Latin, Hebrew, or Arabic letters) establish directionality for themselves and all neutral characters in between (creating "runs" of text), the base direction is necessary in two scenarios:
+
+- It is assumed by neutral characters (like spaces or punctuation) at the boundaries of runs of text with different directionalities, often including at the very beginnings or ends.
+- It is used to order runs of text.
+
+For example, consider the first English paragraph in the [Try it](#try_it) demo. There are two runs of text: the English text (LTR due to the Latin characters) and the final period (which is at the end of the `p` element, so assumes the base direction RTL). These runs of text are laid out right-to-left, so the text appears first on the right edge, followed to its left by the period. Similarly, the first Arabic paragraph inherits the LTR base direction from the HTML document, so the RTL Arabic text appears on the left edge, followed to its right by the period (with LTR direction). Both paragraphs are typographically incorrect.
+
+Even for documents in a single script, it is recommended to explicitly set `dir` on the root element, which is especially important for RTL scripts, because the default LTR base direction is wrong. The [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute declares the language, but does not imply the base direction.
 
 This attribute can be overridden by the CSS properties {{ cssxref("direction") }} and {{ cssxref("unicode-bidi") }}, if a CSS page is active and the element supports these properties.
 
 As the directionality of the text is semantically related to its content and not to its presentation, it is recommended that web developers use this attribute instead of the related CSS properties when possible. That way, the text will display correctly even on a browser that doesn't support CSS or has the CSS deactivated.
 
-## Inheritance
-
-If an element has no `dir` attribute, it will inherit the `dir` value set on its [parent node](/en-US/docs/Glossary/Node/DOM), which in turn may inherit it from its parent, and so on.
-
-## Usage notes
-
 An image can have its `dir` property set to `"rtl"` in which case the HTML attributes `title` and `alt` will be formatted and defined as `"rtl"`.
 
 When a table has its `dir` set to `"rtl"`, the column order is arranged from right to left.
 
-This attribute is mandatory for the {{ HTMLElement("bdo") }} element where it has a different semantic meaning.
-
-This attribute is _not_ inherited by the {{ HTMLElement("bdi") }} element. If not set, its value is `auto`.
+The {{HTMLElement("bdo")}} element requires `dir="ltr"` or `dir="rtl"`. On this element, the attribute overrides the characters' intrinsic directionality instead of only setting a base direction.
 
 Browsers might allow users to change the directionality of {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }} elements in order to assist with authoring content.
 Chrome and Safari provide a directionality option in the contextual menu of input fields.
@@ -61,53 +77,11 @@ These features toggle the `dir` attribute value between `ltr` and `rtl`.
 
 ## Examples
 
-### Setting text direction explicitly
-
-This example uses `dir="ltr"` and `dir="rtl"` to explicitly set the reading direction for two paragraphs.
-Left-to-right is the default for most Western languages; right-to-left is required for languages such as Arabic and Hebrew.
-
-```html
-<p dir="ltr">This sentence is in English and reads left to right.</p>
-<p dir="rtl">هذه الجملة باللغة العربية وتُقرأ من اليمين إلى اليسار.</p>
-```
-
-### Using `dir="auto"` for user-generated content
-
-When displaying text whose language is not known in advance — for example, content entered by a user or fetched from an external source — use `dir="auto"`.
-The browser inspects the first strongly directional character in the element and applies that direction to the whole element.
-
-```html
-<ul>
-  <li dir="auto">This item contains English text.</li>
-  <li dir="auto">هذا العنصر يحتوي على نص عربي.</li>
-</ul>
-```
-
-Without `dir="auto"`, both list items would inherit the page direction (typically `ltr`), causing the Arabic text to be laid out incorrectly.
-
-### Inline bidirectional text
-
-When a right-to-left word or phrase appears inside a left-to-right sentence (or vice versa), wrap it in a {{ HTMLElement("bdi") }} element so the browser can handle the surrounding punctuation and layout correctly without affecting the direction of the rest of the sentence.
-Use the {{ HTMLElement("bdo") }} element when you want to explicitly override the Unicode bidirectional algorithm for a specific span of text.
-
-```html
-<p>
-  The title of the book is
-  <bdi>مفاهيم البرمجة</bdi>
-  and it was published last year.
-</p>
-
-<p dir="rtl">
-  اسم المستخدم هو
-  <!-- Force the username to always read left-to-right -->
-  <bdo dir="ltr">john_doe</bdo>
-</p>
-```
-
 ### Setting document-level direction
 
-Set `dir` on the `<html>` element to establish a base direction for the entire page.
-All elements inherit this direction unless they set their own `dir` attribute.
+Set `dir="rtl"` on the {{HTMLElement("html")}} element when the page is predominantly written in a right-to-left script, such as Arabic or Hebrew. Use `dir` on a block within the page when that block needs a different base direction.
+
+In this Arabic document, the English paragraph needs both `dir="ltr"` and `lang="en"`.
 
 ```html
 <!doctype html>
@@ -118,11 +92,46 @@ All elements inherit this direction unless they set their own `dir` attribute.
   </head>
   <body>
     <p>محتوى الصفحة باللغة العربية.</p>
-    <!-- Override direction for a specific element -->
-    <p dir="ltr">This paragraph is explicitly left-to-right.</p>
+    <p dir="ltr" lang="en">This paragraph is in English.</p>
   </body>
 </html>
 ```
+
+### Setting text direction explicitly
+
+This example explicitly sets the base direction of two paragraphs. The base direction affects the default alignment and the placement of punctuation.
+
+```html
+<p dir="ltr" lang="en">This sentence is in English and reads left to right.</p>
+<p dir="rtl" lang="ar">
+  هذه الجملة باللغة العربية وتُقرأ من اليمين إلى اليسار.
+</p>
+```
+
+### Inline bidirectional text
+
+When an inline phrase has a different base direction from the surrounding text, tightly wrap the whole phrase in an element with the appropriate `dir` value. This also isolates the phrase's direction from its surroundings, so punctuation and numbers outside it are not treated as part of the phrase. Use an existing semantic element, such as {{HTMLElement("cite")}} for a book title, or a {{HTMLElement("bdi")}} if no other element is appropriate.
+
+```html
+<p dir="rtl" lang="ar">
+  اقرأ <cite dir="ltr" lang="en">How the Grinch Stole Christmas!</cite> اليوم.
+</p>
+```
+
+Note that the exclamation mark, a part of the title, is inside the `<cite>` element. If outside, it will adopt the base direction and therefore appear on the left edge of the title.
+
+### Using dir="auto" for user-generated content
+
+When the direction of text is not known in advance, such as for user comments, use `dir="auto"`. The browser uses the first strongly directional character to determine the element's base direction. This is a heuristic, not language detection: a comment that starts with an English name and continues in Arabic will get a left-to-right base direction. Use an explicit direction when it is known.
+
+Here, the paragraphs represent two possible comments. The comments are written by users, so the site is not aware of their languages during rendering.
+
+```html
+<p dir="auto">This comment is in English.</p>
+<p dir="auto">هذا التعليق باللغة العربية.</p>
+```
+
+The {{HTMLElement("bdi")}} element offers the same effect, and is terser for inline isolation, especially when no semantic element is appropriate.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -59,6 +59,71 @@ Chrome and Safari provide a directionality option in the contextual menu of inpu
 Firefox uses <kbd>Ctrl</kbd> (Windows)/<kbd>Cmd</kbd> (macOS) + <kbd>Shift</kbd> + <kbd>X</kbd> inside a `<textarea>` to toggle text direction.
 These features toggle the `dir` attribute value between `ltr` and `rtl`.
 
+## Examples
+
+### Setting text direction explicitly
+
+This example uses `dir="ltr"` and `dir="rtl"` to explicitly set the reading direction for two paragraphs.
+Left-to-right is the default for most Western languages; right-to-left is required for languages such as Arabic and Hebrew.
+
+```html
+<p dir="ltr">This sentence is in English and reads left to right.</p>
+<p dir="rtl">هذه الجملة باللغة العربية وتُقرأ من اليمين إلى اليسار.</p>
+```
+
+### Using `dir="auto"` for user-generated content
+
+When displaying text whose language is not known in advance — for example, content entered by a user or fetched from an external source — use `dir="auto"`.
+The browser inspects the first strongly directional character in the element and applies that direction to the whole element.
+
+```html
+<ul>
+  <li dir="auto">This item contains English text.</li>
+  <li dir="auto">هذا العنصر يحتوي على نص عربي.</li>
+</ul>
+```
+
+Without `dir="auto"`, both list items would inherit the page direction (typically `ltr`), causing the Arabic text to be laid out incorrectly.
+
+### Inline bidirectional text
+
+When a right-to-left word or phrase appears inside a left-to-right sentence (or vice versa), wrap it in a {{ HTMLElement("bdi") }} element so the browser can handle the surrounding punctuation and layout correctly without affecting the direction of the rest of the sentence.
+Use the {{ HTMLElement("bdo") }} element when you want to explicitly override the Unicode bidirectional algorithm for a specific span of text.
+
+```html
+<p>
+  The title of the book is
+  <bdi>مفاهيم البرمجة</bdi>
+  and it was published last year.
+</p>
+
+<p dir="rtl">
+  اسم المستخدم هو
+  <!-- Force the username to always read left-to-right -->
+  <bdo dir="ltr">john_doe</bdo>
+</p>
+```
+
+### Setting document-level direction
+
+Set `dir` on the `<html>` element to establish a base direction for the entire page.
+All elements inherit this direction unless they set their own `dir` attribute.
+
+```html
+<!doctype html>
+<html dir="rtl" lang="ar">
+  <head>
+    <meta charset="utf-8" />
+    <title>صفحة عربية</title>
+  </head>
+  <body>
+    <p>محتوى الصفحة باللغة العربية.</p>
+    <!-- Override direction for a specific element -->
+    <p dir="ltr">This paragraph is explicitly left-to-right.</p>
+  </body>
+</html>
+```
+
 ## Specifications
 
 {{Specifications}}
@@ -72,3 +137,4 @@ These features toggle the `dir` attribute value between `ltr` and `rtl`.
 - All [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 - {{domxref("HTMLElement.dir")}} that reflects this attribute.
 - [Handling different text directions](/en-US/docs/Learn_web_development/Core/Styling_basics/Handling_different_text_directions)
+- [Creating HTML pages in Arabic, Hebrew and other right-to-left scripts](https://www.w3.org/International/tutorials/bidi-xhtml/index.en.html) on w3.org


### PR DESCRIPTION
### Description
Adds an `## Examples` section to the `dir` global attribute page with four practical sub-examples covering all three attribute values, and adds the W3C bidi tutorial link to `## See also`.

### Motivation
The `dir` attribute page had no examples at all, making it hard for readers to understand when and how to use each value. The new examples show:
- explicit `ltr`/`rtl` on paragraphs of different languages
- `dir="auto"` for user-generated or unknown-language content
- inline bidirectional text using `<bdi>` and `<bdo>`
- setting document-level direction on the `<html>` element with per-element overrides

The W3C bidi tutorial link was also requested in the issue as a useful external reference.

### Additional details
W3C tutorial linked in See also: https://www.w3.org/International/tutorials/bidi-xhtml/index.en.html

### Related issues and pull requests
Fixes #44052