### PR TITLE
Fix argument order in dragging elements example

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/drag_data_store/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_data_store/index.md
@@ -266,8 +266,8 @@ A common way to transfer the element is to use the `text/html` type containing s
 You may also include a plain text representation of the HTML or XML data using the `text/plain` type. The data should be just the text without any of the source tags or attributes. For instance:
 
 ```js
-event.dataTransfer.items.add("text/html", element.outerHTML);
-event.dataTransfer.items.add("text/plain", element.innerText);
+event.dataTransfer.items.add(element.outerHTML, "text/html");
+event.dataTransfer.items.add(element.innerText, "text/plain");
 ```
 
 You can also use other types that you invent for custom purposes. Strive to always include a `text/plain` alternative, unless the dragged object is specific to a particular site or application. In this case, the custom type ensures that the data cannot be dropped elsewhere.

--- a/files/en-us/web/api/html_drag_and_drop_api/drag_data_store/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_data_store/index.md
@@ -286,8 +286,8 @@ Chrome supports the non-standard `DownloadURL` type. The payload should be text 
 
 ```js
 event.dataTransfer.items.add(
-  "DownloadURL",
   "image/png:example.png:data:image/png;base64,iVBORw0K...",
+  "DownloadURL",
 );
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Fixed the argument order in the DataTransferItemList.add() calls in the "Dragging elements" example.

### Motivation

The example passes the MIME type and data in the wrong order. add() expects data, type, so the current example does not work as intended.

### Additional details

DataTransferItemList.add() API reference: [https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/add](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList/add)

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
