### PR TITLE
fix(javascript): call findLast in the TypedArray.findLast example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findlast/index.md
@@ -18,7 +18,7 @@ function isNegative(element /*, index, array */) {
 
 const int8 = new Int8Array([10, 0, -10, 20, -30, 40, 50]);
 
-console.log(int8.find(isNegative));
+console.log(int8.findLast(isNegative));
 // Expected output: -30
 ```
 


### PR DESCRIPTION
The interactive example on `TypedArray.prototype.findLast` calls `find()` rather than `findLast()`:

```js
const int8 = new Int8Array([10, 0, -10, 20, -30, 40, 50]);
console.log(int8.find(isNegative));
// Expected output: -30
```

`find()` returns the *first* negative element, `-10`. The documented output `-30` is the *last* one, which is what `findLast()` returns. So the example both contradicts its own stated output and demonstrates the wrong method on the page that documents `findLast`.

Verified in Node:

```
find     : -10
findLast : -30
```

Changing the call to `findLast()` makes the example produce the documented `-30`.

I checked the sibling pages and they are all correct: `typedarray/findLastIndex`, `typedarray/findIndex`, `typedarray/find`, `array/findLast` and `array/findLastIndex` each call their own method. This is the only page with the mismatch.

Found by executing every `js interactive-example` block under `files/en-us/web/javascript` that carries an `// Expected output:` comment and comparing the actual scalar output against the documented one: 467 blocks ran, and this was the single value mismatch.
