### PR TITLE
RTCTransportStats integer props are non-negative

### DIFF
--- a/files/en-us/web/api/rtctransportstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtctransportstats/bytesreceived/index.md
@@ -14,7 +14,7 @@ Only data bytes are counted; overhead such as padding, headers, and so on are no
 
 ## Value
 
-A positive integer indicating the number of received payload bytes.
+A non-negative integer indicating the number of received payload bytes.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/bytessent/index.md
+++ b/files/en-us/web/api/rtctransportstats/bytessent/index.md
@@ -14,7 +14,7 @@ Only data bytes are counted; overhead such as padding, headers, and so on are no
 
 ## Value
 
-A positive integer indicating the number of sent payload bytes.
+A non-negative integer indicating the number of sent payload bytes.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/packetsreceived/index.md
+++ b/files/en-us/web/api/rtctransportstats/packetsreceived/index.md
@@ -12,7 +12,7 @@ The **`packetsReceived`** property of the {{domxref("RTCTransportStats")}} dicti
 
 ## Value
 
-A positive integer indicating the number of packets received on the transport.
+A non-negative integer indicating the number of packets received on the transport.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/packetssent/index.md
+++ b/files/en-us/web/api/rtctransportstats/packetssent/index.md
@@ -12,7 +12,7 @@ The **`packetsSent`** property of the {{domxref("RTCTransportStats")}} dictionar
 
 ## Value
 
-A positive integer indicating the number of packets sent on the transport.
+A non-negative integer indicating the number of packets sent on the transport.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtctransportstats/selectedcandidatepairchanges/index.md
+++ b/files/en-us/web/api/rtctransportstats/selectedcandidatepairchanges/index.md
@@ -12,7 +12,7 @@ The **`selectedCandidatePairChanges`** property of the {{domxref("RTCTransportSt
 
 ## Value
 
-A positive integer that is initially zero and increases whenever a candidate pair is selected or lost.
+A non-negative integer that is initially zero and increases whenever a candidate pair is selected or lost.
 
 ## Specifications
 


### PR DESCRIPTION
This updates the IDL unsigned integer properties of RTCTransportStats to say that the value is a "`non-negative` integer" rather than a positive integer. The difference being that 0 is not positive (or negative).

There are probably many other cases of this error in web API, sadly some added by me.

This is an in-passing fix related to #45185

