### PR TITLE
chore: add words from weekly spelling check to dictionaries

### DIFF
--- a/.vscode/dictionaries/ignore-list.txt
+++ b/.vscode/dictionaries/ignore-list.txt
@@ -293,6 +293,7 @@ spero
 srcs
 takimata
 tatsoi
+Terydactyl
 testuser
 texmf
 theguardian

--- a/.vscode/dictionaries/proper-names.txt
+++ b/.vscode/dictionaries/proper-names.txt
@@ -36,6 +36,7 @@ Artur
 Arun
 Ashlyn
 Ashok
+Ashwood
 Audiocogs
 Audre
 Austerstræti
@@ -172,6 +173,7 @@ Dottoro
 Downey
 Dragomir
 Drasner
+Draymoor
 Dutton
 Dwan
 Dwyane
@@ -212,6 +214,8 @@ Exocoetidae
 Fadeyev
 Fairchild
 FDCP
+Fenwick
+Ferngate
 Firefogg
 Firesheep
 Firestore
@@ -241,6 +245,7 @@ Gordo
 Gorman
 Grahl
 Grande-Dixence
+Graywolf
 Graywolf9
 Grigsby
 Grissom
@@ -460,6 +465,7 @@ Neocities
 Nixpacks
 Noida
 Norah
+Northbridge
 Novak
 Nurek
 Nuxt
@@ -526,6 +532,7 @@ Rauschmayer
 Realtek
 Recep
 Redbeard
+Redcliffe
 Reis
 Rekapi
 Remy

--- a/.vscode/dictionaries/terms-abbreviations.txt
+++ b/.vscode/dictionaries/terms-abbreviations.txt
@@ -191,6 +191,7 @@ doorhanger
 dotless
 downsampled
 downsampling
+DPIA
 dragonfish
 DSCP
 DTLSL
@@ -891,6 +892,7 @@ unlayered
 unlocalized
 unmaps
 unminified
+unmutes
 unmuting
 unobserves
 unpartitioned
@@ -898,6 +900,7 @@ unpinch
 unprefix
 unprefixing
 unprioritized
+unpunctuated
 unreadably
 unregisters
 unregistration


### PR DESCRIPTION
### Summary

Resolves the words reported in #45293. None of the five reported items are actual misspellings, so this is dictionary additions only — no prose changes.

| Word(s) | File | Dictionary |
| --- | --- | --- |
| `unmutes` | `web/api/audiosession/statechange_event` | `terms-abbreviations` |
| `unpunctuated` | `web/api/speechrecognition/unspokenpunctuation` | `terms-abbreviations` |
| `DPIA` | `web/privacy/regulations/gdpr` | `terms-abbreviations` |
| `Ashwood`, `Draymoor`, `Fenwick`, `Ferngate`, `Graywolf`, `Northbridge`, `Redcliffe` | `web/css/reference/properties/flex-line-count` | `proper-names` |
| `Terydactyl` | `web/css/reference/properties/flex-flow` | `ignore-list` |

### Rationale

- **`unmutes`** — `unmuting` is already in `terms-abbreviations.txt`, so the same word family goes in the same place.
- **`unpunctuated`** — a valid English word that just isn't in the base en-US dictionary.
- **`DPIA`** — defined in the page itself ("a _data protection impact assessment_ (DPIA)"), which matches what `terms-abbreviations` is for.
- **The seven names** — fictional publishers in an example list ("published by Northbridge Press", "Ashwood & Kline"). `proper-names` covers companies and is `noSuggest`, so they won't be offered as corrections elsewhere.
- **`Terydactyl`** — sits in an alphabetical filler list (Petunia, Quality, Rancid, Shoelace, **Terydactyl**, Umbrella, …) and reads as a deliberate play on "pterodactyl". Since it's a near-miss of a real word, `ignore-list` keeps it from masking a genuine typo elsewhere.

  Flagging this one for reviewer judgment: if you'd rather treat it as a plain typo for "Pterodactyl", the fix would be editing the list entry instead, and I'm happy to switch.

### Verification

- `node scripts/sort_and_unique_file_lines.js --check .vscode/dictionaries` — passes (entries appended, then sorted with the repo's own script).
- `cspell` with the repo config over the five reported files — **0 issues in 5 files**.
