### PR TITLE
WebTransportSendGroup and WebTransportSendStream etc updates

### DIFF
--- a/files/en-us/web/api/webtransport/createsendgroup/index.md
+++ b/files/en-us/web/api/webtransport/createsendgroup/index.md
@@ -42,7 +42,7 @@ The returned `WebTransportSendGroup` is not initially associated with any stream
 You can associate it with a {{domxref("WebTransportDatagramsWritable")}} or {{domxref("WebTransportSendStream")}} object in a couple of different ways:
 
 - By passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}}.
-- By setting the object's `sendGroup` property afterwards — see `WebTransportSendStream.sendGroup` and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+- By setting the object's `sendGroup` property afterwards — see {{domxref("WebTransportSendStream.sendGroup")}} and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
 
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
 

--- a/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/createwritable/index.md
@@ -40,7 +40,9 @@ A {{domxref("WebTransportDatagramsWritable")}} object, which extends {{domxref("
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the transport's state is `"closed"` or `"failed"`, or if `sendGroup` is specified (non-null) and is associated with a different `WebTransport`.
+  - : Thrown if the transport's state is `"closed"` or `"failed"`.
+- {{jsxref("TypeError")}}
+  - : Thrown if `sendGroup` is specified (non-null) and is associated with a different `WebTransport`.
 
 ## Description
 
@@ -101,5 +103,5 @@ await sendDatagrams(url, datagrams, { sendOrder: 1 });
 
 ## See also
 
-- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
 - {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportdatagramduplexstream/writable/index.md
+++ b/files/en-us/web/api/webtransportdatagramduplexstream/writable/index.md
@@ -15,6 +15,8 @@ The **`writable`** read-only property of the {{domxref("WebTransportDatagramDupl
 
 "Unreliably" means that transmission of data is not guaranteed, nor is arrival in a specific order. This is fine in some situations and provides very fast delivery. For example, you might want to transmit regular game state updates where each message supersedes the last one that arrives, and order is not important.
 
+{{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable()")}} should be used by preference.
+
 ## Value
 
 A {{domxref("WritableStream")}}.
@@ -25,7 +27,7 @@ See the main {{domxref("WebTransportDatagramDuplexStream")}} interface page.
 
 ## Specifications
 
-{{Specifications}}
+This feature has been removed from the specification.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/webtransportdatagramswritable/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/index.md
@@ -53,5 +53,5 @@ See {{domxref("WebTransportDatagramDuplexStream.createWritable", "createWritable
 
 ## See also
 
-- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
 - {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendgroup/index.md
@@ -10,7 +10,7 @@ browser-compat: api.WebTransportDatagramsWritable.sendGroup
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}{{SeeCompatTable}}
 
-The **`sendGroup`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets the {{domxref("WebTransportSendGroup")}} that this `WebTransportDatagramsWritable` is grouped under for the purposes of {{domxref("WebTransportDatagramsWritable.sendOrder", "sendOrder")}} prioritization.
+The **`sendGroup`** property of the {{domxref("WebTransportDatagramsWritable")}} interface represents the {{domxref("WebTransportSendGroup")}} that this `WebTransportDatagramsWritable` is grouped under for the purposes of {{domxref("WebTransportDatagramsWritable.sendOrder", "sendOrder")}} prioritization.
 
 Within a group, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
@@ -18,6 +18,12 @@ Different groups are expected to be treated as equals for the purposes of bandwi
 ## Value
 
 A `WebTransportSendGroup` object, or `null` to specify the default send group.
+The default value is `null`.
+
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if set to a `WebTransportSendGroup` that is associated with a different `WebTransport` object than this stream.
 
 ## Examples
 
@@ -51,5 +57,5 @@ writer.write(data).catch(() => {});
 
 ## See also
 
-- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
 - {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
+++ b/files/en-us/web/api/webtransportdatagramswritable/sendorder/index.md
@@ -10,7 +10,7 @@ browser-compat: api.WebTransportDatagramsWritable.sendOrder
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}{{SeeCompatTable}}
 
-The **`sendOrder`** property of the {{domxref("WebTransportDatagramsWritable")}} interface gets or sets an integer indicating the priority of this stream's datagrams relative to other streams and datagrams in the same {{domxref("WebTransportDatagramsWritable.sendGroup", "sendGroup")}}.
+The **`sendOrder`** property of the {{domxref("WebTransportDatagramsWritable")}} interface represents the priority of this stream's datagrams relative to other streams and datagrams in the same {{domxref("WebTransportDatagramsWritable.sendGroup", "sendGroup")}}, as an integer.
 
 Within a `sendGroup`, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
 Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
@@ -53,5 +53,5 @@ console.log(`Send order: ${writable.sendOrder}`); // Send order: 2
 
 ## See also
 
-- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)
 - {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)

--- a/files/en-us/web/api/webtransportsendgroup/getstats/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/getstats/index.md
@@ -10,8 +10,8 @@ browser-compat: api.WebTransportSendGroup.getStats
 
 {{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}{{SeeCompatTable}}
 
-The **`getStats()`** method of the {{domxref("WebTransportSendGroup")}} interface returns a {{jsxref("Promise")}} that resolves to an object containing statistics aggregated across all of the {{domxref("WebTransportSendStream")}} and {{domxref("WebTransportDatagramsWritable")}} objects currently associated with this group.
-That is, every stream and datagram writable whose `sendGroup` is set to this `WebTransportSendGroup`.
+The **`getStats()`** method of the {{domxref("WebTransportSendGroup")}} interface returns a {{jsxref("Promise")}} that resolves to an object containing statistics aggregated across all of the {{domxref("WebTransportSendStream")}} objects currently associated with this group.
+That is, every stream whose `sendGroup` is set to this `WebTransportSendGroup`.
 
 ## Syntax
 
@@ -25,26 +25,26 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to an object containing aggregated statistics for the group's members.
+A {{jsxref("Promise")}} that resolves to an object containing aggregated statistics for the group's streams.
 The returned object has the following properties:
 
 - `bytesAcknowledged`
-  - : A positive integer indicating the number of bytes written to the group's members that have been sent and acknowledged as received by the server, using QUIC's ACK mechanism.
-    Only sequential bytes up to, but not including, the first unacknowledged byte of each member, are counted.
+  - : A non-negative integer indicating the number of bytes written to the group's streams that have been sent and acknowledged as received by the server, using QUIC's ACK mechanism.
+    Only sequential bytes up to, but not including, the first unacknowledged byte of each stream, are counted.
     This number can only increase and is always less than or equal to `bytesSent`.
 - `bytesSent`
-  - : A positive integer indicating the number of bytes written to the group's members that have been sent at least once (but not necessarily acknowledged).
+  - : A non-negative integer indicating the number of bytes written to the group's streams that have been sent at least once (but not necessarily acknowledged).
     This number can only increase, and is always less than or equal to `bytesWritten`.
     Note that this count does not include bytes sent as network overhead (such as packet headers).
 - `bytesWritten`
-  - : A positive integer indicating the number of bytes successfully written to the group's members.
+  - : A non-negative integer indicating the number of bytes successfully written to the group's streams.
     This number can only increase.
 
 ## Examples
 
 ### Basic usage
 
-The code snippet below uses [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) to wait on the {{jsxref("Promise")}} returned by `getStats()`, then logs the number of bytes that have been sent across the group's members but not yet acknowledged:
+The code snippet below uses [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) to wait on the {{jsxref("Promise")}} returned by `getStats()`, then logs the number of bytes that have been sent across the group's streams but not yet acknowledged:
 
 ```js
 const stats = await sendGroup.getStats();

--- a/files/en-us/web/api/webtransportsendgroup/index.md
+++ b/files/en-us/web/api/webtransportsendgroup/index.md
@@ -30,7 +30,7 @@ A `WebTransportSendGroup` is created using the `createSendGroup()` method of the
 You can then associate it with a `WebTransportDatagramsWritable` or `WebTransportSendStream` by:
 
 - Passing it as the `sendGroup` option when the object is created — see {{domxref("WebTransport.createUnidirectionalStream()")}}, {{domxref("WebTransport.createBidirectionalStream()")}}, and {{domxref("WebTransportDatagramDuplexStream.createWritable()")}}.
-- Setting the object's `sendGroup` property afterwards, for example using {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
+- Setting the object's `sendGroup` property afterwards — see {{domxref("WebTransportSendStream.sendGroup")}} and {{domxref("WebTransportDatagramsWritable.sendGroup")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/webtransportsendstream/index.md
+++ b/files/en-us/web/api/webtransportsendstream/index.md
@@ -25,6 +25,8 @@ When a bidirectional stream is initiated by the remote end, an object of this ty
 
 _Also inherits properties from its parent interface, {{domxref("WritableStream")}}._
 
+- {{domxref("WebTransportSendStream.sendGroup")}}
+  - : The {{domxref("WebTransportSendGroup")}} that this stream is grouped under for the purposes of `sendOrder` prioritization.
 - {{domxref("WebTransportSendStream.sendOrder")}}
   - : Indicates the send priority of this stream relative to other streams for which the value has been set.
 

--- a/files/en-us/web/api/webtransportsendstream/sendgroup/index.md
+++ b/files/en-us/web/api/webtransportsendstream/sendgroup/index.md
@@ -1,0 +1,56 @@
+---
+title: "WebTransportSendStream: sendGroup property"
+short-title: sendGroup
+slug: Web/API/WebTransportSendStream/sendGroup
+page-type: web-api-instance-property
+browser-compat: api.WebTransportSendStream.sendGroup
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`sendGroup`** property of the {{domxref("WebTransportSendStream")}} interface represents the {{domxref("WebTransportSendGroup")}} that this stream is grouped under for the purposes of {{domxref("WebTransportSendStream.sendOrder", "sendOrder")}} prioritization.
+
+Within a group, bytes queued for sending on streams and datagrams with a higher `sendOrder` are sent before any bytes from lower-priority ones.
+Different groups are expected to be treated as equals for the purposes of bandwidth allocation — though the precise way bandwidth is divided between groups is implementation-defined.
+
+## Value
+
+A `WebTransportSendGroup` object, or `null` to specify the default send group.
+The default value is `null`.
+
+### Exceptions
+
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if set to a `WebTransportSendGroup` that is associated with a different `WebTransport` object than this stream.
+
+## Examples
+
+### Basic usage
+
+The example below creates a send group using the {{domxref("WebTransport.createSendGroup()")}} method, and then uses it with a `sendOrder` value, to prioritize the stream relative to other streams and datagrams that are part of the same group:
+
+```js
+const sendGroup = transport.createSendGroup();
+
+const stream = await transport.createUnidirectionalStream({
+  sendGroup,
+  sendOrder: 1,
+});
+
+console.log(stream.sendGroup === sendGroup); // true
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("WebTransportSendGroup")}}
+- {{domxref("WebTransportSendStream.sendOrder")}}
+- {{domxref("Streams API", "Streams API", "", "nocode")}}
+- [Using WebTransport](https://developer.chrome.com/docs/capabilities/web-apis/webtransport)


### PR DESCRIPTION
Docs updates to spec WebTransport following https://bugzilla.mozilla.org/show_bug.cgi?id=2007165 and https://bugzil.la/2007174

This essentially reviews the interfaces touched by those issues ^^^ and makes sure that they have docs, and that those docs match the spec.
- `WebTransportSendStream.sendGroup()` - new doc
- UPdates to
  - WebTransport.createWritable
  - WebTransportDatagramDuplexStream
  - WebTransportDatagramsWritable (and props/methods)
  - WebTransportSendGroup
  - WebTransportSebdStream

Ths is related the issues 
- #45214
- #45215