### PR TITLE
Fix typo in offscreenCanvas variable name

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -21,7 +21,7 @@ myCanvas.offscreenCanvas = document.createElement("canvas");
 myCanvas.offscreenCanvas.width = myCanvas.width;
 myCanvas.offscreenCanvas.height = myCanvas.height;
 
-myCanvas.getContext("2d").drawImage(myCanvas.offScreenCanvas, 0, 0);
+myCanvas.getContext("2d").drawImage(myCanvas.offscreenCanvas, 0, 0);
 ```
 
 ### Avoid floating-point coordinates and use integers instead


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- Fixed a casing mismatch typo in the offscreen canvas code snippet where offScreenCanvas used an uppercase 'S' instead of matching the original variable lowercase 's'. -->

### Motivation

<!-- The existing code snippet contained a variable name mismatch, which throws an error if users copy and paste it into their projects. This change fixes the code snippet so that it runs successfully and prevents confusion for readers trying to learn canvas optimization. -->

### Additional details

<!-- 🔗 [Link to release notes, browser docs, bug trackers, source control, or other resources.](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas#pre-render_similar_primitives_or_repeating_objects_on_an_offscreen_canvas) -->

### Related issues and pull requests

<!-- Fixes #45311 -->
<!--  -->
<!--  -->

<!--  -->
