### PR TITLE
Improve the CSS Grid Lanes description

### DIFF
--- a/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
+++ b/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
@@ -14,7 +14,9 @@ sidebar: cssref
 
 Level 3 of the [CSS grid layout](/en-US/docs/Web/CSS/Guides/Grid_layout) specification defines **grid lanes layout**, which is accessed via the {{cssxref("display")}} values `grid-lanes` and `inline-grid-lanes`. This guide explains how grid lanes layout works and how to use it.
 
-Grid lanes layout is a layout method where one axis uses a typical strict grid layout, most often columns, and the other uses a stacking algorithm. On the stacking axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to fill the gaps.
+Grid lanes layout is often referred to as _masonry layout_, because it resembles the way bricks are laid in a wall, filling gaps as efficiently as possible.
+
+Grid lanes layout is a layout method where one axis uses a strict grid layout and the other uses a stacking algorithm. Each item is placed into the lane with the most available space, producing a tightly packed layout without strict tracks on the stacking axis.
 
 ## Creating a grid lanes layout
 

--- a/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
+++ b/files/en-us/web/css/guides/grid_layout/grid_lanes/index.md
@@ -14,9 +14,9 @@ sidebar: cssref
 
 Level 3 of the [CSS grid layout](/en-US/docs/Web/CSS/Guides/Grid_layout) specification defines **grid lanes layout**, which is accessed via the {{cssxref("display")}} values `grid-lanes` and `inline-grid-lanes`. This guide explains how grid lanes layout works and how to use it.
 
-Grid lanes layout is often referred to as _masonry layout_, because it resembles the way bricks are laid in a wall, filling gaps as efficiently as possible.
-
 Grid lanes layout is a layout method where one axis uses a strict grid layout and the other uses a stacking algorithm. Each item is placed into the lane with the most available space, producing a tightly packed layout without strict tracks on the stacking axis.
+
+Grid lanes layout is often referred to as _masonry layout_, because it resembles the way bricks are laid in a wall, filling gaps as efficiently as possible.
 
 ## Creating a grid lanes layout
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Update the way that CSS Grid Lanes layout is described in the intro at https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Grid_layout/Grid_lanes

### Motivation

I see 4 problems with the existing description. In particular, with this paragraph:

> Grid lanes layout is a layout method where one axis uses a typical strict grid layout, most often columns, and the other uses a stacking algorithm. On the stacking axis, rather than sticking to a strict grid with gaps being left after shorter items, the items in the following row rise up to fill the gaps.

* The word "Masonry" is not mentioned once. 
 
  While that term does not appear in syntax, it is still, by far, the most common way which developers refer to this layout technique. In fact, even the spec says "Grid lanes layout, sometimes also called “masonry layout”". I think it's wrong to omit it completely. Preserving this term is extremely helpful for findability, and for developers to quickly understand what the guide is about.

* The word "row", in "the items in the following row", is very problematic.

  In a column direction grid lanes layout, there are no rows. The user agent does not construct rows. Developers can't style rows. Referring to a bunch of items as being part of a "row" is incorrect and sends the wrong idea to developers learning to use this new layout.

  For illustration, here are 2 grid lanes layouts. The one on the left has items that are sized similarly, with no big differences in height. Items 5 through 8 are therefore arranged in what almost looks like a row, with item 5 in column 1, item 6 in column 2, etc. However, the example on the right shows that this semblance of a "row" doesn't really exist. Items in this second layout are of very different heights, and items 5 through 8 do not get vertically aligned, and are also out of order. Item 5 in column3, item 6 in column 1, item 7 in column 2, item 8 in column 4.

  <img width="1042" height="470" alt="image" src="https://github.com/user-attachments/assets/e1fd1976-c87b-4d6c-9474-d9381bc7b403" />

* The phrase "rise up" in "the items in the following row rise up to fill the gaps" is also very problematic.

  In a column direction grid lanes layout, items don't rise up. Saying that they do makes it sound like the user agent first creates a strict grid with both columns and rows, and then rises up items within their columns to avoid gaps. Here is an animation illustrating this incorrect rising up of items:

  <img width="856" height="483" alt="grid-grid-lanes" src="https://github.com/user-attachments/assets/165a12d3-4986-4f46-af7a-7230bb573edf" />

  That's not how grid lanes work at all. Instead, the stacking algorithm looks at items one by one, and finds the shortest lane to put the next item in, possibly ending up a criss-cross pattern where items don't follow a logical reading order. Here is an animation showing the difference between the incorrect rise up and what grid lanes actually does. It shows that items don't end up in the same order because the final order depends on the length of each lane:

  <img width="856" height="483" alt="grid-grid-lanes-2" src="https://github.com/user-attachments/assets/6b350393-9d52-46a8-82d9-68bb982673c6" />

* The description assumes that most grid lanes layouts are in the column direction.

  While that may be true, I don't think we should say the "most often columns" part. Grid lanes layouts can be in a row or column orientation, just as easily.

### Related issues and pull requests

This is a follow-up to https://github.com/mdn/content/pull/45049.
