### PR TITLE
Update Firefox 155 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -72,13 +72,18 @@ Firefox 155 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Disabled the download panel to prevent the current document from losing focus when a download begins. ([Firefox bug 2035439](https://bugzil.la/2035439)).
+- Fixed the Actions API so that the `dblclick` event is fired when performing a double-click while holding down the `Ctrl` key on non-macOS platforms. ([Firefox bug 2058556](https://bugzil.la/2058556)).
 
-<!-- #### Marionette -->
+#### WebDriver BiDi
+
+- Updated the Mozilla-specific `moz:debugging` module to no longer rely on the same nested event loop API as DevTools, which prevents conflicts when WebDriver BiDi and DevTools are used in parallel. ([Firefox bug 2041335](https://bugzil.la/2041335)).
+- Fixed the `browsingContext.reload` command failing when used for frames. ([Firefox bug 2030909](https://bugzil.la/2030909)).
+- Removed support for the `contexts` argument in the `session.unsubscribe` command. From now on, clients can unsubscribe only by event name or subscription ID. ([Firefox bug 1988723](https://bugzil.la/1988723)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Changes for WebDriver conformance for the Firefox 155 release based on the [release note worthy bugs in this list](https://bugzilla.mozilla.org/buglist.cgi?include_fields=id,component,resolution,assigned_to,summary,bug_type,whiteboard,mentors&product=Remote%20Protocol&resolution=FIXED&f1=cf_status_firefox155&o1=equals&v1=fixed&f2=cf_status_firefox154&o2=notequals&v2=fixed&f3=status_whiteboard&o3=notsubstring&v3=%5Bwptsync%20downstream%5D&f4=status_whiteboard&o4=substring&v4=%5Bwebdriver%3Arelnote%5D&component=Agent&component=Marionette&component=WebDriver%20BiDi).

@juliandescottes and @lutien can you please review? Thanks.