### PR TITLE
Added note about unsupported drag-and-drop API on touch devices

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -11,6 +11,9 @@ spec-urls: https://html.spec.whatwg.org/multipage/dnd.html
 
 The user may select _draggable_ elements with a mouse, drag those elements to a _droppable_ element, and drop them by releasing the mouse button. A translucent representation of the _draggable_ elements follows the pointer during the drag operation.
 
+> [!NOTE]
+> The HTML Drag and Drop API was primarily designed to handle **mouse drag-and-drop**. If you must support some drag-and-drop use cases on touch devices, the [`touch-action` CSS property](/en-US/docs/Web/CSS/Reference/Properties/touch-action) and the [DragDropTouch JavaScript polyfill](https://github.com/drag-drop-touch-js/dragdroptouch)can help.
+
 You can customize which elements can become _draggable_, the type of feedback the _draggable_ elements produce, and the _droppable_ elements.
 
 This overview of HTML Drag and Drop includes a description of the interfaces, basic steps to add drag-and-drop support to an application, and an interoperability summary of the interfaces.


### PR DESCRIPTION
### Description

Added a note about unsupported drag-and-drop API on touch devices.

### Motivation

This information is rather unintuitive. It's important that developers are made aware of this early.

### Additional details

None.

### Related issues and pull requests

None.
