### PR TITLE
fix(css): consolidate nested grid example

### DIFF
--- a/files/en-us/web/css/guides/grid_layout/basic_concepts/index.md
+++ b/files/en-us/web/css/guides/grid_layout/basic_concepts/index.md
@@ -496,7 +496,6 @@ You can omit the end value if the area only spans one track.
 }
 
 .box1 {
-  grid-column: 1 / 4;
   grid-row: 1 / 3;
 }
 
@@ -577,17 +576,6 @@ A grid item can become a grid container. In the following example, we extend the
 
 If we set `box1` to `display: grid`, we can give it a track definition and it too will become a grid. The items then lay out on this new grid.
 
-```css
-.box1 {
-  grid-column-start: 1;
-  grid-column-end: 4;
-  grid-row-start: 1;
-  grid-row-end: 3;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-}
-```
-
 ```html
 <div class="wrapper">
   <div class="box box1">
@@ -625,7 +613,12 @@ If we set `box1` to `display: grid`, we can give it a track definition and it to
 }
 
 .box1 {
-  grid-column: 1 / 4;
+  grid-column-start: 1;
+  grid-column-end: 4;
+  grid-row-start: 1;
+  grid-row-end: 3;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
 }
 
 .nested {


### PR DESCRIPTION
## Summary

- Consolidate the "Nesting without subgrid" example into a single CSS block.
- Move the complete `.box1` definition into the remaining CSS block.
- Preserve the existing example behavior and HTML.

Fixes #45295