### PR TITLE
RTCRtpTransceiver.mid is null only when m-line is absent from descripion

### DIFF
--- a/files/en-us/web/api/rtcrtptransceiver/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/index.md
@@ -23,7 +23,7 @@ A transceiver is uniquely identified using its {{domxref("RTCRtpTransceiver.mid"
 - {{domxref("RTCRtpTransceiver.direction", "direction")}}
   - : A string which is used to set the transceiver's desired direction.
 - {{domxref("RTCRtpTransceiver.mid", "mid")}} {{ReadOnlyInline}}
-  - : The media ID of the m-line associated with this transceiver. This association is established, when possible, whenever either a local or remote description is applied. This field is `null` if neither a local or remote description has been applied, or if its associated m-line is rejected by either a remote offer or any answer.
+  - : The media ID of the m-line associated with this transceiver. This association is established, when possible, whenever either a local or remote description is applied. This field is `null` before a description containing the corresponding m-line is applied, or if a rollback undoes that association.
 - {{domxref("RTCRtpTransceiver.receiver", "receiver")}} {{ReadOnlyInline}}
   - : The {{domxref("RTCRtpReceiver")}} object that handles receiving and decoding incoming media.
 - {{domxref("RTCRtpTransceiver.sender", "sender")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/rtcrtptransceiver/mid/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/mid/index.md
@@ -8,16 +8,11 @@ browser-compat: api.RTCRtpTransceiver.mid
 
 {{APIRef("WebRTC")}}
 
-The read-only {{domxref("RTCRtpTransceiver")}} interface's
-**`mid`** property specifies the negotiated media ID
-(`mid`) which the local and remote peers have agreed upon to uniquely
-identify the stream's pairing of sender and receiver.
+The read-only {{domxref("RTCRtpTransceiver")}} interface's **`mid`** property specifies the media ID (`mid`) which uniquely identifies the stream's pairing of sender and receiver.
 
 ## Value
 
-A string which uniquely identifies the pairing of source and
-destination of the transceiver's stream. Its value is taken from the media ID of the SDP
-m-line. This value is `null` if negotiation has not completed.
+A string which uniquely identifies the pairing of source and destination of the transceiver's stream. Its value is taken from the media ID of the SDP m-line. This value is `null` before a local or remote description containing the corresponding m-line is applied, or if a rollback undoes that association.
 
 ## Specifications
 


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/27502