### PR TITLE
Use American English spelling for signalling, labelled, and colour

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/ui_pseudo-classes/index.md
@@ -261,7 +261,7 @@ Then we give the generated content the content "required", which is what we want
   <fieldset>
     <legend>Feedback form</legend>
 
-    <p>Required fields are labelled with "required".</p>
+    <p>Required fields are labeled with "required".</p>
     <div>
       <label for="fname">First name: </label>
       <input id="fname" name="fname" type="text" required />
@@ -428,7 +428,7 @@ You can try it below (press the **Play** button to run the example in MDN Playgr
   <fieldset>
     <legend>Feedback form</legend>
 
-    <p>Required fields are labelled with "required".</p>
+    <p>Required fields are labeled with "required".</p>
     <div>
       <label for="fname">First name: </label>
       <input id="fname" name="fname" type="text" required />
@@ -609,7 +609,7 @@ This is a similar story to what we had before in the `:required` example, except
   <fieldset>
     <legend>Feedback form</legend>
 
-    <p>Required fields are labelled with "required".</p>
+    <p>Required fields are labeled with "required".</p>
     <div>
       <label for="name">Name: </label>
       <input id="name" name="name" type="text" required />

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -43,7 +43,7 @@ When looking to contribute to the MDN project, you will find yourself in one of 
 
 - **If you are looking to contribute to the project**, you can find tasks under 'Issues' in any of the [MDN GitHub repositories](https://github.com/orgs/mdn/repositories) (for example, [`mdn/content` issues](https://github.com/mdn/content/issues)) and our [public GitHub project boards](https://github.com/orgs/mdn/projects).
   Make sure the issue isn't assigned to someone and no one has already opened a pull request for the task.
-  Issues labelled with `good first issue` are a good place to start.
+  Issues labeled with `good first issue` are a good place to start.
 
 - **If you have found a problem on MDN**, you should open an issue first.
   **Issues need a response from maintainers before you start working** so that you know a problem addressed by a pull request is valid and that your pull request will be accepted.

--- a/files/en-us/mozilla/firefox/releases/41/index.md
+++ b/files/en-us/mozilla/firefox/releases/41/index.md
@@ -41,7 +41,7 @@ Highlights:
 
 ### HTML
 
-- {{HTMLElement("a")}} without an `href` attribute is no longer classified as interactive content. Clicking it inside {{HTMLElement("label")}} will activate labelled content ([Firefox bug 1167816](https://bugzil.la/1167816)).
+- {{HTMLElement("a")}} without an `href` attribute is no longer classified as interactive content. Clicking it inside {{HTMLElement("label")}} will activate labeled content ([Firefox bug 1167816](https://bugzil.la/1167816)).
 - SVG icons are now supported for site icons, that is favicons and shortcut icons ([Firefox bug 366324](https://bugzil.la/366324)).
 - The [`crossorigin`](/en-US/docs/Web/HTML/Reference/Elements/link#crossorigin) attribute is now supported for [\<link rel='preconnect'>](/en-US/docs/Web/HTML/Reference/Elements/link) ([Firefox bug 1174152](https://bugzil.la/1174152)).
 - The picture element does not react to resize/viewport changes ([Firefox bug 1135812](https://bugzil.la/1135812)).

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -96,7 +96,7 @@ After the element's styles have been committed they can be modified and replaced
 This example demonstrates how you can use `commitStyles()` to save the computed styles at the end of the animation, both with and without using `fill`.
 It also provides an example of what happens if neither `commitStyles()` or `fill` are used, for comparison.
 
-The example first displays two buttons labelled "commitStyles() only" and "commitStyles() with fill".
+The example first displays two buttons labeled "commitStyles() only" and "commitStyles() with fill".
 Both buttons animate when you click them, and both buttons call `commitStyles()` to persist the final state of the animation.
 The difference is that "commitStyles() only" does not specify `fill: "forwards"` to persist the animation's final state.
 On browsers that don't match the current specification the final state may not be captured.

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -26,7 +26,7 @@ console.timeStamp(label, start, end, trackName, trackGroup, color, data);
 ### Parameters
 
 - `color` {{Optional_Inline}} {{Experimental_Inline}}
-  - : A string for the display colour of the entry. Must be one of `"primary"`, `"primary-light"`, `"primary-dark"`, `"secondary"`, `"secondary-light"`, `"secondary-dark"`, `"tertiary"`, `"tertiary-light"`, `"tertiary-dark"`, `"error"`.
+  - : A string for the display color of the entry. Must be one of `"primary"`, `"primary-light"`, `"primary-dark"`, `"secondary"`, `"secondary-light"`, `"secondary-dark"`, `"tertiary"`, `"tertiary-light"`, `"tertiary-dark"`, `"error"`.
 
 - `data` {{Optional_Inline}} {{Experimental_Inline}}
   - : An object with additional data to display. URLs may automatically be turned into links by some browsers.

--- a/files/en-us/web/api/gpupipelineerror/gpupipelineerror/index.md
+++ b/files/en-us/web/api/gpupipelineerror/gpupipelineerror/index.md
@@ -30,7 +30,7 @@ new GPUPipelineError(message, options)
 
 ## Examples
 
-A developer would not manually use the constructor to create a `GPUPipelineError` object. The user agent uses this constructor to create an appropriate object when a {{jsxref("Promise")}} returned by a {{domxref("GPUDevice.createComputePipelineAsync()")}} or {{domxref("GPUDevice.createRenderPipelineAsync()")}} call rejects, signalling a pipeline failure.
+A developer would not manually use the constructor to create a `GPUPipelineError` object. The user agent uses this constructor to create an appropriate object when a {{jsxref("Promise")}} returned by a {{domxref("GPUDevice.createComputePipelineAsync()")}} or {{domxref("GPUDevice.createRenderPipelineAsync()")}} call rejects, signaling a pipeline failure.
 
 See the main [`GPUPipelineError`](/en-US/docs/Web/API/GPUPipelineError#examples) page for an example involving a `GPUPipelineError` object instance.
 

--- a/files/en-us/web/api/readablestreamdefaultreader/cancel/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/cancel/index.md
@@ -54,7 +54,7 @@ stream has finished being read, at which point we return out of the recursive fu
 and print the entire stream to another part of the UI.
 
 When the stream is done (`if (done)`), we run `reader.cancel()`
-to cancel the stream, signalling that we don't need to use it any more.
+to cancel the stream, signaling that we don't need to use it any more.
 
 ```js
 function fetchStream() {

--- a/files/en-us/web/api/web_audio_api/best_practices/index.md
+++ b/files/en-us/web/api/web_audio_api/best_practices/index.md
@@ -76,7 +76,7 @@ If your website or application contains sound, you should allow the user control
 
 Some controls you may find useful are: {{HTMLElement("button")}} elements for play/pause, {{HTMLElement("select")}} elements for selecting options like playback speed, [`<input type="checkbox">`](/en-US/docs/Web/HTML/Reference/Elements/input/checkbox) elements for toggling mute, and [`<input type="range">`](/en-US/docs/Web/HTML/Reference/Elements/input/range) elements for volume control and inputting other number values.
 
-All the common considerations about form accessibility apply. When using {{HTMLElement("button")}} elements, you should ensure that they have a clear [label](/en-US/docs/Web/HTML/Reference/Elements/label). This will help screen readers and other assistive technologies to understand the purpose of the button. If you have buttons that switch audio on and off, using the ARIA [`role="switch"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/switch_role) attribute on them is a good option for signalling to assistive technology what the button's exact purpose is, and therefore making the app more accessible.
+All the common considerations about form accessibility apply. When using {{HTMLElement("button")}} elements, you should ensure that they have a clear [label](/en-US/docs/Web/HTML/Reference/Elements/label). This will help screen readers and other assistive technologies to understand the purpose of the button. If you have buttons that switch audio on and off, using the ARIA [`role="switch"`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/switch_role) attribute on them is a good option for signaling to assistive technology what the button's exact purpose is, and therefore making the app more accessible.
 
 ## Setting AudioParam values
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
@@ -28,7 +28,7 @@ In this article we'll set up the server for our phone app. The server file will 
    });
    ```
 
-   We use the `ExpressPeerServer` object to create the peer server, passing it some options in the process. The peer server will handle the signalling required for WebRTC for us, so we don't have to worry about STUN/TURN servers or other protocols.
+   We use the `ExpressPeerServer` object to create the peer server, passing it some options in the process. The peer server will handle the signaling required for WebRTC for us, so we don't have to worry about STUN/TURN servers or other protocols.
 
 4. Finally, you'll need to tell your app to use the `peerServer` by calling `app.use(peerServer)`. Your finished `server.js` should include the other necessary dependencies you'd include in a server file, as well as serving the `index.html` file to the root path.
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
@@ -8,7 +8,7 @@ page-type: guide
 
 {{NextMenu("Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup")}}
 
-One of WebRTC's main issues is that it is pretty complicated to use and develop with — handling the signalling service and knowing when to call the right endpoint can get confusing. But there is some good news; [PeerJS](https://peerjs.com/) is a WebRTC framework that abstracts away all of the ice and signalling logic so that you can focus on the functionality of your application. There are two parts to PeerJS, the client-side framework and the server.
+One of WebRTC's main issues is that it is pretty complicated to use and develop with — handling the signaling service and knowing when to call the right endpoint can get confusing. But there is some good news; [PeerJS](https://peerjs.com/) is a WebRTC framework that abstracts away all of the ice and signaling logic so that you can focus on the functionality of your application. There are two parts to PeerJS, the client-side framework and the server.
 
 In this series of articles we will create a simple phone application using PeerJS. We'll be using both the server and the client-side framework, but most of our work will be involved with handling the client-side code.
 

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -168,7 +168,7 @@ The page structure defined here is using {{HTMLElement("div")}} elements, giving
 
 The `<video>` element with the `id` `received_video` will present video received from the connected user. We specify the `autoplay` attribute, ensuring once the video starts arriving, it immediately plays. This removes any need to explicitly handle playback in our code. The `local_video` `<video>` element presents a preview of the user's camera; specifying the `muted` attribute, as we don't need to hear local audio in this preview panel.
 
-Finally, the `hangup-button` {{HTMLElement("button")}}, to disconnect from a call, is defined and configured to start disabled (setting this as our default for when no call is connected) and apply the function `hangUpCall()` on click. This function's role is to close the call, and send a signalling server notification to the other peer, requesting it also close.
+Finally, the `hangup-button` {{HTMLElement("button")}}, to disconnect from a call, is defined and configured to start disabled (setting this as our default for when no call is connected) and apply the function `hangUpCall()` on click. This function's role is to close the call, and send a signaling server notification to the other peer, requesting it also close.
 
 ### The JavaScript code
 

--- a/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
+++ b/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
@@ -169,12 +169,12 @@ Let's go through this line by line and decipher what it means.
 2. If the offer is created successfully, we pass the blob along to the local connection's {{domxref("RTCPeerConnection.setLocalDescription()")}} method. This configures the local end of the connection.
 3. The next step is to connect the local peer to the remote by telling the remote peer about it. This is done by calling {{domxref("RTCPeerConnection.setRemoteDescription()", "remoteConnection.setRemoteDescription()")}}. Now the `remoteConnection` knows about the connection that's being built. In a real application, this would require a signaling server to exchange the description object.
 4. That means it's time for the remote peer to reply. It does so by calling its {{domxref("RTCPeerConnection.createAnswer", "createAnswer()")}} method. This generates a blob of SDP which describes the connection the remote peer is willing and able to establish. This configuration lies somewhere in the union of options that both peers can support.
-5. Once the answer has been created, it's passed into the remoteConnection by calling {{domxref("RTCPeerConnection.setLocalDescription()")}}. That establishes the remote's end of the connection (which, to the remote peer, is its local end. This stuff can be confusing, but you get used to it). Again, this would normally be exchanged through a signalling server.
+5. Once the answer has been created, it's passed into the remoteConnection by calling {{domxref("RTCPeerConnection.setLocalDescription()")}}. That establishes the remote's end of the connection (which, to the remote peer, is its local end. This stuff can be confusing, but you get used to it). Again, this would normally be exchanged through a signaling server.
 6. Finally, the local connection's remote description is set to refer to the remote peer by calling localConnection's {{domxref("RTCPeerConnection.setRemoteDescription()")}}.
 7. The `catch()` calls a routine that handles any errors that occur.
 
 > [!NOTE]
-> Once again, this process is not a real-world implementation; in normal usage, there's two chunks of code running on two machines, interacting and negotiating the connection. A side channel, commonly called a "signalling server," is usually used to exchange the description (which is in **application/sdp** form) between the two peers.
+> Once again, this process is not a real-world implementation; in normal usage, there's two chunks of code running on two machines, interacting and negotiating the connection. A side channel, commonly called a "signaling server," is usually used to exchange the description (which is in **application/sdp** form) between the two peers.
 
 #### Handling successful peer connection
 

--- a/files/en-us/web/api/webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/index.md
@@ -19,7 +19,7 @@ WebVR provides support for exposing virtual reality devices — for example, hea
 
 Any VR devices attached to your computer will be returned by the {{DOMxRef("Navigator.getVRDisplays()")}} method; each one will be represented by a {{DOMxRef("VRDisplay")}} object.
 
-![Sketch of a person in a chair with wearing goggles labelled "Head mounted display (HMD)" facing a monitor with a webcam labelled "Position sensor"](hw-setup.png)
+![Sketch of a person in a chair with wearing goggles labeled "Head mounted display (HMD)" facing a monitor with a webcam labeled "Position sensor"](hw-setup.png)
 
 {{DOMxRef("VRDisplay")}} is the central interface in the WebVR API — via its properties and methods you can access functionality to:
 

--- a/files/en-us/web/css/guides/backgrounds_and_borders/box-shadow_generator/index.md
+++ b/files/en-us/web/css/guides/backgrounds_and_borders/box-shadow_generator/index.md
@@ -23,7 +23,7 @@ To add a box shadow, click the "+" button at the top-left. This adds a shadow, a
 - Set the shadow to be inset using the "inset" checkbox.
 - Use the sliders to set the element's position, blur, and spread.
 
-To add another shadow, click "+" again. Now any values you set will apply to this new shadow. Change the order in which these two shadows are applied using the ↑ and ↓ buttons at the top-left. Select the first shadow again by clicking it in column on the left. To update the element's own styles, select it by clicking the button labelled "element" along the top.
+To add another shadow, click "+" again. Now any values you set will apply to this new shadow. Change the order in which these two shadows are applied using the ↑ and ↓ buttons at the top-left. Select the first shadow again by clicking it in column on the left. To update the element's own styles, select it by clicking the button labeled "element" along the top.
 
 You can add {{cssxref("::before")}} and {{cssxref("::after")}} pseudo-elements to the element, and give them box shadows as well. To switch between the element and its pseudo-elements, use the buttons along the top labeled "element", "::before", and "::after".
 

--- a/files/en-us/web/css/guides/transforms/index.md
+++ b/files/en-us/web/css/guides/transforms/index.md
@@ -13,7 +13,7 @@ The **CSS transforms** module defines how elements styled with CSS can be transf
 
 ## CSS transforms in action
 
-Use the sliders in the example below to modify the translation, rotation, scale, and skew CSS transform properties of the cube in 3D space. As you move the cube through 3D space, notice the way it interacts with the element labelled `z:0px`, which is located at the 3D position `(0, 0, 0)`.
+Use the sliders in the example below to modify the translation, rotation, scale, and skew CSS transform properties of the cube in 3D space. As you move the cube through 3D space, notice the way it interacts with the element labeled `z:0px`, which is located at the 3D position `(0, 0, 0)`.
 
 ```html hidden live-sample___transforms
 <article>

--- a/files/en-us/web/css/reference/selectors/_colon_valid/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_valid/index.md
@@ -71,7 +71,7 @@ In this example, we include extra `<span>` elements to generate content that ind
 <form>
   <fieldset>
     <legend>Feedback form</legend>
-    <p>Required fields are labelled with "required".</p>
+    <p>Required fields are labeled with "required".</p>
     <div>
       <label for="fname">First name: </label>
       <input id="fname" name="fname" type="text" required />

--- a/files/en-us/web/css/reference/selectors/_doublecolon_search-text/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_search-text/index.md
@@ -40,7 +40,7 @@ p::search-text {
 
 ## Description
 
-Most browsers include some kind of in-page text search functionality, usually labelled "Find" or "Find in page". The `::search-text` pseudo-element, one of the [highlight pseudo-elements](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements#highlight_pseudo-elements), allows you to apply a [limited set of styles](#allowable_properties) to the text results highlighted by the browser search functionality.
+Most browsers include some kind of in-page text search functionality, usually labeled "Find" or "Find in page". The `::search-text` pseudo-element, one of the [highlight pseudo-elements](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements#highlight_pseudo-elements), allows you to apply a [limited set of styles](#allowable_properties) to the text results highlighted by the browser search functionality.
 
 Not all browsers and browser versions highlight search results using in-page highlights that are stylable with CSS. In such cases, `::search-text` may be unimplemented or just ignored.
 

--- a/files/en-us/web/http/reference/headers/expect-ct/index.md
+++ b/files/en-us/web/http/reference/headers/expect-ct/index.md
@@ -60,12 +60,12 @@ Expect-CT: report-uri="<uri>",
 - `report-uri="<uri>"` {{optional_inline}}
   - : The URI where the user agent should report `Expect-CT` failures.
 
-    When present with the `enforce` directive, the configuration is referred to as an "enforce-and-report" configuration, signalling to the user agent both that compliance to the Certificate Transparency policy should be enforced _and_ that violations should be reported.
+    When present with the `enforce` directive, the configuration is referred to as an "enforce-and-report" configuration, signaling to the user agent both that compliance to the Certificate Transparency policy should be enforced _and_ that violations should be reported.
 
 - `enforce` {{optional_inline}}
   - : Signals to the user agent that compliance with the Certificate Transparency policy should be enforced (rather than only reporting compliance) and that the user agent should refuse future connections that violate its Certificate Transparency policy.
 
-    When both the `enforce` directive and the `report-uri` directive are present, the configuration is referred to as an "enforce-and-report" configuration, signalling to the user agent both that compliance to the Certificate Transparency policy should be enforced and that violations should be reported.
+    When both the `enforce` directive and the `report-uri` directive are present, the configuration is referred to as an "enforce-and-report" configuration, signaling to the user agent both that compliance to the Certificate Transparency policy should be enforced and that violations should be reported.
 
 ## Example
 


### PR DESCRIPTION
### Description

Replaces three more British spellings with their American equivalents across 18 files: `signalling` → `signaling` (11), `labelled` → `labeled` (10), and one `colour` → `color` on `console.timeStamp()`.

### Motivation

The writing style guide requires American English spelling: "Use American-English spelling. […] Do not use variant spelling." `npm run lint:typos` cannot catch these, because all three are valid dictionary words.

`signalling` is also inconsistent with the surrounding docs: the WebRTC guide it appears in is itself titled "Signaling and video calling" and lives at `/Web/API/WebRTC_API/Signaling_and_video_calling`, and the WebRTC specification uses "signaling" throughout.

Occurrences that must keep the British spelling are deliberately untouched:

- `aria-labelledby` and the prose describing it, including the note on the `listbox` role page that "labelled", with two L's, is the correct spelling based on the accessibility API conventions.
- The verbatim Firefox error strings on `SyntaxError: functions cannot be labelled` and the `label` statement page.
- The `menu-labelled-open` and `favourite-colour` example repository names, and the `colour` keys in the WebExtensions storage examples that mirror them.
- The style guide's own "Incorrect:" examples.
