### PR TITLE
Fix typos in prose

### DIFF
--- a/files/en-us/learn_web_development/howto/tools_and_setup/upload_files_to_a_web_server/index.md
+++ b/files/en-us/learn_web_development/howto/tools_and_setup/upload_files_to_a_web_server/index.md
@@ -134,7 +134,7 @@ It is seen as a more advanced tool than SFTP, because by default it is used on t
 rsync [-options] SOURCE user@x.x.x.x:DESTINATION
 ```
 
-- `-options` is a dash followed by a one or more letters, for example `-v` for verbose error messages, and `-b` to make backups. You can see the full list at the [rsync man page](https://linux.die.net/man/1/rsync) (search for "Options summary").
+- `-options` is a dash followed by one or more letters, for example `-v` for verbose error messages, and `-b` to make backups. You can see the full list at the [rsync man page](https://linux.die.net/man/1/rsync) (search for "Options summary").
 - `SOURCE` is the path to the local file or directory that you want to copy files over from.
 - `user@` is the credentials of the user on the remote server you want to copy files over to.
 - `x.x.x.x` is the IP address of the remote server.

--- a/files/en-us/mozilla/firefox/releases/150/index.md
+++ b/files/en-us/mozilla/firefox/releases/150/index.md
@@ -56,7 +56,7 @@ No notable changes.
   This allows the method to return the node containing the caret from within a shadow DOM, provided its associated {{domxref("ShadowRoot")}} was passed as an option.
   ([Firefox bug 1914596](https://bugzil.la/1914596)).
 
-- The {{domxref("HighlightRegistry.highlightsFromPoint()")}} method is now supported, providing an mechanism for web pages to get information about all the [CSS custom highlights](/en-US/docs/Web/API/CSS_Custom_Highlight_API) applied at a particular point.
+- The {{domxref("HighlightRegistry.highlightsFromPoint()")}} method is now supported, providing a mechanism for web pages to get information about all the [CSS custom highlights](/en-US/docs/Web/API/CSS_Custom_Highlight_API) applied at a particular point.
   This includes highlights that are inside shadow roots, provided the associated {{domxref("ShadowRoot")}} instance was passed to the method.
   ([Firefox bug 1917991](https://bugzil.la/1917991)).
 

--- a/files/en-us/web/accessibility/aria/reference/roles/listitem_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/listitem_role/index.md
@@ -29,9 +29,9 @@ There are no hard and fast rules about which elements you should use to mark up 
 ### Associated WAI-ARIA Roles, States, and Properties
 
 - [`list`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/list_role)
-  - : A list of items. Elements with role `list` must have one or more elements with the role `listitem` as children, a one or more elements with the role of `group` that have one or more elements with the `listitem` role as children.
+  - : A list of items. Elements with role `list` must have one or more elements with the role `listitem` as children, or one or more elements with the role of `group` that have one or more elements with the `listitem` role as children.
 - [`group`](/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role)
-  - : A collection of related objects, limited to list items when nested in a list, not important enough to have their own place in a pages table of contents.
+  - : A collection of related objects, limited to list items when nested in a list, not important enough to have their own place in a page's table of contents.
 
 ## Best practices
 

--- a/files/en-us/web/api/vttcue/vttcue/index.md
+++ b/files/en-us/web/api/vttcue/vttcue/index.md
@@ -23,7 +23,7 @@ new VTTCue(startTime, endTime, text)
   - : This is a `double` representing the initial text track cue start time.
     This is the time, given in seconds and fractions of a second, denoting the beginning
     of the range of the media data to which this cue applies. For example, if a cue is to
-    be visible from 50 seconds to a one minute, five and a half seconds in the media's
+    be visible from 50 seconds to one minute, five and a half seconds in the media's
     playback, `startTime` will be 50.0.
 - `endTime`
   - : This is a `double` representing the ending time for this text track cue.

--- a/files/en-us/web/css/guides/scroll-driven_animations/timeline_range_names/index.md
+++ b/files/en-us/web/css/guides/scroll-driven_animations/timeline_range_names/index.md
@@ -9,7 +9,7 @@ By default, [view progress timelines](/en-US/docs/Web/CSS/Guides/Scroll-driven_a
 
 This guide explains how to modify timeline range names, specifically examining the various timeline range names, their meanings, and how they are used.
 
-Limiting the animation timeline to a specific portion of an named animation timeline range is discussed in the [insetting scroll animations guide](/en-US/docs/Web/CSS/Guides/Scroll-driven_animations/Timeline_insets).
+Limiting the animation timeline to a specific portion of a named animation timeline range is discussed in the [insetting scroll animations guide](/en-US/docs/Web/CSS/Guides/Scroll-driven_animations/Timeline_insets).
 
 ## View progress timeline primer
 

--- a/files/en-us/web/css/reference/properties/flex-line-count/index.md
+++ b/files/en-us/web/css/reference/properties/flex-line-count/index.md
@@ -324,7 +324,7 @@ We include an {{htmlelement("ol")}} element containing ten {{htmlelement("li")}}
 
 #### CSS
 
-We set the list's {{cssxref("display")}} to `flex`. We set a {{cssxref("flex-direction")}} value of `column`and a {{cssxref("flex-wrap")}} value of `balance` using the {{cssxref("flex-flow")}} shorthand so that the flex lines are arranged in columns and will balance when wrapped. The {{cssxref("gap")}} value `10px 40px` specifies a gap of `10px` between flex items within each column and `40px` between flex lines.
+We set the list's {{cssxref("display")}} to `flex`. We set a {{cssxref("flex-direction")}} value of `column` and a {{cssxref("flex-wrap")}} value of `balance` using the {{cssxref("flex-flow")}} shorthand so that the flex lines are arranged in columns and will balance when wrapped. The {{cssxref("gap")}} value `10px 40px` specifies a gap of `10px` between flex items within each column and `40px` between flex lines.
 
 Finally, we set a `flex-line-count` value of `2`, meaning that, even though no fixed height is set on the list, its content will always be wrapped over two balanced columns, regardless of how much content is included.
 


### PR DESCRIPTION
### Description

Seven small prose typos across six files:

- `HighlightRegistry.highlightsFromPoint()` in the Firefox 150 release notes: "providing **an** mechanism" → "a mechanism".
- Scroll-driven animations timeline range names: "a specific portion of **an** named animation timeline range" → "a named".
- `listitem` role: "must have one or more elements with the role `listitem` as children, **a** one or more elements with the role of `group`" → "**or** one or more elements".
- `listitem` role: "their own place in **a pages** table of contents" → "a page's".
- `VTTCue()`: "visible from 50 seconds to **a one minute**, five and a half seconds" → "to one minute".
- Uploading files to a web server: "a dash followed by **a one or more letters**" → "followed by one or more letters".
- `flex-line-count`: a missing space in "a `flex-direction` value of `` `column`and ``", which renders as "of columnand a".

### Motivation

These are straightforward mistakes rather than style preferences, and none are catchable by the existing lint rules.

The `listitem` fix restores the meaning given in the ARIA specification, which defines the containment as "one or more elements with role listitem as children, **or** one or more elements with role group that have one or more elements with role listitem as children" — a list holds list items, or groups that hold list items. As written, the sentence has no verb connecting the two alternatives.
