### PR TITLE
Restore fonts-stix in the Debian install command for MathML fonts

### DIFF
--- a/files/en-us/web/mathml/guides/fonts/index.md
+++ b/files/en-us/web/mathml/guides/fonts/index.md
@@ -50,18 +50,15 @@ Install the _STIX Two Math_ font as follows:
 ### Linux
 
 Below, you can find commands to execute on popular Linux distributions
-in order to install math fonts from your package manager. Alternative
-approaches are also provided if your Linux distribution does not provide
-dedicated packages for these fonts.
+in order to install the _Latin Modern Math_ and _STIX Two Math_ fonts from your
+package manager. Alternative approaches are also provided if your Linux
+distribution does not provide dedicated packages for these fonts.
 
 #### Debian-based distributions (including Ubuntu and Mint)
 
 ```bash
-sudo apt-get install fonts-lmodern
+sudo apt-get install fonts-lmodern fonts-stix
 ```
-
-> [!NOTE]
-> The Debian `fonts-stix` package installs STIX 1.x fonts, not _STIX Two Math_.
 
 #### Fedora-based distributions
 

--- a/files/en-us/web/mathml/guides/fonts/index.md
+++ b/files/en-us/web/mathml/guides/fonts/index.md
@@ -60,6 +60,9 @@ distribution does not provide dedicated packages for these fonts.
 sudo apt-get install fonts-lmodern fonts-stix
 ```
 
+> [!NOTE]
+> Up until Debian 13 and Ubuntu 24, the `fonts-stix` package installs STIX 1.x fonts, not _STIX Two Math_.
+
 #### Fedora-based distributions
 
 ```bash


### PR DESCRIPTION
### Description

I restored `fonts-stix` to the Debian install command and removed the note saying that package ships STIX 1.x. This reverts the change made in #44385.

### Motivation

The current maintainer of Debian's `fonts-stix` package reported in #45274 that they took the package over and upgraded it to STIX Two, so the original command works again.

I checked the archive before making the change:

| Release | `fonts-stix` version | Math font it installs |
| --- | --- | --- |
| Debian testing (forky) and unstable (sid) | 2.13b171+ds-2 | `STIXTwoMath-Regular.otf` |
| Debian 13 (stable) | 1.1.1-5 | `STIXMath-Regular.otf` |
| Ubuntu 26.04 and later | 2.13b171+ds-2 | `STIXTwoMath-Regular.otf` |
| Ubuntu 24.04 | 1.1.1-5 | `STIXMath-Regular.otf` |

Version 2.13b171 is the same release that the Windows and macOS instructions on this page already link to, so readers on those releases now get the exact font the page asks them to install.

### Additional details

There is a tradeoff here that I want to flag for reviewers rather than bury. On Debian 13 and Ubuntu 24.04 the command still pulls STIX 1.x, and this PR removes the note that warned about that. Those releases are what most readers are running today, and warning about them is why #44385 was filed in the first place.

I went with the straight revert because the issue asks for it and @Josh-Cena said in the issue that reverting was fine. If you would rather keep a warning for the older releases, I can scope the advice by release instead: leave `fonts-lmodern` on its own, then add a second `fonts-stix` command noted as applying to Debian testing and unstable and to Ubuntu 26.04 and later. I have that version ready and can swap it in, so let me know which you prefer.

Sources I used:

- [Debian madison for `fonts-stix`](https://api.ftp-master.debian.org/madison?package=fonts-stix)
- [`fonts-stix` file list in sid](https://packages.debian.org/sid/all/fonts-stix/filelist)
- [`fonts-stix` file list in trixie](https://packages.debian.org/trixie/all/fonts-stix/filelist)

### Related issues and pull requests

Fixes #45274
Relates to #44385
Relates to #38089
