### PR TITLE
Add input links to selection property pages

### DIFF
--- a/files/en-us/web/api/htmlinputelement/selectionend/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionend/index.md
@@ -71,6 +71,8 @@ console.log(colorEnd.selectionEnd); // Output : null
 
 ## See also
 
+- {{HTMLElement("input")}}
+- {{domxref("HTMLInputElement")}}
 - {{domxref("HTMLTextAreaElement.selectionEnd")}} property
 - {{domxref("HTMLInputElement.selectionStart")}} property
 - {{domxref("HTMLInputElement.setSelectionRange")}} method

--- a/files/en-us/web/api/htmlinputelement/selectionstart/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionstart/index.md
@@ -72,6 +72,8 @@ console.log(colorStart.selectionStart); // Output : null
 
 ## See also
 
+- {{HTMLElement("input")}}
+- {{domxref("HTMLInputElement")}}
 - {{domxref("HTMLTextAreaElement.selectionStart")}} property
 - {{domxref("HTMLInputElement.selectionEnd")}} property
 - {{domxref("HTMLInputElement.setSelectionRange")}} method

--- a/files/en-us/web/api/htmltextareaelement/selectionend/index.md
+++ b/files/en-us/web/api/htmltextareaelement/selectionend/index.md
@@ -44,7 +44,7 @@ const end = textarea.selectionEnd;
 - {{domxref("HTMLTextAreaElement.selectionStart")}}
 - {{domxref("HTMLTextAreaElement.selectionDirection")}}
 - {{domxref("HTMLTextAreaElement.textLength")}}
-- {{domxref("HTMLTextAreaElement.selectionChange_event", "selectionChange")}} event
+- {{domxref("HTMLTextAreaElement.selectionchange_event", "selectionchange")}} event
 - {{domxref("HTMLTextAreaElement.select()")}}
 - {{domxref("HTMLTextAreaElement.setSelectionRange()")}}
 - {{domxref("HTMLTextAreaElement.setRangeText()")}}


### PR DESCRIPTION
### Description

Adds links to the input element and HTMLInputElement interface in the See also sections for the selectionStart and selectionEnd property pages.

### Motivation

This makes the property pages consistent with their HTMLTextAreaElement counterparts and gives readers direct links back to the related element and interface.

### Additional details

- Markdownlint: passed
- Prettier check: passed

### Related issues and pull requests

Fixes #45314