### PR TITLE
Clarify image format selection guidance

### DIFF
--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -37,7 +37,7 @@ There are many other attributes to achieve various purposes:
 
 ## Choosing an image format
 
-The HTML standard doesn't list what image formats to support, so {{glossary("user agent","user agents")}} may support different formats.
+The HTML standard doesn't list what image formats to support, so {{glossary("user agent","user agents")}} may allow different formats.
 
 Choose an image format based on factors such as compression, quality, browser support, and whether you need features such as transparency or animation.
 The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) explains the trade-offs in detail.

--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -35,20 +35,7 @@ There are many other attributes to achieve various purposes:
 - Use both [`width`](#width) and [`height`](#height) to set the intrinsic size of the image, allowing it to take up space before it loads, to mitigate content layout shifts.
 - Responsive image hints with [`sizes`](#sizes) and [`srcset`](#srcset) (see also the {{htmlelement("picture")}} element and our [Responsive images](/en-US/docs/Web/HTML/Guides/Responsive_images) tutorial).
 
-## Choosing an image format
-
-The HTML standard doesn't list what image formats to support, so {{glossary("user agent","user agents")}} may allow different formats.
-
-Choose an image format based on factors such as compression, quality, browser support, and whether you need features such as transparency or animation.
-The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) explains the trade-offs in detail.
-
-For raster images, prefer [WebP](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) or [AVIF](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image), which generally provide better compression than PNG, JPEG, and GIF.
-
-You should also consider [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) for large, high-resolution raster images, as it allows progressive rendering on most browsers, which can display an initial version before the full image downloads.
-
-If you need to support browsers without WebP, AVIF, or JPEG XL support, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
-
-For images that must be drawn accurately at different sizes, use [SVG](/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics).
+The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) provides information about the supported image formats and broad recommendations about where they should be used.
 
 ## Image loading errors
 
@@ -72,7 +59,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
     >
     > - Non-visual browsers (such as those used by people with visual impairments)
     > - The user chooses not to display images (saving bandwidth, privacy reasons)
-    > - The image is invalid or an [unsupported type](#choosing_an_image_format)
+    > - The image is invalid or an [unsupported type](/en-US/docs/Web/Media/Guides/Formats/Image_types)
     >
     > In these cases, the browser may replace the image with the text in the element's `alt` attribute. For these reasons and others, provide a useful value for `alt` whenever possible.
 

--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -24,29 +24,6 @@ The **`<img>`** [HTML](/en-US/docs/Web/HTML) element embeds an image into the do
 }
 ```
 
-The above example shows usage of the `<img>` element:
-
-- The `src` attribute holds the path to the image you want to embed. It is not mandatory if the [srcset](/en-US/docs/Web/API/HTMLImageElement/srcset) attribute is available. However, at least one of the `src` or `srcset` attributes must be provided.
-- The `alt` attribute holds a textual replacement for the image, which is mandatory and **incredibly useful** for accessibility — screen readers read the attribute value out to their users so they know what the image means. Alt text is also displayed on the page if the image can't be loaded for some reason: for example, network errors, content blocking, or link rot.
-
-There are many other attributes to achieve various purposes:
-
-- [Referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy)/{{glossary("CORS")}} control for security and privacy: see [`crossorigin`](#crossorigin) and [`referrerpolicy`](#referrerpolicy).
-- Use both [`width`](#width) and [`height`](#height) to set the intrinsic size of the image, allowing it to take up space before it loads, to mitigate content layout shifts.
-- Responsive image hints with [`sizes`](#sizes) and [`srcset`](#srcset) (see also the {{htmlelement("picture")}} element and our [Responsive images](/en-US/docs/Web/HTML/Guides/Responsive_images) tutorial).
-
-The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) provides information about the supported image formats and broad recommendations about where they should be used.
-
-## Image loading errors
-
-If an error occurs while loading or rendering an image, and an `onerror` event handler has been set for the {{domxref("HTMLElement/error_event", "error")}} event, that event handler will get called. This can happen in several situations, including:
-
-- The `src` or `srcset` attributes are empty (`""`) or `null`.
-- The `src` {{glossary("URL")}} is the same as the URL of the page the user is currently on.
-- The image is corrupted in some way that prevents it from being loaded.
-- The image's metadata is corrupted in such a way that it's impossible to retrieve its dimensions, and no dimensions were specified in the `<img>` element's attributes.
-- The image is in a format not supported by the {{Glossary("user agent")}}.
-
 ## Attributes
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -289,7 +266,32 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 - `vspace` {{deprecated_inline}}
   - : The number of pixels of white space above and below the image. Use the {{cssxref('margin')}} CSS property instead.
 
-## Styling with CSS
+## Usage notes
+
+You need at least two attributes for each `<img>` elements. Most commonly, they are `src` and `alt`.
+
+- The `src` attribute holds the path to the image you want to embed. It is not mandatory if the [srcset](/en-US/docs/Web/API/HTMLImageElement/srcset) attribute is available. However, at least one of the `src` or `srcset` attributes must be provided.
+- The `alt` attribute holds a textual replacement for the image, which is mandatory and **incredibly useful** for accessibility — screen readers read the attribute value out to their users so they know what the image means. Alt text is also displayed on the page if the image can't be loaded for some reason: for example, network errors, content blocking, or link rot.
+
+There are many other attributes to achieve various purposes:
+
+- [Referrer](/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy)/{{glossary("CORS")}} control for security and privacy: see [`crossorigin`](#crossorigin) and [`referrerpolicy`](#referrerpolicy).
+- Use both [`width`](#width) and [`height`](#height) to set the intrinsic size of the image, allowing it to take up space before it loads, to mitigate content layout shifts.
+- Responsive image hints with [`sizes`](#sizes) and [`srcset`](#srcset) (see also the {{htmlelement("picture")}} element and our [Responsive images](/en-US/docs/Web/HTML/Guides/Responsive_images) tutorial).
+
+The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) provides information about the supported image formats and broad recommendations about where they should be used.
+
+### Image loading errors
+
+If an error occurs while loading or rendering an image, and an `onerror` event handler has been set for the {{domxref("HTMLElement/error_event", "error")}} event, that event handler will get called. This can happen in several situations, including:
+
+- The `src` or `srcset` attributes are empty (`""`) or `null`.
+- The `src` {{glossary("URL")}} is the same as the URL of the page the user is currently on.
+- The image is corrupted in some way that prevents it from being loaded.
+- The image's metadata is corrupted in such a way that it's impossible to retrieve its dimensions, and no dimensions were specified in the `<img>` element's attributes.
+- The image is in a format not supported by the {{Glossary("user agent")}}.
+
+### Styling with CSS
 
 `<img>` is a {{ glossary("replaced elements", "replaced element")}}; it has a {{cssxref("display")}} value of `inline` by default, but its default dimensions are defined by the embedded image's intrinsic values, like it were `inline-block`. You can set properties like {{cssxref("border")}}/{{cssxref("border-radius")}}, {{cssxref("padding")}}/{{cssxref("margin")}}, {{cssxref("width")}}, {{cssxref("height")}}, etc. on an image.
 

--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -43,13 +43,12 @@ Choose an image format based on factors such as compression, quality, browser su
 The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) explains the trade-offs in detail.
 
 For raster images, prefer [WebP](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) or [AVIF](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image), which generally provide better compression than PNG, JPEG, and GIF.
-If you need to support browsers without WebP or AVIF support, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
+
+You should also consider [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) for large, high-resolution raster images, as it allows progressive rendering on most browsers, which can display an initial version before the full image downloads.
+
+If you need to support browsers without WebP, AVIF, or JPEG XL support, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
 
 For images that must be drawn accurately at different sizes, use [SVG](/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics).
-
-When browser support allows, consider [JPEG XL](https://jpeg.org/jpegxl/) for large, high-resolution raster images.
-It supports progressive rendering, which can display an initial version before the full image downloads.
-Use the {{HTMLElement("picture")}} element to provide a fallback for browsers that do not support it.
 
 ## Image loading errors
 

--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -35,27 +35,21 @@ There are many other attributes to achieve various purposes:
 - Use both [`width`](#width) and [`height`](#height) to set the intrinsic size of the image, allowing it to take up space before it loads, to mitigate content layout shifts.
 - Responsive image hints with [`sizes`](#sizes) and [`srcset`](#srcset) (see also the {{htmlelement("picture")}} element and our [Responsive images](/en-US/docs/Web/HTML/Guides/Responsive_images) tutorial).
 
-## Supported image formats
+## Choosing an image format
 
 The HTML standard doesn't list what image formats to support, so {{glossary("user agent","user agents")}} may support different formats.
 
-> [!NOTE]
-> The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) provides comprehensive information about image formats and their web browser support.
-> This section is just a summary!
+Choose an image format based on factors such as compression, quality, browser support, and whether you need features such as transparency or animation.
+The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) explains the trade-offs in detail.
 
-The image file formats that are most commonly used on the web are:
+For raster images, prefer [WebP](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) or [AVIF](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image), which generally provide better compression than PNG, JPEG, and GIF.
+If you need to support browsers without WebP or AVIF support, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
 
-- [APNG (Animated Portable Network Graphics)](/en-US/docs/Web/Media/Guides/Formats/Image_types#apng_animated_portable_network_graphics) — Good choice for lossless animation sequences (GIF is less performant)
-- [AVIF (AV1 Image File Format)](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image) — Good choice for both images and animated images due to high performance.
-- [GIF (Graphics Interchange Format)](/en-US/docs/Web/Media/Guides/Formats/Image_types#gif_graphics_interchange_format) — Good choice for _simple_ images and animations.
-- [JPEG (Joint Photographic Expert Group image)](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_joint_photographic_experts_group_image) — Good choice for lossy compression of still images (currently the most popular).
-- [PNG (Portable Network Graphics)](/en-US/docs/Web/Media/Guides/Formats/Image_types#png_portable_network_graphics) — Good choice for lossless compression of still images (slightly better quality than JPEG).
-- [SVG (Scalable Vector Graphics)](/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics) — Vector image format. Use for images that must be drawn accurately at different sizes.
-- [WebP (Web Picture format)](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) — Excellent choice for both images and animated images
+For images that must be drawn accurately at different sizes, use [SVG](/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics).
 
-Formats like [WebP](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) and [AVIF](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image) are recommended as they perform much better than PNG, JPEG, GIF for both still and animated images.
-
-SVG remains the recommended format for images that must be drawn accurately at different sizes.
+When browser support allows, consider [JPEG XL](https://jpeg.org/jpegxl/) for large, high-resolution raster images.
+It supports progressive rendering, which can display an initial version before the full image downloads.
+Use the {{HTMLElement("picture")}} element to provide a fallback for browsers that do not support it.
 
 ## Image loading errors
 
@@ -79,7 +73,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
     >
     > - Non-visual browsers (such as those used by people with visual impairments)
     > - The user chooses not to display images (saving bandwidth, privacy reasons)
-    > - The image is invalid or an [unsupported type](#supported_image_formats)
+    > - The image is invalid or an [unsupported type](#choosing_an_image_format)
     >
     > In these cases, the browser may replace the image with the text in the element's `alt` attribute. For these reasons and others, provide a useful value for `alt` whenever possible.
 

--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -268,7 +268,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
 ## Usage notes
 
-You need at least two attributes for each `<img>` elements. Most commonly, they are `src` and `alt`.
+You need at least two attributes for each `<img>` element. Most commonly, they are `src` and `alt`.
 
 - The `src` attribute holds the path to the image you want to embed. It is not mandatory if the [srcset](/en-US/docs/Web/API/HTMLImageElement/srcset) attribute is available. However, at least one of the `src` or `srcset` attributes must be provided.
 - The `alt` attribute holds a textual replacement for the image, which is mandatory and **incredibly useful** for accessibility — screen readers read the attribute value out to their users so they know what the image means. Alt text is also displayed on the page if the image can't be loaded for some reason: for example, network errors, content blocking, or link rot.

--- a/files/en-us/web/media/guides/formats/image_types/index.md
+++ b/files/en-us/web/media/guides/formats/image_types/index.md
@@ -1357,104 +1357,28 @@ static unsigned char square8_bits[] = {
 
 ## Choosing an image format
 
-Picking the best image format for your needs is likely easier than video formats, as there are fewer options with broad support, and each tends to have a specific set of use-cases.
+Image formats are usually selected based on factors such as compression, quality, breadth and depth of browser support, and whether you need features such as transparency or animation.
 
-### Photographs
+For raster images, prefer [WebP](#webp_image) or [AVIF](#avif_image), which generally provide better compression than PNG, JPEG, and GIF.
+You should also consider [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) for large, high-resolution raster images, as it allows progressive rendering on most browsers, which can display an initial version before the full image downloads.
 
-Photographs typically fare well with lossy compression (depending on the encoder's configuration).
-This makes [JPEG](#jpeg_joint_photographic_experts_group_image) and [WebP](#webp_image) good choices for photographs, with JPEG being more compatible but WebP perhaps offering better compression.
-To maximize quality and minimize download time, consider providing both [using a fallback](#providing_image_fallbacks) with WebP as the first choice and JPEG as the second.
-Otherwise, JPEG is the safe choice for compatibility.
+If you need to support browsers that don't allow WebP, AVIF, or JPEG XL, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
+This is shown in [Providing image fallbacks](#providing_image_fallbacks) below.
 
-<table class="standard-table" style="max-width: 42rem">
-  <thead>
-    <tr>
-      <th scope="col" style="width: 50%">Best choice</th>
-      <th scope="col">Fallback</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>WebP or JPEG</td>
-      <td>JPEG</td>
-    </tr>
-  </tbody>
-</table>
-
-### Icons
-
-For smaller images such as icons, use a lossless format to avoid loss of detail in a size-constrained image.
-While lossless WebP is ideal for this purpose, support is not widespread yet, so PNG is a better choice unless you offer a [fallback](#providing_image_fallbacks).
-If your image contains fewer than 256 colors, GIF is an option, although PNG often compresses even smaller with its indexed compression option (PNG-8).
-
-If the icon can be represented using vector graphics, consider [SVG](#svg_scalable_vector_graphics), since it scales across various resolutions and sizes, so it's perfect for responsive design.
-Although SVG support is good, it may be worth offering a PNG fallback for older browsers.
-
-<table class="standard-table" style="max-width: 42rem">
-  <thead>
-    <tr>
-      <th scope="col" style="width: 50%">Best choice</th>
-      <th scope="col">Fallback</th>
-    </tr>
-    <tr>
-      <td>SVG, Lossless WebP, or PNG</td>
-      <td>PNG</td>
-    </tr>
-  </thead>
-</table>
-
-### Screenshots
-
-Unless you're willing to compromise on quality, you should use a lossless format for screenshots.
-This is particularly important if there's any text in your screenshot, as text easily becomes fuzzy and unclear under lossy compression.
-
-PNG is probably your best bet, but lossless WebP is arguably going to be better compressed.
-
-<table class="standard-table" style="max-width: 42rem">
-  <thead>
-    <tr>
-      <th scope="col" style="width: 50%">Best choice</th>
-      <th scope="col">Fallback</th>
-    </tr>
-    <tr>
-      <td>
-        Lossless WebP or PNG;<br />JPEG if compression artifacts aren't a
-        concern
-      </td>
-      <td>PNG or JPEG;<br />GIF for screenshots with low color counts</td>
-    </tr>
-  </thead>
-</table>
-
-### Diagrams, drawings, and charts
-
-For any image that can be represented using vector graphics, SVG is the best choice.
-Otherwise, you should use a lossless format like PNG.
-If you do choose a lossy format, such as JPEG or lossy WebP, carefully weigh the compression level to avoid causing text or other shapes to become fuzzy or unclear.
-
-<table class="standard-table" style="max-width: 42rem">
-  <thead>
-    <tr>
-      <th scope="col" style="width: 50%">Best choice</th>
-      <th scope="col">Fallback</th>
-    </tr>
-    <tr>
-      <td><a href="#svg_scalable_vector_graphics">SVG</a></td>
-      <td><a href="#png_portable_network_graphics">PNG</a></td>
-    </tr>
-  </thead>
-</table>
+For diagrams, charts, and other images that must be drawn accurately at different sizes, use [SVG](#svg_scalable_vector_graphics).
+For icons consider [SVG](#svg_scalable_vector_graphics) [WebP](#webp_image)
 
 ## Providing image fallbacks
 
 While the standard HTML {{HTMLElement("img")}} element doesn't support compatibility fallbacks for images, the {{HTMLElement("picture")}} element does.
 `<picture>` is used as a wrapper for a number of {{HTMLElement("source")}} elements, each specifying a version of the image in a different format or under different [media conditions](/en-US/docs/Web/CSS/Reference/At-rules/@media), as well as an `<img>` element which defines where to display the image and the fallback to the default or "most compatible" version.
 
-For example, if you're displaying a diagram best displayed with SVG, but wish to offer a fallback to a PNG or GIF of the diagram, you would do something like this:
+For example, if you're displaying a diagram best displayed with SVG, but wish to offer a fallback to a WebP, PNG or GIF of the diagram, you would do something like this:
 
 ```html
 <picture>
   <source srcset="diagram.svg" type="image/svg+xml" />
+  <source srcset="diagram.webp" type="image/webp" />
   <source srcset="diagram.png" type="image/png" />
   <img
     src="diagram.gif"

--- a/files/en-us/web/media/guides/formats/image_types/index.md
+++ b/files/en-us/web/media/guides/formats/image_types/index.md
@@ -1360,7 +1360,8 @@ static unsigned char square8_bits[] = {
 Image formats are usually selected based on factors such as compression, quality, breadth and depth of browser support, and whether you need features such as transparency or animation.
 
 For raster images, prefer [WebP](#webp_image) or [AVIF](#avif_image), which generally provide better compression than PNG, JPEG, and GIF.
-You should also consider [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) for large, high-resolution raster images. Most browsers can progressively render them by display an initial version before the full image downloads.
+You should also consider [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) for large, high-resolution raster images.
+Most browsers can progressively render them by displaying an initial version before the full image downloads.
 
 If you need to support browsers that don't allow WebP, AVIF, or JPEG XL, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
 This is shown in [Providing image fallbacks](#providing_image_fallbacks) below.

--- a/files/en-us/web/media/guides/formats/image_types/index.md
+++ b/files/en-us/web/media/guides/formats/image_types/index.md
@@ -1360,7 +1360,7 @@ static unsigned char square8_bits[] = {
 Image formats are usually selected based on factors such as compression, quality, breadth and depth of browser support, and whether you need features such as transparency or animation.
 
 For raster images, prefer [WebP](#webp_image) or [AVIF](#avif_image), which generally provide better compression than PNG, JPEG, and GIF.
-You should also consider [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) for large, high-resolution raster images, as it allows progressive rendering on most browsers, which can display an initial version before the full image downloads.
+You should also consider [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) for large, high-resolution raster images. Most browsers can progressively render them by display an initial version before the full image downloads.
 
 If you need to support browsers that don't allow WebP, AVIF, or JPEG XL, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
 This is shown in [Providing image fallbacks](#providing_image_fallbacks) below.

--- a/files/en-us/web/media/guides/formats/image_types/index.md
+++ b/files/en-us/web/media/guides/formats/image_types/index.md
@@ -1366,7 +1366,7 @@ If you need to support browsers that don't allow WebP, AVIF, or JPEG XL, use the
 This is shown in [Providing image fallbacks](#providing_image_fallbacks) below.
 
 For diagrams, charts, and other images that must be drawn accurately at different sizes, use [SVG](#svg_scalable_vector_graphics).
-For icons consider [SVG](#svg_scalable_vector_graphics) [WebP](#webp_image)
+Most icons have vector graphics versions, and you should prioritize the SVG version whenever possible. If only raster versions are available, choose [WebP](#webp_image) but provide fallback like other raster images.
 
 ## Providing image fallbacks
 

--- a/files/en-us/web/media/guides/formats/image_types/index.md
+++ b/files/en-us/web/media/guides/formats/image_types/index.md
@@ -1373,7 +1373,7 @@ Most icons have vector graphics versions, and you should prioritize the SVG vers
 While the standard HTML {{HTMLElement("img")}} element doesn't support compatibility fallbacks for images, the {{HTMLElement("picture")}} element does.
 `<picture>` is used as a wrapper for a number of {{HTMLElement("source")}} elements, each specifying a version of the image in a different format or under different [media conditions](/en-US/docs/Web/CSS/Reference/At-rules/@media), as well as an `<img>` element which defines where to display the image and the fallback to the default or "most compatible" version.
 
-For example, if you're displaying a diagram best displayed with SVG, but wish to offer a fallback to a WebP, PNG or GIF of the diagram, you would do something like this:
+For example, if you're displaying a diagram best displayed with SVG, but wish to offer a fallback to a PNG or GIF of the diagram, you would do something like this:
 
 ```html
 <picture>

--- a/files/en-us/web/media/guides/formats/image_types/index.md
+++ b/files/en-us/web/media/guides/formats/image_types/index.md
@@ -1366,6 +1366,13 @@ Most browsers can progressively render them by displaying an initial version bef
 If you need to support browsers that don't allow WebP, AVIF, or JPEG XL, use the {{HTMLElement("picture")}} element to provide a PNG or JPEG fallback.
 This is shown in [Providing image fallbacks](#providing_image_fallbacks) below.
 
+Compression can be lossy, discarding image data to get much smaller files, or lossless, reproducing the original exactly.
+For screenshots, diagrams, logos, and line art, prefer lossless encoding, as blurring and colored fringes around text and sharp edges are very visible.
+Photographs and other continuous-tone images can usually tolerate lossy compression, because the discarded detail is harder to see.
+WebP and AVIF support both lossy and lossless compression as a setting you choose when encoding.
+JPEG is lossy, so it is often a good fallback format for photographs, while PNG is lossless, making it better for screenshots, diagrams, and line art.
+PNG is also the fallback for any image needing transparency, as JPEG has no alpha channel.
+
 For diagrams, charts, and other images that must be drawn accurately at different sizes, use [SVG](#svg_scalable_vector_graphics).
 Most icons have vector graphics versions, and you should prioritize the SVG version whenever possible. If only raster versions are available, choose [WebP](#webp_image) but provide fallback like other raster images.
 


### PR DESCRIPTION
### Description

Replaces the format-by-format list on the img element page with concise guidance about choosing formats based on compression, browser support, and image requirements. It also explains fallbacks and the progressive-rendering benefit of JPEG XL for large images.

### Motivation

The previous list called several competing formats a good choice without clearly explaining how to decide between them. This revision directs readers to WebP or AVIF for raster compression, SVG for scalable graphics, and picture-based fallbacks where browser support requires them.

### Additional details

- Markdownlint: passed
- Prettier check: passed
- Updated the affected internal heading link

### Related issues and pull requests

Fixes #45286