### PR TITLE
Use American English spelling for maths, fibre, judgement, tonne, and burnt

### DIFF
--- a/files/en-us/games/publishing_games/game_promotion/index.md
+++ b/files/en-us/games/publishing_games/game_promotion/index.md
@@ -39,7 +39,7 @@ Free portals offer traffic, but only the best ones are popular enough to generat
 
 ## Press
 
-You can try and reach the [press](https://indiegamesplus.com/) about your game, but bear in mind that they get a tonne of requests like this every single day, so be humble and patient if they don't answer right away, and be polite when talking to them. Be sure to check first if they are dealing with specific genres of games or platforms, so you don't send them something that is not relevant to them in the first place. If you're honest with your approach and your game is good, then you've got more of a chance of success.
+You can try and reach the [press](https://indiegamesplus.com/) about your game, but bear in mind that they get a ton of requests like this every single day, so be humble and patient if they don't answer right away, and be polite when talking to them. Be sure to check first if they are dealing with specific genres of games or platforms, so you don't send them something that is not relevant to them in the first place. If you're honest with your approach and your game is good, then you've got more of a chance of success.
 
 If you want to learn more about the etiquette of contacting the press you should check out [How To Contact Press](https://app.box.com/s/p0ft5zdolpi0ydkrykab) - a great guide from Pixel Prospector.
 

--- a/files/en-us/games/publishing_games/game_promotion/index.md
+++ b/files/en-us/games/publishing_games/game_promotion/index.md
@@ -39,7 +39,7 @@ Free portals offer traffic, but only the best ones are popular enough to generat
 
 ## Press
 
-You can try and reach the [press](https://indiegamesplus.com/) about your game, but bear in mind that they get a ton of requests like this every single day, so be humble and patient if they don't answer right away, and be polite when talking to them. Be sure to check first if they are dealing with specific genres of games or platforms, so you don't send them something that is not relevant to them in the first place. If you're honest with your approach and your game is good, then you've got more of a chance of success.
+You can reach out to the [press](https://indiegamesplus.com/) about your game, but bear in mind that they get many requests like this every day, so be humble and patient if they don't answer right away, and be polite when talking to them. Be sure to check first if they deal with specific game genres or platforms, so you don't send them something irrelevant. If you're honest with your approach and your game is good, then you will have a greater chance of success.
 
 If you want to learn more about the etiquette of contacting the press you should check out [How To Contact Press](https://app.box.com/s/p0ft5zdolpi0ydkrykab) - a great guide from Pixel Prospector.
 

--- a/files/en-us/learn_web_development/core/scripting/index.md
+++ b/files/en-us/learn_web_development/core/scripting/index.md
@@ -28,7 +28,7 @@ Before starting this module, you don't need any previous JavaScript knowledge, b
 - [Storing the information you need — Variables](/en-US/docs/Learn_web_development/Core/Scripting/Variables)
   - : After reading the last couple of articles you should now know what JavaScript is, what it can do for you, how you use it alongside other web technologies, and what its main features look like from a high level. In this article, we will get down to the real basics, looking at how to work with the most basic building blocks of JavaScript — Variables.
 - [Basic math in JavaScript — numbers and operators](/en-US/docs/Learn_web_development/Core/Scripting/Math)
-  - : At this point in the course, we discuss maths in JavaScript — how we can combine operators and other features to successfully manipulate numbers to do our bidding.
+  - : At this point in the course, we discuss math in JavaScript — how we can combine operators and other features to successfully manipulate numbers to do our bidding.
 - [Handling text — strings in JavaScript](/en-US/docs/Learn_web_development/Core/Scripting/Strings)
   - : Next, we'll turn our attention to strings — this is what pieces of text are called in programming. In this article, we'll look at all the common things that you really ought to know about strings when learning JavaScript, such as creating strings, escaping quotes in strings, and joining them together.
 - [Useful string methods](/en-US/docs/Learn_web_development/Core/Scripting/Useful_string_methods)

--- a/files/en-us/learn_web_development/core/text_styling/fundamentals/index.md
+++ b/files/en-us/learn_web_development/core/text_styling/fundamentals/index.md
@@ -307,7 +307,7 @@ In our previous module's [CSS values and units](/en-US/docs/Learn_web_developmen
 
 - `px` (pixels): The number of pixels high you want the text to be. This is an absolute unit — it results in the same final computed value for the font on the page in pretty much any situation.
 - `em`s: 1 `em` is equal to the font size set on the parent element of the current element we are styling (more specifically, the width of a capital letter M contained inside the parent element). This can become tricky to work out if you have a lot of nested elements with different font sizes set, but it is doable, as you'll see below. Why bother? It is quite natural once you get used to it, and you can use `em` to size everything, not just text. You can have an entire website sized using `em`, which makes maintenance easy.
-- `rem`s: These work just like `em`, except that 1 `rem` is equal to the font size set on the root element of the document (i.e., {{htmlelement("html")}}), not the parent element. This makes doing the maths to work out your font sizes much easier.
+- `rem`s: These work just like `em`, except that 1 `rem` is equal to the font size set on the root element of the document (i.e., {{htmlelement("html")}}), not the parent element. This makes doing the math to work out your font sizes much easier.
 
 The `font-size` of an element is inherited from that element's parent element. This all starts with the root element of the entire document — {{htmlelement("html")}} — the standard `font-size` of which is set to `16px` across browsers. Any paragraph (or another element that doesn't have a different size set by the browser) inside the root element will have a final size of `16px`. Other elements may have different default sizes. For example, an {{htmlelement("Heading_Elements", "h1")}} element has a size of `2em` set by default, so it will have a final size of `32px`.
 
@@ -322,7 +322,7 @@ Things become more tricky when you start altering the font size of nested elemen
 </article>
 ```
 
-You would need to set its `em` value to 20/24, or 0.83333333 `em`. The maths can be complicated, so you need to be careful about how you style things. It is best to use `rem` where you can to keep things simple, and avoid setting the `font-size` of container elements where possible.
+You would need to set its `em` value to 20/24, or 0.83333333 `em`. The math can be complicated, so you need to be careful about how you style things. It is best to use `rem` where you can to keep things simple, and avoid setting the `font-size` of container elements where possible.
 
 ### Font style, font weight, text transform, and text decoration
 

--- a/files/en-us/learn_web_development/extensions/performance/why_web_performance/index.md
+++ b/files/en-us/learn_web_development/extensions/performance/why_web_performance/index.md
@@ -41,7 +41,7 @@ Web performance — and its associated best practices—are vital for your websi
 
 As an example, consider the loading experience of CNN.com, which at the time of this writing had over 400 HTTP requests with a file size of over 22.6MB.
 
-- Imagine loading this on a desktop computer connected to a fibre optic network. This would seem relatively fast, and the file size would be largely irrelevant.
+- Imagine loading this on a desktop computer connected to a fiber optic network. This would seem relatively fast, and the file size would be largely irrelevant.
 - Imagine loading that same site using tethered mobile data on a nine-year-old iPad while commuting home on public transportation. The same site will be slow to load, possibly verging on unusable depending on cell coverage. You might give up before it finishes loading.
 - Imagine loading that same site on a low-cost device in an area with limited coverage. The site will be very slow to load—if it loads at all—with blocking scripts possibly timing out, and adverse CPU impact potentially causing browser crashes if it does load.
 

--- a/files/en-us/web/api/videotrack/kind/index.md
+++ b/files/en-us/web/api/videotrack/kind/index.md
@@ -29,13 +29,13 @@ The kinds available for video tracks are:
   - : A potential alternative to the main track, such as a different video take or a
     version of the soundtrack with only the music and no dialogue.
 - `"captions"`
-  - : A version of the main video track with captions burnt in.
+  - : A version of the main video track with captions burned in.
 - `"main"`
   - : The primary video track.
 - `"sign"`
   - : A sign-language interpretation of an audio track.
 - `"subtitles"`
-  - : A version of the main video track with subtitles burnt in.
+  - : A version of the main video track with subtitles burned in.
 - `"commentary"`
   - : A video track containing a commentary. This might be used to contain the director's
     commentary track on a movie, for example.

--- a/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
+++ b/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
@@ -30,9 +30,9 @@ A [biquad filter](https://www.mathworks.com/help/dsphdl/ref/biquadfilter.html) i
 
 When you are using an {{domxref("IIRFilterNode")}} instead of a {{domxref("BiquadFilterNode")}} you are creating the filter yourself, rather than just choosing a pre-programmed type. So you can create a highpass filter, or a lowpass filter, or a more bespoke one. And this is where the IIR filter node is useful — you can create your own if none of the already available settings is right for what you want. As well as this, if your audio graph needed a highpass and a bandpass filter within it, you could just use one IIR filter node in place of the two biquad filter nodes you would otherwise need for this.
 
-With the IIR filter node it's up to you to set what `feedforward` and `feedback` values the filter needs — this determines the characteristics of the filter. The downside is that this involves some complex maths.
+With the IIR filter node it's up to you to set what `feedforward` and `feedback` values the filter needs — this determines the characteristics of the filter. The downside is that this involves some complex math.
 
-If you are looking to learn more there's some [information about the maths behind IIR filters here](https://www.staff.ncl.ac.uk/oliver.hinton/eee305/Chapter5.pdf). This enters the realms of signal processing theory — don't worry if you look at it and feel like it's not for you.
+If you are looking to learn more there's some [information about the math behind IIR filters here](https://www.staff.ncl.ac.uk/oliver.hinton/eee305/Chapter5.pdf). This enters the realms of signal processing theory — don't worry if you look at it and feel like it's not for you.
 
 If you want to play with the IIR filter node and need some values to help along the way, there's [a table of already calculated values here](https://www.dspguide.com/CH20.PDF); on pages 4 & 5 of the linked PDF the `an` values refer to the `feedForward` values and the `bn` values refer to the `feedback`. [musicdsp.org](https://www.musicdsp.org/en/latest/) is also a great resource if you want to read more about different filters and how they are implemented digitally.
 

--- a/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
+++ b/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
@@ -11,7 +11,7 @@ The official term for this is **spatialization**, and this article will cover th
 
 ## Basics of spatialization
 
-In Web Audio, complex 3D spatializations are created using the {{domxref("PannerNode")}}, which in layman's terms is basically a whole lotta cool maths to make audio appear in 3D space.
+In Web Audio, complex 3D spatializations are created using the {{domxref("PannerNode")}}, which in layman's terms is basically a whole lotta cool math to make audio appear in 3D space.
 Think sounds flying over you, creeping up behind you, moving across in front of you.
 That sort of thing.
 
@@ -261,7 +261,7 @@ switch (direction) {
 ```
 
 Our rotation values are a little more involved, however, as we need to move the sound _around_.
-Not only do we have to update two axis values (e.g., if you rotate an object around the x-axis, you update the y and z coordinates for that object), but we also need to do some more maths for this.
+Not only do we have to update two axis values (e.g., if you rotate an object around the x-axis, you update the y and z coordinates for that object), but we also need to do some more math for this.
 The rotation is a circle and we need [`Math.sin`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin) and [`Math.cos`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos) to help us draw that circle.
 
 Let's set up a rotation rate, which we'll convert into a radian range value for use in `Math.sin` and `Math.cos` later, when we want to figure out the new coordinates when we're rotating our boombox:
@@ -556,7 +556,7 @@ The values can be hard to manipulate sometimes and depending on your use case it
 
 > [!NOTE]
 > There are slight differences in the way the audio spatialization sounds across different browsers.
-> The panner node does some very involved maths under the hood;
+> The panner node does some very involved math under the hood;
 > there are a [number of tests here](https://wpt.fyi/results/webaudio/the-audio-api/the-pannernode-interface?label=stable&aligned=true) so you can keep track of the status of the inner workings of this node across different platforms.
 
 Again, you can [check out the final demo here](https://mdn.github.io/webaudio-examples/spatialization/), and the [final source code is here](https://github.com/mdn/webaudio-examples/tree/main/spatialization).

--- a/files/en-us/web/html/reference/attributes/autocomplete/index.md
+++ b/files/en-us/web/html/reference/attributes/autocomplete/index.md
@@ -79,7 +79,7 @@ The attribute value is either the keyword `off` or `on`, or a space-separated `<
     > In most modern browsers, setting `autocomplete` to `"off"` will not prevent a password manager from asking the user if they would like to save username and password information, or from automatically filling in those values in a site's login form. See [Managing autofill for login fields](/en-US/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion#managing_autofill_for_login_fields).
 
 - `on`
-  - : The browser is allowed to automatically complete the input. No guidance is provided as to the type of data expected in the field, so the browser may use its own judgement.
+  - : The browser is allowed to automatically complete the input. No guidance is provided as to the type of data expected in the field, so the browser may use its own judgment.
 
 - `<token-list>`
   - : An ordered set of [space-separated tokens](#token_list_tokens) consisting of autofill detail tokens preceded by optional sectioning and either billing or shipping grouping tokens. Phone numbers, email addresses, and messaging protocol tokens are preceded by a token identifying the type of recipient.

--- a/files/en-us/web/html/reference/elements/small/index.md
+++ b/files/en-us/web/html/reference/elements/small/index.md
@@ -73,7 +73,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Referenc
 
 ## Notes
 
-Although the `<small>` element, like the {{htmlelement("b")}} and {{htmlelement("i")}} elements, may be perceived to violate the principle of separation between structure and presentation, all three are valid in HTML. Authors are encouraged to use their best judgement when determining whether to use `<small>` or CSS.
+Although the `<small>` element, like the {{htmlelement("b")}} and {{htmlelement("i")}} elements, may be perceived to violate the principle of separation between structure and presentation, all three are valid in HTML. Authors are encouraged to use their best judgment when determining whether to use `<small>` or CSS.
 
 ## Technical summary
 

--- a/files/en-us/web/http/reference/headers/ect/index.md
+++ b/files/en-us/web/http/reference/headers/ect/index.md
@@ -14,7 +14,7 @@ sidebar: http
 The HTTP **`ECT`** {{Glossary("request header")}} is used in [Client Hints](/en-US/docs/Web/HTTP/Guides/Client_hints) to indicate the {{Glossary("effective connection type")}}: `slow-2g`, `2g`, `3g`, or `4g`.
 
 The value represents the "network profile" that best matches the connection's latency and bandwidth, rather than the actual mechanisms used for transferring the data.
-For example, `2g` might be used to represent a slow Wi-Fi connection with high latency and low bandwidth, while `4g` might represent a fast fibre-based broadband network.
+For example, `2g` might be used to represent a slow Wi-Fi connection with high latency and low bandwidth, while `4g` might represent a fast fiber-based broadband network.
 
 The hint allows a server to choose what information is sent based on the broad characteristics of the network. For example, a server might choose to send smaller versions of images and other resources on less capable connections. The value might also be used as a starting point for determining what information is sent, which is further refined using information in {{HTTPHeader("RTT")}} and {{HTTPHeader("Downlink")}} hints.
 

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/basic_shapes/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/basic_shapes/index.md
@@ -77,7 +77,7 @@ The {{SVGElement("circle")}} element draws a circle on the screen. It takes thre
 
 ## Ellipse
 
-An {{SVGElement("ellipse")}} is a more general form of the {{SVGElement("circle")}} element, where you can scale the x and y radius (commonly referred to as the _semimajor_ and _semiminor_ axes in maths) of the circle separately.
+An {{SVGElement("ellipse")}} is a more general form of the {{SVGElement("circle")}} element, where you can scale the x and y radius (commonly referred to as the _semimajor_ and _semiminor_ axes in math) of the circle separately.
 
 ```xml
 <ellipse cx="75" cy="75" rx="20" ry="5"/>


### PR DESCRIPTION
### Description

Five more British spellings in prose, 16 occurrences across 11 files: `maths` → `math` (9), `fibre` → `fiber` (2), `judgement` → `judgment` (2), `burnt in` → `burned in` (2), and "a tonne of requests" → "a ton of requests" (1).

### Motivation

The writing style guide requires American English spelling: "Use American-English spelling. […] Do not use variant spelling." Each of these is the chiefly-British form of the American spelling used elsewhere in the repo, and `npm run lint:typos` cannot flag any of them because they are valid dictionary words.

Occurrences that are not variant spellings are left untouched:

- `<math>` element reference: the line "…end of fraction, maths" transcribes what a screen reader actually announces, so it is not ours to reword.
- MathML scripts tutorial: `const maths = Array.from(…)` is a variable name.
- `:only-child`: "The Dolby Theatre" is a proper noun.
- `hyphenate-limit-chars`: "acknowledgement" is the sample word whose length the example's `5 9 2` values depend on.
- The `"Million tonne punch"` superhero power in the JSON tutorial's sample data.
