### PR TITLE
Use American English spelling for grey

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -143,7 +143,7 @@ It will create a light `Entity` component and add it to the scene. We can rotate
 app.scene.ambientLight = new pc.Color(0.2, 0.2, 0.2);
 ```
 
-The code above assign a dark grey ambient light for the whole scene. The box looks better now, but it could get some colors to look even better - for that we need to create material for it.
+The code above assign a dark gray ambient light for the whole scene. The box looks better now, but it could get some colors to look even better - for that we need to create material for it.
 
 ## Material
 

--- a/files/en-us/games/techniques/3d_on_the_web/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/index.md
@@ -64,7 +64,7 @@ Three.js, like any other library, gives you a huge advantage: instead of writing
 
 Both [Unity](https://unity.com/) and [Unreal](https://www.unrealengine.com/) can export your game to [WebGL](/en-US/docs/Web/API/WebGL_API) with [asm.js](/en-US/docs/Games/Tools/asm.js), so you're free to use their tools and techniques to build games that will be exported to the web.
 
-![Illustration of three 3D geometry shapes: a grey torus, a blue cube, and a yellow cylinder.](shapes.png)
+![Illustration of three 3D geometry shapes: a gray torus, a blue cube, and a yellow cylinder.](shapes.png)
 
 ## Where to go next
 

--- a/files/en-us/glossary/baseline/compatibility/index.md
+++ b/files/en-us/glossary/baseline/compatibility/index.md
@@ -33,11 +33,11 @@ Features listed as **widely available** have a consistent history of support in 
 
 Features listed as **newly available** work in at least the latest stable version of each of the Baseline browsers, but may not work with older browsers and devices.
 
-![Grey widget with the cross: Limited availability. Four browsers' logos, two with checkmarks, two with crosses.](limited.png)
+![Gray widget with the cross: Limited availability. Four browsers' logos, two with checkmarks, two with crosses.](limited.png)
 
 Features listed with **limited availability** are _not_ yet available in all browsers.
 
-![Grey widget with a dotted diamond: Deprecated. Four browsers' logos, all with checkmarks.](deprecated.png)
+![Gray widget with a dotted diamond: Deprecated. Four browsers' logos, all with checkmarks.](deprecated.png)
 
 Features listed with **deprecated** may be available in one or more browsers, but should not be used in development.
 

--- a/files/en-us/glossary/screen_reader/index.md
+++ b/files/en-us/glossary/screen_reader/index.md
@@ -13,7 +13,7 @@ In terms of web {{glossary("accessibility")}}, most user agents provide an acces
 
 ### VoiceOver
 
-iOS and macOS comes with VoiceOver, a built-in screen reader. To access VoiceOver on macOS, go to System Settings > Accessibility > VoiceOver. You can also toggle VoiceOver on and off with fn + Command + F5. VoiceOver both reads aloud and displays content. The content read aloud is displayed in a dark grey box.
+iOS and macOS comes with VoiceOver, a built-in screen reader. To access VoiceOver on macOS, go to System Settings > Accessibility > VoiceOver. You can also toggle VoiceOver on and off with fn + Command + F5. VoiceOver both reads aloud and displays content. The content read aloud is displayed in a dark gray box.
 
 VoiceOver can also be used with commands shortcuts. See [VoiceOver general commands on Mac](https://support.apple.com/en-sg/guide/voiceover/cpvokys01/mac) for a complete list.
 

--- a/files/en-us/learn_web_development/core/styling_basics/basic_selectors/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/basic_selectors/index.md
@@ -171,7 +171,7 @@ This approach reduces the scope of a rule. The rule will only apply to that part
 
 You can apply multiple classes to an element and target them individually, or only select the element when all of the classes in the selector are present. This can be helpful when building up components that can be combined in different ways on your site.
 
-In the example below, we have a `<div>` that contains a note. The grey border is applied when the box has a class of `notebox`. If it also has a class of `warning` or `danger`, we change the {{cssxref("border-color")}}.
+In the example below, we have a `<div>` that contains a note. The gray border is applied when the box has a class of `notebox`. If it also has a class of `warning` or `danger`, we change the {{cssxref("border-color")}}.
 
 We can tell the browser that we only want to match the element if it has two classes applied by chaining them together with no white space between them. You'll see that the last `<div>` doesn't get any styling applied, as it only has the `danger` class. To get any styles applied, it needs the `notebox` class as well.
 

--- a/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/test_your_skills/selectors/index.md
@@ -84,7 +84,7 @@ span {
 To complete the task:
 
 1. Give the element with an id of `special` a yellow background.
-2. Give the element with a class of `alert` a `2px` solid grey border.
+2. Give the element with a class of `alert` a `2px` solid gray border.
 3. If the element with a class of `alert` also has a class of `stop`, make the background red.
 4. If the element with a class of `alert` also has a class of `go`, make the background green.
 
@@ -274,7 +274,7 @@ To complete the task:
 1. Make any paragraph that directly follows an `<h2>` element red.
 2. Style list items that are a direct child of the `<ul>` with a class of `list` as follows:
    - Remove their bullets.
-   - Give them a `1px` grey bottom border.
+   - Give them a `1px` gray bottom border.
 
 The starting point of the task looks like this:
 

--- a/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -574,7 +574,7 @@ Similar to the {{cssxref("color_value/hwb")}} function is the {{cssxref("color_v
 HSL uses `Hue`, in addition to `Saturation` and `Lightness`:
 
 - **Hue**: Again, this represents the base shade of the color.
-- **Saturation**: How saturated is the color? This takes a value from `0`–`100%`, where `0` is no color (it will appear as a shade of grey), and `100%` is full color saturation.
+- **Saturation**: How saturated is the color? This takes a value from `0`–`100%`, where `0` is no color (it will appear as a shade of gray), and `100%` is full color saturation.
 - **Lightness**: How light or bright is the color? This takes a value from `0`–`100%`, where `0` is no light (it will appear completely black) and `100%` is full light (it will appear completely white).
 
 The {{cssxref("color_value/hsl")}} color value also has an optional fourth value, separated from the color with a slash (`/`), representing the alpha transparency.

--- a/files/en-us/learn_web_development/extensions/forms/basic_native_form_controls/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/basic_native_form_controls/index.md
@@ -72,7 +72,7 @@ It renders like this:
 
 Single line text fields have only one true constraint: if you type text with line breaks, the browser removes those line breaks before sending the data to the server.
 
-The screenshot below shows a text input in default, focused, and disabled states. Most browsers indicate the focused state using a focus ring around the control and the disabled state using grey text or a faded/semi-opaque control.
+The screenshot below shows a text input in default, focused, and disabled states. Most browsers indicate the focused state using a focus ring around the control and the disabled state using gray text or a faded/semi-opaque control.
 
 ![Screenshot of the default, focused and disabled states text input in Chrome on macOS](disabled.png)
 

--- a/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
@@ -400,7 +400,7 @@ textarea {
 }
 ```
 
-When one of these fields gains focus, we highlight them with a light grey, transparent, background (it is always important to have focus style, for usability and keyboard accessibility):
+When one of these fields gains focus, we highlight them with a light gray, transparent, background (it is always important to have focus style, for usability and keyboard accessibility):
 
 ```css
 input:focus,

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -287,7 +287,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are grey with white text. The customize toolbar icon in the url bar in white with a red background is pressed and a popup is open displaying a short list of thing to add to the toolbar such as the browser's library and the sidebars." src="theme-button_background_active.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are gray with white text. The customize toolbar icon in the url bar in white with a red background is pressed and a popup is open displaying a short list of thing to add to the toolbar such as the browser's library and the sidebars." src="theme-button_background_active.png" /></p>
       </td>
     </tr>
     <tr>
@@ -306,7 +306,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are grey with white text. The go back one page icon is white with a red circle background." src="theme-button_background_hover.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are gray with white text. The go back one page icon is white with a red circle background." src="theme-button_background_hover.png" /></p>
       </td>
     </tr>
     <tr>
@@ -333,7 +333,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are grey with white text. The URL bar and open a new tab icons are red. The red icons contrast well with the black background color of the header area." src="theme-icons.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are gray with white text. The URL bar and open a new tab icons are red. The red icons contrast well with the black background color of the header area." src="theme-icons.png" /></p>
       </td>
     </tr>
     <tr>
@@ -363,7 +363,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are grey with white text. The bookmark this page icon is red and pressed, an open popup name edit this bookmark is displayed. While in attention state, the toolbar icons contrast well with the black background of the header area." src="theme-icons_attention.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are gray with white text. The bookmark this page icon is red and pressed, an open popup name edit this bookmark is displayed. While in attention state, the toolbar icons contrast well with the black background of the header area." src="theme-icons_attention.png" /></p>
       </td>
     </tr>
     <tr>
@@ -411,7 +411,7 @@ All these properties can be specified as either a string containing any valid [C
         </details>
         <p>
           <img
-            alt="Browser firefox is grey. Browser's tabs and URL bar are lighter grey. The tab text is white and the URL bar icon are darker grey."
+            alt="Browser firefox is gray. Browser's tabs and URL bar are lighter gray. The tab text is white and the URL bar icon are darker gray."
             src="theme-frame_inactive.png"
           />
         </p>
@@ -493,7 +493,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter grey with icons and text in white. The bookmark this page icon is blue and pressed, an open popup name 'edit this bookmark' is displayed with a red background. The background color of the popup is red." src="theme-popup.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter gray with icons and text in white. The bookmark this page icon is blue and pressed, an open popup name 'edit this bookmark' is displayed with a red background. The background color of the popup is red." src="theme-popup.png" /></p>
       </td>
     </tr>
     <tr>
@@ -514,7 +514,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter grey with icons and text in white. The bookmark this page icon is blue and pressed, an open popup name 'edit this bookmark' is displayed with a red outline and black background. The popup's border is red." src="theme-popup_border.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter gray with icons and text in white. The bookmark this page icon is blue and pressed, an open popup name 'edit this bookmark' is displayed with a red outline and black background. The popup's border is red." src="theme-popup_border.png" /></p>
       </td>
     </tr>
     <tr>
@@ -544,7 +544,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="screenshot of firefox is black. Browser's tabs and URL bar are lighter grey with icons and text in white. A search results popup is displayed with a highlighted item's background in red. The background color of the highlighted item inside the popup is red." src="theme-popup_highlight.png" /></p>
+        <p><img alt="screenshot of firefox is black. Browser's tabs and URL bar are lighter gray with icons and text in white. A search results popup is displayed with a highlighted item's background in red. The background color of the highlighted item inside the popup is red." src="theme-popup_highlight.png" /></p>
       </td>
     </tr>
     <tr>
@@ -570,7 +570,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter grey with icons and text in white. A search results popup is displayed with a highlighted item's text in red with a black background. The text color of the highlighted item contrasts well with the black background color of this item." src="theme-popup_highlight_text.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter gray with icons and text in white. A search results popup is displayed with a highlighted item's text in red with a black background. The text color of the highlighted item contrasts well with the black background color of this item." src="theme-popup_highlight_text.png" /></p>
       </td>
     </tr>
     <tr>
@@ -596,7 +596,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter grey with icons and text in white. A search results popup is displayed with items texts in red. The text color contrasts well with the black background color of the popup." src="popup_text.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are lighter gray with icons and text in white. A search results popup is displayed with items texts in red. The text color contrasts well with the black background color of the popup." src="popup_text.png" /></p>
       </td>
     </tr>
     <tr>
@@ -782,7 +782,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are darker grey with lighter grey icons and white text. The selected tab has a red outline." src="theme-tab_line.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tabs and URL bar are darker gray with lighter gray icons and white text. The selected tab has a red outline." src="theme-tab_line.png" /></p>
       </td>
     </tr>
     <tr>
@@ -801,7 +801,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="A screenshot of a browser window with one open tab. Browser is black. Browser's tabs and URL bar are darker grey with icons and text in white. Inside the selected tab an animated loading indicator is red." src="theme-tab_loading.gif" /></p>
+        <p><img alt="A screenshot of a browser window with one open tab. Browser is black. Browser's tabs and URL bar are darker gray with icons and text in white. Inside the selected tab an animated loading indicator is red." src="theme-tab_loading.gif" /></p>
       </td>
     </tr>
     <tr>
@@ -827,7 +827,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="A screenshot of a browser window with one open tab. Browser is black. Browser's tabs and URL bar are darker grey with icons and text in white. The selected tab has red background and white text." src="theme-tab_selected.png" /></p>
+        <p><img alt="A screenshot of a browser window with one open tab. Browser is black. Browser's tabs and URL bar are darker gray with icons and text in white. The selected tab has red background and white text." src="theme-tab_selected.png" /></p>
       </td>
     </tr>
     <tr>
@@ -861,7 +861,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox has a picture of an insect theme. URL bar is lighter grey with white icons. The selected tab text is red with white background." src="theme-tab_text.png" /></p>
+        <p><img alt="Browser firefox has a picture of an insect theme. URL bar is lighter gray with white icons. The selected tab text is red with white background." src="theme-tab_text.png" /></p>
       </td>
     </tr>
     <tr>
@@ -906,7 +906,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tab and URL bar are lighter grey with white text and icons. A horizontal red line separates the bottom of the toolbar and the beginning of the display of the web page." src="theme-toolbar_bottom_separator.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tab and URL bar are lighter gray with white text and icons. A horizontal red line separates the bottom of the toolbar and the beginning of the display of the web page." src="theme-toolbar_bottom_separator.png" /></p>
       </td>
     </tr>
     <tr>
@@ -931,7 +931,7 @@ All these properties can be specified as either a string containing any valid [C
 }</pre
           >
         </details>
-        <p><img alt="Browser firefox is black. Browser's tab, find in page bar and URL bar are lighter grey with white text and icons. The background color of the URL bar is red. The find in page bar is white with black text. The find in page field is red with black text." src="toolbar-field.png" /></p>
+        <p><img alt="Browser firefox is black. Browser's tab, find in page bar and URL bar are lighter gray with white text and icons. The background color of the URL bar is red. The find in page bar is white with black text. The find in page field is red with black text." src="toolbar-field.png" /></p>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/accessibility/guides/colors_and_luminance/index.md
+++ b/files/en-us/web/accessibility/guides/colors_and_luminance/index.md
@@ -196,7 +196,7 @@ Luminance provides for fine vision details, including differentiating edges and 
 
 For accessibility, this means that luminance contrast is critically important for text. Color, as in hue and colorfulness, is important for _distinguishing_ items such as different lines on a map or bars in a graph.
 
-Another essential point to consider is the color or luminance that is surrounding a color. Colors appear differently depending on what is surrounding them. In the following image, both the yellow dots and the grey squares are the same sRGB color. Context-sensitive color perception makes them appear different; your brain's image processing adjusts the perception based on what it thinks is in shadow or not.
+Another essential point to consider is the color or luminance that is surrounding a color. Colors appear differently depending on what is surrounding them. In the following image, both the yellow dots and the gray squares are the same sRGB color. Context-sensitive color perception makes them appear different; your brain's image processing adjusts the perception based on what it thinks is in shadow or not.
 
 ![An image of a checkerboard, where identical colors look different if they are in shadow](yellowdotcheckershadow_dlyon.png)
 

--- a/files/en-us/web/api/ext_texture_filter_anisotropic/index.md
+++ b/files/en-us/web/api/ext_texture_filter_anisotropic/index.md
@@ -10,7 +10,7 @@ browser-compat: api.EXT_texture_filter_anisotropic
 
 The **`EXT_texture_filter_anisotropic`** extension is part of the [WebGL API](/en-US/docs/Web/API/WebGL_API) and exposes two constants for [anisotropic filtering (AF)](https://en.wikipedia.org/wiki/Anisotropic_filtering).
 
-AF improves the quality of mipmapped texture access when viewing a textured primitive at an oblique angle. Using just mipmapping, these lookups have a tendency to average to grey.
+AF improves the quality of mipmapped texture access when viewing a textured primitive at an oblique angle. Using just mipmapping, these lookups have a tendency to average to gray.
 
 WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExtension()")}} method. For more information, see also [Using Extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions) in the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial).
 

--- a/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/media_capture_and_streams_api/taking_still_photos/index.md
@@ -233,7 +233,7 @@ function clearPhoto() {
 clearPhoto();
 ```
 
-We start by getting a reference to the hidden {{HTMLElement("canvas")}} element that we use for offscreen rendering. Next we set the `fillStyle` to `#aaaaaa` (a fairly light grey), and fill the entire canvas with that color by calling {{domxref("CanvasRenderingContext2D.fillRect()","fillRect()")}}.
+We start by getting a reference to the hidden {{HTMLElement("canvas")}} element that we use for offscreen rendering. Next we set the `fillStyle` to `#aaaaaa` (a fairly light gray), and fill the entire canvas with that color by calling {{domxref("CanvasRenderingContext2D.fillRect()","fillRect()")}}.
 
 Last in this function, we convert the canvas into a PNG image and call {{domxref("Element.setAttribute", "photo.setAttribute()")}} to make our captured still box display the image.
 

--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -3134,7 +3134,7 @@ The values below are derived in part from a number of consumer electronics techn
     <tr>
       <td><code>"ColorF4Grey"</code></td>
       <td>
-        General-purpose media function key, color-coded grey. This has index
+        General-purpose media function key, color-coded gray. This has index
         <code>4</code> among the colored keys.
       </td>
       <td><code>VK_COLORED_KEY_4</code></td>

--- a/files/en-us/web/css/guides/colors/color_values/index.md
+++ b/files/en-us/web/css/guides/colors/color_values/index.md
@@ -230,7 +230,7 @@ The last value is semi-opaque; it includes the optional alpha value, preceded by
 
 The [`hwb()`](/en-US/docs/Web/CSS/Reference/Values/color_value/hwb) color function uses the same hue coordinate system as `hsl()`, with `0deg` being red. However, instead of `hsl()`'s lightness and saturation, `hwb()` functions specify whiteness (`W`) and blackness (`B`). This function is also fairly intuitive — allowing you to pick a hue and then mix in amounts of white and or black to achieve the desired color.
 
-`W` and `B` values range from `0%` to `100%` (or `0` to `1`). If the combined value of `W` and `B` is 100% (or `1`) or greater, the color will be grey, similar to setting the `s` to `0%` with `hsl()`. As with `hsl()`, an optional alpha value can be included, preceded by a forward slash `/`.
+`W` and `B` values range from `0%` to `100%` (or `0` to `1`). If the combined value of `W` and `B` is 100% (or `1`) or greater, the color will be gray, similar to setting the `s` to `0%` with `hsl()`. As with `hsl()`, an optional alpha value can be included, preceded by a forward slash `/`.
 
 Here are some examples of using HWB notation:
 
@@ -387,7 +387,7 @@ Note also how the spread of blue values in CIE Lab is longer than in the other t
 
 As discussed above, the hue (`H`) in the `lch()` and `oklch()` is an `<angle>`, `number` or the keyword `none`. The `lightness` is either a {{cssxref("percentage")}} or for `lch()` a number between `0` and `100` and for `oklch()` a number between `0` and `1`, with `0` or `0%` being the complete lack of lightness, which is black.
 
-The `C` is a `<number>`, `<percentage>`, or the keyword `none` (equivalent to `0%`) is the color's chroma, or the "amount of color". This is similar to the `S` saturation value of the `hsl()` color function. The value `0` is the complete lack of chroma or saturation; resulting in a grey between white and black inclusive, depending on the lightness value. The number values are theoretically unbounded, with `100%` being equal to `150` for `lch()` and `0.4` with `oklch()`.
+The `C` is a `<number>`, `<percentage>`, or the keyword `none` (equivalent to `0%`) is the color's chroma, or the "amount of color". This is similar to the `S` saturation value of the `hsl()` color function. The value `0` is the complete lack of chroma or saturation; resulting in a gray between white and black inclusive, depending on the lightness value. The number values are theoretically unbounded, with `100%` being equal to `150` for `lch()` and `0.4` with `oklch()`.
 
 Like the other color functions, there is also an optional alpha transparency value, preceded by a slash (`/`).
 

--- a/files/en-us/web/css/guides/containment/container_size_and_style_queries/index.md
+++ b/files/en-us/web/css/guides/containment/container_size_and_style_queries/index.md
@@ -315,7 +315,7 @@ output {
 }
 ```
 
-The first style feature query is a custom property with no value. This query type returns true when the computed value for the custom property value is different from the `initial-value` for that property. In this case, it will be true when the value of `--theme` is any value other than any syntax equivalent value of `red` (such as `#ff0000`). When true, the {{htmlelement("output")}} will have a 5px dotted outline. The outline color is the current value of `--theme`. The default text {{cssxref("color")}} is grey.
+The first style feature query is a custom property with no value. This query type returns true when the computed value for the custom property value is different from the `initial-value` for that property. In this case, it will be true when the value of `--theme` is any value other than any syntax equivalent value of `red` (such as `#ff0000`). When true, the {{htmlelement("output")}} will have a 5px dotted outline. The outline color is the current value of `--theme`. The default text {{cssxref("color")}} is gray.
 
 ```css
 @container style(--theme) {
@@ -326,7 +326,7 @@ The first style feature query is a custom property with no value. This query typ
 }
 ```
 
-The second and third style queries include values for the custom property. These will match if the container's `--theme` value is an equivalent color to the value listed, even if that value is the same as the `initial-value`. The first query matches elements whose `--theme` value is equivalent to `red`, `blue`, or `green`. When it is, the {{cssxref("color")}} will be the color current value of `--theme` (in the case of `blue` and `green`, overriding the grey set in the first style query).
+The second and third style queries include values for the custom property. These will match if the container's `--theme` value is an equivalent color to the value listed, even if that value is the same as the `initial-value`. The first query matches elements whose `--theme` value is equivalent to `red`, `blue`, or `green`. When it is, the {{cssxref("color")}} will be the color current value of `--theme` (in the case of `blue` and `green`, overriding the gray set in the first style query).
 
 The second style query states that when `--theme` is equivalent to `red`, the `<output>`'s contents will also be bold. We did this to better demonstrate that the container query is a match.
 

--- a/files/en-us/web/css/guides/logical_properties_and_values/floating_and_positioning/index.md
+++ b/files/en-us/web/css/guides/logical_properties_and_values/floating_and_positioning/index.md
@@ -100,7 +100,7 @@ CSS positioning generally allows us to position an element in a manner relative 
 
 These properties take a length or a percentage as a value, and relate to the user's screen dimensions.
 
-In the below example, the `inset-block-start` and `inset-inline-end` properties are used to position the blue box using absolute positioning inside the area with the grey dotted border, which has `position: relative`. Change the `writing-mode` property to `vertical-rl`, or add `direction: rtl`, and see how the flow relative box stays with the text direction.
+In the below example, the `inset-block-start` and `inset-inline-end` properties are used to position the blue box using absolute positioning inside the area with the gray dotted border, which has `position: relative`. Change the `writing-mode` property to `vertical-rl`, or add `direction: rtl`, and see how the flow relative box stays with the text direction.
 
 ```html live-sample___positioning-inset
 <div class="container">

--- a/files/en-us/web/css/guides/scroll-driven_animations/timeline_insets/index.md
+++ b/files/en-us/web/css/guides/scroll-driven_animations/timeline_insets/index.md
@@ -71,7 +71,7 @@ The following diagram illustrates the position of the subject at the `0%` and `1
 
 {{EmbedLiveSample("svg_view", "100%", "720")}}
 
-The yellow subject elements represents the position of the element when the `from` keyframe is applied, which is the animation range's `0%` progress mark. The red represents the location of the animated element relative to the scrollport when the `to` keyframe is applied, which is the end of the animation, or the `100%` progress mark. The grey represents the scrollport.
+The yellow subject elements represents the position of the element when the `from` keyframe is applied, which is the animation range's `0%` progress mark. The red represents the location of the animated element relative to the scrollport when the `to` keyframe is applied, which is the end of the animation, or the `100%` progress mark. The gray represents the scrollport.
 
 By default, the element animates while it is "in view", but this default definition of "in view" may not fit your needs. Fortunately, we can control which edges define the edges of the animation attachment range and then offset the start and end of that range with the animation range properties.
 
@@ -402,7 +402,7 @@ Only when the element is `50px` tall is the top of the subject still in the scro
 
 Based on the height of our subjects, the `20%` mark is either `60px`, `100px`, or `150px` from the end edge of the scrollport (marked by the green line, which is always in the scrollport), and the `60%` mark is `180px`, `300px`, or `450px` from the same point (marked with a red line, but only visible for the `50px` subject).
 
-For illustrative purposes, there are two light grey lines crossing the container `20%` and `60%` of the way through the scrollport, which are `50px` and `150px` from the bottom of the scrollport, respectively. As the `animation-range-*` percentages are relative to the timeline range, not the scrollport, these lines only show how the percentages **don't** align. We've also included two horizontal light grey lines going across each subject at their own `20%` and `60%` marks. These lines align with the scrollport's light grey lines when each subjects animation starts and ends.
+For illustrative purposes, there are two light gray lines crossing the container `20%` and `60%` of the way through the scrollport, which are `50px` and `150px` from the bottom of the scrollport, respectively. As the `animation-range-*` percentages are relative to the timeline range, not the scrollport, these lines only show how the percentages **don't** align. We've also included two horizontal light gray lines going across each subject at their own `20%` and `60%` marks. These lines align with the scrollport's light gray lines when each subjects animation starts and ends.
 
 The following image demonstrates where the subject elements are located when the animation starts (the `0%` keyframe) and ends (the `100% keyframe`).
 This image includes the insets from the animation timeline in the previous demonstration and the timeline without insets for comparison.
@@ -444,13 +444,13 @@ This image includes the insets from the animation timeline in the previous demon
 
 {{EmbedLiveSample("svg_insets2", "100%", "710")}}
 
-As before, the yellow represents the position of the element when the `from` keyframe is applied, the red represents the location when the `to` keyframe is applied, and the grey represents the scrollport. The striped areas are where the red and yellow element representations overlap. For illustrative purposes, we've added dashed black horizontal lines `20%` and `60%` way through the scrollport, starting from the bottom.
+As before, the yellow represents the position of the element when the `from` keyframe is applied, the red represents the location when the `to` keyframe is applied, and the gray represents the scrollport. The striped areas are where the red and yellow element representations overlap. For illustrative purposes, we've added dashed black horizontal lines `20%` and `60%` way through the scrollport, starting from the bottom.
 
 The animation only begins when the element reaches the `20%` mark along the animation attachment range. This point is `60px`, `100px`, or `150px` from the bottom edge of the scroll port, depending on the size of the element. The location of the subject element at this point, representing the position of the element when the `from` or `0%` keyframe is applied, is shown in yellow.
 
 The red represents the location of the animated element relative to the scrollport when the `to` or `100%` keyframe is applied, which is the end of the animation. This point is either `180px`, `300px`, or `450px` from the bottom edge of the scrollport, depending on the subject size. The animation occurs when the element is between the `to` and the `from` positions.
 
-You may have noticed something interesting about the dashed horizontal lines: when the animation starts, the line that is `20%` from the end edge of the viewport is `20%` from the _top_ of the subject element and the line that is `60%` from the end edge of the viewport is `60%` from the _top_ of the subject element when the animation ends. This is what was illustrated by the very light grey lines in the live demo for this example.
+You may have noticed something interesting about the dashed horizontal lines: when the animation starts, the line that is `20%` from the end edge of the viewport is `20%` from the _top_ of the subject element and the line that is `60%` from the end edge of the viewport is `60%` from the _top_ of the subject element when the animation ends. This is what was illustrated by the very light gray lines in the live demo for this example.
 
 ### Subject size matters
 

--- a/files/en-us/web/css/reference/properties/fill/index.md
+++ b/files/en-us/web/css/reference/properties/fill/index.md
@@ -79,7 +79,7 @@ This example demonstrates how a `fill` is declared, the effect of the property, 
 
 #### HTML
 
-We have an SVG with two complex shapes defined using the SVG {{SVGElement('polygon')}} and {{SVGElement('path')}} elements. Both have the `fill` attribute set to the default `black`. We add a dark grey stroke of `#666666` using the SVG {{SVGAttr("stroke")}} attribute but could have used the {{CSSXRef("stroke")}} property.
+We have an SVG with two complex shapes defined using the SVG {{SVGElement('polygon')}} and {{SVGElement('path')}} elements. Both have the `fill` attribute set to the default `black`. We add a dark gray stroke of `#666666` using the SVG {{SVGAttr("stroke")}} attribute but could have used the {{CSSXRef("stroke")}} property.
 
 ```html
 <svg viewBox="0 0 220 120" xmlns="http://www.w3.org/2000/svg">
@@ -127,7 +127,7 @@ This example demonstrates using keyword values for `fill`.
 
 #### HTML
 
-We include three {{SVGElement("path")}} elements and a {{SVGElement("marker")}} element that adds a {{SVGElement("circle")}} to every path point. We set the circle marker to be black with a grey fill with the SVG {{SVGAttr("stroke")}} and {{SVGAttr("fill")}} attributes.
+We include three {{SVGElement("path")}} elements and a {{SVGElement("marker")}} element that adds a {{SVGElement("circle")}} to every path point. We set the circle marker to be black with a gray fill with the SVG {{SVGAttr("stroke")}} and {{SVGAttr("fill")}} attributes.
 
 ```html
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 90">

--- a/files/en-us/web/css/reference/properties/filter/index.md
+++ b/files/en-us/web/css/reference/properties/filter/index.md
@@ -126,7 +126,7 @@ When the `filter` property values contains multiple functions, the filters are a
     ```
 
 - {{cssxref("filter-function/contrast", "contrast()")}}
-  - : Adjusts the contrast of the input image. A value of `0%` makes the image grey, `100%` has no effect, and values over `100%` create a contrast.
+  - : Adjusts the contrast of the input image. A value of `0%` makes the image gray, `100%` has no effect, and values over `100%` create a contrast.
 
     ```css
     filter: contrast(200%);

--- a/files/en-us/web/css/reference/properties/forced-color-adjust/index.md
+++ b/files/en-us/web/css/reference/properties/forced-color-adjust/index.md
@@ -91,7 +91,7 @@ By using the {{cssxref("@media/forced-colors", "forced-colors")}} media feature,
 
 The following screenshot shows the image above in Windows High Contrast Mode:
 
-![The example above in high contrast mode shows the first box with a black background the second with the grey background of the CSS.](windows-high-contrast.jpg)
+![The example above in high contrast mode shows the first box with a black background the second with the gray background of the CSS.](windows-high-contrast.jpg)
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/properties/mask-border/index.md
+++ b/files/en-us/web/css/reference/properties/mask-border/index.md
@@ -72,7 +72,7 @@ mask-border: unset;
 
 In this example, we will mask an element's border with a diamond pattern. The source for the mask is a ".png" file of 90 by 90 pixels, with three diamonds going vertically and horizontally:
 
-<img src="https://mdn.github.io/shared-assets/images/examples/mask-border-diamonds.png" alt="The image used for the mask examples on this page. The mask is a transparent square with three rows of three diamonds each. The diamonds are a very light, almost white, shade of grey. The middle part between the diamonds is also solid grey. The parts between the outside of the diamonds and the edge of the image are transparent." loading="lazy" style="background-color: black;">
+<img src="https://mdn.github.io/shared-assets/images/examples/mask-border-diamonds.png" alt="The image used for the mask examples on this page. The mask is a transparent square with three rows of three diamonds each. The diamonds are a very light, almost white, shade of gray. The middle part between the diamonds is also solid gray. The parts between the outside of the diamonds and the edge of the image are transparent." loading="lazy" style="background-color: black;">
 
 To match the size of a single diamond, we will use a value of 90 divided by 3, or `30`, for slicing the image into corner and edge regions. A repeat value of `round` will make the mask slices fit evenly, i.e., without clipping or gaps.
 

--- a/files/en-us/web/css/reference/properties/print-color-adjust/index.md
+++ b/files/en-us/web/css/reference/properties/print-color-adjust/index.md
@@ -35,7 +35,7 @@ This property is specified as one of the following keyword values:
 - `exact`
   - : The element's content has been specifically and carefully crafted to use colors, images, and styles in a thoughtful and/or important way, such that being altered by the browser might actually make things worse rather than better.
     The appearance of the content should not be changed except by the user's request.
-    For example, a page might include a list of information with rows whose background colors alternate between white and a light grey.
+    For example, a page might include a list of information with rows whose background colors alternate between white and a light gray.
     Removing the background color would decrease the legibility of the content.
 
 ## Usage notes

--- a/files/en-us/web/css/reference/properties/stop-color/index.md
+++ b/files/en-us/web/css/reference/properties/stop-color/index.md
@@ -49,7 +49,7 @@ This example demonstrates the basic use case of `stop-color`, and how the CSS `s
 
 #### HTML
 
-We have an SVG with three {{SVGElement("rect")}} squares and three {{SVGElement("linearGradient")}} elements. Each gradient has four {{SVGElement("stop")}} elements creating gradients that go from black to white and then white to grey; the only difference between them is the `id` value.
+We have an SVG with three {{SVGElement("rect")}} squares and three {{SVGElement("linearGradient")}} elements. Each gradient has four {{SVGElement("stop")}} elements creating gradients that go from black to white and then white to gray; the only difference between them is the `id` value.
 
 ```html
 <svg viewBox="0 0 264 100" xmlns="http://www.w3.org/2000/svg">

--- a/files/en-us/web/css/reference/properties/stop-opacity/index.md
+++ b/files/en-us/web/css/reference/properties/stop-opacity/index.md
@@ -137,7 +137,7 @@ polygon:nth-of-type(3) {
 
 {{EmbedLiveSample("Defining the opacity of an SVG gradient color stop", "300", "200")}}
 
-The first star is fully opaque. The fill of the second star is 80% opaque because the color stops are slightly translucent; the `stop-opacity: 0.8;` overrode the `stop-opacity="1"` element attribute value. The fill of the last star is barely noticeable with color stops that are 25% opaque. Note the stroke is the same opaque dark grey in all cases.
+The first star is fully opaque. The fill of the second star is 80% opaque because the color stops are slightly translucent; the `stop-opacity: 0.8;` overrode the `stop-opacity="1"` element attribute value. The fill of the last star is barely noticeable with color stops that are 25% opaque. Note the stroke is the same opaque dark gray in all cases.
 
 > [!NOTE]
 > Because we used the same `stop-opacity` value for all the sibling `<stop>` elements in the linear gradient, we could have instead used a single `<linearGradient>` with fully opaque stops, and set a value for each `<polygon>`s {{cssxref("fill-opacity")}} property instead.

--- a/files/en-us/web/css/reference/selectors/_colon_defined/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_defined/index.md
@@ -74,7 +74,7 @@ code {
 }
 ```
 
-In the following CSS, we use the `custom-element:not(:defined)` selector to select the element and color it grey while it is not defined and the `custom-element:defined` selector to select the element and color it black after it is defined.
+In the following CSS, we use the `custom-element:not(:defined)` selector to select the element and color it gray while it is not defined and the `custom-element:defined` selector to select the element and color it black after it is defined.
 
 ```css
 custom-element:not(:defined) {

--- a/files/en-us/web/css/reference/selectors/_colon_state/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_state/index.md
@@ -58,7 +58,7 @@ For a live example of this code in action, see the [Matching the custom state of
 
 This example shows how the `:state()` pseudo-class can be used within the [`:host()`](/en-US/docs/Web/CSS/Reference/Selectors/:host_function) pseudo-class function to match custom states within the implementation of a custom element.
 
-The following CSS injects a grey `[x]` before the element when it is in the "checked" state.
+The following CSS injects a gray `[x]` before the element when it is in the "checked" state.
 
 ```css
 :host(:state(checked))::before {

--- a/files/en-us/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_-moz-range-progress/index.md
@@ -47,7 +47,7 @@ input[type="range"]::-moz-range-progress {
 
 A progress bar using this style might look something like this:
 
-![The progress bar is a thick green square to the left of the thumb and a thin grey line to the right. The thumb is a circle with a diameter the height of the green area.](screen_shot_2015-12-04_at_20.14.48.png)
+![The progress bar is a thick green square to the left of the thumb and a thin gray line to the right. The thumb is a circle with a diameter the height of the green area.](screen_shot_2015-12-04_at_20.14.48.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/selectors/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_-webkit-progress-inner-element/index.md
@@ -58,7 +58,7 @@ progress {
 
 If you're not using a Blink or WebKit browser, the above code results in a progress bar looking like this:
 
-![Progressbar is a long green and grey box with a black border. The left 20% of the box is green. The right 80% is grey.](-webkit-progress-inner-element_example.png)
+![Progressbar is a long green and gray box with a black border. The left 20% of the box is green. The right 80% is gray.](-webkit-progress-inner-element_example.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/selectors/_doublecolon_-webkit-progress-value/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_-webkit-progress-value/index.md
@@ -54,7 +54,7 @@ progress {
 
 A progress bar using the style above would look like this:
 
-![A long orange and grey box. The left 20% is orange. The right 80% is grey.](progress-value.png)
+![A long orange and gray box. The left 20% is orange. The right 80% is gray.](progress-value.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/color_value/hwb/index.md
+++ b/files/en-us/web/css/reference/values/color_value/hwb/index.md
@@ -65,7 +65,7 @@ The angles corresponding to particular hues differ across the sRGB (used by {{CS
 
 An `hwb()` color is fully saturated when its whiteness (`W`) and blackness (`B`) values are both `0`. For any hue value `H`, `hwb(H 0% 0%)` is the same color as `hsl(H 100% 50%)`. Increasing the whiteness value lightens the color. Increasing the blackness darkens the color.
 
-When both the blackness and whiteness are greater than 0, the color gets muted, tending towards grey. When the amount of whiteness and blackness added in are equal to or greater than 100% — in other words, if `W + B >= 100%`, the color function defines a shade of gray. When the sum of both values is greater than 100% (`W + B > 100%`), the whiteness and blackness values of the grey color are effectively normalized as `W / (W + B)` and `B / (W + B)`, respectively.
+When both the blackness and whiteness are greater than 0, the color gets muted, tending towards gray. When the amount of whiteness and blackness added in are equal to or greater than 100% — in other words, if `W + B >= 100%`, the color function defines a shade of gray. When the sum of both values is greater than 100% (`W + B > 100%`), the whiteness and blackness values of the gray color are effectively normalized as `W / (W + B)` and `B / (W + B)`, respectively.
 
 ## Values
 

--- a/files/en-us/web/css/reference/values/color_value/lab/index.md
+++ b/files/en-us/web/css/reference/values/color_value/lab/index.md
@@ -293,7 +293,7 @@ div {
 
 {{EmbedLiveSample("Adjusting_color_axes", "", "200")}}
 
-The left column is at the yellow end (-125) of the b-axis and the right column is at the blue end (125). The top row displays colors at the red end of the a-axis (-125) and the bottom row is at the green end (125). The middle column and row are at the midpoints (0) of each axis, with the middle cell being grey; it contains no red, green, yellow, or blue, with a `0` value for both axes.
+The left column is at the yellow end (-125) of the b-axis and the right column is at the blue end (125). The top row displays colors at the red end of the a-axis (-125) and the bottom row is at the green end (125). The middle column and row are at the midpoints (0) of each axis, with the middle cell being gray; it contains no red, green, yellow, or blue, with a `0` value for both axes.
 
 ### Linear gradients along the a-axis and b-axis
 

--- a/files/en-us/web/css/reference/values/color_value/lch/index.md
+++ b/files/en-us/web/css/reference/values/color_value/lch/index.md
@@ -232,7 +232,7 @@ div {
 
 ### Adjusting color intensity via chroma
 
-The following example shows the effect of varying the `C` (chroma) value of the `lch()` functional notation, with colors decreasing in intensity as the `C` value decreases from fully saturated to almost grey.
+The following example shows the effect of varying the `C` (chroma) value of the `lch()` functional notation, with colors decreasing in intensity as the `C` value decreases from fully saturated to almost gray.
 
 #### HTML
 
@@ -255,7 +255,7 @@ The following example shows the effect of varying the `C` (chroma) value of the 
 
 #### CSS
 
-With the initial starting colors blue, red, and green, we declare progressively smaller values for chroma on them: starting from full color saturation at the highest value of `150` (equivalent to `100%`) down to `3` (equivalent to `2%`), which is almost grey for all the colors.
+With the initial starting colors blue, red, and green, we declare progressively smaller values for chroma on them: starting from full color saturation at the highest value of `150` (equivalent to `100%`) down to `3` (equivalent to `2%`), which is almost gray for all the colors.
 
 ```css hidden
 body {
@@ -314,7 +314,7 @@ div {
 
 {{EmbedLiveSample("Adjusting color intensity via chroma", '', '200')}}
 
-If we had used `0` instead of `3` and `2%`, with the same lightness values, the colors would have all been the same shade of grey. In this example, they are almost grey.
+If we had used `0` instead of `3` and `2%`, with the same lightness values, the colors would have all been the same shade of gray. In this example, they are almost gray.
 
 ### Hues in LCH
 

--- a/files/en-us/web/css/reference/values/color_value/oklab/index.md
+++ b/files/en-us/web/css/reference/values/color_value/oklab/index.md
@@ -342,7 +342,7 @@ div {
 
 {{EmbedLiveSample("Adjusting_color_axes", "", "200")}}
 
-The left column is at the yellow end (`-0.4`) of the b-axis and the right column is at the blue end (`0.4`). The top row displays colors at the red end of the a-axis (`-0.4`) and the bottom row is at the green end (`0.4`). The middle column and row are at the midpoints of each axis, with the middle cell being grey; it contains no red, green, yellow, or blue, with a `0` value for both axes.
+The left column is at the yellow end (`-0.4`) of the b-axis and the right column is at the blue end (`0.4`). The top row displays colors at the red end of the a-axis (`-0.4`) and the bottom row is at the green end (`0.4`). The middle column and row are at the midpoints of each axis, with the middle cell being gray; it contains no red, green, yellow, or blue, with a `0` value for both axes.
 
 ### Linear gradients along the a-axis and b-axis
 

--- a/files/en-us/web/css/reference/values/color_value/oklch/index.md
+++ b/files/en-us/web/css/reference/values/color_value/oklch/index.md
@@ -232,7 +232,7 @@ div {
 
 ### Adjusting color intensity via chroma
 
-The following example shows the effect of varying the `C` (chroma) value of the `oklch()` functional notation, with colors decreasing in intensity as the `C` value decreases from fully saturated to almost grey.
+The following example shows the effect of varying the `C` (chroma) value of the `oklch()` functional notation, with colors decreasing in intensity as the `C` value decreases from fully saturated to almost gray.
 
 #### HTML
 
@@ -255,7 +255,7 @@ The following example shows the effect of varying the `C` (chroma) value of the 
 
 #### CSS
 
-With the initial starting colors blue, red, and green, we declare progressively smaller values for chroma on them: starting from full color saturation at the high value of `0.4` (equivalent to `100%`) down to `0.01` (equivalent to `2%`), which is almost grey for all the colors.
+With the initial starting colors blue, red, and green, we declare progressively smaller values for chroma on them: starting from full color saturation at the high value of `0.4` (equivalent to `100%`) down to `0.01` (equivalent to `2%`), which is almost gray for all the colors.
 
 ```css hidden
 body {
@@ -314,7 +314,7 @@ div {
 
 {{EmbedLiveSample("Adjusting color intensity via chroma", '', '200')}}
 
-If we had used `0` instead of `0.01` and `2%`, with the same lightness values, the colors would have all been the same shade of grey. In this example, they are almost grey.
+If we had used `0` instead of `0.01` and `2%`, with the same lightness values, the colors would have all been the same shade of gray. In this example, they are almost gray.
 
 ### Hues in OkLCh
 

--- a/files/en-us/web/html/reference/attributes/disabled/index.md
+++ b/files/en-us/web/html/reference/attributes/disabled/index.md
@@ -52,7 +52,7 @@ label {
 
 ## Overview
 
-If the `disabled` attribute is specified on a form control, the element and its form control descendants do not participate in constraint validation. Often browsers grey out such controls and it won't receive any browsing events, like mouse clicks or focus-related ones.
+If the `disabled` attribute is specified on a form control, the element and its form control descendants do not participate in constraint validation. Often browsers gray out such controls and it won't receive any browsing events, like mouse clicks or focus-related ones.
 
 The `disabled` attribute is supported by {{ HTMLElement("button") }}, {{ HTMLElement("fieldset") }}, {{ HTMLElement("optgroup") }}, {{ HTMLElement("option") }}, {{ HTMLElement("select") }}, {{ HTMLElement("textarea") }} and {{ HTMLElement("input")}}.
 

--- a/files/en-us/web/html/reference/elements/input/image/index.md
+++ b/files/en-us/web/html/reference/elements/input/image/index.md
@@ -309,7 +309,7 @@ label {
 
 {{EmbedLiveSample("Adjusting_the_image_position_and_scaling", 600, 300)}}
 
-Here, `object-position` is configured to draw the image in the top-right corner of the element, while `object-fit` is set to `contain`, which indicates that the image should be drawn at the largest size that will fit within the element's box without altering its aspect ratio. Note the visible grey background of the element still visible in the area not covered by the image.
+Here, `object-position` is configured to draw the image in the top-right corner of the element, while `object-fit` is set to `contain`, which indicates that the image should be drawn at the largest size that will fit within the element's box without altering its aspect ratio. Note the visible gray background of the element still visible in the area not covered by the image.
 
 ## Technical summary
 

--- a/files/en-us/web/html/reference/elements/optgroup/index.md
+++ b/files/en-us/web/html/reference/elements/optgroup/index.md
@@ -44,7 +44,7 @@ label {
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 
 - [`disabled`](/en-US/docs/Web/HTML/Reference/Attributes/disabled)
-  - : If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones.
+  - : If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers gray out such control and it won't receive any browsing events, like mouse clicks or focus-related ones.
 - `label`
   - : The name of the group of options, which the browser can use when labeling the options in the user interface. This attribute is mandatory if this element is used.
 

--- a/files/en-us/web/html/reference/elements/option/index.md
+++ b/files/en-us/web/html/reference/elements/option/index.md
@@ -43,7 +43,7 @@ select {
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 
 - [`disabled`](/en-US/docs/Web/HTML/Reference/Attributes/disabled)
-  - : If this Boolean attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled {{HTMLElement("optgroup")}} element.
+  - : If this Boolean attribute is set, this option is not checkable. Often browsers gray out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled {{HTMLElement("optgroup")}} element.
 - `label`
   - : This attribute is text for the label indicating the meaning of the option. If the `label` attribute isn't defined, its value is that of the element text content.
 - `selected`

--- a/files/en-us/web/media/guides/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/buffering_seeking_time_ranges/index.md
@@ -211,7 +211,7 @@ The progress event is fired as data is downloaded, this is a good event to react
 
 The timeupdate event is fired 4 times a second as the media plays and that's where we increment our playing progress bar.
 
-This time, you should see two kinds of segments. The light grey bar represents the buffered progress and green bar shows the played progress.
+This time, you should see two kinds of segments. The light gray bar represents the buffered progress and green bar shows the played progress.
 
 {{EmbedLiveSample("buffered-progress", "", 200)}}
 

--- a/files/en-us/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
+++ b/files/en-us/web/svg/tutorials/svg_from_scratch/clipping_and_masking/index.md
@@ -11,7 +11,7 @@ Erasing part of what you have created might seem contradictory at first. But whe
 
 - **Clipping**, which refers to removing parts of elements defined by other parts. In this case, any half-transparent effects are not possible; it's an all-or-nothing approach.
 
-- **Masking**, which, on the other hand, allows soft edges by taking transparency and grey values of the mask into account.
+- **Masking**, which, on the other hand, allows soft edges by taking transparency and gray values of the mask into account.
 
 ## Creating clips
 


### PR DESCRIPTION
### Description

Replaces `grey` with `gray` in prose and image alt text — 79 occurrences across 41 files.

### Motivation

The writing style guide requires American English spelling: "Use American-English spelling. […] Do not use variant spelling." Dictionary.com gives "gray" as the American standard and marks "grey" as chiefly British, the same pattern as the "behaviour"/"behavior" example the style guide itself uses.

Because `grey` is also a real CSS color keyword, this change is limited to running prose and alt text, and every place where the word is a value rather than a description is left alone:

- `<named-color>`: the `grey` row and its `style="background: grey"` swatch, along with `darkgrey`, `dimgrey`, `lightgrey`, `slategrey`, `darkslategrey`, and `lightslategrey`.
- `tabGroups.color`: `grey` is one of the accepted enum values for that property.
- Everything inside code fences, including `border: 1px dotted grey` in the File API example, and every inline `` `grey` ``.

No image filenames or URLs are touched.
