### PR TITLE
chore: Update writing guidlines and remove Deprecated_Header macro mentions

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/banners_and_notices/index.md
@@ -42,7 +42,6 @@ You need to add the following macros manually:
 The following macros are automatically added to the content in order to match the statuses stored in the [browser compat data](https://github.com/mdn/browser-compat-data) repository:
 
 - `\{{SeeCompatTable}}` — generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
-- `\{{Deprecated_Header}}` — generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 - `\{{Non-standard_Header}}` — generates a **Non-Standard** banner that indicates that use of the technology is not part of a formal specification, even if it is implemented in multiple browsers.
 
 [Update the feature status in the browser-compat-data repository](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) in order to change these values.
@@ -51,7 +50,7 @@ The following macros are automatically added to the content in order to match th
 > While you can manually/update these macros in content, values that don't match the browser compatibility data will be replaced/removed.
 
 > [!NOTE]
-> Pages that have the `\{{SeeCompatTable}}`, `\{{Deprecated_Header}}`, or `\{{Non-standard_Header}}` banners will also have the corresponding `experimental`, `deprecated` and `non-standard` status values in the page metadata.
+> Pages that have the `\{{SeeCompatTable}}` or `\{{Non-standard_Header}}` banners will also have the corresponding `experimental` and `non-standard` status values in the page metadata.
 > The metadata is automatically updated at the same time as the headers.
 > The banner macros do not depend on this status metadata (but may one day be generated from it).
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/feature_status/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/feature_status/index.md
@@ -52,11 +52,10 @@ browser-compat: api.feature
 
 ### Feature status page banners
 
-The following macros are used to render the status banners in page headers:
+> [!WARNING]
+> The `\{{Deprecated_Header}}` macro is no longer required to generate a **Deprecated status** banner. The platform now automatically generates the banner using the [`status`](#feature_status_icons_in_sidebars) front matter property or data from [web-features](https://github.com/web-platform-dx/web-features).
 
-- `\{{Deprecated_Header}}`
-  - : For `deprecated` status. It generates a **Deprecated status** banner:
-    {{deprecated_header}}
+The following macros are used to render the status banners in page headers:
 
 - `\{{SeeCompatTable}}`
   - : For `experimental` status. It generates an **Experimental status** banner:

--- a/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
@@ -122,4 +122,4 @@ For example, `\{{CSSxRef("background-color")}}` creates the "{{CSSxRef("backgrou
 
 - [Using macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros)
 - [Commonly used macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros), including BCD macros (`\{{Compat}}`) and specification macros (`\{{Specifications}}`).
-- [Banners and notices guide](/en-US/docs/MDN/Writing_guidelines/Page_structures/Banners_and_notices) including the `\{{SeeCompatTable}}`, `\{{Deprecated_Header}}`, and `\{{SecureContext_Header}}` macros.
+- [Banners and notices guide](/en-US/docs/MDN/Writing_guidelines/Page_structures/Banners_and_notices) including the `\{{SeeCompatTable}}` and `\{{SecureContext_Header}}` macros.

--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -234,7 +234,6 @@ They can also be used to mark up a section on a page.
 - [`SeeCompatTable`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs) used on pages
   that document [experimental features](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
   Example: `\{{SeeCompatTable}}` {{SeeCompatTable}}
-- [`Deprecated_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs): `\{{Deprecated_Header}}` {{Deprecated_Header}}
 - [`SecureContext_Header`](https://github.com/mdn/rari/blob/main/crates/rari-doc/src/templ/templs/banners.rs).
   Should be used on main pages like interface pages, API overview pages, and API entry points (e.g., `navigator.xyz`) but usually not on subpages like method and property pages.
   Example: `\{{SecureContext_Header}}` {{SecureContext_Header}}

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_constructor_subpage_template/index.md
@@ -57,7 +57,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -79,7 +78,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Begin the content on the page with an introductory paragraph — start by naming the constructor and saying what it does.
 This should ideally be one or two short sentences.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_event_subpage_template/index.md
@@ -56,7 +56,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -88,7 +87,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Begin the content on the page with an introductory paragraph — start by naming the event, saying what interface it is part of, and saying what it does.
 This should ideally be one or two short sentences.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_landing_page_template/index.md
@@ -50,7 +50,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -94,7 +93,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing_
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Begin the content on the page with an introductory paragraph — start by naming the API and saying what it does. This should ideally be one or two short sentences.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_method_subpage_template/index.md
@@ -60,7 +60,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -82,7 +81,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 Begin the content on the page with an introductory paragraph — start by naming the method, saying what interface it is part of, and saying what it does.
 This should ideally be one or two short sentences. You could copy most of this from the method's summary on the corresponding API reference page.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_property_subpage_template/index.md
@@ -61,7 +61,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -83,7 +82,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`NameOfTheProperty`** [read-only] property of the \{{domxref("NameOfTheParentInterface")}} interface _\<provide concise summary of behavior\>_.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -52,7 +52,6 @@ sidebar: mdnsidebar
 > These macros are automatically added by the toolchain (there is no need to add/remove):
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental). If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates the technology is [deprecated](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -69,7 +68,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing._
 
-{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SecureContext_Header}}{{AvailableInWorkers}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The summary paragraph — start by naming the interface, saying what API it is part of, and saying what it does. This should ideally be one or two short sentences. You could copy most of this from the Interface's summary on the corresponding API landing page.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_function_page_template/index.md
@@ -54,7 +54,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}`: This macro generates an **Experimental** banner, which indicates that the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If the technology is experimental and is hidden behind a preference in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}`: This macro generates a **Deprecated** banner, which indicates that the use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > Do not provide status header macros manually. Refer to the section ["How feature statuses are added or updated"](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) to add these statuses to the page.
@@ -73,7 +72,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this note block before publishing._
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 Begin the content on the page with an introductory paragraph, which names the function and says what it does.
 This should ideally be one or two short sentences.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -54,7 +54,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}`: This macro generates an **Experimental** banner, which indicates that the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If the technology is experimental and is hidden behind a preference in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}`: This macro generates a **Deprecated** banner, which indicates that the use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -76,7 +75,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this note block before publishing._
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 Begin the content on the page with an introductory paragraph, which names the property and says what it does.
 This should ideally be one or two short sentences. All other explanations, if any, should be included in the "Description" section.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_selector_page_template/index.md
@@ -58,7 +58,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > You should update or delete the following macros according to the advice below:
@@ -77,7 +76,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing_
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 The summary paragraph — start by naming the selector and saying what it does. This should ideally be one or two short sentences.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_attribute_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_attribute_page_template/index.md
@@ -74,7 +74,6 @@ Only add an article if the attribute has enough nuance to deserve its own exampl
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > Do not provide status header macros manually. Refer to the section ["How feature statuses are added or updated"](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) to add these statuses to the page.
@@ -83,7 +82,7 @@ Only add an article if the attribute has enough nuance to deserve its own exampl
 >
 > _Remember to remove this whole explanatory note before publishing_
 >
-> {{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+> {{SeeCompatTable}}{{Non-standard_Header}}
 >
 > Start by introducing the reader to the attribute, and its usage.
 > For example: The **`name-of-the-attribute`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) describes or manipulates [insert usage description].

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/html_element_page_template/index.md
@@ -59,7 +59,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > See ["How feature statuses are added or updated"](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) for information.
@@ -68,7 +67,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing_
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`<insert_the_element_name>`** [HTML](/en-US/docs/Web/HTML) element does _(insert a summary paragraph naming the element and saying what it does, ideally one or two short sentences)_.
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/http_header_page_template/index.md
@@ -62,7 +62,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the header is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{deprecated_header}}` — this generates a **Deprecated** banner that indicates that use of the header is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > Do not provide status header macros manually. Refer to the section ["How feature statuses are added or updated"](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) to add these statuses to the page.
@@ -71,7 +70,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing_
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 The first sentence of the page must follow this format:
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/svg_element_page_template/index.md
@@ -59,7 +59,6 @@ sidebar: mdnsidebar
 >
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#experimental).
 >   If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates that use of the technology is [discouraged](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#deprecated).
 > - `\{{Non-standard_Header}}` — this generates a **Non-standard** banner that indicates that the feature is not part of any specification.
 >
 > See ["How feature statuses are added or updated"](/en-US/docs/MDN/Writing_guidelines/Page_structures/Feature_status#how_feature_statuses_are_added_or_updated) for information.
@@ -68,7 +67,7 @@ sidebar: mdnsidebar
 >
 > _Remember to remove this whole explanatory note before publishing_
 
-{{SeeCompatTable}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{SeeCompatTable}}{{Non-standard_Header}}
 
 Begin the content on the page with an introductory paragraph — start by naming the element and saying what it does.
 This should ideally be one or two short sentences.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -8,8 +8,6 @@ browser-compat: webextensions.api.extension.sendRequest
 sidebar: addonsidebar
 ---
 
-{{Deprecated_Header}}
-
 > [!WARNING]
 > This method has been deprecated. Use {{WebExtAPIRef("runtime.sendMessage")}} instead.
 

--- a/files/en-us/web/api/css_object_model/index.md
+++ b/files/en-us/web/api/css_object_model/index.md
@@ -94,8 +94,6 @@ Several other interfaces are also extended by the CSSOM-related specifications: 
 
 ### Obsolete CSSOM interfaces {{deprecated_inline}}
 
-{{deprecated_header}}
-
 - {{DOMxRef("CSSPrimitiveValue")}} {{deprecated_inline}}
 - {{DOMxRef("CSSValue")}} {{deprecated_inline}}
 - {{DOMxRef("CSSValueList")}} {{deprecated_inline}}

--- a/files/en-us/web/api/idbcursor/index.md
+++ b/files/en-us/web/api/idbcursor/index.md
@@ -47,8 +47,6 @@ You can have an unlimited number of cursors at the same time. You always get the
 
 ## Constants
 
-{{Deprecated_Header}}
-
 > [!WARNING]
 > These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Firefox bug 891944](https://bugzil.la/891944))
 

--- a/files/en-us/web/api/idbtransaction/index.md
+++ b/files/en-us/web/api/idbtransaction/index.md
@@ -83,8 +83,6 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 
 ## Mode constants
 
-{{Deprecated_Header}}
-
 > [!WARNING]
 > These constants are no longer available — they were removed in Gecko 25. You should use the string constants directly instead. ([Firefox bug 888598](https://bugzil.la/888598))
 

--- a/files/en-us/web/mathml/reference/values/index.md
+++ b/files/en-us/web/mathml/reference/values/index.md
@@ -16,7 +16,8 @@ In addition to [CSS data types](/en-US/docs/Web/CSS/Reference/Values/Data_types)
 
 ## Legacy MathML lengths
 
-{{deprecated_header}}
+> [!WARNING]
+> These lengths are deprecated. Using them is no longer recommended.
 
 Instead of {{cssxref("length-percentage")}}, MathML used to define its own [type to describe lengths](https://www.w3.org/TR/MathML3/chapter2.html#type.length). Accepted values included non-zero unitless length values (e.g., `5` to mean `500%`), values containing numbers ending with a dot (e.g., `34.px`), or named spaces (e.g., `thinmathspace`). For compatibility reasons, it is recommended to replace non-zero unitless length values with equivalent {{cssxref("percentage")}} values, to remove unnecessary dots in numbers, and to use the following replacement for named lengths:
 

--- a/files/en-us/web/svg/reference/attribute/attributetype/index.md
+++ b/files/en-us/web/svg/reference/attribute/attributetype/index.md
@@ -6,8 +6,6 @@ browser-compat: svg.elements.animate.attributeType
 sidebar: svgref
 ---
 
-{{Deprecated_Header}}
-
 The **`attributeType`** attribute specifies the namespace in which the target attribute and its associated values are defined.
 
 You can use this attribute with the following SVG elements:


### PR DESCRIPTION
Follow up on
- https://github.com/orgs/mdn/discussions/911
- https://github.com/mdn/content/pull/45259

### Description

The PR updates writing guidelines to instruct contributors to not use the `{{Deprecated_Header}}` macro anymore. Because, now the deprecated status banner is being inferred from front-matter `status` property or data from web-features repository.

### Motivation

Contributors need to know.

### Related issues and pull requests

- https://github.com/orgs/mdn/discussions/911
- https://github.com/mdn/content/pull/45259