### PR TITLE
Use American English spelling for fulfils, signalled, and other inflected forms

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
@@ -77,7 +77,7 @@ Some of the things to consider when choosing a host:
 
 - How busy your site is likely to be and the cost of data and computing resources required to meet that demand.
 - Level of support for scaling horizontally (adding more machines) and vertically (upgrading to more powerful machines) and the costs of doing so.
-- Where the supplier has data centres, and hence where access is likely to be fastest.
+- Where the supplier has data centers, and hence where access is likely to be fastest.
 - The host's historical uptime and downtime performance.
 - Tools provided for managing the site — are they easy to use and are they secure (e.g., SFTP vs. FTP).
 - Inbuilt frameworks for monitoring your server.

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/date_formatting_using_moment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/date_formatting_using_moment/index.md
@@ -7,7 +7,7 @@ sidebar: learnsidebar
 
 The default rendering of dates from our models is very ugly: _Mon Apr 10 2020 15:49:58 GMT+1100 (AUS Eastern Daylight Time)_. In this section we'll show how you can update the _BookInstance List_ page from the previous section to present the `due_date` field in a more friendly format: Apr 10th, 2023.
 
-The approach we will use is to create a virtual property in our `BookInstance` model that returns the formatted date. We'll do the actual formatting using [luxon](https://www.npmjs.com/package/luxon), a powerful, modern, and friendly library for parsing, validating, manipulating, formatting and localising dates.
+The approach we will use is to create a virtual property in our `BookInstance` model that returns the formatted date. We'll do the actual formatting using [luxon](https://www.npmjs.com/package/luxon), a powerful, modern, and friendly library for parsing, validating, manipulating, formatting and localizing dates.
 
 > [!NOTE]
 > It is possible to use _luxon_ to format the strings directly in our Pug templates, or we could format the string in a number of other places. Using a virtual property allows us to get the formatted date in exactly the same way as we get the `due_date` currently.

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -10,7 +10,7 @@ browser-compat: api.AbortSignal.throwIfAborted
 
 The **`throwIfAborted()`** method throws the signal's abort {{domxref("AbortSignal.reason", "reason")}} if the signal has been aborted; otherwise it does nothing.
 
-An API that needs to support aborting can accept an {{domxref("AbortSignal")}} object and use `throwIfAborted()` to test and throw when the [`abort`](/en-US/docs/Web/API/AbortSignal/abort_event) event is signalled.
+An API that needs to support aborting can accept an {{domxref("AbortSignal")}} object and use `throwIfAborted()` to test and throw when the [`abort`](/en-US/docs/Web/API/AbortSignal/abort_event) event is signaled.
 
 This method can also be used to abort operations at particular points in code, rather than passing to functions that take a signal.
 

--- a/files/en-us/web/api/document/fonts/index.md
+++ b/files/en-us/web/api/document/fonts/index.md
@@ -32,7 +32,7 @@ document.fonts.ready.then((fontFaceSet) => {
 });
 ```
 
-The promise fulfils when loading and layout operations of all used fonts are done. The set of used fonts can be different from the set of _declared_ fonts, e.g., if optional fonts (i.e., fonts declared via `font-display: optional`) were not able to load in time.
+The promise fulfills when loading and layout operations of all used fonts are done. The set of used fonts can be different from the set of _declared_ fonts, e.g., if optional fonts (i.e., fonts declared via `font-display: optional`) were not able to load in time.
 
 ## Specifications
 

--- a/files/en-us/web/api/encrypted_media_extensions_api/index.md
+++ b/files/en-us/web/api/encrypted_media_extensions_api/index.md
@@ -42,7 +42,7 @@ The Encrypted Media Extensions API extends the following APIs, adding the listed
 #### Navigator
 
 - {{domxref("Navigator.requestMediaKeySystemAccess()")}}
-  - : Returns a {{jsxref('Promise')}} that fulfils to a {{domxref('MediaKeySystemAccess')}} object that can be used to access a particular media key system, which can in turn be used to create keys for decrypting a media stream.
+  - : Returns a {{jsxref('Promise')}} that fulfills to a {{domxref('MediaKeySystemAccess')}} object that can be used to access a particular media key system, which can in turn be used to create keys for decrypting a media stream.
 
 ## Specifications
 

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.md
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.md
@@ -30,7 +30,7 @@ A Promise that fulfills with a {{jsxref('Boolean')}}.
 ## Examples
 
 The following function compares a single entry with an array of entries, and returns a
-{{jsxref("Promise")}} that fulfils with a new array with any matching entries removed.
+{{jsxref("Promise")}} that fulfills with a new array with any matching entries removed.
 
 ```js
 async function removeMatches(fileEntry, entriesArr) {

--- a/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLMediaElement.setMediaKeys
 
 The **`setMediaKeys()`** method of the {{domxref("HTMLMediaElement")}} interface sets the {{domxref("MediaKeys")}} that will be used to decrypt media during playback.
 
-It returns a {{jsxref("Promise")}} that fulfils if the new keys are successfully set, or rejects if keys cannot be set.
+It returns a {{jsxref("Promise")}} that fulfills if the new keys are successfully set, or rejects if keys cannot be set.
 
 ## Syntax
 

--- a/files/en-us/web/api/idbrequest/error/index.md
+++ b/files/en-us/web/api/idbrequest/error/index.md
@@ -38,9 +38,9 @@ Read errors occur when an IndexedDB stores values and then subsequently fails to
 
 Read errors can be one of two types — **transient** or **unrecoverable**:
 
-Transient read errors are signalled by an `UnknownError` type, and are usually caused by low memory. This shouldn't be a problem for small databases. To avoid low memory situations in large databases, try to split up database access to only load the records you need at any one time, for example using specific [key ranges](/en-US/docs/Web/API/IDBKeyRange) relating to a user's search query or a pagination mechanism. If a low memory error is hit, the user may be asked to close other applications to free up space at the OS-level.
+Transient read errors are signaled by an `UnknownError` type, and are usually caused by low memory. This shouldn't be a problem for small databases. To avoid low memory situations in large databases, try to split up database access to only load the records you need at any one time, for example using specific [key ranges](/en-US/docs/Web/API/IDBKeyRange) relating to a user's search query or a pagination mechanism. If a low memory error is hit, the user may be asked to close other applications to free up space at the OS-level.
 
-Unrecoverable read errors are signalled by a `NotReadableError` type, and are caused by source files being deleted.
+Unrecoverable read errors are signaled by a `NotReadableError` type, and are caused by source files being deleted.
 
 For example, some browsers store large values (for example, audio file blobs for an offline podcast app) as separate files that are accessed via a reference stored in the database. It has been observed that these separate files can end up being deleted because they show up as opaque files to users when they are using disk space recovery programs, resulting in unrecoverable read errors when the IndexedDB is next accessed.
 

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -8,7 +8,7 @@ browser-compat: api.MediaCapabilities.decodingInfo
 
 {{APIRef("Media Capabilities API")}}{{AvailableInWorkers}}
 
-The **`decodingInfo()`** method of the {{domxref("MediaCapabilities")}} interface returns a promise that fulfils with information about how well the user agent can decode/display media with a given configuration.
+The **`decodingInfo()`** method of the {{domxref("MediaCapabilities")}} interface returns a promise that fulfills with information about how well the user agent can decode/display media with a given configuration.
 
 The resolved object contains three boolean properties `supported`, `smooth`, and `powerefficient`, which indicate whether decoding the media described would be supported, and if so, whether decoding would be smooth and power-efficient.
 

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -89,7 +89,7 @@ requestMediaKeySystemAccess(keySystem, supportedConfigurations)
 
 ### Return value
 
-A {{jsxref('Promise')}} that fulfils with a {{domxref('MediaKeySystemAccess')}} object representing the media key system configuration described by `keySystem` and `supportedConfigurations`.
+A {{jsxref('Promise')}} that fulfills with a {{domxref('MediaKeySystemAccess')}} object representing the media key system configuration described by `keySystem` and `supportedConfigurations`.
 
 ### Exceptions
 

--- a/files/en-us/web/api/pressureobserver/observe/index.md
+++ b/files/en-us/web/api/pressureobserver/observe/index.md
@@ -32,7 +32,7 @@ observe(source, options)
 
 ### Return value
 
-A {{jsxref("Promise")}} that fulfils with {{jsxref("undefined")}}.
+A {{jsxref("Promise")}} that fulfills with {{jsxref("undefined")}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/readablebytestreamcontroller/close/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/close/index.md
@@ -49,7 +49,7 @@ if (bytesRead === 0) {
 }
 ```
 
-After calling close, the stream will be closed, and any consumers signalled.
+After calling close, the stream will be closed, and any consumers signaled.
 For example if using a {{domxref("ReadableStreamBYOBReader")}} any {{domxref("ReadableStreamBYOBReader.read()","read()")}} requests would resolve with `done: true` and the promise from {{domxref("ReadableStreamBYOBReader.closed")}} would also be resolved.
 
 ## Specifications

--- a/files/en-us/web/api/websockets_api/using_websocketstream/index.md
+++ b/files/en-us/web/api/websockets_api/using_websocketstream/index.md
@@ -184,7 +184,7 @@ start();
 > [!NOTE]
 > The {{domxref("Window.setTimeout", "setTimeout()")}} function wraps the `write()` call in a [`try...catch`](/en-US/docs/Web/JavaScript/Reference/Statements/try...catch) block to handle any errors that can arise if the application tries to write to the stream after it has been closed.
 
-We now include a promise-style code section to inform the user of the code and reason if the WebSocket connection is closed, as signalled by the {{domxref("WebSocketStream.closed", "closed")}} promise fulfilling:
+We now include a promise-style code section to inform the user of the code and reason if the WebSocket connection is closed, as signaled by the {{domxref("WebSocketStream.closed", "closed")}} promise fulfilling:
 
 ```js
 wss.closed.then((result) => {

--- a/files/en-us/web/api/webtransport/reliability/index.md
+++ b/files/en-us/web/api/webtransport/reliability/index.md
@@ -31,7 +31,7 @@ async function initTransport(url) {
   // Initialize transport connection
   const transport = new WebTransport(url);
 
-  // Once ready fulfils the connection can be used
+  // Once ready fulfills the connection can be used
   // Prior to this the reliability is "pending"
   await transport.ready;
 

--- a/files/en-us/web/css/guides/box_alignment/overview/index.md
+++ b/files/en-us/web/css/guides/box_alignment/overview/index.md
@@ -209,7 +209,7 @@ body {
 
 The {{cssxref("overflow-position")}} keywords `safe` and `unsafe` help define behavior when an alignment subject is larger than the alignment container. The `safe` keyword will align to `start` in the case of a specified alignment causing an overflow, the aim being to avoid "data loss" where part of the item is outside the boundaries of the alignment container and can't be scrolled to.
 
-If you specify `unsafe` then the alignment will be honoured even if it would cause such data loss.
+If you specify `unsafe` then the alignment will be honored even if it would cause such data loss.
 
 ## Gaps between boxes
 

--- a/files/en-us/web/css/guides/cssom_view/viewport_concepts/index.md
+++ b/files/en-us/web/css/guides/cssom_view/viewport_concepts/index.md
@@ -53,7 +53,7 @@ There are several DOM properties that can help you query viewport size, and othe
 - The {{DOMxRef("Window.innerWidth")}} is the width, in CSS pixels, of the browser window viewport including, if rendered, the vertical scrollbar.
 - The {{DOMxRef("Window.outerWidth")}} is the width of the outside of the browser window including all the window {{glossary("chrome")}}.
 
-In an experiment with these, the `innerWidth` and `outerWidth` was seen to be the same, but the `outerHeight` was 100px taller than the `innerHeight`. This is because the `outerHeight` includes the browser chrome: measurements were taken on a browser with an address bar and bookmarks bar totalling 100px in height, but no chrome on the left or right of the window.
+In an experiment with these, the `innerWidth` and `outerWidth` was seen to be the same, but the `outerHeight` was 100px taller than the `innerHeight`. This is because the `outerHeight` includes the browser chrome: measurements were taken on a browser with an address bar and bookmarks bar totaling 100px in height, but no chrome on the left or right of the window.
 
 The area within the `innerHeight` and `innerWidth` is generally considered the **{{glossary("layout viewport")}}**. The browser chrome is not considered part of the viewport.
 

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -207,7 +207,7 @@ thing.showPrivate();
 
 ### Associating metadata
 
-A `WeakMap` can be used to associate metadata with an object, without affecting the lifetime of the object itself. This is very similar to the private members example, since private members are also modelled as external metadata that doesn't participate in [prototypical inheritance](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain).
+A `WeakMap` can be used to associate metadata with an object, without affecting the lifetime of the object itself. This is very similar to the private members example, since private members are also modeled as external metadata that doesn't participate in [prototypical inheritance](/en-US/docs/Web/JavaScript/Guide/Inheritance_and_the_prototype_chain).
 
 This use case can be extended to already-created objects. For example, on the web, we may want to associate extra data with a DOM element, which the DOM element may access later. A common approach is to attach the data as a property:
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/index.md
@@ -500,7 +500,7 @@ A number of audio and video JavaScript libraries exist. The most popular librari
 ### Streaming media
 
 - [Live streaming web audio and video](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Live_streaming_web_audio_and_video)
-  - : Live streaming technology is often employed to relay live events such as sports, concerts and more generally TV and Radio programmes that are output live. Often shortened to just streaming, live streaming is the process of transmitting media 'live' to computers and devices. This is a fairly complex and nascent subject with a lot of variables, so in this article we'll introduce you to the subject and let you know how you can get started.
+  - : Live streaming technology is often employed to relay live events such as sports, concerts and more generally TV and Radio programs that are output live. Often shortened to just streaming, live streaming is the process of transmitting media 'live' to computers and devices. This is a fairly complex and nascent subject with a lot of variables, so in this article we'll introduce you to the subject and let you know how you can get started.
 - [Setting up adaptive streaming media sources](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Setting_up_adaptive_streaming_media_sources)
   - : Let's say you want to set up an adaptive streaming media source on a server, to be consumed inside an HTML media element. How would you do that? This article explains how, looking at two of the most common formats: MPEG-DASH and HLS (HTTP Live Streaming.)
 - [DASH Adaptive Streaming for HTML 5 Video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming)

--- a/files/en-us/web/media/guides/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/live_streaming_web_audio_and_video/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: mediasidebar
 ---
 
-Livestreaming technology is often employed to relay live events such as sports, concerts and more generally TV and Radio programmes that are output live. Often shortened to just streaming, livestreaming is the process of transmitting media 'live' to computers and devices. This is a fairly complex and nascent subject with a lot of variables, so in this article, we'll introduce you to the subject and let you know how you can get started.
+Livestreaming technology is often employed to relay live events such as sports, concerts and more generally TV and Radio programs that are output live. Often shortened to just streaming, livestreaming is the process of transmitting media 'live' to computers and devices. This is a fairly complex and nascent subject with a lot of variables, so in this article, we'll introduce you to the subject and let you know how you can get started.
 
 The key consideration when streaming media to a browser is the fact that rather than playing a finite file we are relaying a file that is being created on the fly and has no pre-determined start or end.
 


### PR DESCRIPTION
### Description

Twenty British spellings across 19 files, all inflected forms: `fulfils` → `fulfills` (8), `signalled` → `signaled` (5), `TV and Radio programmes` → `programs` (2), and one each of `honoured` → `honored`, `centres` → `centers`, `totalling` → `totaling`, `modelled` → `modeled`, and `localising` → `localizing`.

### Motivation

The writing style guide requires American English spelling: "Use American-English spelling. […] Do not use variant spelling." These are the same variants already corrected elsewhere in the repo, just in forms that a whole-word search for the base spelling does not reach — `fulfil` and `signalling` have both been fixed while `fulfils` and `signalled` were left behind, so this also makes those pages internally consistent.

Matches that are not variant spellings are left alone:

- Spec and vendor URLs that contain the British spelling in the path or fragment: `ordinary-and-exotic-objects-behaviours.html`, `#normalised-timeranges-object`, `cwe.mitre.org`, and `upu.int/…/Programmes-Services/…`.
- `Intl.NumberFormat`: "16 litres" is the correct output of the `en-GB` example, not a typo.
- `ENQUIRE`, the name of Tim Berners-Lee's 1980 program, and the `favourite-colour` example extension.
- The `anticlockwise` glosses on `arc()` and `ellipse()`, which deliberately give the British term alongside the `counterclockwise` parameter name.
