### PR TITLE
Use branded capitalization for Node.js, webpack, Mustache, and Handlebars

### DIFF
--- a/files/en-us/learn_web_development/extensions/client-side_tools/overview/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_tools/overview/index.md
@@ -118,7 +118,7 @@ Generally, web development is thought of as three languages: [HTML](/en-US/docs/
    - Frameworks such as [React](https://react.dev/), [Ember](https://emberjs.com/), and [Vue](https://vuejs.org/): Frameworks provide a lot of functionality for free and allow you to use it via custom syntax built on top of vanilla JavaScript. In the background, the framework's JavaScript code works hard to interpret this custom syntax and render it as a final web app.
 
 3. Optimization. This is provided by _bundlers_, which are tools that get your code ready for production, for example by "[tree-shaking](/en-US/docs/Glossary/Tree_shaking)" to make sure only the parts of your code libraries that you are actually using are put into your final production code, or "[minifying](/en-US/docs/Glossary/Minification)" to remove all the whitespace in your production code, making it as small as possible before it is uploaded to a server. For example:
-   - [Webpack](https://webpack.js.org/) has been the most popular bundler for a long time, featuring a huge number of plugins and a powerful configuration system. However, it is also known for being quite complex to set up, and is slow compared to more modern alternatives.
+   - [webpack](https://webpack.js.org/) has been the most popular bundler for a long time, featuring a huge number of plugins and a powerful configuration system. However, it is also known for being quite complex to set up, and is slow compared to more modern alternatives.
    - [Vite](https://vite.dev/) is a more modern build tool that is popular for its speed, simplicity, and richness of features.
 
 ### Post development

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
@@ -64,7 +64,7 @@ A few solutions that were popular at the time of writing are:
 - [Bookshelf](https://www.npmjs.com/package/bookshelf): Features both promise-based and traditional callback interfaces, providing transaction support, eager/nested-eager relation loading, polymorphic associations, and support for one-to-one, one-to-many, and many-to-many relations. Works with PostgreSQL, MySQL, and SQLite3.
 - [Objection](https://www.npmjs.com/package/objection): Makes it as easy as possible to use the full power of SQL and the underlying database engine (supports SQLite3, Postgres, and MySQL).
 - [Sequelize](https://www.npmjs.com/package/sequelize) is a promise-based ORM for Node.js and io.js. It supports the dialects PostgreSQL, MySQL, MariaDB, SQLite, and MSSQL and features solid transaction support, relations, read replication and more.
-- [Node ORM2](https://node-orm.readthedocs.io/en/latest/) is an Object Relationship Manager for NodeJS. It supports MySQL, SQLite, and Postgres, helping to work with the database using an object-oriented approach.
+- [Node ORM2](https://node-orm.readthedocs.io/en/latest/) is an Object Relationship Manager for Node.js. It supports MySQL, SQLite, and Postgres, helping to work with the database using an object-oriented approach.
 - [GraphQL](https://graphql.org/): Primarily a query language for restful APIs, GraphQL is very popular, and has features available for reading data from databases.
 
 As a general rule, you should consider both the features provided and the "community activity" (downloads, contributions, bug reports, quality of documentation, etc.) when selecting a solution. At the time of writing Mongoose is by far the most popular ODM, and is a reasonable choice if you're using MongoDB for your database.

--- a/files/en-us/learn_web_development/extensions/server-side/first_steps/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/first_steps/introduction/index.md
@@ -84,7 +84,7 @@ Client-side code is written using [HTML](/en-US/docs/Learn_web_development/Core/
 
 Web developers can't control what browser every user might be using to view a website — browsers provide inconsistent levels of compatibility with client-side code features, and part of the challenge of client-side programming is handling differences in browser support gracefully.
 
-Server-side code can be written in any number of programming languages — examples of popular server-side web languages include PHP, Python, Ruby, C#, and JavaScript (NodeJS). The server-side code has full access to the server operating system and the developer can choose what programming language (and specific version) they wish to use.
+Server-side code can be written in any number of programming languages — examples of popular server-side web languages include PHP, Python, Ruby, C#, and JavaScript (Node.js). The server-side code has full access to the server operating system and the developer can choose what programming language (and specific version) they wish to use.
 
 Developers typically write their code using **web frameworks**. Web frameworks are collections of functions, objects, rules and other code constructs designed to solve common problems, speed up development, and simplify the different types of tasks faced in a particular domain.
 

--- a/files/en-us/learn_web_development/extensions/server-side/first_steps/web_frameworks/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/first_steps/web_frameworks/index.md
@@ -147,7 +147,7 @@ Web frameworks often provide a mechanism to make it easy to generate other forma
 For example, the Django template system allows you to specify variables using a "double-handlebars" syntax (e.g., `\{{ variable_name }}`), which will be replaced by values passed in from the view function when a page is rendered. The template system also provides support for expressions (with syntax: `{% expression %}`), which allow templates to perform simple operations like iterating list values passed into the template.
 
 > [!NOTE]
-> Many other templating systems use a similar syntax, e.g.: Jinja2 (Python), handlebars (JavaScript), moustache (JavaScript), etc.
+> Many other templating systems use a similar syntax, e.g.: Jinja2 (Python), Handlebars (JavaScript), Mustache (JavaScript), etc.
 
 The code snippet below shows how this works. Continuing the "youngest team" example from the previous section, the HTML template is passed a list variable called `youngest_teams` by the view. Inside the HTML skeleton we have an expression that first checks if the `youngest_teams` variable exists, and then iterates it in a `for` loop. On each iteration the template displays the team's `team_name` value in a list item.
 

--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -682,9 +682,9 @@ Once you stop the session, you'll return to the _Live Web Testing_ page, where y
 
 TestingBot has a [restful API](https://testingbot.com/support/api) that allows you to programmatically retrieve details of your account and existing tests, and annotate tests with further details, such as their pass/fail state which isn't recordable by manual testing alone.
 
-TestingBot has several API clients you can use to interact with the API, including clients for NodeJS, Python, Ruby, Java and PHP.
+TestingBot has several API clients you can use to interact with the API, including clients for Node.js, Python, Ruby, Java and PHP.
 
-Below is an example on how to interact with the TestingBot API with the NodeJS client [testingbot-api](https://www.npmjs.com/package/testingbot-api).
+Below is an example on how to interact with the TestingBot API with the Node.js client [testingbot-api](https://www.npmjs.com/package/testingbot-api).
 
 1. First, set up a new npm project to test this out, as detailed in [Setting up Node and npm](#setting_up_node_and_npm). Use a different directory name than before, like `tb-test` for example.
 2. Install the Node TestingBot wrapper using the following command:

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -239,7 +239,7 @@ Each message is serialized using JSON, UTF-8 encoded and is preceded with an uns
 
 The maximum size of a single message from the application is 1 MB. The maximum size of a message sent to the application is 4 GB.
 
-You can quickly get started sending and receiving messages with this NodeJS code, `nm_nodejs.mjs`:
+You can quickly get started sending and receiving messages with this Node.js code, `nm_nodejs.mjs`:
 
 ```js
 #!/usr/bin/env -S /full/path/to/node

--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -251,7 +251,7 @@ The example function `tetheredGetNumber()` shows that a promise generator will u
 
 Note that the function `troubleWithGetNumber()` ends with a `throw`. That is forced because a promise chain goes through all the `.then()` promises, even after an error, and without the `throw`, the error would seem "fixed". This is a hassle, and for this reason, it is common to omit `onRejected` throughout the chain of `.then()` promises, and just have a single `onRejected` in the final `catch()`.
 
-This code can be run under NodeJS. Comprehension is enhanced by seeing the errors actually occur. To force more errors, change the `threshold` values.
+This code can be run under Node.js. Comprehension is enhanced by seeing the errors actually occur. To force more errors, change the `threshold` values.
 
 ```js
 // To experiment with error handling, "threshold" values cause errors randomly

--- a/files/en-us/web/javascript/reference/statements/var/index.md
+++ b/files/en-us/web/javascript/reference/statements/var/index.md
@@ -84,7 +84,7 @@ delete globalThis.x; // TypeError in strict mode. Fails silently otherwise.
 delete x; // SyntaxError in strict mode. Fails silently otherwise.
 ```
 
-In both NodeJS [CommonJS](https://wiki.commonjs.org/wiki/CommonJS) modules and native [ECMAScript modules](/en-US/docs/Web/JavaScript/Guide/Modules), top-level variable declarations are scoped to the module, and are not added as properties to the global object.
+In both Node.js [CommonJS](https://wiki.commonjs.org/wiki/CommonJS) modules and native [ECMAScript modules](/en-US/docs/Web/JavaScript/Guide/Modules), top-level variable declarations are scoped to the module, and are not added as properties to the global object.
 
 The list that follows the `var` keyword is called a _{{Glossary("binding")}} list_ and is separated by commas, where the commas are _not_ [comma operators](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_operator) and the `=` signs are _not_ [assignment operators](/en-US/docs/Web/JavaScript/Reference/Operators/Assignment). Initializers of later variables can refer to earlier variables in the list and get the initialized value.
 


### PR DESCRIPTION
### Description

Nine product-name capitalizations across 8 files: `NodeJS` → `Node.js` (6), `Webpack` → `webpack` (1), and on a single line listing templating systems, `handlebars` → `Handlebars` and `moustache` → `Mustache`.

### Motivation

The writing style guide is explicit about this: "Some tool names and projects have their own branded capitalization rules. These might require names that are all lower case ("npm" or "webpack") […] The branded capitalization from the official website or documentation should always be used, even at the start of a sentence." It names `webpack` as one of its own examples.

The repo already overwhelmingly agrees — 231 uses of `Node.js` against these few `NodeJS`, and 45 uses of `webpack` against the single `Webpack` — so this is a consistency fix rather than a new convention.

`moustache` is a plain misspelling: the templating library is [Mustache](https://mustache.github.io/), and a moustache is something else entirely.

Left unchanged on purpose:

- `Selenium with NodeJS` on the BrowserStack note, which is link text for an external page and not ours to restyle.
- `// a NodeJS IPC channel` inside a `DisposableStack` code example.
- The heading "Testing your Nodejs and npm installation". Another page links to its generated anchor `#testing_your_nodejs_and_npm_installation`, and changing the heading text risks changing that anchor, so it needs its own change with the inbound link updated alongside it.
