### PR TITLE
Fix small prose errors

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
@@ -31,7 +31,7 @@ _Node_ and _Express_ make it very easy to set up your computer in order to start
 
 ### What is the Express development environment?
 
-The _Express_ development environment includes an installation of _Nodejs_, the _npm package manager_, and (optionally) the _Express Application Generator_ on your local computer.
+The _Express_ development environment includes an installation of _Node.js_, the _npm package manager_, and (optionally) the _Express Application Generator_ on your local computer.
 
 _Node_ and the _npm_ package manager are installed together from prepared binary packages, installers, operating system package managers or from source (as shown in the following sections). _Express_ is then installed by npm as a dependency of your individual _Express_ web applications (along with other libraries like template engines, database drivers, authentication middleware, middleware to serve static files, etc.).
 
@@ -62,7 +62,7 @@ Other dependencies, such as database drivers, template engines, authentication e
 
 ## Installing Node
 
-In order to use _Express_ you will have to install _Nodejs_ and the [Node Package Manager (npm)](https://docs.npmjs.com/) on your operating system.
+In order to use _Express_ you will have to install _Node.js_ and the [Node Package Manager (npm)](https://docs.npmjs.com/) on your operating system.
 To make this easier we'll first install a node version manager, and then we'll use it to install the latest Long Term Supported (LTS) versions of node and npm.
 
 > [!NOTE]
@@ -126,7 +126,7 @@ A good way to do this is to use the "version" command in your terminal/command p
 v22.17.0
 ```
 
-The _Nodejs_ package manager _npm_ should also have been installed, and can be tested in the same way:
+The _Node.js_ package manager _npm_ should also have been installed, and can be tested in the same way:
 
 ```bash
 > npm -v

--- a/files/en-us/web/css/reference/selectors/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_-webkit-scrollbar/index.md
@@ -23,7 +23,7 @@ The `::-webkit-scrollbar` CSS pseudo-element affects the style of an element's s
 The {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}} standard properties may be used as alternatives for browsers that do not support this pseudo-element and the related `::-webkit-scrollbar-*` pseudo-elements (see [Browser compatibility](#browser_compatibility)).
 
 > [!NOTE]
-> If an element's computed {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}} values are anything other than `auto`, they will override [`::-webkit-scrollbar-*`](/en-US/docs/Web/CSS/Reference/Selectors/::-webkit-scrollbar) styling.
+> If an element's computed {{cssxref("scrollbar-color")}} and {{cssxref("scrollbar-width")}} values are anything other than `auto`, they will override `::-webkit-scrollbar-*` styling.
 > Because `scrollbar-color` is inherited, an element is affected when an ancestor sets it, even if the element itself doesn't.
 > Setting `scrollbar-color: auto` on the element restores its `::-webkit-scrollbar-*` styling if it was previously removed by a `scrollbar-color` setting on an ancestor.
 > See [Adding a fallback for scrollbar styles](#adding_a_fallback_for_scrollbar_styles) for more details.

--- a/files/en-us/web/security/attacks/xs-leaks/index.md
+++ b/files/en-us/web/security/attacks/xs-leaks/index.md
@@ -72,7 +72,7 @@ An attacker may even be able to discover a user's ID, by iteratively trying to l
 
 ### Frame counting using window references
 
-In a frame counting attack, the attacker finds out the number of frames currently loaded in the target page. In turn, that leaks information about the state of the target site, which may enable to attacker to learn, for example, whether the user is currently logged into the site.
+In a frame counting attack, the attacker finds out the number of frames currently loaded in the target page. In turn, that leaks information about the state of the target site, which may enable an attacker to learn, for example, whether the user is currently logged into the site.
 
 If an attacker site gets a reference to a {{domxref("Window")}} object containing the target site, the attacker can count the number of frames in the target site by reading the {{domxref("Window.length", "window.length")}} property.
 


### PR DESCRIPTION
### Description

Five small errors across three files:

- Cross-site leaks: "which may enable **to** attacker to learn" → "may enable **an** attacker to learn".
- `::-webkit-scrollbar`: the note links `` `::-webkit-scrollbar-*` `` to `/en-US/docs/Web/CSS/Reference/Selectors/::-webkit-scrollbar`, which is the page the note is on. Dropped the link and kept the code text.
- Setting up a Node development environment: three occurrences of `_Nodejs_` in prose → `_Node.js_`.

### Motivation

The first is a typo that changes the meaning of the sentence. The second is a link that goes nowhere useful — a self-link renders as a link to the page the reader is already on.

The `Nodejs` spellings are covered by the style guide's rule that "the branded capitalization from the official website or documentation should always be used", and the page already writes `Node.js` correctly elsewhere.

One occurrence on that page is deliberately left alone: the heading "Testing your Nodejs and npm installation". Its generated anchor `#testing_your_nodejs_and_npm_installation` is linked from the automated testing page, and MDN preserves the dot in heading anchors — `### Node.js flag` produces `#node.js_flag_--disable-proto` — so renaming the heading would move the anchor. That is worth doing, but as its own change with the inbound links updated together, not folded into a typo fix.
