### PR TITLE
Use American English spelling for anticlockwise

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -11,6 +11,7 @@
     "non-english",
     "code-entities",
     "ignore-list",
+    "forbidden-spelling",
     "bash",
     "css",
     "fonts",
@@ -142,6 +143,13 @@
       "name": "ignore-list",
       "path": "./dictionaries/ignore-list.txt",
       "description": "Other gibberish words that are used for specific purposes. For example, placeholder identifiers, random strings, URLs (all lowercase), hashes, filler texts, etc. For purposefully misspelled words and/or words that are likely typos in other contexts, consider using cSpell:ignore instead.",
+      "addWords": false,
+      "noSuggest": true
+    },
+    {
+      "name": "forbidden-spelling",
+      "path": "./dictionaries/forbidden-spelling.txt",
+      "description": "MDN uses American English, but some British English spellings are included by cSpell's built-in dictionaries. Put the British spellings here so they get reported.",
       "addWords": false,
       "noSuggest": true
     }

--- a/.vscode/dictionaries/forbidden-spelling.txt
+++ b/.vscode/dictionaries/forbidden-spelling.txt
@@ -1,0 +1,1 @@
+!anticlockwise

--- a/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
@@ -447,7 +447,7 @@ Now let's look at how to draw a circle in canvas. This is accomplished using the
    ctx.fill();
    ```
 
-   `arc()` takes six parameters. The first two specify the position of the arc's center (X and Y, respectively). The third is the circle's radius, the fourth and fifth are the start and end angles at which to draw the circle (so specifying 0 and 360 degrees gives us a full circle), and the sixth parameter defines whether the circle should be drawn counterclockwise (anticlockwise) or clockwise (`false` is clockwise).
+   `arc()` takes six parameters. The first two specify the position of the arc's center (X and Y, respectively). The third is the circle's radius, the fourth and fifth are the start and end angles at which to draw the circle (so specifying 0 and 360 degrees gives us a full circle), and the sixth parameter defines whether the circle should be drawn counterclockwise or clockwise (`false` is clockwise).
 
    > [!NOTE]
    > 0 degrees is horizontally to the right.

--- a/files/en-us/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/index.md
@@ -122,7 +122,7 @@ function draw() {
   // Clipping path
   ctx.beginPath();
   ctx.rect(-75, -75, 150, 150); // Outer rectangle
-  ctx.arc(0, 0, 60, 0, Math.PI * 2, true); // Hole anticlockwise
+  ctx.arc(0, 0, 60, 0, Math.PI * 2, true); // Hole counterclockwise
   ctx.clip();
 
   // Draw background

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -624,7 +624,7 @@ We'll take another look at `fillStyle`, in more detail, later in this tutorial. 
 
 ### Shapes with holes
 
-To draw a shape with a hole in it, we need to draw the hole in different clock directions as we draw the outer shape. We either draw the outer shape clockwise and the inner shape anticlockwise or the outer shape anticlockwise and the inner shape clockwise.
+To draw a shape with a hole in it, we need to draw the hole in different clock directions as we draw the outer shape. We either draw the outer shape clockwise and the inner shape counterclockwise or the outer shape counterclockwise and the inner shape clockwise.
 
 ```html hidden
 <canvas id="my-canvas" width="150" height="150"></canvas>
@@ -642,7 +642,7 @@ function draw() {
   ctx.lineTo(150, 0);
   ctx.lineTo(75, 129.9);
 
-  // Inner shape anticlockwise ↺
+  // Inner shape counterclockwise ↺
   ctx.moveTo(75, 20);
   ctx.lineTo(50, 60);
   ctx.lineTo(100, 60);
@@ -657,7 +657,7 @@ draw();
 
 {{EmbedLiveSample("Shapes_with_holes", "", "160")}}
 
-In the example above, the outer triangle goes clockwise (move to the top-left corner, then draw a line to the top-right corner, and finish at the bottom) and the inner triangle goes anticlockwise (move to the top, then line to the bottom-left corner, and finish at the bottom-right).
+In the example above, the outer triangle goes clockwise (move to the top-left corner, then draw a line to the top-right corner, and finish at the bottom) and the inner triangle goes counterclockwise (move to the top, then line to the bottom-left corner, and finish at the bottom-right).
 
 ## Path2D objects
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -44,7 +44,7 @@ the direction given by `counterclockwise` (defaulting to clockwise).
     expressed in radians.
 - `counterclockwise` {{optional_inline}}
   - : An optional boolean value which, if `true`, draws the ellipse
-    counterclockwise (anticlockwise). The default value is `false`
+    counterclockwise. The default value is `false`
     (clockwise).
 
 ### Return value


### PR DESCRIPTION
### Description

Replaces `anticlockwise` with `counterclockwise` in the Canvas tutorial — five occurrences across two files, in the prose describing how to draw a shape with a hole in it and in two of the accompanying code comments.

### Motivation

The writing style guide requires American English spelling, and `counterclockwise` is already the settled form here by 47 occurrences to 7. It is also the name of the parameter these very sentences are describing — `arc()` and `ellipse()` both take a boolean called `counterclockwise` — so the prose now matches the API it documents.

The two remaining occurrences are deliberately untouched: the `arc()` tutorial and the `ellipse()` reference both write "counterclockwise (anticlockwise)", giving the British term alongside the parameter name for readers who know it by that word.
