### PR TITLE
Fix alt text of union() Venn diagram (said "symmetric difference")

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/set/union/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/union/index.md
@@ -37,7 +37,7 @@ In mathematical notation, _union_ is defined as:
 
 And using Venn diagram:
 
-![A Venn diagram where two circles overlap. The symmetric difference of A and B is the region contained by either or both circles.](diagram.svg)
+![A Venn diagram where two circles overlap. The union of A and B is the region contained by either or both circles.](diagram.svg)
 
 `union()` accepts [set-like](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#set-like_objects) objects as the `other` parameter. It requires {{jsxref("this")}} to be an actual {{jsxref("Set")}} instance, because it directly retrieves the underlying data stored in `this` without invoking any user code. Then, it iterates over `other` by calling its `keys()` method, and constructs a new set with all elements in `this`, followed by all elements in `other` that are not present in `this`.
 


### PR DESCRIPTION
### Description

Fixes the alt text of the Venn diagram on the `Set.prototype.union()` page: it currently says "The **symmetric difference** of A and B is the region contained by either or both circles", which describes the wrong operation (copied from the `symmetricDifference()` page). The diagram on this page illustrates the union, and "the region contained by either or both circles" is exactly the union, so only the operation name needs correcting.

### Motivation

Accurate alt text matters for screen-reader users; noticed while translating this page.
