### PR TITLE
Use American English spelling for Cancelling, greyed, and bevelled

### DIFF
--- a/files/en-us/learn_web_development/core/structuring_content/basic_html_syntax/index.md
+++ b/files/en-us/learn_web_development/core/structuring_content/basic_html_syntax/index.md
@@ -213,7 +213,7 @@ As shorthand, it is acceptable to write the `disabled` attribute without a value
 <br />
 ```
 
-For reference, let's also provide a non-disabled `<input>` element so you can compare and contrast (note how the `disabled` inputs are somewhat greyed out in the below rendering):
+For reference, let's also provide a non-disabled `<input>` element so you can compare and contrast (note how the `disabled` inputs are somewhat grayed out in the below rendering):
 
 ```html live-sample___boolean-example
 <label for="third-input">This input isn't disabled; you can type into it</label>

--- a/files/en-us/learn_web_development/extensions/forms/basic_native_form_controls/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/basic_native_form_controls/index.md
@@ -278,7 +278,7 @@ These examples render like so:
 
 Buttons always behave the same whether you use a {{HTMLElement("button")}} element or an {{HTMLElement("input")}} element. As you can see from the examples, however, {{HTMLElement("button")}} elements let you use HTML in their content, which is inserted between the opening and closing `<button>` tags. {{HTMLElement("input")}} elements on the other hand are {{glossary("void element", "void elements")}}; their displayed content is inserted inside the `value` attribute, and therefore only accepts plain text as content.
 
-The following screenshot shows a button in the default, focused, and disabled states. In the focused state, there is a focus ring around the button, and in the disabled state, the button is greyed out.
+The following screenshot shows a button in the default, focused, and disabled states. In the focused state, there is a focus ring around the button, and in the disabled state, the button is grayed out.
 
 ![Default, focus, and disabled button states in chrome 115 on macOS](buttons.png)
 

--- a/files/en-us/learn_web_development/getting_started/web_standards/the_web_standards_model/index.md
+++ b/files/en-us/learn_web_development/getting_started/web_standards/the_web_standards_model/index.md
@@ -110,7 +110,7 @@ Open standards enable the web to remain a freely-available public resource, wher
 
 ### Accessible and interoperable
 
-The web and web browsers are fundamentally designed so that web content is **accessible** to people with disabilities. It was originally envisaged as a great leveller, enabling people to access information regardless of circumstance. This means that, for example:
+The web and web browsers are fundamentally designed so that web content is **accessible** to people with disabilities. It was originally envisaged as a great leveler, enabling people to access information regardless of circumstance. This means that, for example:
 
 - People who are unable to use a mouse or pointing device can use the keyboard to navigate the web.
 - People who are visually impaired can magnify content, or use a program called a **screen reader** to read content out to them and describe controls in a way that makes sense.

--- a/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
@@ -48,8 +48,8 @@ This page is based largely on [https://www.squarefree.com/burningedg...eases/](h
   - : Text written in new documents created with document.open("text/plain") is now treated as text rather than HTML, so line breaks will remain intact and tags will not be parsed.
 - XML Events
   - : "XML Events" is a W3C specification to provide XML languages with the ability to integrate declarative event listeners and event handlers.
-- Cancelling keydown
-  - : Cancelling the keydown event now properly cancels any corresponding keyup/keypress events, per the DOM specification.
+- Canceling keydown
+  - : Canceling the keydown event now properly cancels any corresponding keyup/keypress events, per the DOM specification.
 - Accessibility APIs for DHTML
   - : Mozilla now allows DHTML authors to add role and state semantics to custom elements, and exposes that information via MSAA and ATK.
 - DHTML Performance Fixes

--- a/files/en-us/web/api/element/beforescriptexecute_event/index.md
+++ b/files/en-us/web/api/element/beforescriptexecute_event/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Element.beforescriptexecute_event
 > [!WARNING]
 > This event was a proposal in an early version of the specification. Do not rely on it.
 
-The **`beforescriptexecute`** event is fired when a script is about to be executed. Cancelling the event prevents the script from executing.
+The **`beforescriptexecute`** event is fired when a script is about to be executed. Canceling the event prevents the script from executing.
 
 It is a proprietary event specific to Gecko (Firefox).
 

--- a/files/en-us/web/api/gpupipelineerror/index.md
+++ b/files/en-us/web/api/gpupipelineerror/index.md
@@ -27,7 +27,7 @@ _Inherits properties from its parent, {{domxref("DOMException")}}._
 
 <!-- cSpell:ignore maijn -->
 
-In the following snippet we are attempting to create a {{domxref("GPUComputePipeline")}} using {{domxref("GPUDevice.createComputePipelineAsync()")}}. However, we have misspelt our compute pipeline `entryPoint` as `"maijn"` (it should be `"main"`), therefore pipeline creation fails, and our `catch` block prints the resulting reason and error message to the console.
+In the following snippet we are attempting to create a {{domxref("GPUComputePipeline")}} using {{domxref("GPUDevice.createComputePipelineAsync()")}}. However, we have misspelled our compute pipeline `entryPoint` as `"maijn"` (it should be `"main"`), therefore pipeline creation fails, and our `catch` block prints the resulting reason and error message to the console.
 
 ```js
 // …

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -117,7 +117,7 @@ Some properties only apply to input element types that support the corresponding
   - : A boolean that represents the default state of a radio button or checkbox as originally specified in HTML that created this object.
 
 - {{domxref("HTMLInputElement.indeterminate", "indeterminate")}}
-  - : A boolean that represents whether the checkbox or radio button is in indeterminate state. For checkboxes, the effect is that the appearance of the checkbox is obscured/greyed in some way as to indicate its state is indeterminate (not checked but not unchecked). Does not affect the value of the `checked` attribute, and clicking the checkbox will set the value to false.
+  - : A boolean that represents whether the checkbox or radio button is in indeterminate state. For checkboxes, the effect is that the appearance of the checkbox is obscured/grayed in some way as to indicate its state is indeterminate (not checked but not unchecked). Does not affect the value of the `checked` attribute, and clicking the checkbox will set the value to false.
 
 ### Instance properties that apply only to elements of type image
 

--- a/files/en-us/web/api/languagemodel/create_static/index.md
+++ b/files/en-us/web/api/languagemodel/create_static/index.md
@@ -270,7 +270,7 @@ const response = await session.prompt("What's the weather like in Tokyo?");
 console.log(response);
 ```
 
-### Cancelling a session
+### Canceling a session
 
 The following example enables a user to cancel a prompt. It does this by first creating an {{domxref("AbortController")}} and assigning its `abort()` method to a cancel button's click handler. Next, it calls `create()` and passes `AbortController.signal` as the `signal` property.
 
@@ -291,7 +291,7 @@ const session = await LanguageModel.create({
 });
 ```
 
-See also [Using the Prompt API > Cancelling operations and destroying instances](/en-US/docs/Web/API/Prompt_API/Using#cancelling_operations_and_destroying_instances).
+See also [Using the Prompt API > Canceling operations and destroying instances](/en-US/docs/Web/API/Prompt_API/Using#canceling_operations_and_destroying_instances).
 
 ## Specifications
 

--- a/files/en-us/web/api/languagemodel/destroy/index.md
+++ b/files/en-us/web/api/languagemodel/destroy/index.md
@@ -48,7 +48,7 @@ const session = await LanguageModel.create({
 session.destroy();
 ```
 
-See also [Using the Prompt API > Cancelling operations and destroying instances](/en-US/docs/Web/API/Prompt_API/Using#cancelling_operations_and_destroying_instances).
+See also [Using the Prompt API > Canceling operations and destroying instances](/en-US/docs/Web/API/Prompt_API/Using#canceling_operations_and_destroying_instances).
 
 ## Specifications
 

--- a/files/en-us/web/api/languagemodel/prompt/index.md
+++ b/files/en-us/web/api/languagemodel/prompt/index.md
@@ -151,7 +151,7 @@ console.log(planets); // ["Mercury", "Venus", "Earth"]
 
 See also [Adding context with initial and ongoing prompt inputs > Adding response constraints](/en-US/docs/Web/API/Prompt_API/Adding_context#adding_response_constraints).
 
-### Cancelling a prompt
+### Canceling a prompt
 
 The following example shows how to enable a user to cancel a prompt with a button. It does this by creating an {{domxref("AbortController")}}. Its `abort()` is callable from a button's `click` handler. For this to work, a reference to the controller's `signal` property must be passed to `prompt()`.
 
@@ -180,7 +180,7 @@ try {
 }
 ```
 
-See also [Using the Prompt API > Cancelling operations and destroying instances](/en-US/docs/Web/API/Prompt_API/Using#cancelling_operations_and_destroying_instances).
+See also [Using the Prompt API > Canceling operations and destroying instances](/en-US/docs/Web/API/Prompt_API/Using#canceling_operations_and_destroying_instances).
 
 ## Specifications
 

--- a/files/en-us/web/api/prompt_api/using/index.md
+++ b/files/en-us/web/api/prompt_api/using/index.md
@@ -189,7 +189,7 @@ await secondClone.prompt("Another question, please.");
 
 Creating a new session via `clone()` is also a common way to get around the problem of running out of tokens.
 
-## Cancelling operations and destroying instances
+## Canceling operations and destroying instances
 
 You can cancel pending `prompt()`, `clone()` and other operations using an {{domxref("AbortController")}}, with the associated {{domxref("AbortSignal")}} being included inside the method options object as a `signal` property value. For example, aborting a `LanguageModel.prompt()` operation via a button press could look like this:
 

--- a/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
+++ b/files/en-us/web/api/streams_api/using_readable_byte_streams/index.md
@@ -368,7 +368,7 @@ function readStream(reader) {
 }
 ```
 
-#### Cancelling the stream using the reader
+#### Canceling the stream using the reader
 
 We can use {{domxref("ReadableStreamBYOBReader.cancel()")}} to cancel the stream.
 For this example we call the method if a button is clicked with a reason "user choice" (other HTML and code for the button not shown).

--- a/files/en-us/web/api/summarizer_api/using/index.md
+++ b/files/en-us/web/api/summarizer_api/using/index.md
@@ -83,7 +83,7 @@ console.log("Stream complete");
 summaryOutput.textContent = summary;
 ```
 
-## Cancelling operations and destroying instances
+## Canceling operations and destroying instances
 
 You can cancel a pending `create()`, `summarize()`, or `summarizeStreaming()` operation using an {{domxref("AbortController")}}, with the associated {{domxref("AbortSignal")}} being included inside the method options object as a `signal` property value. For example, aborting a `Summarizer.create()` operation would look like this:
 

--- a/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
+++ b/files/en-us/web/api/translator_and_language_detector_apis/using/index.md
@@ -113,7 +113,7 @@ These methods return an enumerated value indicating whether support is, or will 
 
 If a download is required, it will be started automatically by the browser once a `LanguageDetector` or `Translator` instance is created using the relevant `create()` method. You can track download progress automatically using a [monitor](#monitoring_download_progress).
 
-## Cancelling operations and destroying instances
+## Canceling operations and destroying instances
 
 You can cancel a pending detection or translation operation using an {{domxref("AbortController")}}, with the associated {{domxref("AbortSignal")}} being included inside the method options object as a `signal` property value. For example, aborting a `Translator.create()` operation would look like this:
 

--- a/files/en-us/web/api/viewtransition/waituntil/index.md
+++ b/files/en-us/web/api/viewtransition/waituntil/index.md
@@ -199,7 +199,7 @@ function showLog() {
 
 {{embedlivesample("basic-waituntil", "100%", 200)}}
 
-Try long pressing on the button with your keyboard, mouse, or other pointing device — you'll see that the cross-fade transition animation occurs, but the content remains greyed out (due to the `opacity: 0.5` set on the view transition pseudo-elements) until you end the long press. This is because the `p` promise referenced inside the `waitUntil()` call is not resolved, and therefore, the view transition is not finished, until the `pointerup`/`keyup` events are fired.
+Try long pressing on the button with your keyboard, mouse, or other pointing device — you'll see that the cross-fade transition animation occurs, but the content remains grayed out (due to the `opacity: 0.5` set on the view transition pseudo-elements) until you end the long press. This is because the `p` promise referenced inside the `waitUntil()` call is not resolved, and therefore, the view transition is not finished, until the `pointerup`/`keyup` events are fired.
 
 The "View transition finished" log message also doesn't appear until the view transition is finished, because the function that handles this is tied to the `ViewTransition.finished` promise.
 

--- a/files/en-us/web/css/guides/colors/using_color_wisely/index.md
+++ b/files/en-us/web/css/guides/colors/using_color_wisely/index.md
@@ -73,7 +73,7 @@ If the proposed color doesn't work for your needs, you can change the color sche
 
 ![Triad color scheme selected](paletton4.png)
 
-Click on the greyish blue in the top-right. The color is `#556E8D`. This can be used as an accent color to make things stand out, such as for headlines, tabs highlights, or other indicators on the site:
+Click on the grayish blue in the top-right. The color is `#556E8D`. This can be used as an accent color to make things stand out, such as for headlines, tabs highlights, or other indicators on the site:
 
 ![Triad color scheme selected](paletton-color-detail.png)
 

--- a/files/en-us/web/css/reference/properties/corner-shape/index.md
+++ b/files/en-us/web/css/reference/properties/corner-shape/index.md
@@ -59,7 +59,7 @@ The `corner-shape` property may be specified using one, two, three, or four {{cs
 
 ## Description
 
-The `corner-shape` property is used to modify the shape of rounded corners created by the {{cssxref("border-radius")}} property and its associated longhands. Already-rounded corners can be further customized in terms of the degree of rounding applied to them, allowing the creation of, for example, bevelled, notched, and squircle corners. Borders, outlines, shadows, and background effects applied to the container will follow the defined corner shape.
+The `corner-shape` property is used to modify the shape of rounded corners created by the {{cssxref("border-radius")}} property and its associated longhands. Already-rounded corners can be further customized in terms of the degree of rounding applied to them, allowing the creation of, for example, beveled, notched, and squircle corners. Borders, outlines, shadows, and background effects applied to the container will follow the defined corner shape.
 
 If a `border-radius` is not applied to a container, or the `border-radius` resolves to `0`, `corner-shape` will have no effect.
 

--- a/files/en-us/web/css/reference/properties/filter/index.md
+++ b/files/en-us/web/css/reference/properties/filter/index.md
@@ -207,7 +207,7 @@ If the filter lists are of different lengths, the missing equivalent filter func
 
 ### Applying filter functions
 
-The `filter` property is applied to the second image, greying and blurring both the image and its border.
+The `filter` property is applied to the second image, graying and blurring both the image and its border.
 
 ```css
 img {

--- a/files/en-us/web/css/reference/properties/stroke-linejoin/index.md
+++ b/files/en-us/web/css/reference/properties/stroke-linejoin/index.md
@@ -30,7 +30,7 @@ stroke-linejoin: unset;
 ### Values
 
 - `bevel`
-  - : Indicates that a bevelled corner is to be used to join path segments. The bevel is formed by truncating the corner by a line perpendicular to a line that bisects the difference in the subpath angles where they meet the join point.
+  - : Indicates that a beveled corner is to be used to join path segments. The bevel is formed by truncating the corner by a line perpendicular to a line that bisects the difference in the subpath angles where they meet the join point.
 
 - `miter`
   - : Indicates that a sharp corner is to be used to join path segments. The corner is formed by extending the outer edges of the stroke at the tangents of the path segments until they intersect. This is the default value.

--- a/files/en-us/web/css/reference/values/superellipse/index.md
+++ b/files/en-us/web/css/reference/values/superellipse/index.md
@@ -119,7 +119,7 @@ The following diagram illustrates different `superellipse()` values for the top 
 
 ![Line diagram illustrating the ellipses created using different K values, as described subsequently](superellipse-param.svg)
 
-- A `K` value of `0` creates a straight line. This value can be used to create bevelled corners and corresponds to the {{cssxref("&lt;corner-shape-value>")}} `bevel` keyword.
+- A `K` value of `0` creates a straight line. This value can be used to create beveled corners and corresponds to the {{cssxref("&lt;corner-shape-value>")}} `bevel` keyword.
 - A `K` value of `1` creates an ordinary ellipse, corresponding to the `round` keyword.
 - A `K` value of `>1` makes the ellipse shape more square; `2` corresponds to the `squircle` keyword.
 - A `K` value of `infinity` creates a perfect square (corresponding to the `square` keyword), although `K` values of `10` or more are virtually indistinguishable from a square.

--- a/files/en-us/web/html/reference/attributes/disabled/index.md
+++ b/files/en-us/web/html/reference/attributes/disabled/index.md
@@ -78,7 +78,7 @@ Because a disabled field cannot have its value changed, [`required`](/en-US/docs
 
 ### Usability
 
-Browsers display disabled form controls greyed as disabled form controls are immutable, won't receive focus or any browsing events, like mouse clicks or focus-related ones, and aren't submitted with the form.
+Browsers display disabled form controls grayed as disabled form controls are immutable, won't receive focus or any browsing events, like mouse clicks or focus-related ones, and aren't submitted with the form.
 
 If present on a supporting elements, the {{cssxref(':disabled')}} pseudo class will match. If the attribute is not included, the {{cssxref(':enabled')}} pseudo class will match. If the element doesn't support the disabled attribute, the attribute will have no effect, including not leading to being matched by the `:disabled` and `:enabled` pseudo classes.
 
@@ -88,7 +88,7 @@ If the element is `disabled`, then the element's value can not receive focus and
 
 ## Examples
 
-When form controls are disabled, many browsers will display them in a lighter, greyed-out color by default. Here are examples of a disabled checkbox, radio button, {{ HTMLElement("option") }} and {{ HTMLElement("optgroup") }}, as well as some form controls that are disabled via the disabled attribute set on the ancestor `{{ HTMLElement("fieldset")}}` element. The {{ HTMLElement("option") }}s are disabled, but the {{ HTMLElement("select") }} itself is not. We could have disable the entire {{ HTMLElement("select") }} by adding the attribute to that element rather than its descendants.
+When form controls are disabled, many browsers will display them in a lighter, grayed-out color by default. Here are examples of a disabled checkbox, radio button, {{ HTMLElement("option") }} and {{ HTMLElement("optgroup") }}, as well as some form controls that are disabled via the disabled attribute set on the ancestor `{{ HTMLElement("fieldset")}}` element. The {{ HTMLElement("option") }}s are disabled, but the {{ HTMLElement("select") }} itself is not. We could have disable the entire {{ HTMLElement("select") }} by adding the attribute to that element rather than its descendants.
 
 ```html
 <fieldset>

--- a/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
+++ b/files/en-us/web/html/reference/global_attributes/writingsuggestions/index.md
@@ -9,7 +9,7 @@ sidebar: htmlsidebar
 
 The **`writingsuggestions`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) is an {{glossary("enumerated")}} attribute indicating if browser-provided writing suggestions should be enabled under the scope of the element or not.
 
-Some browsers provide writing suggestions to users as they type in editable fields. Suggestions usually appear as greyed-out text positioned after the text cursor, completing the user's sentence. While this can be helpful to users, developers might want to turn writing suggestions off in some cases, such as when providing site-specific writing suggestions.
+Some browsers provide writing suggestions to users as they type in editable fields. Suggestions usually appear as grayed-out text positioned after the text cursor, completing the user's sentence. While this can be helpful to users, developers might want to turn writing suggestions off in some cases, such as when providing site-specific writing suggestions.
 
 The `writingsuggestions` attribute can be set on editable fields such as {{htmlelement('input')}} or {{htmlelement('textarea')}} elements, or on other HTML elements to control the behavior of the browser's suggestions on sections of a page, or on the entire page.
 

--- a/files/en-us/web/svg/reference/attribute/stroke-linejoin/index.md
+++ b/files/en-us/web/svg/reference/attribute/stroke-linejoin/index.md
@@ -175,7 +175,7 @@ svg {
 
 ### bevel
 
-The `bevel` value indicates that a bevelled corner is to be used to join path segments.
+The `bevel` value indicates that a beveled corner is to be used to join path segments.
 
 ```css hidden
 html,


### PR DESCRIPTION
### Description

Thirty occurrences across 23 files: `Cancelling` → `Canceling` (12, plus 3 anchor updates), `greyed`/`greyish`/`greying` → `grayed`/`grayish`/`graying` (9), `bevelled` → `beveled` (4), `leveller` → `leveler`, and `misspelt` → `misspelled`.

Six of the `Cancelling` occurrences are section headings, including "Cancelling operations and destroying instances" on the Prompt API usage guide. Three pages — `LanguageModel.destroy()`, `LanguageModel.prompt()`, and `LanguageModel.create()` — link to that heading's generated anchor, so the heading and all three `#cancelling_operations_and_destroying_instances` fragments are updated together in this change.

### Motivation

The writing style guide requires American English spelling: "Use American-English spelling. […] Do not use variant spelling."

These are the capitalized and inflected forms of variants already corrected in this repo, which whole-word lowercase searches did not reach. The split is visible in the current counts: `canceling` outnumbers `cancelling` 47 to 1 in lowercase, while capitalized it was `Canceling` 12 against `Cancelling` 13. Likewise `gray` is used throughout, but `greyed`, `greyish`, and `greying` were untouched.

`bevelled` describes the SVG and CSS `bevel` keyword on `stroke-linejoin`, `corner-shape`, and `superellipse`, so the prose now matches the value it documents.

Two occurrences are left alone, both inside code fences: the `log("Cancelling fetch")` call in the `ReadableStream.cancel()` example and a string in the drag-and-drop example.
