### PR TITLE
Fix a heading spelling, a preposition, and a grammar leftover

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/development_environment/index.md
@@ -116,7 +116,7 @@ nvm use 22.17.0
 Use the command `nvm --help` to find out other command line options.
 These are often similar to, or the same as, those offered by `nvm-windows`.
 
-### Testing your Nodejs and npm installation
+### Testing your Node.js and npm installation
 
 Once you have set `nvm` to use a particular node version, you can test the installation.
 A good way to do this is to use the "version" command in your terminal/command prompt and check that the expected version string is returned:

--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -51,7 +51,7 @@ As we said above, you can drastically speed up common tasks such as linting and 
 Most tools these days are based on {{Glossary("Node.js")}}, so you'll need to install it along with its counterpart package manager, [`npm`](https://www.npmjs.com/):
 
 1. The easiest way to install and update Node.js and `npm` is via a node version manager: Follow the instructions at [Installing Node](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment#installing_node) to do so.
-2. Make sure to [test that your installation was successful](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment#testing_your_nodejs_and_npm_installation) before continuing.
+2. Make sure to [test that your installation was successful](/en-US/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment#testing_your_node.js_and_npm_installation) before continuing.
 3. If you previously installed Node.js/`npm`, you should update them to their latest versions. This can be done by using the node version manager to install the latest LTS versions (refer again to the linked instructions above).
 
 To start using Node/npm-based packages on your projects, you need to set up your project directories as npm projects. This is easy to do.

--- a/files/en-us/web/api/cryptokey/algorithm/index.md
+++ b/files/en-us/web/api/cryptokey/algorithm/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CryptoKey.algorithm
 
 The read-only **`algorithm`** property of the {{DOMxRef("CryptoKey")}} interface returns an object describing the algorithm for which this key can be used, and any associated extra parameters.
 
-The object returned depends of the algorithm used to generate the key.
+The object returned depends on the algorithm used to generate the key.
 
 ## Value
 

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -84,7 +84,7 @@ The following session features and reference spaces can be requested, either as 
 - `depth-sensing`
   - : Enable the ability to obtain depth information using {{domxref("XRDepthInformation")}} objects.
 - `dom-overlay`
-  - : Enable allowing to specify a DOM overlay element that will be displayed to the user.
+  - : Enable specifying a DOM overlay element that will be displayed to the user.
 - `hand-tracking`
   - : Enable articulated hand pose information from hand-based input controllers (see {{domxref("XRHand")}} and {{domxref("XRInputSource.hand")}}).
 - `hit-test`


### PR DESCRIPTION
### Description

Three fixes across four files:

- "Testing your **Nodejs** and npm installation" → "Testing your **Node.js** and npm installation" on the Node development environment page, together with the one link to that heading's anchor, on the automated testing page.
- `CryptoKey.algorithm`: "The object returned **depends of** the algorithm" → "depends on".
- `XRSystem.requestSession()`, the `dom-overlay` feature: "Enable **allowing to specify** a DOM overlay element" → "Enable specifying a DOM overlay element".

### Motivation

`Nodejs` is covered by the style guide's rule that "the branded capitalization from the official website or documentation should always be used"; the same page already writes `Node.js` in its prose.

Renaming the heading moves its generated anchor, so the inbound link is updated in the same change. MDN preserves the dot in heading IDs — the Prototype pollution page's "Node.js flag `--disable-proto`" heading renders as `id="node.js_flag_--disable-proto"` — so `#testing_your_nodejs_and_npm_installation` becomes `#testing_your_node.js_and_npm_installation`. That link on the automated testing page is the only reference to it in this repo.

"Depends of" is a preposition error. "Enable allowing to specify" is missing the object of "allow", and the neighboring entries in the same list read "Enable the ability to obtain depth information" and "Enable articulated hand pose information", so the shorter "Enable specifying" fits the list without adding wordiness.
