### PR TITLE
Cookies can have duplicate names

### DIFF
--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -120,6 +120,17 @@ async function cookieTest() {
 }
 ```
 
+### Setting cookies with the same name
+
+These calls create two separate cookies because their paths differ:
+
+```js
+await cookieStore.set({ name: "theme", value: "light", path: "/" });
+await cookieStore.set({ name: "theme", value: "dark", path: "/docs" });
+```
+
+On a page under `/docs/`, {{domxref("CookieStore.getAll()", 'cookieStore.getAll("theme")')}} can retrieve both cookies. Calling `cookieStore.set("theme", "blue")` updates the cookie at the default path `/`, leaving the `/docs` cookie unchanged.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/http/reference/headers/cookie/index.md
+++ b/files/en-us/web/http/reference/headers/cookie/index.md
@@ -48,7 +48,7 @@ Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1
 
 ### Cookies with the same name
 
-Multiple cookies can have the same name if they were set with different `Path` or `Domain` attributes. 
+Multiple cookies can have the same name if they were set with different `Path` or `Domain` attributes.
 This includes the case where one cookie was set with a `Domain` attribute and the other without, even if they apply to the same host. If more than one matches a request, the browser can include all of them in the `Cookie` header.
 
 Partitioned cookies are keyed on the top-level site as well, so cookies can have the same name if set by the same host in two different embedding contexts. See [CHIPS](/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies).

--- a/files/en-us/web/http/reference/headers/cookie/index.md
+++ b/files/en-us/web/http/reference/headers/cookie/index.md
@@ -48,7 +48,10 @@ Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1
 
 ### Cookies with the same name
 
-Multiple cookies can have the same name if they were set with different `Path` or `Domain` attributes. If more than one matches a request, the browser can include all of them in the `Cookie` header.
+Multiple cookies can have the same name if they were set with different `Path` or `Domain` attributes. 
+This includes the case where one cookie was set with a `Domain` attribute and the other without, even if they apply to the same host. If more than one matches a request, the browser can include all of them in the `Cookie` header.
+
+Partitioned cookies are keyed on the top-level site as well, so cookies can have the same name if set by the same host in two different embedding contexts. See [CHIPS](/en-US/docs/Web/Privacy/Guides/Third-party_cookies/Partitioned_cookies).
 
 For example, suppose separate responses from the same host set these cookies:
 

--- a/files/en-us/web/http/reference/headers/cookie/index.md
+++ b/files/en-us/web/http/reference/headers/cookie/index.md
@@ -40,9 +40,30 @@ Cookie: name=value; name2=value2; name3=value3
 
 ## Examples
 
+### Sending cookies
+
 ```http
 Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1
 ```
+
+### Cookies with the same name
+
+Multiple cookies can have the same name if they were set with different `Path` or `Domain` attributes. If more than one matches a request, the browser can include all of them in the `Cookie` header.
+
+For example, suppose separate responses from the same host set these cookies:
+
+```http
+Set-Cookie: theme=light; Path=/
+Set-Cookie: theme=dark; Path=/docs
+```
+
+A request to `/docs` can contain both of them:
+
+```http
+Cookie: theme=dark; theme=light
+```
+
+The `Cookie` header does not include the cookies' attributes, and the cookie entries are unordered, so the server cannot determine their paths or domains from the header alone.
 
 ## Specifications
 
@@ -57,3 +78,4 @@ Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1
 - {{HTTPStatus("413", "413 Content Too Large")}}
 - {{HTTPHeader("Set-Cookie")}}
 - {{domxref("Document.cookie")}}
+- [Cookie Store API](/en-US/docs/Web/API/Cookie_Store_API)


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/39562.

I did not add this information to more places. The API landing page and the `CookieStore` pages are very high-level and I don't think this information fits very nicely. It also has nothing to do with `CookieStore` in particular; cookie storage is a browser mechanism, so if anything this should be in CHIPS or the HTTP cookies guide.