### PR TITLE
Document conditional WebAuthn credential creation

### DIFF
--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -29,6 +29,8 @@ create(options)
 
 - `options` {{optional_inline}}
   - : An object that contains options for the requested new `Credentials` object. It can contain the following properties:
+    - `mediation` {{optional_inline}}
+      - : A string that specifies how the user agent should mediate credential creation. The default is `"optional"`. When set to `"conditional"`, the user agent may create the credential without additional prominent modal interaction if the user has previously consented to credential creation and the user agent recently mediated an authentication. Otherwise, the promise rejects with `NotAllowedError`. See [Automatic passkey creation](/en-US/docs/Web/API/Web_Authentication_API#automatic_passkey_creation).
     - `signal` {{optional_inline}}
       - : An {{domxref("AbortSignal")}} object instance that allows an ongoing `create()` operation to be aborted. An aborted operation may complete normally (generally if the abort was received after the operation finished) or reject with an `AbortError` {{domxref("DOMException")}}.
 
@@ -63,6 +65,7 @@ If no credential object can be created, the promise resolves with `null`.
     - The function is called cross-origin but the iframe's [`allow`](/en-US/docs/Web/HTML/Reference/Elements/iframe#allow) attribute does not set an appropriate {{HTTPHeader("Permissions-Policy/publickey-credentials-create","publickey-credentials-create")}} policy.
     - The function is called cross-origin and the `<iframe>` does not have {{glossary("transient activation")}}.
     - The function tried to create a [discoverable credential](/en-US/docs/Web/API/Web_Authentication_API#discoverable_and_non-discoverable_credentials) ([`residentKey`](/en-US/docs/Web/API/PublicKeyCredentialCreationOptions#residentkey) is set to `required` in the `create()` call's {{domxref("PublicKeyCredentialCreationOptions")}} option), but the user does not have an authenticator that supports discoverable credentials.
+    - `mediation` is `"conditional"`, but the user agent did not recently mediate an authentication or does not have consent to create the credential.
 - `AbortError` {{domxref("DOMException")}}
   - : The operation was aborted.
 
@@ -168,6 +171,34 @@ Some of this data will need to be stored on the server for future authentication
 
 > [!NOTE]
 > See [Creating a key pair and registering a user](/en-US/docs/Web/API/Web_Authentication_API#creating_a_key_pair_and_registering_a_user) for more information about how the overall flow works.
+
+### Creating a public key credential conditionally
+
+Conditional creation lets a user agent create a passkey without additional prominent modal interaction after the user signs in, provided the user has previously consented to credential creation. First use {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} to check whether the client supports conditional creation.
+
+```js
+const capabilities = await PublicKeyCredential.getClientCapabilities();
+
+if (capabilities.conditionalCreate) {
+  try {
+    const credential = await navigator.credentials.create({
+      publicKey,
+      mediation: "conditional",
+    });
+
+    if (credential) {
+      await registerCredentialWithServer(credential);
+    }
+  } catch (error) {
+    if (error.name !== "NotAllowedError") {
+      throw error;
+    }
+    // The conditions for creating the credential were not met.
+  }
+}
+```
+
+Client support does not guarantee that conditional creation succeeds. The user agent rejects the promise with `NotAllowedError` if it did not recently mediate an authentication or does not have consent to create the credential. For the full flow and its requirements, see [Automatic passkey creation](/en-US/docs/Web/API/Web_Authentication_API#automatic_passkey_creation).
 
 ## Specifications
 

--- a/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientcapabilities_static/index.md
@@ -29,7 +29,7 @@ A {{jsxref("Promise")}} that resolves to an object where the property names are 
 The WebAuthn client capability strings are:
 
 - `"conditionalCreate"`
-  - : The client is capable of creating [discoverable credentials](/en-US/docs/Web/API/Web_Authentication_API#discoverable_and_non-discoverable_credentials).
+  - : The client supports [automatic passkey creation](/en-US/docs/Web/API/Web_Authentication_API#automatic_passkey_creation) using {{domxref("CredentialsContainer.create()", "navigator.credentials.create()")}} with conditional mediation.
 - `"conditionalGet"`
   - : The client is capable of [conditional mediation](/en-US/docs/Web/API/Web_Authentication_API#autofill_ui).
     This capability is equivalent to [`isConditionalMediationAvailable()`](/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable_static) resolving to `true`.
@@ -75,6 +75,7 @@ For example, support for the `userVerifyingPlatformAuthenticator` capability ind
 A web application could use this to display a fingerprint icon if the capability is supported, or a password input if it is not.
 If biometric login is required, then it could instead provide notification that the site cannot authenticate using this browser or device.
 Similarly, `conditionalGet` indicates that the client supports conditional mediation when signing in a user, which means the browser can provide auto-filled discoverable credentials in a login form (for example an autocompleting text field or a drop-down list), along with a sign-in button.
+The `conditionalCreate` capability indicates that the client supports automatic passkey creation after a recently mediated authentication, without requiring another prominent modal interaction.
 
 If the value of a given capability is present in the returned object, then `true` indicates that the capability is currently supported, and `false` indicates that it is not.
 However, if a key is not present for a particular capability, no assumptions can be made about the availability of the associated feature.

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -205,6 +205,36 @@ This essentially enables a website to provide a unified autofill, including both
 > [!NOTE]
 > Note that only [discoverable credentials](#discoverable_and_non-discoverable_credentials) are included in calls that use conditional mediation, because the browser needs to request applicable credentials without knowing the credential ID values for them.
 
+### Automatic passkey creation
+
+Conditional mediation can also be used when creating a credential, but its behavior differs from the [autofill UI](#autofill_ui) used for authentication. With a conditional {{domxref("CredentialsContainer.create()", "create()")}} request, the user agent may create a passkey without additional prominent modal interaction if the user has previously consented to credential creation and the user agent recently mediated an authentication. This is also called _conditional create_ or _automatic passkey creation_.
+
+Use {{domxref("PublicKeyCredential.getClientCapabilities_static", "PublicKeyCredential.getClientCapabilities()")}} to check whether the client supports conditional creation, then set the top-level [`mediation`](/en-US/docs/Web/API/CredentialsContainer/create#mediation) option to `"conditional"` alongside the `publicKey` creation options:
+
+```js
+const capabilities = await PublicKeyCredential.getClientCapabilities();
+
+if (capabilities.conditionalCreate) {
+  try {
+    const credential = await navigator.credentials.create({
+      publicKey: publicKeyOptionsFromServer,
+      mediation: "conditional",
+    });
+
+    if (credential) {
+      await registerCredentialWithServer(credential);
+    }
+  } catch (error) {
+    if (error.name !== "NotAllowedError") {
+      throw error;
+    }
+    // The user agent could not create the credential conditionally.
+  }
+}
+```
+
+The capability check only reports client support. If the user agent did not recently mediate an authentication or does not have consent to create the credential, `create()` rejects with `NotAllowedError`. The resulting credential is otherwise registered with the relying party server like a public key credential created with the standard modal flow.
+
 ### Discoverable credential synchronization methods
 
 It is possible for the information stored in a user's authenticator about a discoverable credential to go out sync with the relying party's server. This might happen when the user deletes a credential or modifies their user/display name on the RP web app without updating the authenticator.


### PR DESCRIPTION
### Description

Documents conditional credential creation (automatic passkey creation) across the relevant WebAuthn pages:

- adds the `mediation` option, rejection behavior, and a conditional creation example to `CredentialsContainer.create()`
- separates automatic passkey creation from authentication autofill in the Web Authentication API overview
- clarifies what the `conditionalCreate` client capability represents

The behavior and terminology follow the Credential Management specification change in w3c/webappsec-credential-management#224.

### Motivation

Developers could discover `conditionalCreate` in `getClientCapabilities()`, but MDN did not explain how to use `mediation: "conditional"` with `navigator.credentials.create()` or how that behavior differs from conditional `get()`/autofill.

### Additional details

- Markdownlint: 0 issues across the three changed pages
- Prettier: all three pages pass
- CSpell: 0 issues across the three changed pages
- Rari build with warnings denied: 3 pages built, no issues found

Fixes #42516
