### PR TITLE
Ff155 WebTransport application-specific protocols docs

### DIFF
--- a/files/en-us/web/api/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/index.md
@@ -30,7 +30,7 @@ The **`WebTransport`** interface of the {{domxref("WebTransport API", "WebTransp
   - : Represents one or more unidirectional streams opened by the server. Returns a {{domxref("ReadableStream")}} of {{domxref("WebTransportReceiveStream")}} objects. Each one can be used to read data from the server.
 - {{domxref("WebTransport.protocol", "protocol")}} {{ReadOnlyInline}}
   - : Returns a string representing the application-specific protocol selected by the server, or `""` if none has been selected.
-    Client preferences for the protocol are passed to the constructor in the [`options.protocols`](/en-US/docs/Web/API/WebTransport/WebTransport#protocols) parameter.
+    Client preferences for the protocol are passed to the constructor in the [`protocols`](/en-US/docs/Web/API/WebTransport/WebTransport#protocols) constructor option.
 - {{domxref("WebTransport.ready", "ready")}} {{ReadOnlyInline}}
   - : Returns a promise that resolves when the transport is ready to use.
 - {{domxref("WebTransport.reliability", "reliability")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/index.md
@@ -28,6 +28,9 @@ The **`WebTransport`** interface of the {{domxref("WebTransport API", "WebTransp
   - : Represents one or more bidirectional streams opened by the server. Returns a {{domxref("ReadableStream")}} of {{domxref("WebTransportBidirectionalStream")}} objects. Each one can be used to read data from the server and write data back to it.
 - {{domxref("WebTransport.incomingUnidirectionalStreams", "incomingUnidirectionalStreams")}} {{ReadOnlyInline}}
   - : Represents one or more unidirectional streams opened by the server. Returns a {{domxref("ReadableStream")}} of {{domxref("WebTransportReceiveStream")}} objects. Each one can be used to read data from the server.
+- {{domxref("WebTransport.protocol", "protocol")}} {{ReadOnlyInline}}
+  - : Returns a string representing the application-specific protocol selected by the server, or `""` if none has been selected.
+    Client preferences for the protocol are passed to the constructor in the [`options.protocols`](/en-US/docs/Web/API/WebTransport/WebTransport#protocols) parameter.
 - {{domxref("WebTransport.ready", "ready")}} {{ReadOnlyInline}}
   - : Returns a promise that resolves when the transport is ready to use.
 - {{domxref("WebTransport.reliability", "reliability")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/webtransport/protocol/index.md
+++ b/files/en-us/web/api/webtransport/protocol/index.md
@@ -1,0 +1,56 @@
+---
+title: "WebTransport: protocol property"
+short-title: protocol
+slug: Web/API/WebTransport/protocol
+page-type: web-api-instance-property
+browser-compat: api.WebTransport.protocol
+---
+
+{{APIRef("WebTransport API")}}{{SecureContext_Header}} {{AvailableInWorkers}}
+
+The **`protocol`** read-only property of the {{domxref("WebTransport")}} interface returns the application-specific protocol selected by the server.
+
+The value is selected from those offered in the [`protocols`](/en-US/docs/Web/API/WebTransport/WebTransport#protocols) constructor option.
+Note that the value is set once the connection is established and the {{domxref("WebTransport.ready","ready")}} promise fulfills.
+It is the empty string if `protocols` was not used, or if the server chose not select one of the offered protocols.
+
+## Value
+
+A string.
+Defaults to `""`.
+
+## Examples
+
+### Basic usage
+
+This example shows how to request a set of candidate protocols and read back the one the server selected.
+
+```js
+const url = "https://example.com:4999/wt";
+
+async function initTransport(url) {
+  const transport = new WebTransport(url, {
+    protocols: ["chat", "file-transfer"],
+  });
+
+  try {
+    // The connection can be used once ready fulfills
+    await transport.ready;
+    console.log(transport.protocol); // e.g. "chat", or "" if none was selected
+    return transport;
+  } catch (error) {
+    // ready may reject if the offered protocols aren't supported
+    console.error(`Connection failed: ${error}`);
+  }
+}
+
+initTransport(url);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/webtransport/protocol/index.md
+++ b/files/en-us/web/api/webtransport/protocol/index.md
@@ -11,8 +11,8 @@ browser-compat: api.WebTransport.protocol
 The **`protocol`** read-only property of the {{domxref("WebTransport")}} interface returns the application-specific protocol selected by the server.
 
 The value is selected from those offered in the [`protocols`](/en-US/docs/Web/API/WebTransport/WebTransport#protocols) constructor option.
-Note that the value is set once the connection is established and the {{domxref("WebTransport.ready","ready")}} promise fulfills.
-It is the empty string if `protocols` was not used, or if the server chose not select one of the offered protocols.
+Note that the value is set once the {{domxref("WebTransport.ready", "ready")}} promise fulfills.
+It is the empty string if `protocols` was not used, or if the server chose not to select one of the offered protocols.
 
 ## Value
 
@@ -21,7 +21,7 @@ Defaults to `""`.
 
 ## Examples
 
-### Basic usage
+### Requesting and reading a negotiated protocol
 
 This example shows how to request a set of candidate protocols and read back the one the server selected.
 
@@ -39,7 +39,7 @@ async function initTransport(url) {
     console.log(transport.protocol); // e.g. "chat", or "" if none was selected
     return transport;
   } catch (error) {
-    // ready may reject if the offered protocols aren't supported
+    // Ready may reject if the offered protocols aren't supported
     console.error(`Connection failed: ${error}`);
   }
 }

--- a/files/en-us/web/api/webtransport/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/webtransport/index.md
@@ -32,6 +32,14 @@ new WebTransport(url, options)
       - : A string indicating the application's preference that the congestion control algorithm used when sending data over this connection be tuned for either throughput or low-latency.
         This is a hint to the user agent.
         The allowed values are: `default` (default), `throughput`, and `low-latency`.
+    - `protocols` {{optional_inline}}
+      - : An array of strings, each that indicates an application-specific protocol name.
+        This defaults to an empty array.
+
+        The server may select and return one of the protocols, in which case the selected value will become available in the {{domxref("WebTransport/protocol","protocol")}} property after the {{jsxref("Promise")}} returned by the {{domxref("WebTransport/ready","ready")}} property fulfills.
+        The server may also choose not to return its preferred protocol, in which case the `protocol` will return an empty string (`""`).
+        The server may also reject the connection if it doesn't support any of the protocols, in which case {{domxref("WebTransport/ready","ready")}} will reject with an error.
+
     - `requireUnreliable` {{optional_inline}}
       - : A boolean value.
         If `true`, the connection cannot be established over HTTP/2 if an HTTP/3 connection is not possible.

--- a/files/en-us/web/api/webtransport/webtransport/index.md
+++ b/files/en-us/web/api/webtransport/webtransport/index.md
@@ -33,11 +33,12 @@ new WebTransport(url, options)
         This is a hint to the user agent.
         The allowed values are: `default` (default), `throughput`, and `low-latency`.
     - `protocols` {{optional_inline}}
-      - : An array of strings, each that indicates an application-specific protocol name.
-        This defaults to an empty array.
+      - : An array of strings, each indicating an application-specific protocol name, listed in order of preference.
+        By default, the value is an empty array.
 
-        The server may select and return one of the protocols, in which case the selected value will become available in the {{domxref("WebTransport/protocol","protocol")}} property after the {{jsxref("Promise")}} returned by the {{domxref("WebTransport/ready","ready")}} property fulfills.
-        The server may also choose not to return its preferred protocol, in which case the `protocol` will return an empty string (`""`).
+        The server may select and return one of the protocols.
+        In this case, the selected value becomes available in the {{domxref("WebTransport/protocol", "protocol")}} property once the {{domxref("WebTransport/ready", "ready")}} promise fulfills.
+        The server may also choose not to select any of the offered protocols, in which case `protocol` will return an empty string (`""`).
         The server may also reject the connection if it doesn't support any of the protocols, in which case {{domxref("WebTransport/ready","ready")}} will reject with an error.
 
     - `requireUnreliable` {{optional_inline}}
@@ -80,6 +81,7 @@ new WebTransport(url, options)
   - : Thrown if `serverCertificateHashes` is specified but the transport protocol does not support this feature.
 - `SyntaxError`
   - : Thrown if the specified `url` is invalid, if the scheme is not HTTPS, or if the URL includes a fragment.
+    Also thrown if `protocols` contains a duplicate value, a value with characters not allowed in a protocol token, or a value whose encoded length is `0` or greater than `512` bytes.
 - `TypeError`
   - : Thrown if a `serverCertificateHashes` is set for a non-dedicated connection (in other words, if `allowPooling` is `true`).
 

--- a/files/en-us/web/api/webtransport_api/index.md
+++ b/files/en-us/web/api/webtransport_api/index.md
@@ -58,6 +58,34 @@ async function closeTransport(transport) {
 }
 ```
 
+### Negotiating an application protocol
+
+A WebTransport server can support multiple applications, each using its own "custom" communication protocol.
+To support this, the client can offer a list of candidate protocol names in preference order via the [`protocols`](/en-US/docs/Web/API/WebTransport/WebTransport#protocols) option of the `WebTransport()` constructor.
+The server can then choose to select one of these during connection establishment.
+
+Once the {{domxref("WebTransport.ready")}} promise fulfills, the negotiated protocol (if any) is available via the {{domxref("WebTransport.protocol")}} property.
+This is the empty string if `protocols` was not used, or if the server did not select any of the offered protocols.
+A server that supports none of the offered protocols may instead reject the connection outright, causing `ready` to reject.
+
+```js
+const url = "https://example.com:4999/wt";
+
+async function initTransport(url) {
+  const transport = new WebTransport(url, {
+    protocols: ["chat", "file-transfer"],
+  });
+
+  try {
+    await transport.ready;
+    console.log(transport.protocol); // e.g. "chat", or "" if none was selected
+    return transport;
+  } catch (error) {
+    console.error(`Connection failed: ${error}`);
+  }
+}
+```
+
 ### Unreliable transmission via datagrams
 
 "Unreliable" means that transmission of data is not guaranteed, nor is arrival in a specific order. This is fine in some situations and provides very fast delivery. For example, you might want to transmit regular game state updates where each message supersedes the last one that arrives, and order is not important.


### PR DESCRIPTION
FF155 adds support for a `WebTransport` app to specify a list of preferred application-specific protocols in the constructor, and for the server to return its preferred option in `WebTransport.protocol`. This documents both parts of that story and adds a section in the guide.

Note, what this does not do is explain the underlying browser and server mechanisms for sharing the data. That's not needed in the Web API docs, but would be useful for a server developer. However we don't have any of that context for WebTransport and I don't think is in scope for this task.

Related docs work can be tracked in #45302