### PR TITLE
Use American English spelling for dialog box

### DIFF
--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/creating_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/creating_a_call/index.md
@@ -44,7 +44,7 @@ Exciting times — now you're going to give your users the ability to create cal
 
 3. To test this out, open `localhost:8000` in two browser windows and click Call inside one of them. You should see this:
 
-   ![Two screens side by side both A cream background with the words 'phone a friend' in bold, dark green font as the heading. The first screen has 'Your device ID is: 3b77' and the second 'Your device ID is: 2doa', is immediately below the title and 'please use headphones!' below that. Following on, a big dark green button with 'Call' written in the same cream color of the background. The second screen has a browser dialogue that asks for a peer id.](screens_side_by_side.png)
+   ![Two screens side by side both A cream background with the words 'phone a friend' in bold, dark green font as the heading. The first screen has 'Your device ID is: 3b77' and the second 'Your device ID is: 2doa', is immediately below the title and 'please use headphones!' below that. Following on, a big dark green button with 'Call' written in the same cream color of the background. The second screen has a browser dialog that asks for a peer id.](screens_side_by_side.png)
 
    If you submit the other peer's ID, the call will be connected!
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
@@ -44,7 +44,7 @@ The `getUserMedia()` endpoint takes a `constraints` object that specifies which 
 
 3. Refresh your app, which should still be running at `localhost:8000`; you should see the following permission pop up:
 
-   ![A browser permission dialogue box which says "http://localhost:8000 wants to use your microphone" with two options: "block" and "allow"](use_microphone_dialogue_box.png)
+   ![A browser permission dialog box which says "http://localhost:8000 wants to use your microphone" with two options: "block" and "allow"](use_microphone_dialogue_box.png)
 
 4. Plugin in some headphones before you allow the microphone usage so that when you unmute yourself later, you don't get any feedback. If you didn't see the permission prompt, open the inspector to see if you have any errors. Make sure your JavaScript file is correctly linked to your `index.html` too.
 


### PR DESCRIPTION
### Description

Changes "dialogue box" to "dialog box", and "dialogue" to "dialog", in two image descriptions in the Build a phone with PeerJS tutorial.

### Motivation

The [writing style guide](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#american_english) requires American English spelling. Both instances describe a browser UI dialog rather than a conversation: a microphone permission prompt, and a prompt asking for a peer ID.

"dialog box" is used 59 times elsewhere in the repository, and this tutorial holds the only "dialogue box". The image filenames are unchanged.
