### PR TITLE
Fix text node example

### DIFF
--- a/files/en-us/web/api/text/index.md
+++ b/files/en-us/web/api/text/index.md
@@ -24,7 +24,7 @@ To understand what a text node is, consider the following document:
 </html>
 ```
 
-In that document, there are five text nodes, with the following contents in which all spaces are shown as ◦ and all newlines as ⏎:
+In that document, there are five text nodes, with the following contents (all spaces are shown as `◦` and all newlines as `⏎`):
 
 - `"⏎◦◦◦◦"` (after the `<head>` start tag, a newline followed by four spaces)
 - `"Aliens?"` (the contents of the `<title>` element)

--- a/files/en-us/web/api/text/index.md
+++ b/files/en-us/web/api/text/index.md
@@ -26,11 +26,11 @@ To understand what a text node is, consider the following document:
 
 In that document, there are five text nodes, with the following contents:
 
-- `"\n    "` (after the `<head>` start tag, a newline followed by four spaces)
+- `"\n&nbsp;&nbsp;&nbsp;&nbsp;"` (after the `<head>` start tag, a newline followed by four spaces)
 - `"Aliens?"` (the contents of the `title` element)
-- `"\n  "` (after the `</head>` end tag, a newline followed by two spaces)
-- `"\n  "` (after the `<body>` start tag, a newline followed by two spaces)
-- `"\n Why yes.\n \n\n"` (the contents of the `body` element)
+- `"\n&nbsp;&nbsp;"` (after the `</title>` end tag, a newline followed by two spaces)
+- `"\n&nbsp;&nbsp;"` (after the `</head>` end tag, a newline followed by two spaces)
+- `"\n&nbsp;&nbsp;&nbsp;&nbsp;Why yes.\n&nbsp;&nbsp;\n"` (the contents of the `body` element)
 
 Each of those text nodes is an object that has the properties and methods documented in this article.
 

--- a/files/en-us/web/api/text/index.md
+++ b/files/en-us/web/api/text/index.md
@@ -24,13 +24,13 @@ To understand what a text node is, consider the following document:
 </html>
 ```
 
-In that document, there are five text nodes, with the following contents:
+In that document, there are five text nodes, with the following contents in which all spaces are shown as ◦ and all newlines as ⏎:
 
-- `"\n&nbsp;&nbsp;&nbsp;&nbsp;"` (after the `<head>` start tag, a newline followed by four spaces)
-- `"Aliens?"` (the contents of the `title` element)
-- `"\n&nbsp;&nbsp;"` (after the `</title>` end tag, a newline followed by two spaces)
-- `"\n&nbsp;&nbsp;"` (after the `</head>` end tag, a newline followed by two spaces)
-- `"\n&nbsp;&nbsp;&nbsp;&nbsp;Why yes.\n&nbsp;&nbsp;\n"` (the contents of the `body` element)
+- `"⏎◦◦◦◦"` (after the `<head>` start tag, a newline followed by four spaces)
+- `"Aliens?"` (the contents of the `<title>` element)
+- `"⏎◦◦"` (after the `</title>` end tag, a newline followed by two spaces)
+- `"⏎◦◦"` (after the `</head>` end tag, a newline followed by two spaces)
+- `"⏎◦◦◦◦Why◦yes.⏎◦◦⏎"` (the contents of the `<body>` element)
 
 Each of those text nodes is an object that has the properties and methods documented in this article.
 


### PR DESCRIPTION
### Description

Replaces spaces with non-breaking spaces to stop them from collapsing into a single space.
Corrects the location of the third and fourth text nodes.
Corrects the content of the fifth text node which had an additional newline that I wasn't able to observe while opening up the document and running the TreeWalker from https://github.com/mdn/content/issues/23353.
An additional change I have considered making is to replace the "after the <x> tag" sentence structure with "between the <x> tag and <y> tag" to potentionally make the locations of the text nodes clearer to readers, feel free to let me know if I should make that additional change.