### PR TITLE
Remove remaining Deprecated_Header macros

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -2,6 +2,8 @@
 title: The MDN Content Kitchensink
 slug: MDN/Kitchensink
 page-type: guide
+status:
+  - deprecated
 browser-compat: html.elements.video
 ---
 
@@ -455,5 +457,4 @@ The [`AvailableInWorkers`](https://github.com/mdn/rari/blob/main/crates/rari-doc
   - : Information about a particular alarm.
 
 {{Non-standard_Header}}
-{{Deprecated_Header}}
 [![Iceberg pic](iceberg.jpg)](iceberg.jpg)

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -2,8 +2,6 @@
 title: The MDN Content Kitchensink
 slug: MDN/Kitchensink
 page-type: guide
-status:
-  - deprecated
 browser-compat: html.elements.video
 ---
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -8,8 +8,6 @@ browser-compat: webextensions.api.runtime.onBrowserUpdateAvailable
 sidebar: addonsidebar
 ---
 
-{{Deprecated_header}}
-
 Fired when an update for the browser is available, but it isn't installed immediately because a browser restart is required.
 
 ## Syntax

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -8,6 +8,9 @@ browser-compat: webextensions.api.runtime.onBrowserUpdateAvailable
 sidebar: addonsidebar
 ---
 
+> [!WARNING]
+> This event has been deprecated. Use {{WebExtAPIRef("runtime.onRestartRequired")}} instead.
+
 Fired when an update for the browser is available, but it isn't installed immediately because a browser restart is required.
 
 ## Syntax

--- a/files/en-us/web/api/htmlallcollection/index.md
+++ b/files/en-us/web/api/htmlallcollection/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.HTMLAllCollection
 ---
 
-{{APIRef("DOM")}}{{Deprecated_Header}}
+{{APIRef("DOM")}}
 
 The **`HTMLAllCollection`** interface represents a collection of _all_ of the document's elements, accessible by index (like an array) and by the element's [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id). It is returned by the {{domxref("document.all")}} property.
 


### PR DESCRIPTION
Related threads
- https://github.com/mdn/content/pull/45345
- https://github.com/mdn/mdn/issues/835


### Description

This is follow up of #45345 . The files that have been pulled here are the once should be updated only after the following requirement is implemented in the backend mdn/rari:

> If there are pages on MDN where a deprecated banner is required but is not covered by web features, the front-matter status: deprecated will be used to display this labelling.

If we remove the Deprecated_header macro now, then the deprecated banner won't be shown till the rari implements the requirement. 

### Motivation

Let us wait till rari implements inferring the deprecated banner from front-matter.

### Additional details

- https://github.com/orgs/mdn/discussions/911

