### PR TITLE
Fix subject-verb agreement and a wrong preposition

### DIFF
--- a/files/en-us/learn_web_development/howto/solve_css_problems/create_fancy_boxes/index.md
+++ b/files/en-us/learn_web_development/howto/solve_css_problems/create_fancy_boxes/index.md
@@ -287,7 +287,7 @@ So it's possible to create a wonderful effect when we mix all of this together. 
 <div class="fancy">Hi! I want to be fancy.</div>
 ```
 
-Let's create some partial drop-shadow effects. The {{cssxref("box-shadow")}} property allow us to create inner light and a flat drop shadow effect, but with some little extra work it becomes possible to create a more natural geometry by using a pseudo-element and the {{cssxref("rotate")}} property, one of the three individual {{cssxref("transform")}} properties.
+Let's create some partial drop-shadow effects. The {{cssxref("box-shadow")}} property allows us to create inner light and a flat drop shadow effect, but with some little extra work it becomes possible to create a more natural geometry by using a pseudo-element and the {{cssxref("rotate")}} property, one of the three individual {{cssxref("transform")}} properties.
 
 ```css
 .fancy {

--- a/files/en-us/web/api/characterdata/data/index.md
+++ b/files/en-us/web/api/characterdata/data/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CharacterData.data
 
 {{APIRef("DOM")}}
 
-The **`data`** property of the {{domxref("CharacterData")}} interface represent the value of the current object's data.
+The **`data`** property of the {{domxref("CharacterData")}} interface represents the value of the current object's data.
 
 ## Value
 

--- a/files/en-us/web/api/csslayerstatementrule/namelist/index.md
+++ b/files/en-us/web/api/csslayerstatementrule/namelist/index.md
@@ -8,7 +8,7 @@ browser-compat: api.CSSLayerStatementRule.nameList
 
 {{APIRef("CSSOM")}}
 
-The read-only **`nameList`** property of the {{DOMxRef("CSSLayerStatementRule")}} interface return the list of associated cascade layer names. The names can't be modified.
+The read-only **`nameList`** property of the {{DOMxRef("CSSLayerStatementRule")}} interface returns the list of associated cascade layer names. The names can't be modified.
 
 ## Value
 

--- a/files/en-us/web/api/document/createtreewalker/index.md
+++ b/files/en-us/web/api/document/createtreewalker/index.md
@@ -59,7 +59,7 @@ A new {{domxref("TreeWalker")}} object.
 
 ### Using whatToShow
 
-This example uses `whatToShow` to transform text contents into upper case. Note that the text nodes of the descendants of the `#root` element are also traversed despite of the fact that they are not child nodes of the `#root` element.
+This example uses `whatToShow` to transform text contents into upper case. Note that the text nodes of the descendants of the `#root` element are also traversed despite the fact that they are not child nodes of the `#root` element.
 
 #### HTML
 

--- a/files/en-us/web/css/reference/properties/border-bottom-left-radius/index.md
+++ b/files/en-us/web/css/reference/properties/border-bottom-left-radius/index.md
@@ -96,7 +96,7 @@ With two values:
 
 ## Description
 
-The rounding can be a circle or an ellipse, or if one of the value is `0` no rounding is done and the corner is square.
+The rounding can be a circle or an ellipse, or if one of the values is `0` no rounding is done and the corner is square.
 
 ![border-bottom-left-radius.png](border-bottom-left-radius.png)
 

--- a/files/en-us/web/css/reference/properties/border-bottom-right-radius/index.md
+++ b/files/en-us/web/css/reference/properties/border-bottom-right-radius/index.md
@@ -90,7 +90,7 @@ With two values:
 
 ## Description
 
-The rounding can be a circle or an ellipse, or if one of the value is `0` no rounding is done and the corner is square.
+The rounding can be a circle or an ellipse, or if one of the values is `0` no rounding is done and the corner is square.
 
 ![border-bottom-right-radius.png](border-bottom-right-radius.png)
 

--- a/files/en-us/web/css/reference/properties/border-top-left-radius/index.md
+++ b/files/en-us/web/css/reference/properties/border-top-left-radius/index.md
@@ -87,7 +87,7 @@ With two values:
 
 ## Description
 
-The rounding can be a circle or an ellipse, or if one of the value is `0`, no rounding is done and the corner is square.
+The rounding can be a circle or an ellipse, or if one of the values is `0`, no rounding is done and the corner is square.
 
 ![border-radius.png](border-radius.png)
 

--- a/files/en-us/web/css/reference/properties/border-top-right-radius/index.md
+++ b/files/en-us/web/css/reference/properties/border-top-right-radius/index.md
@@ -87,7 +87,7 @@ With two values:
 
 ## Description
 
-The rounding can be a circle or an ellipse, or if one of the value is `0` no rounding is done and the corner is square.
+The rounding can be a circle or an ellipse, or if one of the values is `0` no rounding is done and the corner is square.
 
 ![border-top-right-radius.png](border-top-right-radius.png)
 


### PR DESCRIPTION
### Description

Fixes eight grammar errors on seven pages: three subject-verb agreement slips, a singular noun after "one of the", and a wrong preposition.

### Motivation

**Missing the third-person `-s`.** Three pages use a plural verb with a singular subject:

- `CharacterData.data`: "The **`data`** property of the `CharacterData` interface **represent** the value of the current object's data."
- `CSSLayerStatementRule.nameList`: "The read-only **`nameList`** property of the `CSSLayerStatementRule` interface **return** the list of associated cascade layer names."
- "How to create fancy boxes": "The `box-shadow` property **allow** us to create inner light and a flat drop shadow effect."

**"one of the" requires a plural noun.** All four individual `border-*-radius` pages carry the same sentence: "The rounding can be a circle or an ellipse, or if one of the **value** is `0`, no rounding is done and the corner is square." Each property takes a horizontal and a vertical radius, so the intended noun is plural.

**Wrong preposition.** `Document.createTreeWalker()`: "the text nodes of the descendants of the `#root` element are also traversed **despite of** the fact that they are not child nodes". "Despite" does not take "of".
