### PR TITLE
Clarify implicit form submission conditions

### DIFF
--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -10,21 +10,6 @@ browser-compat: api.HTMLFormElement.submit_event
 
 The **`submit`** event fires when a {{HtmlElement("form")}} is submitted.
 
-Note that the `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}` inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
-
-The `submit` event fires when:
-
-- the user clicks a {{Glossary("submit button")}},
-- the user submits the form implicitly (for example, by pressing <kbd>Enter</kbd> while editing a text field, depending on the user agent),
-- a script calls the {{domxref("HTMLFormElement.requestSubmit()", "form.requestSubmit()")}} method.
-
-When a form is submitted implicitly, the user agent fires a `click` event at the form's default submit button (the first submit button in tree order), if one exists and is not disabled. If the default button is disabled, the form is not submitted implicitly. If the form has no submit button, the form is submitted implicitly only when it has no more than one field that blocks implicit submission. Blocking fields include {{HTMLElement("input")}} elements whose `type` is `text`, `search`, `tel`, `url`, `email`, `password`, `date`, `month`, `week`, `time`, `datetime-local`, or `number`.
-
-However, the event is _not_ sent to the form when a script calls the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
-
-> [!NOTE]
-> Trying to submit a form that does not pass [validation](/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation) triggers an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event. In this case, the validation prevents form submission, and thus there is no `submit` event.
-
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -40,6 +25,27 @@ onsubmit = (event) => { }
 A {{domxref("SubmitEvent")}}. Inherits from {{domxref("Event")}}.
 
 {{InheritanceDiagram("SubmitEvent")}}
+
+## Description
+
+The `submit` event fires on the `<form>` element itself, and not on any {{HtmlElement("button")}} or `{{HtmlElement('input/submit', '&lt;input type="submit"&gt;')}}` inside it. However, the {{domxref("SubmitEvent")}} which is sent to indicate the form's submit action has been triggered includes a {{domxref("SubmitEvent.submitter", "submitter")}} property, which is the button that was invoked to trigger the submit request.
+
+The `submit` event fires when:
+
+- the user clicks a {{Glossary("submit button")}},
+- the user submits the form [implicitly](#implicit_submission),
+- a script calls the {{domxref("HTMLFormElement.requestSubmit()", "form.requestSubmit()")}} method
+
+However, the event is _not_ sent to the form when a script calls the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
+
+Trying to submit a form that does not pass [validation](/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation) triggers an {{domxref("HTMLInputElement/invalid_event", "invalid")}} event. In this case, the validation prevents form submission, and thus there is no `submit` event.
+
+### Implicit submission
+
+The [HTML specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission) does not formally define what user gestures should trigger implicit submission, because it depends on operating system and device conventions. Usually, pressing <kbd>Enter</kbd> while focusing on a text input is considered an implicit submission. When a user performs such a gesture:
+
+- If the form has a non-disabled default submit button, the browser fires a `click` event at that button. The default button is the first submit button in tree order whose [form owner](/en-US/docs/Web/HTML/Reference/Attributes/form) is that form. This then triggers the form submission process (as if the button has been pressed by the user), unless the event is canceled.
+- If the form has no submit button, it is submitted implicitly only when it has at most one {{HTMLElement("input")}} element of type `text`, `search`, `tel`, `url`, `email`, `password`, `date`, `month`, `week`, `time`, `datetime-local`, or `number`. {{HTMLElement("textarea")}} and {{HTMLElement("select")}} elements do not block implicit submission.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -42,10 +42,11 @@ Trying to submit a form that does not pass [validation](/en-US/docs/Learn_web_de
 
 ### Implicit submission
 
-The [HTML specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission) does not formally define what user gestures should trigger implicit submission, because it depends on operating system and device conventions. Usually, pressing <kbd>Enter</kbd> while focusing on a text input is considered an implicit submission. When a user performs such a gesture:
+The [HTML specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission) does not formally define what user gestures may trigger implicit submission, because it depends on operating system and device conventions. For example, pressing <kbd>Enter</kbd> while focusing on a text input is a common gesture. However, the browser's reaction to such a gesture is standardized:
 
-- If the form has a non-disabled default submit button, the browser fires a `click` event at that button. The default button is the first submit button in tree order whose [form owner](/en-US/docs/Web/HTML/Reference/Attributes/form) is that form. This then triggers the form submission process (as if the button has been pressed by the user), unless the event is canceled.
+- If the form has a non-disabled default submit button, the browser fires a `click` event at that button. The default button is the first submit button in tree order whose [form owner](/en-US/docs/Web/API/HTMLButtonElement/form) is that form. This then triggers the form submission process (as if the button has been pressed by the user), unless the event is canceled.
 - If the form has no submit button, it is submitted implicitly only when it has at most one {{HTMLElement("input")}} element of type `text`, `search`, `tel`, `url`, `email`, `password`, `date`, `month`, `week`, `time`, `datetime-local`, or `number`. {{HTMLElement("textarea")}} and {{HTMLElement("select")}} elements do not block implicit submission.
+- Otherwise, if the form has a disabled default submit button, or no submit button and more than one input blocking implicit submission, the gesture never triggers implicit submission.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -15,8 +15,10 @@ Note that the `submit` event fires on the `<form>` element itself, and not on an
 The `submit` event fires when:
 
 - the user clicks a {{Glossary("submit button")}},
-- the user presses <kbd>Enter</kbd> while editing a field (e.g., {{HtmlElement('input/text', '&lt;input type="text"&gt;')}}) in a form,
-- a script calls the {{domxref("HTMLFormElement.requestSubmit()", "form.requestSubmit()")}} method
+- the user submits the form implicitly (for example, by pressing <kbd>Enter</kbd> while editing a text field, depending on the user agent),
+- a script calls the {{domxref("HTMLFormElement.requestSubmit()", "form.requestSubmit()")}} method.
+
+When a form is submitted implicitly, the user agent fires a `click` event at the form's default submit button (the first submit button in tree order), if one exists and is not disabled. If the default button is disabled, the form is not submitted implicitly. If the form has no submit button, the form is submitted implicitly only when it has no more than one field that blocks implicit submission. Blocking fields include {{HTMLElement("input")}} elements whose `type` is `text`, `search`, `tel`, `url`, `email`, `password`, `date`, `month`, `week`, `time`, `datetime-local`, or `number`.
 
 However, the event is _not_ sent to the form when a script calls the {{domxref("HTMLFormElement.submit()", "form.submit()")}} method directly.
 


### PR DESCRIPTION
## Summary

- distinguish implicit form submission from unconditional Enter-key behavior
- document default submit-button activation, including disabled buttons
- explain when a form without a submit button can submit implicitly

Fixes #43972.

## Validation

- `markdownlint-cli2@0.23.2` with `markdownlint-rule-search-replace@1.2.0`: 0 issues
- `prettier@3.9.6 --check`: passed
- `cspell@10.1.1`: 1 file checked, 0 issues
- `git diff --check`: passed