### PR TITLE
fix(pointerrawupdate): describe the difference as latency, not precision

### DIFF
--- a/files/en-us/web/api/element/pointermove_event/index.md
+++ b/files/en-us/web/api/element/pointermove_event/index.md
@@ -10,6 +10,8 @@ browser-compat: api.Element.pointermove_event
 
 The `pointermove` event is fired when a pointer changes coordinates, and the pointer has not been [canceled](/en-US/docs/Web/API/Element/pointercancel_event) by a browser [touch-action](/en-US/docs/Web/CSS/Reference/Properties/touch-action). It's very similar to the {{domxref("Element/mousemove_event", "mousemove")}} event, but with more features.
 
+The event is also fired when a pointer changes any of its other properties, provided the change doesn't produce some other pointer event. This includes any change to pressure, tangential pressure, tilt, twist, contact geometry (width and height), or [chorded buttons](https://w3c.github.io/pointerevents/#dfn-chorded-buttons).
+
 These events happen whether or not any pointer buttons are pressed. They can fire at a very high rate, depends on how fast the user moves the pointer, how fast the machine is, what other tasks and processes are happening, etc.
 
 ## Syntax

--- a/files/en-us/web/api/element/pointermove_event/index.md
+++ b/files/en-us/web/api/element/pointermove_event/index.md
@@ -8,11 +8,17 @@ browser-compat: api.Element.pointermove_event
 
 {{APIRef("Pointer Events")}}
 
-The `pointermove` event is fired when a pointer changes coordinates, and the pointer has not been [canceled](/en-US/docs/Web/API/Element/pointercancel_event) by a browser [touch-action](/en-US/docs/Web/CSS/Reference/Properties/touch-action). It's very similar to the {{domxref("Element/mousemove_event", "mousemove")}} event, but with more features.
+The `pointermove` event is fired when a pointer changes coordinates, and the pointer has not been [canceled](/en-US/docs/Web/API/Element/pointercancel_event) by a browser [touch-action](/en-US/docs/Web/CSS/Reference/Properties/touch-action). The event is also fired when a pointer changes any of its other properties, provided the change doesn't produce some other pointer event. This includes any change to pressure, tangential pressure, tilt, twist, contact geometry (width and height), or [chorded buttons](https://w3c.github.io/pointerevents/#dfn-chorded-buttons).
 
-The event is also fired when a pointer changes any of its other properties, provided the change doesn't produce some other pointer event. This includes any change to pressure, tangential pressure, tilt, twist, contact geometry (width and height), or [chorded buttons](https://w3c.github.io/pointerevents/#dfn-chorded-buttons).
+The `pointermove` event may have coalesced events if there is already another `pointermove` event with the same pointer ID that hasn't been dispatched in the event loop.
+If events are coalesced, the `target` of the dispatched event is the same as the last coalesced one.
+For information on coalesced events, see the {{domxref("PointerEvent.getCoalescedEvents()")}} documentation.
 
-These events happen whether or not any pointer buttons are pressed. They can fire at a very high rate, depends on how fast the user moves the pointer, how fast the machine is, what other tasks and processes are happening, etc.
+This event is very similar to the {{domxref("Element/mousemove_event", "mousemove")}} event, but with more features. These events happen whether or not any pointer buttons are pressed. They can fire at a very high rate, depends on how fast the user moves the pointer, how fast the machine is, what other tasks and processes are happening, etc.
+
+The difference between {{domxref("Element/pointerrawupdate_event", "pointerrawupdate")}} and `pointermove` is in their firing frequency.
+A browser may delay `pointermove` events to improve performance, while `pointerrawupdate` events are dispatched as soon and as frequently as the browser can produce them.
+For most use cases, you should prefer `pointermove` to avoid performance issues.
 
 ## Syntax
 

--- a/files/en-us/web/api/element/pointerrawupdate_event/index.md
+++ b/files/en-us/web/api/element/pointerrawupdate_event/index.md
@@ -12,17 +12,18 @@ The **`pointerrawupdate`** event is fired when a pointer changes any properties 
 See {{domxref('Element/pointermove_event', 'pointermove')}} for a list of these properties.
 
 The `pointerrawupdate` event may have coalesced events if there is already another `pointerrawupdate` event with the same pointer ID that hasn't been dispatched in the event loop.
+If events are coalesced, the `target` of the dispatched event is the same as the last coalesced one.
 For information on coalesced events, see the {{domxref("PointerEvent.getCoalescedEvents()")}} documentation.
 
-The difference between `pointerrawupdate` and {{domxref('Element/pointermove_event', 'pointermove')}} is when the events are dispatched, not how precise they are.
-A browser may delay `pointermove` events, for example to align them with rendering, while `pointerrawupdate` events are dispatched as soon and as frequently as the browser can produce them.
+The difference between `pointerrawupdate` and {{domxref("Element/pointermove_event", "pointermove")}} is in their firing frequency.
+A browser may delay `pointermove` events to improve performance, while `pointerrawupdate` events are dispatched as soon and as frequently as the browser can produce them.
 Both event types coalesce, but `pointerrawupdate` coalesces less, so its listeners run more often.
 Any single event carries the same property values either way, so `pointerrawupdate` is not more precise in space or time than the `pointermove` event covering the same movement.
 
 `pointerrawupdate` is therefore intended for applications that need lower-latency input handling than `pointermove` offers, such as drawing or dragging that would otherwise visibly lag behind the pointer.
 Because the events arrive more often, an application that keeps up with them can also feel smoother.
 However, because listening to `pointerrawupdate` events can affect performance, you should add these listeners only if your JavaScript needs high-frequency events and can handle them as quickly as they are dispatched.
-An application that cannot keep up will feel less responsive rather than more, so it helps to do as little work as possible in the listener, and to separate reading the events from rendering the result.
+An application that cannot keep up will feel less responsive rather than more, so heavy optimization inside the event listener is needed.
 For most use cases, other pointer event types should suffice.
 
 This event [bubbles](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling) and is [composed](/en-US/docs/Web/API/Event/composed), but is not [cancelable](/en-US/docs/Web/API/Event/cancelable) and has no default action.
@@ -46,10 +47,11 @@ A {{domxref("PointerEvent")}}. Inherits from {{domxref("Event")}}.
 ## Example
 
 ```js
-addEventListener("pointerrawupdate", (event) => {
-  if (event.getCoalescedEvents && event.getCoalescedEvents().length > 1) {
-    console.log("Coalesced events:", event.getCoalescedEvents().length);
-    for (let coalescedEvent of event.getCoalescedEvents()) {
+canvas.addEventListener("pointerrawupdate", (event) => {
+  const events = event.getCoalescedEvents();
+  if (events.length > 1) {
+    console.log("Coalesced events:", events.length);
+    for (const coalescedEvent of events) {
       // Do something with the coalesced events.
     }
   } else {

--- a/files/en-us/web/api/element/pointerrawupdate_event/index.md
+++ b/files/en-us/web/api/element/pointerrawupdate_event/index.md
@@ -14,8 +14,15 @@ See {{domxref('Element/pointermove_event', 'pointermove')}} for a list of these 
 The `pointerrawupdate` event may have coalesced events if there is already another `pointerrawupdate` event with the same pointer ID that hasn't been dispatched in the event loop.
 For information on coalesced events, see the {{domxref("PointerEvent.getCoalescedEvents()")}} documentation.
 
-`pointerrawupdate` is intended for applications that require high-precision input handling and cannot achieve smooth interaction using coalesced [`pointermove`](/en-US/docs/Web/API/Element/pointermove_event) events alone.
+The difference between `pointerrawupdate` and {{domxref('Element/pointermove_event', 'pointermove')}} is when the events are dispatched, not how precise they are.
+A browser may delay `pointermove` events, for example to align them with rendering, while `pointerrawupdate` events are dispatched as soon and as frequently as the browser can produce them.
+Both event types coalesce, but `pointerrawupdate` coalesces less, so its listeners run more often.
+Any single event carries the same property values either way, so `pointerrawupdate` is not more precise in space or time than the `pointermove` event covering the same movement.
+
+`pointerrawupdate` is therefore intended for applications that need lower-latency input handling than `pointermove` offers, such as drawing or dragging that would otherwise visibly lag behind the pointer.
+Because the events arrive more often, an application that keeps up with them can also feel smoother.
 However, because listening to `pointerrawupdate` events can affect performance, you should add these listeners only if your JavaScript needs high-frequency events and can handle them as quickly as they are dispatched.
+An application that cannot keep up will feel less responsive rather than more, so it helps to do as little work as possible in the listener, and to separate reading the events from rendering the result.
 For most use cases, other pointer event types should suffice.
 
 This event [bubbles](/en-US/docs/Learn_web_development/Core/Scripting/Event_bubbling) and is [composed](/en-US/docs/Web/API/Event/composed), but is not [cancelable](/en-US/docs/Web/API/Event/cancelable) and has no default action.


### PR DESCRIPTION
### Description

Rewrites the `pointerrawupdate` explainer so it describes the event's actual difference from `pointermove`, dispatch latency, rather than "high-precision input handling". Also adds to `pointermove` the property list that `pointerrawupdate` sends readers there to find.

### Motivation

Fixes #44029.

The page said `pointerrawupdate` "is intended for applications that require high-precision input handling". A `pointerrawupdate` event carries the same coordinate, timestamp, pressure and other property values that the `pointermove` event covering the same movement would carry, so it is not more precise in space or time. What actually differs is when events are dispatched: a browser may delay `pointermove`, for example to align it with rendering, while `pointerrawupdate` is dispatched as soon and as frequently as the browser can produce it, and both coalesce to different extents.

Following @Josh-Cena's review points on the issue:

- **Latency, not precision.** The rewritten paragraph leads with the dispatch-timing difference and says explicitly that a single event carries the same values either way.
- **Smoothness retained.** The reporter suggested dropping the smoothness claim entirely, but as @Josh-Cena noted it does still hold: events arriving more often is precisely why an application that keeps up feels more responsive. That is now stated as a consequence of the higher event rate rather than as a precision property.
- **Performance caveat retained and sharpened.** It is a tradeoff, so the existing caveat stays, plus the point that an application which cannot keep up ends up less responsive rather than more. I kept the guidance general rather than prescribing a technique, since the right answer depends on the app.
- **The missing list.** `pointerrawupdate` says "See `pointermove` for a list of these properties", wording inherited from the spec, but `pointermove` never stated the list. Added it there: pressure, tangential pressure, tilt, twist, contact geometry, and chorded buttons, matching the spec's own enumeration of what fires `pointermove` when no other pointer event would.

I did not change the "See `pointermove`" sentence itself, since it becomes accurate once the target page carries the list.

### Additional details

Property enumeration is from the Pointer Events spec's `pointermove` firing conditions, and the chorded-buttons link points at the spec's own definition.

### Related issues and pull requests

Fixes #44029
