### PR TITLE
Document periodic background sync permission requirements

### DIFF
--- a/files/en-us/web/api/periodicsyncmanager/register/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.md
@@ -14,8 +14,7 @@ The **`register()`** method of the
 {{domxref("PeriodicSyncManager")}} interface registers a periodic sync request with the
 browser with the specified tag and options. It returns a {{jsxref('Promise')}} that
 resolves when the registration completes.
-The method requires the `periodic-background-sync` permission; see the API's
-[security considerations](/en-US/docs/Web/API/Web_Periodic_Background_Synchronization_API#security_considerations) for details.
+The method requires the `periodic-background-sync` permission; see the API's [security considerations](/en-US/docs/Web/API/Web_Periodic_Background_Synchronization_API#security_considerations) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/periodicsyncmanager/register/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.md
@@ -14,6 +14,7 @@ The **`register()`** method of the
 {{domxref("PeriodicSyncManager")}} interface registers a periodic sync request with the
 browser with the specified tag and options. It returns a {{jsxref('Promise')}} that
 resolves when the registration completes.
+
 The method requires the `periodic-background-sync` permission; see the API's [security considerations](/en-US/docs/Web/API/Web_Periodic_Background_Synchronization_API#security_considerations) for details.
 
 ## Syntax

--- a/files/en-us/web/api/periodicsyncmanager/register/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.md
@@ -14,6 +14,8 @@ The **`register()`** method of the
 {{domxref("PeriodicSyncManager")}} interface registers a periodic sync request with the
 browser with the specified tag and options. It returns a {{jsxref('Promise')}} that
 resolves when the registration completes.
+The method requires the `periodic-background-sync` permission; see the API's
+[security considerations](/en-US/docs/Web/API/Web_Periodic_Background_Synchronization_API#security_considerations) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -68,6 +68,7 @@ A non-exhaustive list of permission-aware APIs includes:
 - [Storage API](/en-US/docs/Web/API/Storage_API): `persistent-storage`
 - [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API): `bluetooth`
 - [Web MIDI API](/en-US/docs/Web/API/Web_MIDI_API): `midi`
+- [Web Periodic Background Synchronization API](/en-US/docs/Web/API/Web_Periodic_Background_Synchronization_API): `periodic-background-sync`
 - [Window Management API](/en-US/docs/Web/API/Window_Management_API): `window-management`
 
 ## Interfaces

--- a/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
+++ b/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
@@ -51,8 +51,8 @@ const status = await navigator.permissions.query({
 });
 ```
 
-In Chrome, the permission is granted only to an installed web app that has been launched as a separate application.
-Chrome also uses the site's engagement score to determine whether and how often to fire periodic sync events.
+In Chrome, the permission is granted only to an [installed web app](/en-US/docs/Web/Progressive_web_apps/Guides/Installing) that has been launched as a separate application.
+Chrome also uses the [site's engagement score](https://developer.chrome.com/docs/capabilities/periodic-background-sync#getting_user_engagement_right) to determine whether and how often to fire periodic sync events.
 
 ## Examples
 

--- a/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
+++ b/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
@@ -40,6 +40,20 @@ The following additions to the {{domxref("Service Worker API", "", "", "nocode")
 - {{domxref("ServiceWorkerGlobalScope/periodicsync_event", "periodicsync")}} event {{Experimental_Inline}}
   - : Occurs at periodic intervals, which were specified when registering a {{domxref("PeriodicSyncManager")}}.
 
+## Security considerations
+
+Access to periodic background sync is controlled by the `periodic-background-sync` permission.
+You can use the [Permissions API](/en-US/docs/Web/API/Permissions_API) to check whether this permission is granted:
+
+```js
+const status = await navigator.permissions.query({
+  name: "periodic-background-sync",
+});
+```
+
+In Chrome, the permission is granted only to an installed web app that has been launched as a separate application.
+Chrome also uses the site's engagement score to determine whether and how often to fire periodic sync events.
+
 ## Examples
 
 The following examples show how to use the interface.


### PR DESCRIPTION
### Description

I documented the periodic-background-sync permission in the Permissions API list, added security considerations to the Web Periodic Background Synchronization API overview, and linked the register() method to that guidance.

### Motivation

I found that the existing pages documented the NotAllowedError but did not explain how to query the permission or the Chrome-specific installation and engagement requirements. This left readers without the context needed to understand why registration may be unavailable or events may not fire.

### Additional details

I based the Chrome-specific guidance on the Chrome for Developers article linked from the existing MDN pages and issue discussion.

I validated the three edited pages with:

- markdownlint-cli2
- Prettier check
- cspell
- a targeted Rari render of all three pages

### Related issues and pull requests

Relates to #33692
Relates to #45230