### PR TITLE
Fix casing of Python assertion names and True

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/models/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/models/index.md
@@ -345,7 +345,7 @@ For more information see the [Constraints reference](https://docs.djangoproject.
 Copy the `Book` model below and again paste it into the bottom of your file. The `Book` model represents all information about an available book in a general sense, but not a particular physical "instance" or "copy" available for loan.
 
 The model uses a `CharField` to represent the book's `title` and `isbn`.
-For `isbn`, note how the first unnamed parameter explicitly sets the label as "ISBN" (otherwise, it would default to "Isbn"). We also set the parameter `unique` as `true` to ensure all books have a unique ISBN (the unique parameter makes the field value globally unique in a table).
+For `isbn`, note how the first unnamed parameter explicitly sets the label as "ISBN" (otherwise, it would default to "Isbn"). We also set the parameter `unique` as `True` to ensure all books have a unique ISBN (the unique parameter makes the field value globally unique in a table).
 Unlike for the `isbn` (and the genre name), the `title` is not set to be unique, because it is possible for different books to have the same name.
 The model uses `TextField` for the `summary`, because this text may need to be quite long.
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/testing/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/testing/index.md
@@ -175,9 +175,9 @@ The new class defines two methods that you can use for pre-test configuration (f
 > [!NOTE]
 > The test classes also have a `tearDown()` method which we haven't used. This method isn't particularly useful for database tests, since the `TestCase` base class takes care of database teardown for you.
 
-Below those we have a number of test methods, which use `Assert` functions to test whether conditions are true, false or equal (`AssertTrue`, `AssertFalse`, `AssertEqual`). If the condition does not evaluate as expected then the test will fail and report the error to your console.
+Below those we have a number of test methods, which use `assert` functions to test whether conditions are true, false or equal (`assertTrue`, `assertFalse`, `assertEqual`). If the condition does not evaluate as expected then the test will fail and report the error to your console.
 
-The `AssertTrue`, `AssertFalse`, `AssertEqual` are standard assertions provided by **unittest**. There are other standard assertions in the framework, and also [Django-specific assertions](https://docs.djangoproject.com/en/5.0/topics/testing/tools/#assertions) to test if a view redirects (`assertRedirects`), to test if a particular template has been used (`assertTemplateUsed`), etc.
+The `assertTrue`, `assertFalse`, `assertEqual` are standard assertions provided by **unittest**. There are other standard assertions in the framework, and also [Django-specific assertions](https://docs.djangoproject.com/en/5.0/topics/testing/tools/#assertions) to test if a view redirects (`assertRedirects`), to test if a particular template has been used (`assertTemplateUsed`), etc.
 
 > [!NOTE]
 > You should **not** normally include **print()** functions in your tests as shown above. We do that here only so that you can see the order that the setup functions are called in the console (in the following section).


### PR DESCRIPTION
### Description

Corrects the capitalization of the `unittest` assertion methods in the Django testing tutorial, and one Python `True` literal.

### Motivation

The "Testing a Django web application" page writes the assertion methods with a leading capital — `Assert`, `AssertTrue`, `AssertFalse`, `AssertEqual` — in two paragraphs. Python's `unittest` methods are `assertTrue`, `assertFalse` and `assertEqual`, and Python is case-sensitive, so a reader copying the names out of the prose gets an `AttributeError`.

The page itself is the evidence: its code samples use `assertEqual` and friends about forty times, and the very sentence that introduces `AssertTrue` goes on to name `assertRedirects` correctly.

Separately, the models page says "We also set the parameter `unique` as `true`". Python's boolean literal is `True`, which is what the surrounding code samples on that page use.
