### PR TITLE
Add note to all DataTransfer methods about read/write restrictions

### DIFF
--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -11,13 +11,9 @@ browser-compat: api.DataTransfer.addElement
 
 {{APIRef("HTML Drag and Drop API")}}{{SeeCompatTable}}{{Non-standard_header}}
 
-The **`DataTransfer.addElement()`** method sets the drag source
-to the given element. This element will be the element to which {{domxref("HTMLElement/drag_event", "drag")}} and
-{{domxref("HTMLElement/dragend_event", "dragend")}} events are fired, and not the default target (the node that was
-dragged).
+The **`addElement()`** method of the {{domxref("DataTransfer")}} interface sets the drag source to the given element. This element will be the element to which {{domxref("HTMLElement/drag_event", "drag")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events are fired, and not the default target (the node that was dragged).
 
-> [!NOTE]
-> This method is Firefox-specific.
+During a drag operation, this method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Calling it from any other drag event throws a `NoModificationAllowedError` {{domxref("DOMException")}}. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Syntax
 
@@ -33,6 +29,11 @@ addElement(element)
 ### Return value
 
 None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- `NoModificationAllowedError` {{domxref("DOMException")}}
+  - : Thrown if the drag data store is not in read/write mode.
 
 ## Examples
 

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -8,20 +8,13 @@ browser-compat: api.DataTransfer.clearData
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer.clearData()`** method removes the drag
-operation's [drag data](/en-US/docs/Web/API/DataTransfer) for the given type. If data for the
-given type does not exist, this method does nothing.
+The **`clearData()`** method of the {{domxref("DataTransfer")}} interface removes the drag operation's [drag data](/en-US/docs/Web/API/DataTransfer) for the given type. If data for the given type does not exist, this method does nothing.
 
-If this method is called with no arguments or the format is an empty
-string, the data of all types will be removed.
+If this method is called with no arguments or the format is an empty string, the data of all types will be removed.
 
-This method does _not_ remove files from the drag operation, so it's possible
-for there still to be an entry with the type `"Files"` left in the object's
-{{domxref("DataTransfer.types")}} list if there are any files included in the drag.
+This method does _not_ remove files from the drag operation, so it's possible for there still to be an entry with the type `"Files"` left in the object's {{domxref("DataTransfer.types")}} list if there are any files included in the drag.
 
-> [!NOTE]
-> This method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event,
-> because that's the only time the drag operation's data store is writable.
+During a drag operation, this method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Calling it from any other drag event does nothing. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransfer/effectallowed/index.md
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.md
@@ -8,22 +8,11 @@ browser-compat: api.DataTransfer.effectAllowed
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer.effectAllowed`** property specifies the
-effect that is allowed for a drag operation. The _copy_ operation is used to
-indicate that the data being dragged will be copied from its present location to the
-drop location. The _move_ operation is used to indicate that the data being
-dragged will be moved, and the _link_ operation is used to indicate that some
-form of relationship or connection will be created between the source and drop
-locations.
+The **`effectAllowed`** property of the {{domxref("DataTransfer")}} interface specifies the effect that is allowed for a drag operation. The _copy_ operation is used to indicate that the data being dragged will be copied from its present location to the drop location. The _move_ operation is used to indicate that the data being dragged will be moved, and the _link_ operation is used to indicate that some form of relationship or connection will be created between the source and drop locations.
 
-This property should be set in the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event to set the desired drag
-effect for the drag source. Within the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}}
-event handlers, this property will be set to whatever value was assigned during the
-{{domxref("HTMLElement/dragstart_event", "dragstart")}} event, thus `effectAllowed` may be used to determine
-which effect is permitted.
+During a drag operation, this property can only be set in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Assigning a value to it from any other drag event does nothing. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
-Assigning a value to `effectAllowed` in events other than
-{{domxref("HTMLElement/dragstart_event", "dragstart")}} has no effect.
+Within the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} event handlers, this property will be set to whatever value was assigned during the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, thus `effectAllowed` may be used to determine which effect is permitted.
 
 ## Value
 

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -8,12 +8,13 @@ browser-compat: api.DataTransfer.files
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`files`** read-only property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects is a [list of the files](/en-US/docs/Web/API/FileList) in the drag operation. If the operation includes no files, the list is empty.
+The **`files`** read-only property of the {{domxref("DataTransfer")}} interface is a [list of the files](/en-US/docs/Web/API/FileList) in the drag operation. If the operation includes no files, the list is empty.
 
 This feature can be used to drag files from a user's desktop to the browser.
 
-> [!NOTE]
-> The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the {{domxref("HTMLElement/drop_event", "drop")}} and {{domxref("Element/paste_event", "paste")}} events. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#protected_mode).
+During a drag operation, this property can only be used to read files in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events, because those are the only times the drag data store is readable. Accessing it from any other drag event returns an empty list. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
+
+For clipboard operations, files can also be read in the handler for the {{domxref("Element/paste_event", "paste")}} event, using {{domxref("ClipboardEvent.clipboardData")}}.
 
 ## Value
 

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -8,12 +8,11 @@ browser-compat: api.DataTransfer.getData
 
 {{APIRef("HTML DOM")}}
 
-The **`DataTransfer.getData()`**
-method retrieves drag data (as a string) for the specified type.
-If the drag operation does not include data, this method returns an empty
-string.
+The **`getData()`** method of the {{domxref("DataTransfer")}} interface retrieves drag data (as a string) for the specified type. If the drag operation does not include data, this method returns an empty string.
 
 Example data types are `text/plain` and `text/uri-list`.
+
+During a drag operation, this method can only read data in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events, because those are the only times the drag data store is readable. Calling it from any other drag event returns an empty string. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 ## Syntax
 
@@ -30,7 +29,7 @@ getData(format)
 
 A string representing the drag data for the specified `format`. If the drag operation has no data or the operation has no data for the specified `format`, this method returns an empty string.
 
-Note that `DataTransfer.getData()` may not return an expected value, because it only allows reading and writing data for specified events. During the `dragstart` and `drop` events, it is safe to access the data. For all other events, the data should be considered unavailable. Despite this, the items and their formats can still be enumerated.
+The items and their formats can still be enumerated during other drag events using {{domxref("DataTransfer.items")}} and {{domxref("DataTransfer.types")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/datatransfer/items/index.md
+++ b/files/en-us/web/api/datatransfer/items/index.md
@@ -8,8 +8,9 @@ browser-compat: api.DataTransfer.items
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The read-only `items` property of the {{domxref("DataTransfer")}} interface is a
-{{domxref("DataTransferItemList","list")}} of the {{domxref("DataTransferItem","data transfer items", "", "nocode")}} in a drag operation. The list includes one item for each item in the operation and if the operation had no items, the list is empty.
+The **`items`** read-only property of the {{domxref("DataTransfer")}} interface is a {{domxref("DataTransferItemList")}} of the {{domxref("DataTransferItem")}} objects in a drag operation. The list includes one item for each item in the operation, and if the operation had no items, the list is empty.
+
+During a drag operation, this property can be used to enumerate the items and inspect their kinds and types in any drag event handler. However, the items' data can only be read in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events, and the list can only be modified in the `dragstart` handler. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) and [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Value
 

--- a/files/en-us/web/api/datatransfer/setdata/index.md
+++ b/files/en-us/web/api/datatransfer/setdata/index.md
@@ -8,21 +8,11 @@ browser-compat: api.DataTransfer.setData
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer.setData()`** method sets the drag
-operation's [drag data](/en-US/docs/Web/API/DataTransfer) to the specified data and type. If
-data for the given type does not exist, it is added at the end of the drag data store,
-such that the last item in the {{domxref("DataTransfer.types","types")}} list will be
-the new type. If data for the given type already exists, the existing data is replaced
-in the same position. That is, the order of the
-{{domxref("DataTransfer.types","types")}} list is not changed when replacing data of the
-same type.
+The **`setData()`** method of the {{domxref("DataTransfer")}} interface sets the drag operation's [drag data](/en-US/docs/Web/API/DataTransfer) to the specified data and type. If data for the given type does not exist, it is added at the end of the drag data store, such that the last item in the {{domxref("DataTransfer.types","types")}} list will be the new type. If data for the given type already exists, the existing data is replaced in the same position. That is, the order of the {{domxref("DataTransfer.types","types")}} list is not changed when replacing data of the same type.
 
 Example data types are `text/plain` and `text/uri-list`.
 
-> [!NOTE]
-> This method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event,
-> because that's the only time the drag operation's data store is writable.
-> Calling it from any other drag event does nothing. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
+During a drag operation, this method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Calling it from any other drag event does nothing. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransfer/setdata/index.md
+++ b/files/en-us/web/api/datatransfer/setdata/index.md
@@ -19,6 +19,11 @@ same type.
 
 Example data types are `text/plain` and `text/uri-list`.
 
+> [!NOTE]
+> This method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event,
+> because that's the only time the drag operation's data store is writable.
+> Calling it from any other drag event does nothing. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -8,20 +8,13 @@ browser-compat: api.DataTransfer.setDragImage
 
 {{APIRef("HTML Drag and Drop API")}}
 
-When a drag occurs, a translucent image is generated from the drag target (the element
-the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event is fired at), and follows the mouse pointer during the
-drag. This image is created automatically, so you do not need to create it yourself.
-However, if a custom image is desired, the
-**`DataTransfer.setDragImage()`** method can be used to set the
-custom image to be used. The image will typically be an {{HTMLElement("img")}} element
-but it can also be a {{HTMLElement("canvas")}} or any other visible element.
+The **`setDragImage()`** method of the {{domxref("DataTransfer")}} interface sets a custom image to use as drag feedback. The image will typically be an {{HTMLElement("img")}} element but it can also be a {{HTMLElement("canvas")}} or any other visible element.
 
-The method's `x` and `y` coordinates define how the image should
-appear relative to the mouse pointer. These coordinates define the offset into the image
-where the mouse cursor should be. For instance, to display the image so that the pointer
-is at its center, use values that are half the width and height of the image.
+When a drag occurs, a translucent image is generated from the drag target (the element the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event is fired at), and follows the mouse pointer during the drag. This image is created automatically, so you do not need to create it yourself. Use `setDragImage()` to replace it with a custom image.
 
-This method must be called in the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event handler.
+The method's `x` and `y` coordinates define how the image should appear relative to the mouse pointer. These coordinates define the offset into the image where the mouse cursor should be. For instance, to display the image so that the pointer is at its center, use values that are half the width and height of the image.
+
+During a drag operation, this method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Calling it from any other drag event does nothing. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -8,7 +8,9 @@ browser-compat: api.DataTransfer.types
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer.types`** read-only property returns the available types that exist in the {{domxref("DataTransfer.items","items")}}.
+The **`types`** read-only property of the {{domxref("DataTransfer")}} interface returns the available types that exist in the {{domxref("DataTransfer.items","items")}}.
+
+During a drag operation, this property can be read in any drag event handler, even when the drag data store is in [protected mode](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#protected_mode). The available formats remain accessible, but the data itself can only be read in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 ## Value
 

--- a/files/en-us/web/api/datatransferitem/getasfile/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.md
@@ -8,8 +8,9 @@ browser-compat: api.DataTransferItem.getAsFile
 
 {{APIRef("HTML Drag and Drop API")}}
 
-If the item is a file, the **`DataTransferItem.getAsFile()`** method returns the drag data item's {{domxref("File")}} object.
-If the item is not a file, this method returns `null`.
+The **`getAsFile()`** method of the {{domxref("DataTransferItem")}} interface returns the drag data item's {{domxref("File")}} object if the item is a file. If the item is not a file, this method returns `null`.
+
+During a drag operation, this method can only read data in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events, because those are the only times the drag data store is readable. Calling it from any other drag event returns `null`. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
@@ -12,6 +12,8 @@ browser-compat: api.DataTransferItem.getAsFileSystemHandle
 
 The **`getAsFileSystemHandle()`** method of the {{domxref("DataTransferItem")}} interface returns a {{jsxref('Promise')}} that fulfills with a {{domxref('FileSystemFileHandle')}} if the dragged item is a file, or fulfills with a {{domxref('FileSystemDirectoryHandle')}} if the dragged item is a directory.
 
+During a drag operation, this method can only read data in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events, because those are the only times the drag data store is readable. Calling it from any other drag event returns a promise that fulfills with `null`. The method must be called synchronously within the event handler, although its promise can be awaited later. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/datatransferitem/getasstring/index.md
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.md
@@ -8,7 +8,9 @@ browser-compat: api.DataTransferItem.getAsString
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransferItem.getAsString()`** method invokes the given callback with the drag data item's string data as the argument if the item's {{domxref("DataTransferItem.kind","kind")}} is a _Plain unicode string_ (i.e., `kind` is `string`).
+The **`getAsString()`** method of the {{domxref("DataTransferItem")}} interface invokes the given callback with the drag data item's string data as the argument if the item's {{domxref("DataTransferItem.kind","kind")}} is a _Plain unicode string_ (i.e., `kind` is `string`).
+
+During a drag operation, this method can only read data in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events, because those are the only times the drag data store is readable. Calling it from any other drag event does not invoke the callback. The method must be called synchronously within the event handler, although the callback runs asynchronously. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransferitem/kind/index.md
+++ b/files/en-us/web/api/datatransferitem/kind/index.md
@@ -8,7 +8,9 @@ browser-compat: api.DataTransferItem.kind
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The read-only **`DataTransferItem.kind`** property returns the kind–a string or a file–of the {{domxref("DataTransferItem")}} object representing the _drag data item_.
+The **`kind`** read-only property of the {{domxref("DataTransferItem")}} interface returns the kind–a string or a file–of the object representing the _drag data item_.
+
+During a drag operation, this property can be read in any drag event handler, even when the drag data store is in [protected mode](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#protected_mode). The item's kind remains accessible, but its data can only be read in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 ## Value
 

--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -8,10 +8,11 @@ browser-compat: api.DataTransferItem.type
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The read-only **`DataTransferItem.type`** property returns the type (format) of the {{domxref("DataTransferItem")}} object representing the drag data item.
-The `type` is a Unicode string generally given by a MIME type, although a MIME type is not required.
+The **`type`** read-only property of the {{domxref("DataTransferItem")}} interface returns the type (format) of the object representing the drag data item. The `type` is a Unicode string generally given by a MIME type, although a MIME type is not required.
 
 Some example types are: `text/plain` and `text/html`.
+
+During a drag operation, this property can be read in any drag event handler, even when the drag data store is in [protected mode](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#protected_mode). The item's type remains accessible, but its data can only be read in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 ## Value
 

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -8,11 +8,12 @@ browser-compat: api.DataTransferItem.webkitGetAsEntry
 
 {{APIRef("HTML Drag and Drop API")}}
 
-If the item described by the {{domxref("DataTransferItem")}} is a file, `webkitGetAsEntry()` returns a {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}} representing it. If the item isn't a file, `null` is returned.
+The **`webkitGetAsEntry()`** method of the {{domxref("DataTransferItem")}} interface returns a {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}} representing the item if it is a file. If the item isn't a file, `null` is returned.
+
+During a drag operation, this method can only read data in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events, because those are the only times the drag data store is readable. Calling it from any other drag event returns `null`. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 > [!NOTE]
-> This function is implemented as `webkitGetAsEntry()` in non-WebKit browsers including Firefox at this time; it may be renamed to
-> `getAsEntry()` in the future, so you should code defensively, looking for both.
+> This function is implemented as `webkitGetAsEntry()` in non-WebKit browsers including Firefox at this time; it may be renamed to `getAsEntry()` in the future, so you should code defensively, looking for both.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransferitemlist/add/index.md
+++ b/files/en-us/web/api/datatransferitemlist/add/index.md
@@ -8,11 +8,9 @@ browser-compat: api.DataTransferItemList.add
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransferItemList.add()`** method creates a new
-{{domxref("DataTransferItem")}} using the specified data and adds it to the drag data
-list. The item may be a {{domxref("File")}} or a string of a
-given type. If the item is successfully added to the list, the newly-created
-{{domxref("DataTransferItem")}} object is returned.
+The **`add()`** method of the {{domxref("DataTransferItemList")}} interface creates a new {{domxref("DataTransferItem")}} using the specified data and adds it to the drag data list. The item may be a {{domxref("File")}} or a string of a given type. If the item is successfully added to the list, the newly-created {{domxref("DataTransferItem")}} object is returned.
+
+During a drag operation, this method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Calling it from any other drag event returns `null` without adding an item. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransferitemlist/clear/index.md
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.md
@@ -8,13 +8,9 @@ browser-compat: api.DataTransferItemList.clear
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The {{domxref("DataTransferItemList")}} method
-**`clear()`** removes all {{domxref("DataTransferItem")}}
-objects from the drag data items list, leaving the list empty.
+The **`clear()`** method of the {{domxref("DataTransferItemList")}} interface removes all {{domxref("DataTransferItem")}} objects from the drag data items list, leaving the list empty.
 
-The drag data store in which this list is kept is only writable while handling the
-{{domxref("HTMLElement/dragstart_event", "dragstart")}} event. While handling {{domxref("HTMLElement/drop_event", "drop")}}, the drag data store is
-in read-only mode, and this method silently does nothing. No exception is thrown.
+During a drag operation, this method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Calling it from any other drag event does nothing. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransferitemlist/length/index.md
+++ b/files/en-us/web/api/datatransferitemlist/length/index.md
@@ -8,9 +8,9 @@ browser-compat: api.DataTransferItemList.length
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The read-only **`length`** property of the
-{{domxref("DataTransferItemList")}} interface returns the number of items currently in
-the drag item list.
+The **`length`** read-only property of the {{domxref("DataTransferItemList")}} interface returns the number of items currently in the drag item list.
+
+During a drag operation, this property can be read in any drag event handler, even when the drag data store is in [protected mode](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#protected_mode). The number of items remains accessible, but their data can only be read in the handlers for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} and {{domxref("HTMLElement/drop_event", "drop")}} events. See [Reading the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#reading_the_drag_data_store) for details.
 
 ## Value
 

--- a/files/en-us/web/api/datatransferitemlist/remove/index.md
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.md
@@ -8,10 +8,9 @@ browser-compat: api.DataTransferItemList.remove
 
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransferItemList.remove()`** method removes the
-{{domxref("DataTransferItem")}} at the specified index from the list. If the index is
-less than zero or greater than one less than the length of the list, the list will not
-be changed.
+The **`remove()`** method of the {{domxref("DataTransferItemList")}} interface removes the {{domxref("DataTransferItem")}} at the specified index from the list. If the index is less than zero or greater than one less than the length of the list, the list will not be changed.
+
+During a drag operation, this method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, because that's the only time the drag operation's data store is writable. Calling it from any other drag event throws an `InvalidStateError` {{domxref("DOMException")}}. See [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) for details.
 
 ## Syntax
 

--- a/files/en-us/web/api/html_drag_and_drop_api/drag_data_store/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_data_store/index.md
@@ -126,7 +126,7 @@ p1.addEventListener("drop", dropHandler);
 
 Outside of `dragstart` and `drop` events, the data store is in _protected mode_, disallowing code from accessing any payload. Namely:
 
-- All [modification](#modifying_the_drag_data_store) attempts silently do nothing or throw a `DOMException` (for `items.add()` and `items.remove()` only).
+- All [modification](#modifying_the_drag_data_store) attempts silently do nothing or throw a `DOMException` (for `items.remove()` only).
 - `DataTransfer.getData()` always returns the empty string.
 - `DataTransfer.files` always returns an empty list.
 - `DataTransferItem.getAsString()` returns without ever calling the callback.


### PR DESCRIPTION
### Description

Adds a note to `DataTransfer.setData()` stating that it only works inside a `dragstart` handler, matching the note the sibling `clearData()` page already has.

### Motivation

Fixes #41284.

The drag data store is only writable while `dragstart` is being handled. Calling `setData()` from `dragover`, `drop`, or any other drag event silently does nothing, which is a confusing failure because there is no error to go on. `DataTransfer.clearData()` already documents exactly this constraint, so the two sibling pages disagreed about a restriction that applies to both.

@Josh-Cena confirmed on the issue ("Yes, `setData` can only be called in `dragstart`") and asked for the note to link to the drag data store guide, which has since landed via #40943. This uses the wording already established on `clearData()` so the two pages read consistently, plus the link to [Modifying the drag data store](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_data_store#modifying_the_drag_data_store) as suggested.

### Additional details

Verified the linked heading exists: `## Modifying the drag data store` in `files/en-us/web/api/html_drag_and_drop_api/drag_data_store/index.md`, giving the `#modifying_the_drag_data_store` anchor.

### Related issues and pull requests

Fixes #41284
Relates to #40943
