### PR TITLE
Use the verb forms back up and set up

### DIFF
--- a/files/en-us/learn_web_development/extensions/client-side_tools/introducing_complete_toolchain/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_tools/introducing_complete_toolchain/index.md
@@ -78,7 +78,7 @@ Sign up for [GitHub](https://github.com/) by clicking the _Sign Up_ link on the 
 
 We'll install another software, git, to help with revision control.
 
-It's possible you've heard of "git" before. [Git](https://git-scm.com/) is currently the most popular source code revision control tool available to developers — revision control provides many advantages, such as a way to backup your work in a remote place, and a mechanism to work in a team on the same project without fear of overwriting each other's code.
+It's possible you've heard of "git" before. [Git](https://git-scm.com/) is currently the most popular source code revision control tool available to developers — revision control provides many advantages, such as a way to back up your work in a remote place, and a mechanism to work in a team on the same project without fear of overwriting each other's code.
 
 It might be obvious to some, but it bears repeating: Git is not the same thing as GitHub. Git is the revision control tool, whereas [GitHub](https://github.com/) is an online store for git repositories (plus a number of useful tools for working with them). Note that, although we're using GitHub in this chapter, there are several alternatives including [GitLab](https://about.gitlab.com/) and [Bitbucket](https://www.atlassian.com/software/bitbucket), and you could even host your own git repositories.
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
@@ -372,7 +372,7 @@ This can make deployment and iterative development much easier.
 You should already be using GitHub to store the local library source code (this was set up in [Source code management with Git and GitHub](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/development_environment#source_code_management_with_git_and_github) as part of setting up your development environment.
 
 This is a good point to make a backup of your "vanilla" project — while some of the changes we're going to be making in the following sections might be useful for deployment on any hosting service (or for development) others might not.
-Assuming you have already backed up all the changes made so far to the `main` branch on GitHub you can create a new branch to backup your changes as shown:
+Assuming you have already backed up all the changes made so far to the `main` branch on GitHub you can create a new branch to back up your changes as shown:
 
 ```bash
 # Fetch the latest main branch

--- a/files/en-us/learn_web_development/extensions/server-side/django/development_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/development_environment/index.md
@@ -416,7 +416,7 @@ Git (and GitHub) use repositories ("repos") as the top level "bucket" for storin
 Repositories can be public, in which case the code is visible to everyone on the internet, or private, in which case they are restricted to the owning organization or user account.
 
 All work is done on a particular "branch" of code in your repo.
-When you want to backup some changes to a branch you can create a "commit", which stores all changes since your last commit to the current branch.
+When you want to back up some changes to a branch you can create a "commit", which stores all changes since your last commit to the current branch.
 
 The repo is created with a default branch named "main". You can spawn other branches off this using git, which initially have all the commits of the original branch.
 You can evolve branches separately by adding commits, and then later on use a "Pull Request" (PR) on GitHub to merge changes from one branch to another.

--- a/files/en-us/learn_web_development/extensions/server-side/django/skeleton_website/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/skeleton_website/index.md
@@ -349,9 +349,9 @@ At this point, we know that Django is working!
 > [!NOTE]
 > The example page demonstrates a great Django feature — automated debug logging. Whenever a page cannot be found, Django displays an error screen with useful information or any error raised by the code. In this case, we can see that the URL we've supplied doesn't match any of our URL patterns (as listed). Logging is turned off in production (which is when we put the site live on the Web), in which case a less informative but more user-friendly page will be served.
 
-## Don't forget to backup to GitHub
+## Don't forget to back up to GitHub
 
-We've just done some significant work, so now is a good time to backup the project using GitHub.
+We've just done some significant work, so now is a good time to back up the project using GitHub.
 
 First move the _content_ of the top level **locallibrary** folder into the **django_local_library** folder that you [created as a local GitHub repository](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/development_environment#clone_the_repo_to_your_local_computer) when setting up the development environment.
 This will include **manage.py**, the **locallibrary** subfolder, the **catalog** subfolder, and anything else inside the top level folder.

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -57,7 +57,7 @@ Firefox 141 was released on [July 22, 2025](https://whattrainisitnow.com/release
 
 #### WebDriver BiDi
 
-- Added support for the "proxy" argument of the `browser.createUserContext` command. This allows clients to setup either a "direct" or "manual" proxy when creating a user context (ie Firefox Container). Support for additional proxy types will be added later on ([Firefox bug 1967653](https://bugzil.la/1967653)).
+- Added support for the "proxy" argument of the `browser.createUserContext` command. This allows clients to set up either a "direct" or "manual" proxy when creating a user context (ie Firefox Container). Support for additional proxy types will be added later on ([Firefox bug 1967653](https://bugzil.la/1967653)).
 - Implemented the new `browsingContext.historyUpdated` event which is emitted when `history.pushState()`, `history.replaceState()` or `document.open()` is called within the context of a web page ([Firefox bug 1906051](https://bugzil.la/1906051)).
 - Improved the error message shown when attempting to permanently install an unpacked, unsigned web extension ([Firefox bug 1958723](https://bugzil.la/1958723)).
 - Updated the `browsingContext.navigate` and `browsingContext.reload` commands to wait for the `browsingContext.navigationCommitted` event when using the "wait" condition "none" ([Firefox bug 1967469](https://bugzil.la/1967469)).

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -13,7 +13,7 @@ The **`decodingInfo()`** method of the {{domxref("MediaCapabilities")}} interfac
 The resolved object contains three boolean properties `supported`, `smooth`, and `powerefficient`, which indicate whether decoding the media described would be supported, and if so, whether decoding would be smooth and power-efficient.
 
 The method can also be used to test the user agent capabilities for decoding media encoded with a key system, but only when called in the main thread and in a secure context.
-If the configuration passed in the `configuration.keySystemConfiguration` property is supported for decoding the data, the resolved promise also includes a {{domxref("MediaKeySystemAccess")}} object that can be used to create a {{domxref("MediaKeys")}} object to setup encrypted playback.
+If the configuration passed in the `configuration.keySystemConfiguration` property is supported for decoding the data, the resolved promise also includes a {{domxref("MediaKeySystemAccess")}} object that can be used to create a {{domxref("MediaKeys")}} object to set up encrypted playback.
 
 > [!NOTE]
 > Calling `decodingInfo()` with this property may result in user-visible effects, such as asking for permission to access one or more system resources.
@@ -145,7 +145,7 @@ A {{jsxref('Promise')}} fulfilling with an object containing the following attri
 - `powerEfficient`
   - : `true` if playback of the media will be power efficient. Otherwise, it is `false`.
 - `keySystemAccess`
-  - : A {{domxref("MediaKeySystemAccess")}} that can be used to create a {{domxref("MediaKeys")}} object to setup encrypted playback, or `null` if decoding is not supported using the supplied configuration.
+  - : A {{domxref("MediaKeySystemAccess")}} that can be used to create a {{domxref("MediaKeys")}} object to set up encrypted playback, or `null` if decoding is not supported using the supplied configuration.
 
 Browsers will report a supported media configuration as `smooth` and `powerEfficient` until stats on this device have been recorded.
 All supported audio codecs report `powerEfficient` as true.


### PR DESCRIPTION
### Description

Uses the two-word verbs "back up" and "set up" in the eight places where the one-word noun forms are used as verbs.

### Motivation

"Backup" and "setup" are nouns and modifiers; the verbs are "back up" and "set up". Noun uses are left alone — "no additional configuration or setup", "Tools and setup", "backup and source files", and "browser or operating system sync or backup" are all correct and untouched.

The changed sentences are, for example, "such as a way to backup your work in a remote place", "you can create a new branch to backup your changes", "now is a good time to backup the project using GitHub", "This allows clients to setup either a `direct` or `manual` proxy", and "a `MediaKeys` object to setup encrypted playback".

One is a heading, "Don't forget to backup to GitHub". Nothing links to its anchor and no live sample refers to it, so renaming it is self-contained.
