### PR TITLE
fix(css): correct flex-shink typo in flex-shrink docs

### DIFF
--- a/files/en-us/web/css/reference/properties/flex-shrink/index.md
+++ b/files/en-us/web/css/reference/properties/flex-shrink/index.md
@@ -170,7 +170,7 @@ div {
 
 {{EmbedLiveSample('Setting_flex_item_shrink_factor', 500, 100)}}
 
-The flex items don't overflow their container because they can shrink: the `500px` of negative free space is distributed among the five items based on their `flex-shrink` values. The total of all the shrink values for the five items is `1 + 1 + 1 + 1.5 + 2` = `6.5`. As a result, the width of items with `flex-shrink: 1` is reduced by `1/6.5 * 500px` = `76.92px`, the width of items with `flex-shrink: 1.5` is reduced by `1.5/6.5 * 500px` = `115.38px`, and the width of items with `flex-shink: 2` is reduced by `2/6.5 * 500px` = `153.85px`.
+The flex items don't overflow their container because they can shrink: the `500px` of negative free space is distributed among the five items based on their `flex-shrink` values. The total of all the shrink values for the five items is `1 + 1 + 1 + 1.5 + 2` = `6.5`. As a result, the width of items with `flex-shrink: 1` is reduced by `1/6.5 * 500px` = `76.92px`, the width of items with `flex-shrink: 1.5` is reduced by `1.5/6.5 * 500px` = `115.38px`, and the width of items with `flex-shrink: 2` is reduced by `2/6.5 * 500px` = `153.85px`.
 
 ## Specifications
 


### PR DESCRIPTION
Closes #45404

Corrects flex-shink: 2 to flex-shrink: 2 in the flex-shrink
distribution example. The weekly spelling check flagged shink as
unknown; it is a typo for shrink in the prose, not a word to add
to the dictionaries.