### PR TITLE
docs(webassembly): add production Wasm architecture case study to See also

### DIFF
--- a/files/en-us/webassembly/index.md
+++ b/files/en-us/webassembly/index.md
@@ -35,3 +35,4 @@ Our reference documentation has several live examples to demonstrate how the dif
 - [webassembly.org](https://webassembly.org/)
 - [WebAssembly browser feature support status](https://webassembly.org/features/?categories=browsers) on webassembly.org (2026)
 - [W3C WebAssembly Community Group](https://www.w3.org/community/webassembly/)
+- [How WebAssembly became our privacy architecture (not just a performance trick)](https://dev.to/iqbalhssn78/how-webassembly-became-our-privacy-architecture-not-just-a-performance-trick-5c00): A production case study documenting how Wasm's sandboxed execution model was used as a structural privacy guarantee across 90+ browser-based file tools.


### PR DESCRIPTION
## Summary

Adds a production case study to the WebAssembly landing page's "See also" section, per the guidance in issue #45413 where @Josh-Cena noted:

> "If you have blog posts or similar written works documenting the architecture of said applications, with a strong focus on Wasm, we would be more willing to add them to See also."

## The article

**[How WebAssembly became our privacy architecture (not just a performance trick)](https://dev.to/iqbalhssn78/how-webassembly-became-our-privacy-architecture-not-just-a-performance-trick-5c00)**

The article documents how Wasm's sandboxed execution model (specifically: Wasm modules cannot initiate network connections directly) was used as a structural privacy guarantee across 90+ browser-based file tools (PDF processing, OCR, image conversion).

**Strong Wasm focus:** Covers the full in-browser pipeline (FileReader ? ArrayBuffer ? Wasm module ? Blob ? URL.createObjectURL), the open source Wasm stack used (Tesseract.js Apache 2.0, pdfjs-dist Apache 2.0, pdf-lib MIT, heic2any MIT), Web Worker isolation for CPU-intensive Wasm operations, transferable ArrayBuffer usage for zero-copy memory, and honest performance tradeoffs of client-side Wasm.

This is not a product listing - it's a technical architecture writeup focused on a non-obvious property of WebAssembly's execution model.

## MDN external link policy compliance

- The linked article is educational/technical content documenting architecture
- No paywall, no login required
- Focuses on Wasm concepts (sandboxing, memory model, Worker isolation) that derive directly from the WebAssembly spec
- Authored by the builder of the described system (transparent attribution)