### PR TITLE
FF154 Relnote: No-Vary-Search

### DIFF
--- a/files/en-us/mozilla/firefox/releases/154/index.md
+++ b/files/en-us/mozilla/firefox/releases/154/index.md
@@ -37,6 +37,14 @@ No notable changes.
   The difference between the methods is that the `chunks()` helper splits the elements from the original iterator into consecutive array chunks, while the `windows()` helper returns an array that is a sliding window over the original iterator (each iteration yields an array that slides forward one element: dropping the first element in the previous iteration and fetching a new element from the original iterator).
   ([Firefox bug 2047997](https://bugzil.la/2047997)).
 
+### HTTP
+
+- The {{httpheader("No-Vary-Search")}} response header is now supported.
+  By default a browser will create a separate HTTP cache entry to store the response for each query string, even if the response does not change for some or all parameters, or depend on their order.
+  This header allows the server to specify whether ordering matters and which query parameters, if any, will change the content of responses.
+  The browser can then avoid having to cache or fetch duplicate resources.
+  ([Firefox bug 2038013](https://bugzil.la/2038013)).
+
 ### APIs
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF154 adds support for `No-Vary-Search` . This adds the release note.

Related docs work can be tracked in #45298