### PR TITLE
fix(javascript): correct two regex examples that throw SyntaxError

### DIFF
--- a/files/en-us/web/javascript/reference/errors/regex_character_class_escape_in_class_range/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_character_class_escape_in_class_range/index.md
@@ -49,7 +49,7 @@ In Unicode-unaware mode, this syntax causes the `-` to become a literal characte
 // Remove the hyphen so the two bounds represent two alternatives
 /[\p{L}\p{N}]/u;
 // Use -- in unicodeSets mode, which represents set subtraction
-/[[A-z]--_]]/v;
+/[[A-z]--_]/v;
 ```
 
 ## See also

--- a/files/en-us/web/javascript/reference/errors/regex_invalid_group/index.md
+++ b/files/en-us/web/javascript/reference/errors/regex_invalid_group/index.md
@@ -48,7 +48,7 @@ SyntaxError: Invalid regular expression: unrecognized character after (? (Safari
 ```js example-good
 /Hello(\?|!)/;
 // This is JavaScript syntax for character set operations
-/[\p{Thai}&&\p{Digit}]/v;
+/[\p{Script=Thai}&&\p{Nd}]/v;
 ```
 
 ## See also


### PR DESCRIPTION
### Summary

Two lines sit in `example-good` blocks on the JavaScript error reference pages but are not valid regexes. Both throw `SyntaxError` if pasted into a console, which is the opposite of what the block demonstrates.

### `Regex_character_class_escape_in_class_range`

```js
/[[A-z]--_]]/v;   // SyntaxError: Invalid regular expression
```

There is a stray `]` at the end. The neighbouring `example-bad` block already shows the failing form, so the good one is meant to parse. Removing the extra bracket gives `/[[A-z]--_]/v`, which compiles and still demonstrates `--` as set subtraction.

### `Regex_invalid_group`

```js
/[\p{Thai}&&\p{Digit}]/v;   // SyntaxError: Invalid property name
```

Neither `Thai` nor `Digit` is a valid Unicode property name in JavaScript. `Thai` is a script, so it needs `Script=Thai`, and the general category for digits is `Nd`. `/[\p{Script=Thai}&&\p{Nd}]/v` compiles and keeps the point of the example, that `&&` is the set intersection syntax in `v` mode.

### How I checked

I evaluated the regexes as they appear on the **rendered** pages rather than in the source, because Yari collapses escapes inside code blocks. Both throw on the live pages today and compile after this change, and no other `example-good` regex on either page is affected.

Worth noting for review: the similar-looking double-escaped braces on `Regex_raw_bracket` and `Regex_invalid_char_in_class` are **not** a bug. Those render correctly, and the `<!-- Note: the {} need to be double-escaped, once for Yari -->` comments there are accurate. I checked those separately and left them alone.