### PR TITLE
correct "modal" to "non-modal" in dialog popover section

### DIFF
--- a/files/en-us/web/html/reference/elements/dialog/index.md
+++ b/files/en-us/web/html/reference/elements/dialog/index.md
@@ -78,7 +78,7 @@ The `<dialog>` must be turned into a popover by adding the `popover` attribute.
 You can then use `popovertarget` on a button/input to indicate the target popover, and `popovertargetaction` to specify the action to occur on the popover when the button is clicked.
 Note that, because the dialog is a popover, it will be non-modal, so you can close it by clicking outside the dialog.
 
-The HTML below shows how to apply the attributes to a `<button>` element so it can be pressed to show and hide a modal `<dialog>` with an `id` of "my-dialog".
+The HTML below shows how to apply the attributes to a `<button>` element so it can be pressed to show and hide a non-modal `<dialog>` with an `id` of "my-dialog".
 
 ```html
 <button popovertarget="my-dialog">Open dialog</button>


### PR DESCRIPTION
In the section ["Non-modal dialogs using popover commands"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#non-modal_dialogs_using_popover_commands), the sentence that introduces the example describes the dialog as modal. However, the paragraph directly above it says the opposite: "because the dialog is a popover, it will be non-modal".

The correct word is "non-modal".