### PR TITLE
Fix the interface name in two inheritance notes

### DIFF
--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -37,7 +37,7 @@ _The `PerformanceNavigation` interface doesn't inherit any properties._
 
 ## Instance methods
 
-_The `Performance` interface doesn't inherit any methods._
+_The `PerformanceNavigation` interface doesn't inherit any methods._
 
 - {{domxref("PerformanceNavigation.toJSON()")}} {{deprecated_inline}}
   - : A {{Glossary("Serialization","serializer")}} returning a JSON object representing the `PerformanceNavigation` object.

--- a/files/en-us/web/api/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/index.md
@@ -27,7 +27,7 @@ _The `RTCSessionDescription` interface doesn't inherit any properties._
 
 ## Instance methods
 
-_The `RTCSessionDescription` doesn't inherit any methods._
+_The `RTCSessionDescription` interface doesn't inherit any methods._
 
 - {{domxref("RTCSessionDescription.toJSON()")}}
   - : Returns a {{Glossary("JSON")}} description of the object. The values of both properties, {{domxref("RTCSessionDescription.type", "type")}} and {{domxref("RTCSessionDescription.sdp", "sdp")}}, are contained in the generated JSON.


### PR DESCRIPTION
### Description

Corrects the interface named in two "doesn't inherit any methods" notes.

### Motivation

`PerformanceNavigation` ends its "Instance methods" section with "_The `Performance` interface doesn't inherit any methods._" — the wrong interface. `Performance` is a separate interface with its own page, which carries that sentence correctly. The page itself shows the intended name: its "Instance properties" section two lines earlier reads "_The `PerformanceNavigation` interface doesn't inherit any properties._", the front-matter title is `PerformanceNavigation`, and every `{{domxref}}` in both lists points at `PerformanceNavigation.*`.

`RTCSessionDescription` drops the word "interface" from the same sentence. Across the repository this note appears twelve times with "interface" and only here without, for example on `GeolocationCoordinates`, `History`, `Performance` and `DOMMatrixReadOnly`.
