### PR TITLE
Fix verb form and possessive in an ARIA note and a proxy description

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
@@ -39,7 +39,7 @@ Values of this type are objects. They contain the following properties:
 - `tabId`
   - : `integer`. ID of the tab in which the request takes place. Set to -1 if the request is not related to a tab.
 - `thirdParty`
-  - : `boolean`. Indicates whether the request and its content window hierarchy is third party.
+  - : `boolean`. Indicates whether the request and its content window hierarchy are third party.
 - `timeStamp`
   - : `number`. The time when this event fired, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
 - `type`

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-placeholder/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-placeholder/index.md
@@ -29,7 +29,7 @@ If you are creating a `textbox` using any other element, `placeholder` is not su
 The placeholder hint should be shown to the user whenever the control's value is empty, including when a value is deleted.
 
 > [!NOTE]
-> ARIA is only modify the accessibility tree for an element and therefore how assistive technology presents the content to your users. ARIA doesn't change anything about an elements function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior.
+> ARIA only modifies the accessibility tree for an element and therefore how assistive technology presents the content to your users. ARIA doesn't change anything about an element's function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior.
 
 The `aria-placeholder` is used in addition to, not instead of, a label. They have different purposes and different functionality. A label explains what kind of information is expected. Placeholder text provides a hint about the expected value.
 


### PR DESCRIPTION
### Description

Fixes a verb form and a possessive in the ARIA note on `aria-placeholder`, and a subject-verb disagreement in the `proxy` API.

### Motivation

The `aria-placeholder` page carries the standard ARIA caveat, but with two errors the other copies don't have: "ARIA **is only modify** the accessibility tree for an element" should be "ARIA only modifies", and "anything about **an elements** function or behavior" needs the possessive "an element's". The canonical wording appears seven times elsewhere, including on the ARIA attributes index and `aria-modal`.

In `proxy.requestDetails`, the `thirdParty` description reads "Indicates whether the request and its content window hierarchy **is** third party". The subject is coordinated, so it takes a plural verb. The same description appears with "are" on eight `webRequest` event pages, for example `webRequest.onBeforeRedirect`.
