### PR TITLE
Restore words dropped from four sentences

### DIFF
--- a/files/en-us/mozilla/firefox/releases/135/index.md
+++ b/files/en-us/mozilla/firefox/releases/135/index.md
@@ -77,6 +77,6 @@ These features are newly shipped in Firefox 135 but are disabled by default. To 
 
 - **Temporal API** (Nightly release): <code>javascript.options.experimental.temporal</code>. The [Temporal object](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) aims to simplify working with dates and times in various scenarios, with built-in time zone and calendar representations. ([Firefox bug 1912511](https://bugzil.la/1912511)).
 - **Prioritized Task Scheduling API**: <code>dom.enable_web_task_scheduling</code>.
-  The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.
+  The [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides a standardized way to prioritize all tasks belonging to an application, whether they are defined in a website developer's code, or in third party libraries and frameworks.
   This has temporarily been disabled in Nightly builds in order to avoid [breakage in-the-wild](https://bugzil.la/1937232).
   ([Firefox bug 1938242](https://bugzil.la/1938242)).

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.md
@@ -15,7 +15,7 @@ property returns the {{domxref("BluetoothRemoteGATTService")}} this characterist
 
 ## Value
 
-An instance {{domxref("BluetoothRemoteGATTService")}}.
+An instance of {{domxref("BluetoothRemoteGATTService")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -49,7 +49,7 @@ _This interface doesn't inherit any methods. None of the following methods alter
 - {{domxref("DOMMatrixReadOnly.inverse()")}}
   - : Returns a new {{domxref("DOMMatrix")}} created by inverting the source matrix. The original matrix is not altered.
 - {{domxref("DOMMatrixReadOnly.multiply()")}}
-  - : Returns a new {{domxref("DOMMatrix")}} created by computing the dot product of the source matrix and the specified matrix. The original matrix is not
+  - : Returns a new {{domxref("DOMMatrix")}} created by computing the dot product of the source matrix and the specified matrix. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.rotateAxisAngle()")}}
   - : Returns a new {{domxref("DOMMatrix")}} created by rotating the source matrix by the given angle around the specified vector. The original matrix is not modified.
 - {{domxref("DOMMatrixReadOnly.rotate()")}}

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -49,7 +49,7 @@ The index of the first element in the array that passes the test. Otherwise, `-1
 
 ## Description
 
-The `findIndex()` is an [iterative method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods). It calls a provided `callbackFn` function once for each element in an array in ascending-index order, until `callbackFn` returns a [truthy](/en-US/docs/Glossary/Truthy) value. `findIndex()` then returns the index of that element and stops iterating through the array. If `callbackFn` never returns a truthy value, `findIndex()` returns `-1`. Read the [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods) section for more information about how these methods work in general.
+The `findIndex()` method is an [iterative method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods). It calls a provided `callbackFn` function once for each element in an array in ascending-index order, until `callbackFn` returns a [truthy](/en-US/docs/Glossary/Truthy) value. `findIndex()` then returns the index of that element and stops iterating through the array. If `callbackFn` never returns a truthy value, `findIndex()` returns `-1`. Read the [iterative methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#iterative_methods) section for more information about how these methods work in general.
 
 `callbackFn` is invoked for _every_ index of the array, not just those with assigned values. Empty slots in [sparse arrays](/en-US/docs/Web/JavaScript/Guide/Indexed_collections#sparse_arrays) behave the same as `undefined`.
 


### PR DESCRIPTION
### Description

Restores a word dropped from four sentences.

### Motivation

- `DOMMatrixReadOnly`: the `multiply()` entry ends mid-sentence — "The original matrix is not" — with no period. All fifteen sibling glosses in the same list complete it, thirteen of them with "modified.", and the dedicated `DOMMatrixReadOnly.multiply()` page ends the same way.
- Firefox 135 release notes: "whether they defined in a website developer's code" is missing "are". The identical blurb is reused in the Firefox 139 and 140 notes and on the Prioritized Task Scheduling API page, all three reading "whether they are defined".
- `Array.prototype.findIndex()`: "The `findIndex()` is an iterative method" is missing "method". Eight sibling `Array` pages open with this exact sentence and all include it, among them `find()`, `filter()`, `every()` and `map()`.
- `BluetoothRemoteGATTCharacteristic.service`: "An instance {{domxref("BluetoothRemoteGATTService")}}." is missing "of". The pattern appears ten times with the preposition and once without, including on the sibling pages `BluetoothRemoteGATTService.device` and `BluetoothRemoteGATTDescriptor.characteristic`.
