### PR TITLE
Give four API opener sentences a finite verb

### DIFF
--- a/files/en-us/web/api/htmlimageelement/attributionsrc/index.md
+++ b/files/en-us/web/api/htmlimageelement/attributionsrc/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HTMLImageElement.attributionSrc
 
 {{APIRef("Attribution Reporting API")}}{{securecontext_header}}{{non-standard_header}}
 
-The **`attributionSrc`** property of the {{domxref("HTMLImageElement")}} interface that you want the browser to send an {{httpheader("Attribution-Reporting-Eligible")}} header along with the image request. It reflects the `<img>` element's [`attributionsrc`](/en-US/docs/Web/HTML/Reference/Elements/img#attributionsrc) content attribute.
+The **`attributionSrc`** property of the {{domxref("HTMLImageElement")}} interface specifies that you want the browser to send an {{httpheader("Attribution-Reporting-Eligible")}} header along with the image request. It reflects the `<img>` element's [`attributionsrc`](/en-US/docs/Web/HTML/Reference/Elements/img#attributionsrc) content attribute.
 
 See the [Attribution Reporting API](/en-US/docs/Web/API/Attribution_Reporting_API) for more details.
 

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLImageElement.referrerPolicy
 
 {{APIRef("HTML DOM")}}
 
-The **`referrerPolicy`** property of the {{domxref("HTMLImageElement")}} interface defining which referrer is sent when fetching the resource. It reflects the `<img>` element's [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/img#referrerpolicy) content attribute.
+The **`referrerPolicy`** property of the {{domxref("HTMLImageElement")}} interface defines which referrer is sent when fetching the resource. It reflects the `<img>` element's [`referrerpolicy`](/en-US/docs/Web/HTML/Reference/Elements/img#referrerpolicy) content attribute.
 
 ## Value
 

--- a/files/en-us/web/api/htmlimageelement/usemap/index.md
+++ b/files/en-us/web/api/htmlimageelement/usemap/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLImageElement.useMap
 
 {{APIRef("HTML DOM")}}
 
-The **`useMap`** property of the {{domxref("HTMLImageElement")}} interface providing the name of the client-side image map to apply to the image. It reflects the `<img>` element's [`usemap`](/en-US/docs/Web/HTML/Reference/Elements/img#usemap) content attribute.
+The **`useMap`** property of the {{domxref("HTMLImageElement")}} interface provides the name of the client-side image map to apply to the image. It reflects the `<img>` element's [`usemap`](/en-US/docs/Web/HTML/Reference/Elements/img#usemap) content attribute.
 
 ## Value
 

--- a/files/en-us/web/api/svglength/unittype/index.md
+++ b/files/en-us/web/api/svglength/unittype/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGLength.unitType
 
 {{APIRef("SVG")}}
 
-The **`unitType`** property of the {{domxref("SVGLength")}} interface that represents type of the value as specified by one of the `SVG_LENGTHTYPE_*` constants defined on this interface.
+The **`unitType`** property of the {{domxref("SVGLength")}} interface represents the type of the value as specified by one of the `SVG_LENGTHTYPE_*` constants defined on this interface.
 
 ## Value
 


### PR DESCRIPTION
### Description

Gives four opening sentences a finite verb. Each is currently a sentence fragment.

### Motivation

Three are on `HTMLImageElement` property pages, where the head verb was lost and a participle or relative pronoun was left stranded:

- `useMap`: "The **`useMap`** property of the `HTMLImageElement` interface **providing** the name of the client-side image map" → "provides". The next sentence already carries the reflection clause, so nothing else needs to move.
- `referrerPolicy`: "… interface **defining** which referrer is sent" → "defines". The `HTMLLinkElement.referrerPolicy` page shows where the wording came from: there "defining" is a legitimate participle inside a longer clause headed by "reflects".
- `attributionSrc`: "… interface **that you want** the browser to send an `Attribution-Reporting-Eligible` header" → "specifies that you want". That predicate appears verbatim on the `<img>` element page.

The other twenty-five `HTMLImageElement` openers all use a finite verb, among them "provides", "specifies", "indicates" and "reflects".

`SVGLength.unitType` has the same defect plus a missing article: "… interface **that represents type of** the value" → "represents the type of the value". The parent `SVGLength` page glosses this property as "The type of the value as specified by one of the `SVG_LENGTHTYPE_*` constants", and the peer page `SVGAngle.unitType` opens with a finite verb.
