### PR TITLE
Fix missing articles, a plural, and a tense

### DIFF
--- a/files/en-us/web/api/svgclippathelement/clippathunits/index.md
+++ b/files/en-us/web/api/svgclippathelement/clippathunits/index.md
@@ -18,7 +18,7 @@ The read-only **`clipPathUnits`** property of the {{domxref("SVGClipPathElement"
 An {{domxref("SVGAnimatedEnumeration")}} representing the coordinate system. The possible values are defined in the {{domxref("SVGUnitTypes")}} interface:
 
 - `0` (`SVG_UNIT_TYPE_UNKNOWN`)
-  - : The type is not one of the predefined type.
+  - : The type is not one of the predefined types.
 - `1` (`SVG_UNIT_TYPE_USERSPACEONUSE`)
   - : Corresponds to a value of `userSpaceOnUse` for the {{SVGAttr("clipPathUnits")}} attribute and means that all coordinates inside the element refer to the user coordinate system as defined when the clipping path was created. It is the default value.
 - `2` (`SVG_UNIT_TYPE_OBJECTBOUNDINGBOX`)

--- a/files/en-us/web/css/reference/at-rules/@counter-style/system/index.md
+++ b/files/en-us/web/css/reference/at-rules/@counter-style/system/index.md
@@ -383,4 +383,4 @@ ul {
 
 - Other {{cssxref("@counter-style")}} descriptors, including {{cssxref("@counter-style/symbols", "symbols")}}, {{cssxref("@counter-style/additive-symbols", "additive-symbols")}}, {{cssxref("@counter-style/negative", "negative")}}, {{cssxref("@counter-style/prefix", "prefix")}}, {{cssxref("@counter-style/suffix", "suffix")}}, {{cssxref("@counter-style/range", "range")}}, {{cssxref("@counter-style/pad", "pad")}}, {{cssxref("@counter-style/speak-as", "speak-as")}}, and {{cssxref("@counter-style/fallback", "fallback")}}
 - {{cssxref("list-style")}}, {{cssxref("list-style-image")}}, {{cssxref("list-style-position")}}
-- {{cssxref("symbols()")}}, the functional notation creating anonymous counter styles.
+- {{cssxref("symbols()")}}, the functional notation for creating anonymous counter styles.

--- a/files/en-us/web/css/reference/properties/justify-items/index.md
+++ b/files/en-us/web/css/reference/properties/justify-items/index.md
@@ -116,7 +116,7 @@ This property can take one of four different forms:
 - `normal`
   - : The effect of this keyword is dependent of the layout mode we are in:
     - In block-level layouts, the keyword is a synonym of `start`.
-    - In absolutely-positioned layouts, the keyword behaved like `start` on _replaced_ absolutely-positioned boxes, and as `stretch` on _all other_ absolutely-positioned boxes.
+    - In absolutely-positioned layouts, the keyword behaves like `start` on _replaced_ absolutely-positioned boxes, and as `stretch` on _all other_ absolutely-positioned boxes.
     - In table cell layouts, this keyword has no meaning as this property is _ignored_.
     - In flexbox layouts, this keyword has no meaning as this property is _ignored._
     - In grid layouts, this keyword leads to a behavior similar to the one of `stretch`, except for boxes with an aspect ratio or an intrinsic size where it behaves like `start`.

--- a/files/en-us/web/javascript/reference/global_objects/regexp/symbol.match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/symbol.match/index.md
@@ -46,7 +46,7 @@ An {{jsxref("Array")}} whose contents depend on the presence or absence of the g
 
 ## Description
 
-This method exists for customizing match behavior within `RegExp` subclasses. It is called internally in {{jsxref("String.prototype.match()")}}. For example, the following two examples return same result.
+This method exists for customizing match behavior within `RegExp` subclasses. It is called internally in {{jsxref("String.prototype.match()")}}. For example, the following two examples return the same result.
 
 ```js
 "abc".match(/a/);


### PR DESCRIPTION
### Description

Fixes a missing article, a singular that should be plural, a tense, and a missing preposition.

### Motivation

- `RegExp.prototype[Symbol.match]()`: "the following two examples return same result" is missing "the". The sibling page `RegExp.prototype[Symbol.matchAll]()` has the identical sentence with "the same result".
- `SVGClipPathElement.clipPathUnits`: "The type is not one of the predefined **type**." — "one of the" requires a plural complement. Sibling SVG enumeration pages such as `SVGMaskElement.maskContentUnits` use "predefined types".
- `justify-items`: "In absolutely-positioned layouts, the keyword **behaved** like `start`" is past tense in a list where every other entry is present. The verbatim-identical sentence is present tense on all four siblings — `align-items`, `align-self`, `justify-self` and `place-self`.
- `@counter-style/system`: "`symbols()`, the functional notation **creating** anonymous counter styles" reads as a reduced relative clause where the rest of the list uses "for creating". That phrasing appears five times elsewhere, including on `@counter-style/fallback`.
