### PR TITLE
Capitalize four definition list descriptions

### DIFF
--- a/files/en-us/web/accessibility/aria/reference/roles/tree_role/index.md
+++ b/files/en-us/web/accessibility/aria/reference/roles/tree_role/index.md
@@ -69,7 +69,7 @@ Elements with the role `tree` have an implicit [`aria-orientation`](/en-US/docs/
 - [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label)
   - : Defines a string value that labels the `tree` when no visible label is present.
 - [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-orientation)
-  - : indicates whether the tree orientation is horizontal or vertical; defaults to `vertical` if omitted.
+  - : Indicates whether the tree orientation is horizontal or vertical; defaults to `vertical` if omitted.
 - [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-multiselectable)
   - : When set to true, indicates the user may select more than one tree item from the tree's current selectable descendants.
 

--- a/files/en-us/web/api/idbobjectstore/index.md
+++ b/files/en-us/web/api/idbobjectstore/index.md
@@ -33,7 +33,7 @@ The **`IDBObjectStore`** interface of the [IndexedDB API](/en-US/docs/Web/API/In
 - {{domxref("IDBObjectStore.createIndex()")}}
   - : Creates a new index during a version upgrade, returning a new {{domxref("IDBIndex")}} object in the connected database.
 - {{domxref("IDBObjectStore.delete()")}}
-  - : returns an {{domxref("IDBRequest")}} object and, in a separate thread, deletes the store object selected by the specified key. This is for deleting individual records out of an object store.
+  - : Returns an {{domxref("IDBRequest")}} object and, in a separate thread, deletes the store object selected by the specified key. This is for deleting individual records out of an object store.
 - {{domxref("IDBObjectStore.deleteIndex()")}}
   - : Destroys the specified index in the connected database, used during a version upgrade.
 - {{domxref("IDBObjectStore.get()")}}

--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -153,7 +153,7 @@ _Doesn't inherit any method._
 - {{domxref("Navigator.getBattery()")}} {{SecureContext_Inline}}
   - : Returns a promise that resolves with a {{domxref("BatteryManager")}} object that returns information about the battery charging status.
 - {{domxref("Navigator.getGamepads()")}}
-  - : returns an array of {{domxref("Gamepad")}} objects, one for each gamepad connected to the device.
+  - : Returns an array of {{domxref("Gamepad")}} objects, one for each gamepad connected to the device.
 - {{domxref("Navigator.getInstalledRelatedApps()")}} {{Experimental_Inline}} {{SecureContext_Inline}}
   - : Returns a promise that resolves with an array of objects representing any related native or [Progressive Web Applications](/en-US/docs/Web/Progressive_web_apps) that the user has installed.
 - {{domxref("Navigator.registerProtocolHandler()")}} {{SecureContext_Inline}}

--- a/files/en-us/web/api/webgpu_api/index.md
+++ b/files/en-us/web/api/webgpu_api/index.md
@@ -579,7 +579,7 @@ You can find more information about WebGPU error handling in the explainer — s
 - {{domxref("GPUComputePassEncoder")}}
   - : Encodes commands related to controlling the compute shader stage, as issued by a {{domxref("GPUComputePipeline")}}. Part of the overall encoding activity of a {{domxref("GPUCommandEncoder")}}.
 - {{domxref("GPUQueue")}}
-  - : controls execution of encoded commands on the GPU.
+  - : Controls execution of encoded commands on the GPU.
 - {{domxref("GPURenderBundle")}}
   - : A container for pre-recorded bundles of commands (see {{domxref("GPURenderBundleEncoder")}}).
 - {{domxref("GPURenderBundleEncoder")}}


### PR DESCRIPTION
### Description

Capitalizes four definition list descriptions that begin lowercase in lists where every other entry is capitalized.

### Motivation

In each case the item is the only lowercase description in its list, so the surrounding list establishes the convention:

- `IDBObjectStore`: the `delete()` entry reads "returns an `IDBRequest` object and, in a separate thread, …". The identical opening phrase is capitalized four times in the same list, on `add()`, `count()`, `get()` and `getKey()`.
- `Navigator`: the `getGamepads()` entry reads "returns an array of `Gamepad` objects". Its immediate neighbors — `getAutoplayPolicy()`, `getBattery()`, `getInstalledRelatedApps()` and `requestMediaKeySystemAccess()` — all begin "Returns".
- WebGPU API: the `GPUQueue` entry reads "controls execution of encoded commands on the GPU", in an interface list that otherwise reads "Represents…", "Encodes…", "Used to…".
- `tree` role: the `aria-orientation` entry reads "indicates whether the tree orientation is horizontal or vertical", in an attribute list that otherwise reads "An item in a tree.", "Identifies the element…", "Defines a string value…".
