### PR TITLE
Add accessibility information and fix the example for ElementInternals.labels

### DIFF
--- a/files/en-us/web/api/elementinternals/labels/index.md
+++ b/files/en-us/web/api/elementinternals/labels/index.md
@@ -14,6 +14,42 @@ The **`labels`** read-only property of the {{domxref("ElementInternals")}} inter
 
 A {{domxref("NodeList")}} containing all of the label elements associated with this element.
 
+### Exceptions
+
+- `NotSupportedError` {{domxref("DOMException")}}
+  - : Thrown if the element does not have its `formAssociated` property set to `true`.
+
+## Accessibility
+
+A {{HTMLElement("label")}} associated with a form-associated custom element is exposed to assistive technology in the same way as a label on a built-in form control.
+In Chrome and Firefox it provides the accessible name for the element.
+
+For a screen reader to reach that name, the element also has to be focusable.
+A custom element is not focusable by default, so it needs a [`tabindex`](/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex) attribute, or a shadow root created with `delegatesFocus: true` and a focusable element inside it.
+
+Safari does not expose the label this way.
+VoiceOver does not read a `<label>` that is associated with a form-associated custom element ([WebKit bug 259124](https://bugs.webkit.org/show_bug.cgi?id=259124)), so an element that relies on the association alone has no accessible name in that combination.
+
+To give the element an accessible name in every browser, set {{domxref("ElementInternals.ariaLabel", "ariaLabel")}} on the element's internals as well as associating the label:
+
+```js
+class CustomCheckbox extends HTMLElement {
+  static formAssociated = true;
+  #internals;
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+    this.#internals.role = "checkbox";
+    this.#internals.ariaLabel = "Join newsletter";
+  }
+}
+```
+
+> [!NOTE]
+> Setting `ariaLabel` on the internals defines a _default_ semantic for the element.
+> An `aria-label` attribute set on the element itself takes precedence over it, which lets a page author override the name without the component losing its own fallback.
+
 ## Examples
 
 The following example shows a custom checkbox component with a {{HTMLElement("label")}} element linked to it.
@@ -21,15 +57,32 @@ Printing the value of `labels` to the console returns a {{domxref("NodeList")}} 
 
 ```html
 <form id="myForm">
-  <custom-checkbox id="custom-checkbox"></custom-checkbox>
+  <custom-checkbox id="custom-checkbox" tabindex="0"></custom-checkbox>
   <label for="custom-checkbox">Join newsletter</label>
 </form>
 ```
 
 ```js
-let element = document.getElementById("custom-checkbox");
-console.log(element.internals_.label);
+class CustomCheckbox extends HTMLElement {
+  static formAssociated = true;
+
+  constructor() {
+    super();
+    this.internals_ = this.attachInternals();
+  }
+
+  // …
+}
+
+window.customElements.define("custom-checkbox", CustomCheckbox);
+
+const element = document.getElementById("custom-checkbox");
+console.log(element.internals_.labels); // NodeList [ label ]
 ```
+
+> [!NOTE]
+> A label is only listed once it has been parsed.
+> Reading `labels` from [`connectedCallback()`](/en-US/docs/Web/API/Web_components/Using_custom_elements#custom_element_lifecycle_callbacks) returns an empty list when the associated `<label>` comes after the element in the source, because the parser has not reached it yet.
 
 ## Specifications
 
@@ -38,3 +91,9 @@ console.log(element.internals_.label);
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("ElementInternals.ariaLabel")}}
+- {{domxref("HTMLElement.attachInternals()")}}
+- {{domxref("ElementInternals.form")}}


### PR DESCRIPTION
### Description

Adds an Accessibility section to `ElementInternals.labels`, documents the `NotSupportedError` exception, and corrects the example, which could not run as written.

### Motivation

The page documents what `labels` returns but not the thing a reader is usually trying to find out: whether an associated `<label>` gives the custom element an accessible name. It does in Chrome and Firefox, and it does not in Safari, which seems worth stating on the page rather than leaving to be discovered.

The example was also misleading:

- it read `internals_.label`, but the property is `labels`;
- it never defined the custom element that `internals_` belongs to, so the snippet could not run on its own;
- it omitted `static formAssociated = true`, without which the getter throws `NotSupportedError`, the exception this page did not document.

### Additional details

- VoiceOver does not read a `<label>` associated with a form-associated custom element: [WebKit bug 259124](https://bugs.webkit.org/show_bug.cgi?id=259124), still open, reported against Safari 16. The reporter notes the same case works in Chrome and Firefox.
- The `NotSupportedError` wording follows the sibling [`form`](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/form), [`validity`](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/validity) and [`willValidate`](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/willValidate) pages, which already document it.
- `ElementInternals.ariaLabel` is Baseline Widely Available since October 2023, so recommending it as the cross-browser fallback should be safe. The note records that it sets a default semantic, so an author's `aria-label` attribute still takes precedence.
- I have described the label as providing the accessible name rather than describing a specific announcement, since I have not tested every screen reader and browser pairing myself. I can make the wording more specific if you would prefer.

### Related issues and pull requests

Fixes #44395
