### PR TITLE
Update advanced form styling for accent-color, file pickers and number inputs

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
@@ -229,7 +229,7 @@ Because the controls keep their native appearance, they follow platform conventi
 
 ### Styling checkboxes and radio buttons using `appearance`
 
-Styling more than the color of a checkbox or a radio button requires more effort. The default sizes of checkboxes and radio buttons were not meant to be changed, and browsers react very differently when you try. Some increase the control size, and some keep it the same and add extra space around the control.
+Further styling of a checkbox or a radio button requires more effort. The default sizes of checkboxes and radio buttons were not meant to be changed, and browsers react very differently when you try. Some increase the control size, and some keep it the same and add extra space around the control.
 
 A much better approach is to remove the default appearance of checkboxes and radio buttons altogether with {{cssxref("appearance", "appearance: none;")}}, and then add your own styles to their various states.
 

--- a/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
@@ -657,9 +657,9 @@ input[type="file"]::file-selector-button {
 
 {{EmbedLiveSample("file-selector-button", '100%', 100)}}
 
-You can't style the text beside the button — the "no file chosen" message — or the displayed filename once chosen. The browser generates that text and doesn't expose it to CSS. To work around this problem, you can use the control's label and the fact that clicking the label activates the control.
+You can't style the text beside the button — the "no file chosen" message — or the displayed filename once chosen. The browser generates that text and doesn't expose it to CSS. To work around this problem, use the control's label and the fact that clicking the label activates the control.
 
-You could hide the actual form input using something like this:
+You can hide the actual form input using something like this:
 
 ```css
 input[type="file"] {
@@ -792,18 +792,18 @@ function returnFileSize(number) {
 
 {{EmbedLiveSample("styled-file-picker", '100%', 200)}}
 
-You can also press the **Play** button to run the example in MDN Playground and edit the source code.
+You can also press the **Play** button to run the example in MDN Playground and check out the full source code.
 
 ### Meters and progress bars
 
-[`<meter>`](/en-US/docs/Web/HTML/Reference/Elements/meter) and [`<progress>`](/en-US/docs/Web/HTML/Reference/Elements/progress) are possibly the worst of the lot. As you saw in the earlier example, we can set them to the desired width relatively accurately. But beyond that, they are really difficult to style in any way. They don't handle height settings consistently between each other and between browsers, you can color the background but not the foreground bar, and setting `appearance: none` on them makes things worse, not better.
+[`<meter>`](/en-US/docs/Web/HTML/Reference/Elements/meter) and [`<progress>`](/en-US/docs/Web/HTML/Reference/Elements/progress) are possibly the worst of the lot. As you saw in the earlier example, we can set them to the desired width relatively accurately. But beyond that, they are really difficult to style. They don't handle height settings consistently between each other and between browsers, you can color the background but not the foreground bar, and setting `appearance: none` on them makes things worse, not better.
 
-It is easier to create your own custom solution for these features if you want to control the styling, or use a third-party solution such as [progressbar.js](https://kimmobrunfeldt.github.io/progressbar.js/#examples).
+It is easier to create your own custom solution to control the styling for these features, or use a third-party solution such as [progressbar.js](https://kimmobrunfeldt.github.io/progressbar.js/#examples).
 
 ## Summary
 
-While there are still difficulties using CSS with HTML forms, there are ways to get around many of the problems. There are no clean, universal solutions, but modern browsers offer new possibilities. For now, the best solution is to learn more about the way the different browsers support CSS when applied to HTML form controls.
+Styling HTML forms presents some challenges; there are however ways to get around many of them. There are no clean, universal solutions, but modern browsers offer new possibilities. For now, the best solution is to learn more about how different browsers support CSS when applied to HTML form controls.
 
-In the next article of this module, we will explore creating [fully-customized `<select>` elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select) using the dedicated, modern HTML and CSS features available for this purpose.
+In the next article, we will explore creating [fully-customized `<select>` elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select) using the dedicated, modern HTML and CSS features available for this purpose.
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Forms/Styling_web_forms", "Learn_web_development/Extensions/Forms/Customizable_select", "Learn_web_development/Extensions/Forms")}}

--- a/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
@@ -186,6 +186,41 @@ input[type="search"]:not(:focus, :active)::-webkit-search-cancel-button {
 }
 ```
 
+### Styling checkboxes and radio buttons using `accent-color`
+
+If the only thing you want to change is the color, {{cssxref("accent-color")}} will do it without taking the control apart. The browser carries on drawing the checkbox or radio button itself, and tints it:
+
+```html live-sample___checkboxes-accent-color
+<form>
+  <fieldset>
+    <legend>Fruit preferences</legend>
+
+    <p>
+      <label>
+        <input type="checkbox" name="fruit" value="cherry" checked />
+        I like cherry
+      </label>
+    </p>
+    <p>
+      <label>
+        <input type="radio" name="favorite" value="banana" checked />
+        Banana is my favorite
+      </label>
+    </p>
+  </fieldset>
+</form>
+```
+
+```css live-sample___checkboxes-accent-color
+input {
+  accent-color: rebeccapurple;
+}
+```
+
+{{EmbedLiveSample("checkboxes-accent-color", '100%', 160)}}
+
+Because the control keeps its native appearance, it goes on following platform conventions — including forced-colors modes — with no further work on your part. Reach for the `appearance: none` approach below when you need to change more than the color.
+
 ### Styling checkboxes and radio buttons using `appearance`
 
 Styling a checkbox or a radio button is tricky by default. The sizes of checkbox and radio button default styles are not meant to be changed, and browsers react very differently when you try. Some increase the size of the control, and some keep the control the same size and add extra space around it.
@@ -558,7 +593,7 @@ The date/time input types ([`datetime-local`](/en-US/docs/Web/HTML/Reference/Ele
 However, the internal parts of the control (e.g., the popup calendar that you use to pick a date, the spinner that you can use to increment/decrement values) are not stylable at all, and you can't get rid of them using `appearance: none;`. If you really need full control over the styling, you'll have to either use a library to generate a custom control or build your own.
 
 > [!NOTE]
-> It is worth mentioning [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number) here too — this also has a spinner that you can use to increment/decrement values, so potentially suffers from the same problem. However, in the case of the `number` type the data being collected is simpler, and it is easy to just use a `tel` input type instead, which has the appearance of `text`, but displays the numeric keypad in devices with touch keyboards.
+> [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number) has a spinner too, and its internal parts are no easier to style. If the spinner is the part you want to be rid of, don't reach for `tel`: that changes what the field means, and the browser will validate it as a telephone number rather than as a number. Use [`<input type="text">`](/en-US/docs/Web/HTML/Reference/Elements/input/text) with [`inputmode="numeric"`](/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode) and a [`pattern`](/en-US/docs/Web/HTML/Reference/Attributes/pattern) attribute instead. You still get the numeric keypad on devices with touch keyboards, without the spinner and without claiming the value is a phone number. See [Accessibility](/en-US/docs/Web/HTML/Reference/Elements/input/number#accessibility) on the `<input type="number">` page.
 
 ### Range input types
 
@@ -595,9 +630,21 @@ However, a custom solution is the only way to get anything significantly differe
 
 Inputs of type file are generally OK — as you saw in our example, it is fairly easy to create something that fits in OK with the rest of the page — the output line that is part of the control will inherit the parent font if you tell the input to do so, and you can style the custom list of file names and sizes in any way you want; we created it after all.
 
-The only problem with file pickers is that the button you press to open the file picker is completely unstylable — it can't be sized or colored, and it won't even accept a different font.
+The button you press to open the file picker can be styled with the {{cssxref("::file-selector-button")}} pseudo-element, which accepts the same properties as any other button:
 
-One way around this is to take advantage of the fact that if you have a label associated with a form control, clicking the label will activate the control. So you could hide the actual form input using something like this:
+```css
+input[type="file"]::file-selector-button {
+  border: 1px solid darkgrey;
+  border-radius: 5px;
+  background: linear-gradient(to bottom, #eeeeee, #cccccc);
+  padding: 0.25em 0.75em;
+  font: inherit;
+}
+```
+
+What you can't reach this way is the text beside the button — the "no file chosen" message, and the name of the file once one has been picked. The browser generates that text and doesn't expose it to CSS.
+
+If you need control over that part as well, you can take advantage of the fact that if you have a label associated with a form control, clicking the label will activate the control. So you could hide the actual form input using something like this:
 
 ```css
 input[type="file"] {

--- a/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
@@ -186,11 +186,11 @@ input[type="search"]:not(:focus, :active)::-webkit-search-cancel-button {
 }
 ```
 
-### Styling checkboxes and radio buttons using `accent-color`
+### Setting form control color tints using `accent-color`
 
-If the only thing you want to change is the color, {{cssxref("accent-color")}} will do it without taking the control apart. The browser carries on drawing the checkbox or radio button itself, and tints it:
+If you only want to style the primary tint color of checkboxes, radio buttons, or range sliders, the {{cssxref("accent-color")}} will do it without requiring `appearance: none`. This is useful for basic styling cases, as the controls maintain their OS-level styling, but with an altered main color.
 
-```html live-sample___checkboxes-accent-color
+```html live-sample___accent-color
 <form>
   <fieldset>
     <legend>Fruit preferences</legend>
@@ -207,23 +207,29 @@ If the only thing you want to change is the color, {{cssxref("accent-color")}} w
         Banana is my favorite
       </label>
     </p>
+    <p>
+      <label>
+        How much do you like fruit?
+        <input type="range" name="amount" min="0" max="10" value="7" />
+      </label>
+    </p>
   </fieldset>
 </form>
 ```
 
-```css live-sample___checkboxes-accent-color
+```css live-sample___accent-color
 input {
   accent-color: rebeccapurple;
 }
 ```
 
-{{EmbedLiveSample("checkboxes-accent-color", '100%', 160)}}
+{{EmbedLiveSample("accent-color", '100%', 200)}}
 
-Because the control keeps its native appearance, it goes on following platform conventions — including forced-colors modes — with no further work on your part. Reach for the `appearance: none` approach below when you need to change more than the color.
+Because the control keeps its native appearance, it follows platform conventions — including forced-colors modes — with no further work on your part. In addition, the browser automatically chooses a complementary secondary color with enough contrast to the `accent-color` to keep the control accessible. Play with the above live example and set some light and dark `accent-color` values to see the effects.
 
 ### Styling checkboxes and radio buttons using `appearance`
 
-Styling a checkbox or a radio button is tricky by default. The sizes of checkbox and radio button default styles are not meant to be changed, and browsers react very differently when you try. Some increase the size of the control, and some keep the control the same size and add extra space around it.
+Styling more than the color of a checkbox or a radio button requires more effort. The default sizes of checkboxes and radio buttons were not meant to be changed, and browsers react very differently when you try. Some increase the control size, and some keep it the same and add extra space around the control.
 
 A much better approach is to remove the default appearance of checkboxes and radio buttons altogether with {{cssxref("appearance", "appearance: none;")}}, and then add your own styles to their various states.
 
@@ -593,7 +599,7 @@ The date/time input types ([`datetime-local`](/en-US/docs/Web/HTML/Reference/Ele
 However, the internal parts of the control (e.g., the popup calendar that you use to pick a date, the spinner that you can use to increment/decrement values) are not stylable at all, and you can't get rid of them using `appearance: none;`. If you really need full control over the styling, you'll have to either use a library to generate a custom control or build your own.
 
 > [!NOTE]
-> [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number) has a spinner too, and its internal parts are no easier to style. If the spinner is the part you want to be rid of, don't reach for `tel`: that changes what the field means, and the browser will validate it as a telephone number rather than as a number. Use [`<input type="text">`](/en-US/docs/Web/HTML/Reference/Elements/input/text) with [`inputmode="numeric"`](/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode) and a [`pattern`](/en-US/docs/Web/HTML/Reference/Attributes/pattern) attribute instead. You still get the numeric keypad on devices with touch keyboards, without the spinner and without claiming the value is a phone number. See [Accessibility](/en-US/docs/Web/HTML/Reference/Elements/input/number#accessibility) on the `<input type="number">` page.
+> [`<input type="number">`](/en-US/docs/Web/HTML/Reference/Elements/input/number) has a spinner too, and its internal parts are no easier to style. If you want to remove the spinner, use [`<input type="text">`](/en-US/docs/Web/HTML/Reference/Elements/input/text) with [`inputmode="numeric"`](/en-US/docs/Web/HTML/Reference/Global_attributes/inputmode) set to display a numeric keypad on devices with touch keyboards and a [`pattern`](/en-US/docs/Web/HTML/Reference/Attributes/pattern) attribute that limits input values to a number. See also [`<input type="number">` > Accessibility](/en-US/docs/Web/HTML/Reference/Elements/input/number#accessibility).
 
 ### Range input types
 
@@ -628,11 +634,18 @@ However, a custom solution is the only way to get anything significantly differe
 
 ### File input types
 
-Inputs of type file are generally OK — as you saw in our example, it is fairly easy to create something that fits in OK with the rest of the page — the output line that is part of the control will inherit the parent font if you tell the input to do so, and you can style the custom list of file names and sizes in any way you want; we created it after all.
+Inputs of type file are generally OK — it is fairly easy to create something that fits in OK with the rest of the page. The output line that is part of the control will inherit the parent font if you tell the input to do so, and you can style the custom list of file names and sizes in any way you want.
 
 The button you press to open the file picker can be styled with the {{cssxref("::file-selector-button")}} pseudo-element, which accepts the same properties as any other button:
 
-```css
+```html live-sample___file-selector-button
+<form>
+  <label for="avatar">Choose a profile picture</label>
+  <input id="avatar" name="avatar" type="file" />
+</form>
+```
+
+```css live-sample___file-selector-button
 input[type="file"]::file-selector-button {
   border: 1px solid darkgrey;
   border-radius: 5px;
@@ -642,9 +655,11 @@ input[type="file"]::file-selector-button {
 }
 ```
 
-What you can't reach this way is the text beside the button — the "no file chosen" message, and the name of the file once one has been picked. The browser generates that text and doesn't expose it to CSS.
+{{EmbedLiveSample("file-selector-button", '100%', 100)}}
 
-If you need control over that part as well, you can take advantage of the fact that if you have a label associated with a form control, clicking the label will activate the control. So you could hide the actual form input using something like this:
+You can't style the text beside the button — the "no file chosen" message — or the displayed filename once chosen. The browser generates that text and doesn't expose it to CSS. To work around this problem, you can use the control's label and the fact that clicking the label activates the control.
+
+You could hide the actual form input using something like this:
 
 ```css
 input[type="file"] {

--- a/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/advanced_form_styling/index.md
@@ -225,7 +225,7 @@ input {
 
 {{EmbedLiveSample("accent-color", '100%', 200)}}
 
-Because the control keeps its native appearance, it follows platform conventions — including forced-colors modes — with no further work on your part. In addition, the browser automatically chooses a complementary secondary color with enough contrast to the `accent-color` to keep the control accessible. Play with the above live example and set some light and dark `accent-color` values to see the effects.
+Because the controls keep their native appearance, they follow platform conventions — including forced-colors modes — with no further work on your part. In addition, the browser automatically chooses a complementary secondary color with enough contrast to the `accent-color` to keep the control accessible. Play with the above live example and set some light and dark `accent-color` values to see the effects.
 
 ### Styling checkboxes and radio buttons using `appearance`
 

--- a/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/styling_web_forms/index.md
@@ -62,6 +62,8 @@ The article [Advanced form styling](/en-US/docs/Learn_web_development/Extensions
 - Date-related controls such as [`<input type="datetime-local">`](/en-US/docs/Web/HTML/Reference/Elements/input/datetime-local)
 - [`<input type="range">`](/en-US/docs/Web/HTML/Reference/Elements/input/range)
 - [`<input type="file">`](/en-US/docs/Web/HTML/Reference/Elements/input/file)
+  > [!NOTE]
+  > The button that opens the file picker can be styled with {{cssxref("::file-selector-button")}}. The text beside it, which names the selected file, cannot.
 - Elements involved in creating dropdown widgets, including {{HTMLElement("select")}}, {{HTMLElement("option")}}, {{HTMLElement("optgroup")}} and {{HTMLElement("datalist")}}.
   > [!NOTE]
   > Some browsers now support [Customizable select elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select), a set of HTML and CSS features that together enable full customization of `<select>` elements and their contents just like any regular DOM elements.


### PR DESCRIPTION
### Description

Three fixes to the Advanced form styling page, which @Josh-Cena asked to be handled together in #36090, #24304 and #42946, plus one related note on Styling web forms.

- `accent-color` (#24304): adds a short section covering the color-only case. The page went straight to `appearance: none` and rebuilding the control by hand, with no mention of the one-property option that covers the common case of only wanting a different color.
- File picker button (#36090): the page said the button is "completely unstylable". It has been stylable with `::file-selector-button` for some years. The existing label technique is kept, since it is still the way to control the text beside the button, which CSS cannot reach.
- Number inputs (#42946): replaces the note suggesting `<input type="tel">` as a way to avoid the spinner.

### Motivation

All three are cases where the page tells a learner something that is no longer true, or steers them toward a workaround with a cost the page doesn't mention.

The `tel` suggestion is the one I would single out. Swapping the input type to get rid of a spinner changes what the field means and what the browser validates, which is a lot to trade for an appearance problem. The replacement recommends `inputmode="numeric"` with a `pattern` attribute, which is what the [Accessibility section of `<input type="number">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/number#accessibility) already recommends, so this brings the Learn page in line with the reference page rather than introducing new advice.

### Additional details

- The approach for #42946 follows @AhamadAlii's suggestion in that thread. @bhargavikondaka also offered to take it in March. I hope picking it up now is welcome rather than stepping on toes, and I can step back if either would rather carry it.
- On placement of the `accent-color` section: I put it immediately before the `appearance` one, so a reader meets the cheaper option first. That does mean the heading sits under the `## appearance: controlling OS-level styling` parent, which is a slightly awkward fit. I can move it out to its own `##` section, or after the `appearance` one, if you prefer.
- The Styling web forms change is easy to drop. #36090 notes that page carries the same wrong impression, since it lists `<input type="file">` under "having internals that can't be styled in CSS alone". Rather than recategorizing it, given the button is stylable but the file name text still isn't, I added a note in the style of the existing `<select>` one. Let me know if you would rather handle that page separately.
- The new live sample tints more than one control type, so the shared effect is visible in a single example.

### Related issues and pull requests

Fixes #24304
Fixes #36090
Fixes #42946
