### PR TITLE
Replace the image format list on <img> with guidance on choosing one

### DIFF
--- a/files/en-us/web/html/reference/elements/img/index.md
+++ b/files/en-us/web/html/reference/elements/img/index.md
@@ -43,19 +43,28 @@ The HTML standard doesn't list what image formats to support, so {{glossary("use
 > The [Image file type and format guide](/en-US/docs/Web/Media/Guides/Formats/Image_types) provides comprehensive information about image formats and their web browser support.
 > This section is just a summary!
 
-The image file formats that are most commonly used on the web are:
+### Choosing a format
 
-- [APNG (Animated Portable Network Graphics)](/en-US/docs/Web/Media/Guides/Formats/Image_types#apng_animated_portable_network_graphics) — Good choice for lossless animation sequences (GIF is less performant)
-- [AVIF (AV1 Image File Format)](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image) — Good choice for both images and animated images due to high performance.
-- [GIF (Graphics Interchange Format)](/en-US/docs/Web/Media/Guides/Formats/Image_types#gif_graphics_interchange_format) — Good choice for _simple_ images and animations.
-- [JPEG (Joint Photographic Expert Group image)](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_joint_photographic_experts_group_image) — Good choice for lossy compression of still images (currently the most popular).
-- [PNG (Portable Network Graphics)](/en-US/docs/Web/Media/Guides/Formats/Image_types#png_portable_network_graphics) — Good choice for lossless compression of still images (slightly better quality than JPEG).
-- [SVG (Scalable Vector Graphics)](/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics) — Vector image format. Use for images that must be drawn accurately at different sizes.
-- [WebP (Web Picture format)](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) — Excellent choice for both images and animated images
+For most images, prefer [AVIF](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image) or [WebP](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image). Both compress considerably better than the older formats at comparable quality, and current versions of every major browser support them. To support older browsers as well, offer [JPEG](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_joint_photographic_experts_group_image) or [PNG](/en-US/docs/Web/Media/Guides/Formats/Image_types#png_portable_network_graphics) as a fallback [using the `<picture>` element](/en-US/docs/Web/Media/Guides/Formats/Image_types#providing_image_fallbacks):
 
-Formats like [WebP](/en-US/docs/Web/Media/Guides/Formats/Image_types#webp_image) and [AVIF](/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image) are recommended as they perform much better than PNG, JPEG, GIF for both still and animated images.
+```html
+<picture>
+  <source srcset="photo.avif" type="image/avif" />
+  <source srcset="photo.webp" type="image/webp" />
+  <img src="photo.jpg" alt="A herd of goats grazing on a hillside" />
+</picture>
+```
 
-SVG remains the recommended format for images that must be drawn accurately at different sizes.
+Which format suits a particular image depends on what the image is:
+
+- Artwork that has to stay sharp at any size, such as logos, icons and diagrams, belongs in [SVG](/en-US/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics). It is a vector format, so it has no resolution of its own and does not blur when scaled up.
+- Photographs and similarly detailed images are what AVIF and WebP are built for, and AVIF usually produces the smaller file of the two.
+- Screenshots, and graphics with flat color and hard edges, compress well losslessly. AVIF, WebP and [PNG](/en-US/docs/Web/Media/Guides/Formats/Image_types#png_portable_network_graphics) all have lossless modes; PNG is the one that older browsers understand.
+- Large images that a reader should see something of before the transfer finishes are the case where [JPEG](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_joint_photographic_experts_group_image) still has an advantage, because it renders progressively. AVIF does not, so an AVIF file has to arrive in full before any of it is drawn.
+- Animations are handled by both AVIF and WebP, at a fraction of the size of the equivalent [GIF](/en-US/docs/Web/Media/Guides/Formats/Image_types#gif_graphics_interchange_format) or [APNG](/en-US/docs/Web/Media/Guides/Formats/Image_types#apng_animated_portable_network_graphics).
+
+> [!NOTE]
+> [JPEG XL](/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image) is designed to cover most of these cases at once: it compresses well, renders progressively, and can losslessly transcode an existing JPEG file. Browser support is not yet broad enough to rely on it. Safari 17 and later enables it, Chrome 145 and later supports it behind the `#enable-jxl-image-format` flag, and Firefox supports it in preview releases, so serve it with a fallback.
 
 ## Image loading errors
 


### PR DESCRIPTION
### Description

Replaces the format list in the `<img>` page's "Supported image formats" section with guidance on choosing a format, along the lines @hamishwillee set out in #45286.

### Motivation

The list called almost every format a "good choice", then the paragraph under it said WebP and AVIF "perform much better than PNG, JPEG, GIF". Taken together those tell a reader both that any of the seven will do and that two of them are the real answer, which is the confusion @HybridDog reported.

The replacement leads with the recommendation — prefer AVIF or WebP, fall back to JPEG or PNG with `<picture>` — and then gives the cases where something else fits better: SVG for artwork that has to stay sharp, lossless modes for flat-color graphics, JPEG where progressive rendering matters, AVIF or WebP over GIF for animation. Every format named in the old list is still covered, and all the links into the [Image file type and format guide](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types) are kept.

### Additional details

Two places where I did something other than what the issue thread proposed, both easy to change if you'd rather:

**JPEG XL is a note, not a recommendation.** The thread anticipated it landing in the main browsers "within a few months" and suggested recommending it for large high-resolution images. As of today that hasn't happened: Safari 17+ enables it, Chrome 145+ has it behind `#enable-jxl-image-format` and off by default, and Firefox has it in preview releases only. That matches what [the Image types guide already says](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types#jpeg_xl_image). The progressive-download argument is also weaker than it looks, since that same guide notes Safari — currently the only browser shipping JXL by default — doesn't do progressive JPEG XL. So I recorded the status and the need for a fallback rather than recommending it. Happy to strengthen the wording once Chrome flips the flag.

**I kept the `## Supported image formats` heading** and added the guidance as a `### Choosing a format` subsection under it, rather than renaming the section to match the new framing. Renaming would change the `#supported_image_formats` anchor, which is linked from other pages and from the issue itself. Glad to rename it and fix up the inbound links if you'd prefer the heading to match the content.

I have not moved the section into the Image types guide, which the thread raised as a possibility — that seemed better as its own change than folded in here.

### Related issues and pull requests

Fixes #45286
