### PR TITLE
Fix a typo in the CSS math function notes

### DIFF
--- a/files/en-us/web/css/reference/values/acos/index.md
+++ b/files/en-us/web/css/reference/values/acos/index.md
@@ -43,7 +43,7 @@ The inverse cosine of a `number` will always return an {{cssxref("angle")}} betw
 
 ### Rotate elements
 
-The `acos()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it return an {{cssxref("angle")}}.
+The `acos()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it returns an {{cssxref("angle")}}.
 
 #### HTML
 

--- a/files/en-us/web/css/reference/values/asin/index.md
+++ b/files/en-us/web/css/reference/values/asin/index.md
@@ -43,7 +43,7 @@ The inverse sine of a `number` will always return an {{cssxref("angle")}} betwee
 
 ### Rotate elements
 
-The `asin()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it return an {{cssxref("angle")}}.
+The `asin()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it returns an {{cssxref("angle")}}.
 
 #### HTML
 

--- a/files/en-us/web/css/reference/values/atan/index.md
+++ b/files/en-us/web/css/reference/values/atan/index.md
@@ -52,7 +52,7 @@ That is:
 
 ### Rotate elements
 
-The `atan()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it return an {{cssxref("angle")}}.
+The `atan()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it returns an {{cssxref("angle")}}.
 
 #### HTML
 

--- a/files/en-us/web/css/reference/values/atan2/index.md
+++ b/files/en-us/web/css/reference/values/atan2/index.md
@@ -47,7 +47,7 @@ Given two values `x` and `y`, the function `atan2(y, x)` calculates and returns 
 
 ### Rotate elements
 
-The `atan2()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it return an {{cssxref("angle")}} .
+The `atan2()` function can be used to {{cssxref("transform-function/rotate", "rotate")}} elements as it returns an {{cssxref("angle")}}.
 
 #### HTML
 

--- a/files/en-us/web/css/reference/values/exp/index.md
+++ b/files/en-us/web/css/reference/values/exp/index.md
@@ -46,7 +46,7 @@ Returns a non-negative {{CSSxRef("number")}} representing e<sup>number</sup>, wh
 
 ### Rotate elements
 
-The `exp()` function can be used to {{CSSxRef("transform-function/rotate", "rotate")}} elements as it return a {{CSSxRef("number")}}.
+The `exp()` function can be used to {{CSSxRef("transform-function/rotate", "rotate")}} elements as it returns a {{CSSxRef("number")}}.
 
 #### HTML
 


### PR DESCRIPTION
### Description

Fixes a typo repeated across five CSS math function pages, plus a stray space.

### Motivation

`exp()`, `acos()`, `asin()`, `atan()` and `atan2()` each end their introduction with "as it **return** a `<number>`" (or `<angle>`), missing the third-person `-s`. Repository-wide, "as it return " appears five times and "as it returns " zero, so there is no correct copy to compare against — the whole cluster is one typo that propagated when the pages were created from each other.

The `atan2()` page additionally has a stray space before the closing period, "`{{cssxref("angle")}}` ." The four siblings all close without it.
