### PR TITLE
Fix a typo in the ARIA element reflection arrays

### DIFF
--- a/files/en-us/web/api/element/ariadescribedbyelements/index.md
+++ b/files/en-us/web/api/element/ariadescribedbyelements/index.md
@@ -18,7 +18,7 @@ The [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible description.
 
-When read, the returned array is a static and read-only.
+When read, the returned array is static and read-only.
 When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
 
 ## Description

--- a/files/en-us/web/api/element/ariadetailselements/index.md
+++ b/files/en-us/web/api/element/ariadetailselements/index.md
@@ -18,7 +18,7 @@ The [`aria-details`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/ari
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the accessible details.
 
-When read, the returned array is a static and read-only.
+When read, the returned array is static and read-only.
 When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
 
 ## Description

--- a/files/en-us/web/api/element/ariaerrormessageelements/index.md
+++ b/files/en-us/web/api/element/ariaerrormessageelements/index.md
@@ -17,7 +17,7 @@ The [`aria-errormessage`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attribute
 An array of subclasses of {{domxref("HTMLElement")}}.
 The inner text of these elements can be joined with spaces to get the error message.
 
-When read, the returned array is a static and read-only.
+When read, the returned array is static and read-only.
 When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
 
 ## Description

--- a/files/en-us/web/api/element/ariaflowtoelements/index.md
+++ b/files/en-us/web/api/element/ariaflowtoelements/index.md
@@ -18,7 +18,7 @@ The [`aria-flowto`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria
 
 An array of subclasses of {{domxref("HTMLElement")}}.
 
-When read, the returned array is a static and read-only.
+When read, the returned array is static and read-only.
 When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
 
 ## Description

--- a/files/en-us/web/api/element/arialabelledbyelements/index.md
+++ b/files/en-us/web/api/element/arialabelledbyelements/index.md
@@ -18,7 +18,7 @@ The main difference is that the property can be used to provide label text from 
 An array of elements.
 The inner text of these elements can be joined with spaces to get the accessible name.
 
-When read, the returned array is a static and read-only.
+When read, the returned array is static and read-only.
 When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
 
 ## Description

--- a/files/en-us/web/api/element/ariaownselements/index.md
+++ b/files/en-us/web/api/element/ariaownselements/index.md
@@ -17,7 +17,7 @@ The [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-o
 
 An array of subclasses of {{domxref("HTMLElement")}}.
 
-When read, the returned array is a static and read-only.
+When read, the returned array is static and read-only.
 When written, the assigned array is copied: subsequent changes to the array do not affect the value of the property.
 
 ## Description


### PR DESCRIPTION
### Description

Removes a stray article repeated across six ARIA element reflection pages.

### Motivation

`ariaDescribedByElements`, `ariaDetailsElements`, `ariaErrorMessageElements`, `ariaFlowToElements`, `ariaLabelledByElements` and `ariaOwnsElements` all say "When read, the returned array is **a** static and read-only." The article has no head noun to attach to, so the sentence doesn't parse.

The sibling page `ariaControlsElements` has the same sentence written correctly: "When read, the returned array is static and read-only." The only alternative repair, "is a static and read-only array", would repeat "array" from the subject of the same clause.
