### PR TITLE
Fix missing preposition typos

### DIFF
--- a/files/en-us/web/api/gyroscope/gyroscope/index.md
+++ b/files/en-us/web/api/gyroscope/gyroscope/index.md
@@ -28,7 +28,7 @@ new Gyroscope(options)
         be taken, meaning the number of times per second that the
         {{domxref('sensor.reading_event', 'reading')}} event will be called. A whole number or decimal may be
         used, the latter for frequencies less than a second. The actual reading frequency
-        depends device hardware and consequently may be less than requested.
+        depends on device hardware and consequently may be less than requested.
     - `referenceFrame` {{optional_inline}}
       - : Either `'device'` or
         `'screen'`. The default is `'device'`.

--- a/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.md
+++ b/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.md
@@ -28,7 +28,7 @@ new RelativeOrientationSensor(options)
         should be taken, meaning the number of times per second that the
         {{domxref('sensor.reading_event', 'reading')}} event will be called. A whole number or decimal
         may be used, the latter for frequencies less than a second. The actual
-        reading frequency depends device hardware and consequently may be less
+        reading frequency depends on device hardware and consequently may be less
         than requested.
     - `referenceFrame` {{optional_inline}}
       - : Either `'device'` or

--- a/files/en-us/web/api/svglengthlist/replaceitem/index.md
+++ b/files/en-us/web/api/svglengthlist/replaceitem/index.md
@@ -25,7 +25,7 @@ replaceItem(newItem, index)
 
 ### Return value
 
-The {{domxref("SVGLength")}} that was added the list.
+The {{domxref("SVGLength")}} that was added to the list.
 
 ### Exceptions
 

--- a/files/en-us/web/api/svgnumberlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgnumberlist/replaceitem/index.md
@@ -25,7 +25,7 @@ replaceItem(newItem, index)
 
 ### Return value
 
-The {{domxref("SVGNumber")}} that was added the list.
+The {{domxref("SVGNumber")}} that was added to the list.
 
 ### Exceptions
 

--- a/files/en-us/web/api/svgstringlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgstringlist/replaceitem/index.md
@@ -28,7 +28,7 @@ replaceItem(newItem, index)
 
 ### Return value
 
-The string that was added the list.
+The string that was added to the list.
 
 ### Exceptions
 

--- a/files/en-us/web/css/reference/properties/fill/index.md
+++ b/files/en-us/web/css/reference/properties/fill/index.md
@@ -14,7 +14,7 @@ The areas inside the outline of the SVG shape or text are painted. What is "insi
 If subpaths are open, `fill` closes the path before painting, as if a "closepath" command were included connecting the last point of the subpath with the first point of the subpath. In other words, `fill` applies to open subpaths within `path` elements (i.e., subpaths without a closepath command) and `polyline` elements.
 
 > [!NOTE]
-> The `fill` property only applies to {{SVGElement('circle')}}, {{SVGElement('ellipse')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('text')}}, {{SVGElement('textPath')}}, and {{SVGElement('tspan')}} elements nested in an {{SVGElement("svg")}}. It doesn't apply other SVG, HTML, or pseudo-elements.
+> The `fill` property only applies to {{SVGElement('circle')}}, {{SVGElement('ellipse')}}, {{SVGElement('path')}}, {{SVGElement('polygon')}}, {{SVGElement('polyline')}}, {{SVGElement('rect')}}, {{SVGElement('text')}}, {{SVGElement('textPath')}}, and {{SVGElement('tspan')}} elements nested in an {{SVGElement("svg")}}. It doesn't apply to other SVG, HTML, or pseudo-elements.
 
 ## Syntax
 

--- a/files/en-us/web/xml/xslt/reference/element/output/index.md
+++ b/files/en-us/web/xml/xslt/reference/element/output/index.md
@@ -52,7 +52,7 @@ None.
 
 ### Type
 
-Top-level, must be the child `<xsl:stylesheet>` or `<xsl:transform>`.
+Top-level, must be the child of `<xsl:stylesheet>` or `<xsl:transform>`.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

Restores a preposition dropped from seven sentences.

### Motivation

Each is contradicted by a sibling page carrying the same sentence correctly:

- The three `replaceItem()` pages on `SVGStringList`, `SVGLengthList` and `SVGNumberList` say "The item that was added **the** list." The `appendItem()`, `initialize()` and `insertItemBefore()` pages in the same interfaces all say "added **to** the list" — nine correct against these three.
- `Gyroscope()` and `RelativeOrientationSensor()` say "The actual reading frequency **depends** device hardware". The five other sensor constructors, including `GravitySensor()`, `Magnetometer()` and `Accelerometer()`, all say "depends **on**".
- The `fill` property note says "It doesn't apply **other** SVG, HTML, or pseudo-elements." The same boilerplate reads "doesn't apply **to** other" twelve times elsewhere, for example on `baseline-shift`, and the preceding clause in this very sentence is "The `fill` property only applies **to** …".
- The XSLT `<xsl:output>` page says "must be the child `<xsl:stylesheet>`". Sibling XSLT element pages such as `<xsl:attribute-set>` say "must be the child **of**".
