### PR TITLE
Convert `webkitdirectory` to standard

### DIFF
--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -74,6 +74,9 @@ In addition to the attributes listed above, the following non-standard attribute
 
 The Boolean `webkitdirectory` attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.
 
+> [!NOTE]
+> `webkitdirectory` is in the process of being standardized as part of the [File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory), a Web Platform Incubator Community Group (WICG) draft specification that is not yet a W3C standard.
+
 ## Unique file type specifiers
 
 A **unique file type specifier** is a string that describes a type of file that may be selected by the user in an {{HTMLElement("input")}} element of type `file`. Each unique file type specifier may take one of the following forms:

--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -66,16 +66,12 @@ The [`capture`](/en-US/docs/Web/HTML/Reference/Attributes/capture) attribute val
 
 When the [`multiple`](/en-US/docs/Web/HTML/Reference/Attributes/multiple) Boolean attribute is specified, the file input allows the user to select more than one file.
 
-## Non-standard attributes
-
-In addition to the attributes listed above, the following non-standard attributes are available on some browsers. You should try to avoid using them when possible, since doing so will limit the ability of your code to function in browsers that don't implement them.
-
-### `webkitdirectory`
+### webkitdirectory
 
 The Boolean `webkitdirectory` attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.
 
 > [!NOTE]
-> `webkitdirectory` is in the process of being standardized as part of the [File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory), a Web Platform Incubator Community Group (WICG) draft specification that is not yet a W3C standard.
+> `webkitdirectory` is defined in the [File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory), a Web Platform Incubator Community Group (WICG) specification. It's named `webkitdirectory` because of its origins as a Google Chrome-specific API.
 
 ## Unique file type specifiers
 

--- a/files/en-us/web/html/reference/elements/input/file/index.md
+++ b/files/en-us/web/html/reference/elements/input/file/index.md
@@ -71,7 +71,7 @@ When the [`multiple`](/en-US/docs/Web/HTML/Reference/Attributes/multiple) Boolea
 The Boolean `webkitdirectory` attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.
 
 > [!NOTE]
-> `webkitdirectory` is defined in the [File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory), a Web Platform Incubator Community Group (WICG) specification. It's named `webkitdirectory` because of its origins as a Google Chrome-specific API.
+> `webkitdirectory` is defined in the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API). It's named `webkitdirectory` because of its origins as a Chrome-specific API. It is now available in all browsers.
 
 ## Unique file type specifiers
 

--- a/files/en-us/web/html/reference/elements/input/index.md
+++ b/files/en-us/web/html/reference/elements/input/index.md
@@ -637,6 +637,11 @@ A few additional non-standard attributes are listed following the descriptions o
 - `value`
   - : The input control's value. When specified in the HTML, this is the initial value, and from then on it can be altered or retrieved at any time using JavaScript to access the respective {{domxref("HTMLInputElement")}} object's `value` property. The `value` attribute is always optional, though should be considered mandatory for `checkbox`, `radio`, and `hidden`.
 
+- `webkitdirectory`
+  - : The Boolean `webkitdirectory` attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.
+
+    `webkitdirectory` is defined in the [File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory), a Web Platform Incubator Community Group (WICG) specification. It's named `webkitdirectory` because of its origins as a Google Chrome-specific API.
+
 - `width`
   - : Valid for the `image` input button only, the `width` is the width of the image file to display to represent the graphical submit button. See the {{HTMLElement("input/image", "image")}} input type.
 
@@ -680,14 +685,6 @@ The following non-standard attributes are also available on some browsers. As a 
         The maximum number of items that should be displayed in the drop-down list of previous search queries. <strong>Safari only.</strong>
       </td>
     </tr>
-    <tr>
-      <td>
-        <a href="#webkitdirectory"><code>webkitdirectory</code></a>
-      </td>
-      <td>
-        A Boolean indicating whether to only allow the user to choose a directory (or directories, if <a href="#multiple"><code>multiple</code></a> is also present)
-      </td>
-    </tr>
   </tbody>
 </table>
 
@@ -705,11 +702,6 @@ The following non-standard attributes are also available on some browsers. As a 
   - : The `results` attribute—supported only by Safari—is a numeric value that lets you override the maximum number of entries to be displayed in the `<input>` element's natively-provided drop-down menu of previous search queries.
 
     The value must be a non-negative decimal number. If not provided, or an invalid value is given, the browser's default maximum number of entries is used.
-
-- `webkitdirectory` {{non-standard_inline}}
-  - : The Boolean `webkitdirectory` attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.
-
-    Though originally implemented only for WebKit-based browsers, `webkitdirectory` is also usable in Microsoft Edge as well as Firefox 50 and later. However, even though it has relatively broad support, it is still not standard and should not be used unless you have no alternative.
 
 ## Methods
 

--- a/files/en-us/web/html/reference/elements/input/index.md
+++ b/files/en-us/web/html/reference/elements/input/index.md
@@ -640,7 +640,8 @@ A few additional non-standard attributes are listed following the descriptions o
 - `webkitdirectory`
   - : The Boolean `webkitdirectory` attribute, if present, indicates that only directories should be available to be selected by the user in the file picker interface. See {{domxref("HTMLInputElement.webkitdirectory")}} for additional details and examples.
 
-    `webkitdirectory` is defined in the [File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory), a Web Platform Incubator Community Group (WICG) specification. It's named `webkitdirectory` because of its origins as a Google Chrome-specific API.
+    > [!NOTE]
+    > `webkitdirectory` is defined in the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API). It's named `webkitdirectory` because of its origins as a Chrome-specific API. It is now available in all browsers.
 
 - `width`
   - : Valid for the `image` input button only, the `width` is the width of the image file to display to represent the graphical submit button. See the {{HTMLElement("input/image", "image")}} input type.


### PR DESCRIPTION
### Description

Add a note to the `<input type="file">` reference page's "Non-standard attributes" section explaining that `webkitdirectory` is in the process of being standardized.

### Motivation

The issue reported that the page doesn't mention `webkitdirectory` is being standardized. I confirmed the current spec status before editing:

- The [WICG File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory) spec, which defines `webkitdirectory`, explicitly states it "is not a W3C Standard nor is it on the W3C Standards Track" — it's a WICG Community Group draft, not a full standard.
- `browser-compat-data`'s entry for `html/elements/input.json`'s `webkitdirectory` still has `"standard_track": false`.
- The WHATWG HTML Standard does not define `webkitdirectory`.

Since it isn't yet part of a full WHATWG/W3C standard, I kept it in the "Non-standard attributes" section (rather than moving it out) and added a note pointing to the WICG spec that is standardizing it, so readers get the "it's on track to become standard" context the issue asked for without an inaccurate "this is now standard" claim.

I also checked the sibling `HTMLInputElement.webkitdirectory` property page — it doesn't make any explicit standard/non-standard text claim (its Specifications/Compat sections are auto-generated from BCD), so it's already consistent and didn't need a change.

### Additional details

- [WICG entries-api spec](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory)
- [`webkitdirectory` BCD entry](https://github.com/mdn/browser-compat-data/blob/main/html/elements/input.json) (`standard_track: false`)

### Related issues and pull requests

Fixes #45466
