### PR TITLE
Remove unnecessary `initial-scale` attribute content of viewport meta

### DIFF
--- a/files/en-us/learn_web_development/core/css_layout/fundamental_layout_comprehension/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/fundamental_layout_comprehension/index.md
@@ -22,7 +22,7 @@ We are going to get you to solve this challenge in your local development enviro
    <html lang="en-US">
      <head>
        <meta charset="utf-8" />
-       <meta name="viewport" content="width=device-width, initial-scale=1" />
+       <meta name="viewport" content="width=device-width" />
        <title>Layout Task</title>
        <link href="style.css" rel="stylesheet" type="text/css" />
      </head>

--- a/files/en-us/learn_web_development/core/css_layout/media_queries/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/media_queries/index.md
@@ -349,7 +349,7 @@ First of all, copy the HTML code from the block below into a text editor, save i
 ```html live-sample___walkthrough
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="viewport" content="width=device-width" />
   <title>Media Queries: a simple mobile first design, step 1</title>
   <style>
     /* Add styles here */
@@ -560,10 +560,10 @@ That's the example finished. If you look at the result at different widths you c
 If you look at the HTML source in the above example, you'll see the following element included in the head of the document:
 
 ```html
-<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="viewport" content="width=device-width" />
 ```
 
-This is the [`viewport`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport) meta tag — it exists as a way to control how mobile browsers render content, making sure they respect your media queries. The one above tells mobile browsers "don't render the content with a 980-pixel viewport — render it using the real device width instead, and set a default initial scale level for better consistency." The media queries will then kick in as expected.
+This is the [`viewport`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport) meta tag — it exists as a way to control how mobile browsers render content, making sure they respect your media queries. The one above tells mobile browsers "don't render the content with a 980-pixel viewport — render it using the real device width instead." The media queries will then kick in as expected.
 
 For more information on why this is needed, see [The viewport meta tag](/en-US/docs/Learn_web_development/Core/CSS_layout/Responsive_Design#the_viewport_meta_tag) section in the previous article.
 

--- a/files/en-us/learn_web_development/core/css_layout/mobile-first_challenge/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/mobile-first_challenge/index.md
@@ -358,7 +358,7 @@ The following screenshot shows what the finished widescreen layout should look l
 To cause the layouts to display properly in mobile browsers, you need to add a viewport `<meta>` tag inside the `<head>` of the HTML document:
 
 ```html
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width" />
 ```
 
 The finished CSS should look something like this:

--- a/files/en-us/learn_web_development/core/css_layout/responsive_design/index.md
+++ b/files/en-us/learn_web_development/core/css_layout/responsive_design/index.md
@@ -468,10 +468,10 @@ Try resizing the browser window, as before, and note how this time the heading s
 If you look at the HTML source of a responsive page, you will usually see the following {{htmlelement("meta")}} tag in the `<head>` of the document.
 
 ```html
-<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="viewport" content="width=device-width" />
 ```
 
-This [`viewport`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport) meta tag tells mobile browsers that they should set the width of the viewport to the device's width, and scale the document to 100% of its intended size, which shows the document at the mobile-optimized size that you intended.
+This [`viewport`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport) meta tag tells mobile browsers that they should set the width of the viewport to the device's width which shows the document at the mobile-optimized size that you intended.
 
 Why is this needed? Because mobile browsers tend to lie about their viewport width.
 

--- a/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/drawing_graphics/index.md
@@ -223,7 +223,7 @@ Let's start by creating our own canvas template to create future experiments in.
    <html lang="en-US">
      <head>
        <meta charset="utf-8" />
-       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+       <meta name="viewport" content="width=device-width" />
        <title>Canvas</title>
        <script src="script.js" defer></script>
        <link href="style.css" rel="stylesheet" />
@@ -998,7 +998,7 @@ Let's look at an example of how to create something with a WebGL library. We'll 
    <html lang="en-US">
      <head>
        <meta charset="utf-8" />
-       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+       <meta name="viewport" content="width=device-width" />
 
        <title>Three.js basic cube example</title>
 

--- a/files/en-us/learn_web_development/extensions/client-side_apis/video_and_audio_apis/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_apis/video_and_audio_apis/index.md
@@ -377,7 +377,7 @@ To get started with this example, follow these steps:
    <html lang="en-gb">
      <head>
        <meta charset="utf-8" />
-       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+       <meta name="viewport" content="width=device-width" />
        <title>Video player example</title>
        <link rel="stylesheet" type="text/css" href="style.css" />
      </head>

--- a/files/en-us/learn_web_development/extensions/client-side_tools/package_management/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_tools/package_management/index.md
@@ -193,7 +193,7 @@ In Vite, the `index.html` file is front and central. It defines the starting poi
   <head>
     <meta charset="UTF-8" />
     <title>My test page</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width" />
   </head>
   <body>
     <div id="root"></div>

--- a/files/en-us/learn_web_development/extensions/server-side/django/home_page/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/home_page/index.md
@@ -239,7 +239,7 @@ Create a new file **base_generic.html** in **/django-locallibrary-tutorial/catal
       <title>Local Library</title>
     {% endblock %}
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/locallibrary_base_template/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/locallibrary_base_template/index.md
@@ -15,7 +15,7 @@ html(lang='en')
   head
     title= title
     meta(charset='utf-8')
-    meta(name='viewport', content='width=device-width, initial-scale=1')
+    meta(name='viewport', content='width=device-width')
     link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css", integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr", crossorigin="anonymous")
     script(src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js", integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q", crossorigin="anonymous")
     link(rel='stylesheet', href='/stylesheets/style.css')

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/template_primer/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/displaying_data/template_primer/index.md
@@ -84,7 +84,7 @@ html(lang="en")
 Element attributes are defined in parentheses after their associated element. Inside the parentheses, the attributes are defined in comma- or whitespace- separated lists of the pairs of attribute names and attribute values, for example:
 
 - `script(type='text/javascript')`, `link(rel='stylesheet', href='/stylesheets/style.css')`
-- `meta(name='viewport' content='width=device-width initial-scale=1')`
+- `meta(name='viewport' content='width=device-width')`
 
 The values of all attributes are _escaped_ (e.g., characters like `>` are converted to their HTML code equivalents like `&gt;`) to prevent JavaScript injection or cross-site scripting attacks.
 

--- a/files/en-us/web/api/cspviolationreport/documenturl/index.md
+++ b/files/en-us/web/api/cspviolationreport/documenturl/index.md
@@ -31,7 +31,7 @@ This page just contains a link to another page `../report_sample/index.html`.
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width" />
   </head>
   <body>
     <ul>

--- a/files/en-us/web/api/cspviolationreport/referrer/index.md
+++ b/files/en-us/web/api/cspviolationreport/referrer/index.md
@@ -36,7 +36,7 @@ This page just contains a link to another page `../report_sample/index.html`.
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width" />
   </head>
   <body>
     <ul>

--- a/files/en-us/web/api/document_object_model/anatomy_of_the_dom/index.md
+++ b/files/en-us/web/api/document_object_model/anatomy_of_the_dom/index.md
@@ -41,7 +41,7 @@ You rarely work with plain `Node` objects—instead, all objects in the DOM impl
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width" />
     <title>Document</title>
   </head>
   <body>

--- a/files/en-us/web/api/htmlmetaelement/index.md
+++ b/files/en-us/web/api/htmlmetaelement/index.md
@@ -60,7 +60,7 @@ The `content` attribute sets the viewport size and is appended to the document `
 ```js
 const meta = document.createElement("meta");
 meta.name = "viewport";
-meta.content = "width=device-width, initial-scale=1";
+meta.content = "width=device-width";
 document.head.appendChild(meta);
 ```
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
@@ -46,7 +46,7 @@ So let's get started by setting up the basis for our WebRTC-powered phone app.
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
     <title>Lola's Web Phone!</title>
     <meta
       property="og:description"

--- a/files/en-us/web/html/reference/elements/meta/name/text-scale/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/text-scale/index.md
@@ -75,7 +75,7 @@ We include the `<meta name="text-scale" content="scale">` element in the documen
 <html lang="en-US">
   <head>
     <meta name="text-scale" content="scale" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
   </head>
   <body>
     <p class="text-scale">
@@ -96,7 +96,7 @@ We include the `<meta name="text-scale" content="scale">` element in the documen
 <!doctype html>
 <html lang="en-US">
   <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
   </head>
   <body>
     <p class="text-scale">
@@ -156,7 +156,7 @@ Like the previous example, our markup again includes the `<meta name="text-scale
 <html lang="en-US">
   <head>
     <meta name="text-scale" content="scale" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
   </head>
   <body>
     <main>Main content</main>

--- a/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
@@ -72,6 +72,8 @@ The recommended setting is the following, which sets the viewport to match the d
 ```html
 <meta name="viewport" content="width=device-width" />
 ```
+> [!NOTE]
+> Including `initial-scale=1.0` was historically necessary to prevent unintended zooming behaviors in older mobile browsers. While modern browsers don't require `initial-scale` to resolve this behavior, `initial-scale` is not entirely redundant and remains useful when defining custom scale defaults or fixed layout widths.
 
 Sites can set their viewport to a specific size. For example, the definition `"width=320, initial-scale=1"` can be used to fit precisely onto a small phone display in portrait mode. This can cause problems when the browser renders a page at a larger size. To fix this, browsers will expand the viewport width if necessary to fill the screen at the requested scale. This is especially useful on large-screen devices.
 

--- a/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
@@ -67,10 +67,10 @@ The browser's {{glossary("viewport")}} is the area of the window in which web co
 
 Some mobile devices and other narrow screens render pages in a virtual window or viewport that is wider than the screen, and then shrink the rendered result down to fit the screen size. Users can then zoom and pan to look more closely at different areas of the page. For example, if a mobile screen has a width of 640px, pages might be rendered with a virtual viewport of 980px, and then it will be shrunk down to fit into the 640px space. This is done because not all pages are optimized for mobile and break (or at least look bad) when rendered at a small viewport width. This virtual viewport is a way to make non-mobile-optimized sites in general look better on narrow screen devices. However, this mechanism is not so good for pages that are optimized for narrow screens using [media queries](/en-US/docs/Web/CSS/Guides/Media_queries) — if the virtual viewport is 980px for example, media queries that kick in at 640px or 480px or less will never be used, limiting the effectiveness of such responsive design techniques. The viewport `<meta>` element mitigates this problem of virtual viewport on narrow screen devices.
 
-The most common setting is the following, which sets the viewport to match the device's width and displays content at 100% zoom:
+The recommended setting is the following, which sets the viewport to match the device's width:
 
 ```html
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width" />
 ```
 
 Sites can set their viewport to a specific size. For example, the definition `"width=320, initial-scale=1"` can be used to fit precisely onto a small phone display in portrait mode. This can cause problems when the browser renders a page at a larger size. To fix this, browsers will expand the viewport width if necessary to fill the screen at the requested scale. This is especially useful on large-screen devices.
@@ -104,9 +104,7 @@ The following example indicates to the browser that the page should be rendered 
 The following `content` value uses multiple keywords that hint to the browser to use fullscreen mode, along with `viewport-fit`, which helps avoid display cutouts such as mobile device notches:
 
 ```html
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="viewport" content="width=device-width, viewport-fit=cover" />
 ```
 
 ### The effect of interactive UI widgets

--- a/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
+++ b/files/en-us/web/html/reference/elements/meta/name/viewport/index.md
@@ -72,6 +72,7 @@ The recommended setting is the following, which sets the viewport to match the d
 ```html
 <meta name="viewport" content="width=device-width" />
 ```
+
 > [!NOTE]
 > Including `initial-scale=1.0` was historically necessary to prevent unintended zooming behaviors in older mobile browsers. While modern browsers don't require `initial-scale` to resolve this behavior, `initial-scale` is not entirely redundant and remains useful when defining custom scale defaults or fixed layout widths.
 

--- a/files/en-us/web/performance/guides/dns-prefetch/index.md
+++ b/files/en-us/web/performance/guides/dns-prefetch/index.md
@@ -25,7 +25,7 @@ When a browser requests a resource from a (third party) server, that [cross-orig
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
     <link rel="dns-prefetch" href="https://fonts.googleapis.com/" />
     <!-- and all other head elements -->
   </head>

--- a/files/en-us/web/progressive_web_apps/tutorials/js13kgames/app_structure/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/js13kgames/app_structure/index.md
@@ -29,7 +29,7 @@ From the HTML point of view, the app shell is everything outside the content sec
       content="A list of A-Frame entries submitted to the js13kGames 2017 competition, used as an example for the MDN articles about Progressive Web Apps." />
     <meta name="author" content="end3r" />
     <meta name="theme-color" content="#B12A34" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width" />
     <meta
       property="og:image"
       content="https://js13kgames.com/img/js13kgames-banner.png" />


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

I have removed suggestions to include `initial-scale=1.0` in the meta viewport head of HTML files. Now relevant sections state `<meta name="viewport" content="width=device-width">` rather than `<meta name="viewport" content="width=device-width, initial-scale=1.0">`.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

The `initial-scale=1` attribute content of the meta viewport declaration is unneeded and superfluous. It was only popular and necessary to fix a bug relating to switching device orientation from portrait to landscape in older versions of Apple's iOS (iOS 8 and down). The removal makes affected code snippets and articles more concise, provides cleaner code to readers, and stops readers from carrying forward obsolete workarounds.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

https://vale.rocks/micros/20260902-1350
https://quirksmode.org/quirksblog/2026/0902-initial.html

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->

N/A