### PR TITLE
Change anyfunc to funcref

### DIFF
--- a/files/en-us/webassembly/reference/javascript_interface/global/global/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/global/global/index.md
@@ -19,14 +19,14 @@ new WebAssembly.Global(descriptor, value)
 ### Parameters
 
 - `descriptor`
-  - : An object, which contains two properties:
+  - : An object containing two properties:
     - `value`
       - : A string representing the data type of the global. This can be any one of:
         - `i32`: A 32-bit integer.
         - `i64`: A 64-bit integer. (In JavaScript, this is represented as a {{jsxref("BigInt")}})
         - `f32`: A 32-bit floating point number.
         - `f64`: A 64-bit floating point number.
-        - [`anyfunc`](/en-US/docs/WebAssembly/Reference/Value_types/funcref)
+        - [`funcref`](/en-US/docs/WebAssembly/Reference/Value_types/funcref)
         - [`externref`](/en-US/docs/WebAssembly/Reference/Value_types/externref)
     - `mutable`
       - : A boolean value that determines whether the global is mutable or not. By default, this is `false`.
@@ -36,7 +36,7 @@ new WebAssembly.Global(descriptor, value)
     If no value is specified:
     - a typed `0` value is used if `descriptor.value` is `i32`, `i64`, `f32`, or `f64`
     - a reference to `undefined` is used if `descriptor.value` is `externref`
-    - `null` is used if `descriptor.value` is `anyfunc`
+    - `null` is used if `descriptor.value` is `funcref`
 
 ### Exceptions
 


### PR DESCRIPTION
As funcref is the current term, whereas anyfunc is legacy

<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
