### PR TITLE
fix(jsxref): correct ill-cased macro arguments

### DIFF
--- a/files/en-us/learn_web_development/extensions/performance/javascript/index.md
+++ b/files/en-us/learn_web_development/extensions/performance/javascript/index.md
@@ -147,7 +147,7 @@ scriptElem.addEventListener("load", () => {
 document.head.append(scriptElem);
 ```
 
-JavaScript modules can be dynamically loaded using the {{jsxref("operators/import", "import()")}} function:
+JavaScript modules can be dynamically loaded using the {{jsxref("Operators/import", "import()")}} function:
 
 ```js
 import("./modules/myModule.js").then((module) => {

--- a/files/en-us/mozilla/firefox/releases/38/index.md
+++ b/files/en-us/mozilla/firefox/releases/38/index.md
@@ -67,7 +67,7 @@ Highlights:
 - When defining a [generator method](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions), `set` and `get` are no longer invalid names ([Firefox bug 1073809](https://bugzil.la/1073809)).
 - {{jsxref("RegExp.prototype.source")}} now returns "(?:)" instead of an empty string for empty regular expressions ([Firefox bug 1130798](https://bugzil.la/1130798)).
 - {{jsxref("RegExp.prototype.source")}} and {{jsxref("RegExp.prototype.toString()")}} now escape regular expression patterns properly (e.g., line terminators, "\n") ([Firefox bug 1130860](https://bugzil.la/1130860)).
-- The {{jsxref("Regexp")}} {{jsxref("Regexp.global", "global")}}, {{jsxref("Regexp.ignoreCase", "ignoreCase")}}, {{jsxref("Regexp.multiline", "multiline")}}, and {{jsxref("Regexp.sticky", "sticky")}} properties are now prototype accessor properties rather than own data properties of `RegExp` instances ([Firefox bug 1120169](https://bugzil.la/1120169)).
+- The {{jsxref("RegExp")}} {{jsxref("RegExp.global", "global")}}, {{jsxref("RegExp.ignoreCase", "ignoreCase")}}, {{jsxref("RegExp.multiline", "multiline")}}, and {{jsxref("RegExp.sticky", "sticky")}} properties are now prototype accessor properties rather than own data properties of `RegExp` instances ([Firefox bug 1120169](https://bugzil.la/1120169)).
 - The {{jsxref("RegExp.prototype.source")}} property is now prototype accessor property rather than own data property of `RegExp` instances ([Firefox bug 1120169](https://bugzil.la/1120169)). Available only in non-Release version, due to [Firefox bug 1150297](https://bugzil.la/1150297).
 - {{jsxref("Function.prototype.toString()")}} now throws for {{jsxref("Proxy")}} objects ([Firefox bug 1100936](https://bugzil.la/1100936)).
 

--- a/files/en-us/web/api/gamepad/index/index.md
+++ b/files/en-us/web/api/gamepad/index/index.md
@@ -17,7 +17,7 @@ and reconnected will retain the same index.
 
 ## Value
 
-A {{jsxref("number") }}.
+A {{jsxref("Number")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/sensor_apis/index.md
+++ b/files/en-us/web/api/sensor_apis/index.md
@@ -34,7 +34,7 @@ Sensor interfaces are only proxies for the underlying device sensors. Consequent
 
 Therefore, feature detection for sensor APIs must include both detection of the APIs themselves and [defensive programming strategies (see below)](#defensive_programming).
 
-The examples below show three methods for detecting sensor APIs. Additionally you can put object instantiation inside a {{jsxref('statements/try...catch', 'try...catch')}} block. Notice that detection through the {{domxref('Navigator')}} interface is not one of the available options.
+The examples below show three methods for detecting sensor APIs. Additionally you can put object instantiation inside a {{jsxref('Statements/try...catch', 'try...catch')}} block. Notice that detection through the {{domxref('Navigator')}} interface is not one of the available options.
 
 ```js
 if (typeof Gyroscope === "function") {
@@ -58,7 +58,7 @@ As stated in Feature Detection, checking for a particular sensor API is insuffic
 - Listening for errors thrown during its use.
 - Handling the errors gracefully so that the user experience is enhanced rather than degraded.
 
-The code example below illustrates these principles. The {{jsxref('statements/try...catch', 'try...catch')}} block catches errors thrown during sensor instantiation. It listens for {{domxref('Sensor.error_event', 'error')}} events to catch errors thrown during use. The only time anything is shown to the user is when [permissions](/en-US/docs/Web/API/Permissions_API) need to be requested and when the sensor type isn't supported by the device.
+The code example below illustrates these principles. The {{jsxref('Statements/try...catch', 'try...catch')}} block catches errors thrown during sensor instantiation. It listens for {{domxref('Sensor.error_event', 'error')}} events to catch errors thrown during use. The only time anything is shown to the user is when [permissions](/en-US/docs/Web/API/Permissions_API) need to be requested and when the sensor type isn't supported by the device.
 
 In addition, this feature may be blocked by a [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) set on your server.
 

--- a/files/en-us/web/api/summarizer/inputquota/index.md
+++ b/files/en-us/web/api/summarizer/inputquota/index.md
@@ -14,7 +14,7 @@ The **`inputQuota`** read-only property of the {{domxref("Summarizer")}} interfa
 
 ## Value
 
-A number specifying the available input quota. This number is implementation-dependent. For example, it might be {{jsxref("infinity")}} if there are no limits beyond the user's memory and the maximum length of JavaScript strings, or it might be a number of tokens in the case of AI models that use a token/credits scheme.
+A number specifying the available input quota. This number is implementation-dependent. For example, it might be {{jsxref("Infinity")}} if there are no limits beyond the user's memory and the maximum length of JavaScript strings, or it might be a number of tokens in the case of AI models that use a token/credits scheme.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
@@ -34,7 +34,7 @@ A {{jsxref("BigInt")}} value. Number values must be integers and are converted t
 - {{jsxref("TypeError")}}
   - : Thrown in one of the following cases:
     - The parameter cannot be converted to a primitive.
-    - After conversion to a primitive, the result is {{jsxref("undefined")}}, {{jsxref("null")}}, {{jsxref("symbol")}}.
+    - After conversion to a primitive, the result is {{jsxref("undefined")}}, {{jsxref("null")}}, {{jsxref("Symbol", "symbol")}}.
 - {{jsxref("SyntaxError")}}
   - : Thrown if the parameter is a string that cannot be parsed as a `BigInt`.
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/bigint/index.md
@@ -34,7 +34,7 @@ A {{jsxref("BigInt")}} value. Number values must be integers and are converted t
 - {{jsxref("TypeError")}}
   - : Thrown in one of the following cases:
     - The parameter cannot be converted to a primitive.
-    - After conversion to a primitive, the result is {{jsxref("undefined")}}, {{jsxref("null")}}, {{jsxref("Symbol", "symbol")}}.
+    - After conversion to a primitive, the result is {{jsxref("undefined")}}, {{jsxref("null")}}, or {{jsxref("Symbol")}}.
 - {{jsxref("SyntaxError")}}
   - : Thrown if the parameter is a string that cannot be parsed as a `BigInt`.
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

### Description

Fix `jsxref` arguments whose casing did not match the canonical page path:

- `operators/import` -> `Operators/import`
- `Regexp`, `Regexp.global`, `Regexp.ignoreCase`, `Regexp.multiline`, `Regexp.sticky` -> `RegExp…`
- `number` -> `Number`
- `statements/try...catch` -> `Statements/try...catch`
- `infinity` -> `Infinity`
- `symbol` -> `Symbol`

### Motivation

Ensure `jsxref` arguments use the canonical casing, so links resolve without relying on case-insensitive fallbacks.

### Additional details

For `Symbol`, the rendered text is kept lowercase (`{{jsxref("Symbol", "symbol")}}`), because the surrounding prose lists primitive types next to `undefined` and `null`.

For `Number`, `A {{jsxref("Number")}}.` matches the wording already used on other Web/API value sections.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.
