### PR TITLE
fix(webextapiref): repair malformed userScripts.execute() macro

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
@@ -51,7 +51,7 @@ When an extension updates, user scripts are cleared. To restore scripts, add cod
 ## Types
 
 - {{WebExtAPIRef("userScripts.ExecutionWorld")}}
-  - : The execution environment for a script injected with {{WebExtAPIRef("userScripts.,"execute()", "execute()"}}, {{WebExtAPIRef("userScripts.register()", "register()")}}, or {{WebExtAPIRef("userScripts.update()", "update()")}}.
+  - : The execution environment for a script injected with {{WebExtAPIRef("userScripts.execute()", "execute()")}}, {{WebExtAPIRef("userScripts.register()", "register()")}}, or {{WebExtAPIRef("userScripts.update()", "update()")}}.
 - {{WebExtAPIRef("userScripts.RegisteredUserScript")}}
   - : An `object` returned by {{WebExtAPIRef("userScripts.getScripts","getScripts()")}} representing registered user scripts and used as input to {{WebExtAPIRef("userScripts.register","register()")}} and {{WebExtAPIRef("userScripts.update","update()")}}.
 - {{WebExtAPIRef("userScripts.ScriptSource")}}


### PR DESCRIPTION
### Description

Fix the `WebExtAPIRef` macro call for `userScripts.execute()` in the userScripts API landing page.

### Motivation

Ensure the reference renders as a link instead of literal text.

### Additional details

Before: `{{WebExtAPIRef("userScripts.,"execute()", "execute()"}}` (stray comma, unbalanced quotes and parentheses).
After: `{{WebExtAPIRef("userScripts.execute()", "execute()")}}`.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.