### PR TITLE
Hyphenate cross-browser, cross-site, and cross-origin modifiers

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_a-frame/index.md
@@ -320,7 +320,7 @@ render();
 
 ## Summary
 
-A-Frame targets web developers by offering web markup with advantages such as JavaScript manipulation. It provides a powerful API for advanced concepts, as well as dealing with cross browser differences. It's a great time to start experimenting with such frameworks.
+A-Frame targets web developers by offering web markup with advantages such as JavaScript manipulation. It provides a powerful API for advanced concepts, as well as dealing with cross-browser differences. It's a great time to start experimenting with such frameworks.
 
 ## See also
 

--- a/files/en-us/learn_web_development/extensions/client-side_tools/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/client-side_tools/deployment/index.md
@@ -171,7 +171,7 @@ When approaching tests there are a good deal of ways to approach the problem:
 - End-to-end testing, which involves your visitor clicking a thing and some other thing happening.
 - Integration testing, which basically says "does one block of code still work when connected to another block?"
 - Unit testing, where small and specific bits of functionality are tested to see if they do what they are supposed to do.
-- [And many more types](https://en.wikipedia.org/wiki/Functional_testing). Also, see our [cross browser testing module](/en-US/docs/Learn_web_development/Extensions/Testing) for a bunch of useful testing information.
+- [And many more types](https://en.wikipedia.org/wiki/Functional_testing). Also, see our [cross-browser testing module](/en-US/docs/Learn_web_development/Extensions/Testing) for a bunch of useful testing information.
 
 Remember also that tests are not limited to JavaScript; tests can be run against the rendered DOM, user interactions, CSS, and even how a page looks.
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/web_application_security/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/web_application_security/index.md
@@ -41,7 +41,7 @@ The good news for Django users is that many of the more common threats are handl
 
 Rather than duplicate the Django documentation here, in this article we'll demonstrate just a few of the security features in the context of our Django [LocalLibrary](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) tutorial.
 
-### Cross site scripting (XSS)
+### Cross-site scripting (XSS)
 
 XSS is a term used to describe a class of attacks that allow an attacker to inject client-side scripts _through_ the website into the browsers of other users. This is usually achieved by storing malicious scripts in the database where they can be retrieved and displayed to other users, or by getting users to click a link that will cause the attacker's JavaScript to be executed by the user's browser.
 
@@ -74,7 +74,7 @@ Using Django templates protects you against the majority of XSS attacks. However
 
 It is also possible for XSS attacks to originate from other untrusted source of data, such as cookies, Web services or uploaded files (whenever the data is not sufficiently sanitized before including in a page). If you're displaying data from these sources, then you may need to add your own sanitization code.
 
-### Cross site request forgery (CSRF) protection
+### Cross-site request forgery (CSRF) protection
 
 CSRF attacks allow a malicious user to execute actions using the credentials of another user without that user's knowledge or consent. For example consider the case where we have a hacker who wants to create additional authors for our LocalLibrary.
 

--- a/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/automated_testing/index.md
@@ -40,7 +40,7 @@ We agree — testing all the things we've looked at in previous articles manuall
 We will look at how to set up your own Selenium-based testing system in the next article. In this article, we'll look at how to set up a task runner, and use the basic functionality of commercial systems like the ones mentioned above.
 
 > [!NOTE]
-> The above two categories are not mutually exclusive. It is possible to set up a task runner to access a service like Sauce Labs via an API, run cross browser tests, and return results. We will look at this below as well.
+> The above two categories are not mutually exclusive. It is possible to set up a task runner to access a service like Sauce Labs via an API, run cross-browser tests, and return results. We will look at this below as well.
 
 ## Using a task runner to automate testing tools
 

--- a/files/en-us/learn_web_development/extensions/testing/html_and_css/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/html_and_css/index.md
@@ -21,14 +21,14 @@ With the scene set, we'll now look specifically at the common cross-browser prob
         of the high level
         <a
           href="/en-US/docs/Learn_web_development/Extensions/Testing/Introduction"
-          >principles of cross browser testing</a
+          >principles of cross-browser testing</a
         >.
       </td>
     </tr>
     <tr>
       <th scope="row">Objective:</th>
       <td>
-        To be able to diagnose common HTML and CSS cross browser problems, and
+        To be able to diagnose common HTML and CSS cross-browser problems, and
         use appropriate tools and techniques to fix them.
       </td>
     </tr>
@@ -39,11 +39,11 @@ With the scene set, we'll now look specifically at the common cross-browser prob
 
 Some of the trouble with HTML and CSS lies with the fact that both languages are fairly simple, and often developers don't take them seriously, in terms of making sure the code is well-crafted, efficient, and semantically describes the purpose of the features on the page. In the worst cases, JavaScript is used to generate the entire web page content and style, which makes your pages inaccessible, and less performant (generating DOM elements is expensive). In other cases, nascent features are not supported consistently across browsers, which can make some features and styles not work for some users. Responsive design problems are also common — a site that looks good in a desktop browser might provide a terrible experience on a mobile device, because the content is too small to read, or perhaps the site is slow because of expensive animations.
 
-Let's go forth and look at how we can reduce cross browser errors that result from HTML/CSS.
+Let's go forth and look at how we can reduce cross-browser errors that result from HTML/CSS.
 
 ## First things first: fixing general problems
 
-We said in the [first article of this series](/en-US/docs/Learn_web_development/Extensions/Testing/Introduction#testingdiscovery) that a good strategy to begin with is to test in a couple of modern browsers on desktop/mobile, to make sure your code is working generally, before going on to concentrate on the cross browser issues.
+We said in the [first article of this series](/en-US/docs/Learn_web_development/Extensions/Testing/Introduction#testingdiscovery) that a good strategy to begin with is to test in a couple of modern browsers on desktop/mobile, to make sure your code is working generally, before going on to concentrate on the cross-browser issues.
 
 In our [Debugging HTML](/en-US/docs/Learn_web_development/Core/Structuring_content/Debugging_HTML) and [Debugging CSS](/en-US/docs/Learn_web_development/Core/Styling_basics/Debugging_CSS) articles, we provided some really basic guidance on debugging HTML/CSS — if you are not familiar with the basics, you should definitely study these articles before carrying on.
 
@@ -89,9 +89,9 @@ As an example, in Firefox the CSS inspector will show CSS declarations that aren
 
 Other browser devtools have similar features.
 
-## Common cross browser problems
+## Common cross-browser problems
 
-Now let's move on to look at some of the most common cross browser HTML and CSS problems. The main areas we'll look at are lack of support for modern features, and layout issues.
+Now let's move on to look at some of the most common cross-browser HTML and CSS problems. The main areas we'll look at are lack of support for modern features, and layout issues.
 
 ### Browsers not supporting modern features
 
@@ -354,6 +354,6 @@ Aside from that, try searching your favorite search engine for an answer to your
 
 ## Summary
 
-Now you should be familiar with the main types of cross browser HTML and CSS problems that you'll meet in web development, and how to go about fixing them.
+Now you should be familiar with the main types of cross-browser HTML and CSS problems that you'll meet in web development, and how to go about fixing them.
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Testing/Testing_strategies","Learn_web_development/Extensions/Testing/Feature_detection", "Learn_web_development/Extensions/Testing")}}

--- a/files/en-us/learn_web_development/extensions/testing/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/index.md
@@ -18,8 +18,8 @@ Before starting this module, You should really have learned the fundamentals of 
 
 ## Tutorials
 
-- [Introduction to cross browser testing](/en-US/docs/Learn_web_development/Extensions/Testing/Introduction)
-  - : This article starts the module off by providing an overview of the topic of cross browser testing, answering questions such as "what is cross browser testing?", "what are the most common types of problems you'll encounter?", and "what are the main approaches for testing, identifying, and fixing problems?"
+- [Introduction to cross-browser testing](/en-US/docs/Learn_web_development/Extensions/Testing/Introduction)
+  - : This article starts the module off by providing an overview of the topic of cross-browser testing, answering questions such as "what is cross-browser testing?", "what are the most common types of problems you'll encounter?", and "what are the main approaches for testing, identifying, and fixing problems?"
 - [Strategies for carrying out testing](/en-US/docs/Learn_web_development/Extensions/Testing/Testing_strategies)
   - : Next, we drill down into carrying out testing, looking at identifying a target audience (e.g., what browsers, devices, and other segments should you make sure are tested), lo-fi testing strategies (get yourself a range of devices and some virtual machines and do ad hoc tests when needed), higher tech strategies (automation, using dedicated testing apps), and testing with user groups.
 - [Handling common HTML and CSS problems](/en-US/docs/Learn_web_development/Extensions/Testing/HTML_and_CSS)

--- a/files/en-us/learn_web_development/extensions/testing/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/introduction/index.md
@@ -167,6 +167,6 @@ Just to reiterate on what was said above, if you discover bugs in browsers, you 
 
 ## Summary
 
-This article should have given you a high-level understanding of the most important concepts you need to know about cross browser testing. Armed with this knowledge, you are now ready to move on and start learning about Cross-browser testing strategies.
+This article should have given you a high-level understanding of the most important concepts you need to know about cross-browser testing. Armed with this knowledge, you are now ready to move on and start learning about Cross-browser testing strategies.
 
 {{NextMenu("Learn_web_development/Extensions/Testing/Testing_strategies", "Learn_web_development/Extensions/Testing")}}

--- a/files/en-us/learn_web_development/extensions/testing/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/introduction/index.md
@@ -167,6 +167,6 @@ Just to reiterate on what was said above, if you discover bugs in browsers, you 
 
 ## Summary
 
-This article should have given you a high-level understanding of the most important concepts you need to know about cross-browser testing. Armed with this knowledge, you are now ready to move on and start learning about Cross-browser testing strategies.
+This article should have given you a high-level understanding of the most important concepts in cross-browser testing. Armed with this knowledge, you're ready to move on and start learning about cross-browser testing strategies.
 
 {{NextMenu("Learn_web_development/Extensions/Testing/Testing_strategies", "Learn_web_development/Extensions/Testing")}}

--- a/files/en-us/learn_web_development/extensions/testing/your_own_automation_environment/index.md
+++ b/files/en-us/learn_web_development/extensions/testing/your_own_automation_environment/index.md
@@ -19,7 +19,7 @@ In this article, we will teach you how to install your own automation environmen
         <a href="/en-US/docs/Learn_web_development/Core/Styling_basics">CSS</a>, and
         <a href="/en-US/docs/Learn_web_development/Core/Scripting">JavaScript</a> languages; an idea
         of the high-level
-        <a href="/en-US/docs/Learn_web_development/Extensions/Testing/Introduction">principles of cross browser testing</a>, and
+        <a href="/en-US/docs/Learn_web_development/Extensions/Testing/Introduction">principles of cross-browser testing</a>, and
         <a href="/en-US/docs/Learn_web_development/Extensions/Testing/Automated_testing">automated testing</a>.
       </td>
     </tr>

--- a/files/en-us/mozilla/firefox/releases/111/index.md
+++ b/files/en-us/mozilla/firefox/releases/111/index.md
@@ -32,7 +32,7 @@ No notable changes.
 
 ### HTTP
 
-- The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Reference/Headers/Authorization) header is removed from cross origin redirects.
+- The HTTP [`Authorization`](/en-US/docs/Web/HTTP/Reference/Headers/Authorization) header is removed from cross-origin redirects.
   See [Firefox bug 1802086](https://bugzil.la/1802086) for more details.
 
 ### APIs

--- a/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
@@ -52,7 +52,7 @@ Now, the audio context we've created needs some sound to play through it. There 
 ```
 
 > [!NOTE]
-> If the sound file you're loading is held on a different domain you will need to use the `crossorigin` attribute; see [Cross Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/Guides/CORS) for more information.
+> If the sound file you're loading is held on a different domain you will need to use the `crossorigin` attribute; see [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/Guides/CORS) for more information.
 
 To use all the nice things we get with the Web Audio API, we need to grab the source from this element and _pipe_ it into the context we have created. Lucky for us there's a method that allows us to do just that — {{domxref("AudioContext.createMediaElementSource")}}:
 

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -90,7 +90,7 @@ Cross-Origin-Opener-Policy: same-origin
 Cross-Origin-Embedder-Policy: require-corp
 ```
 
-To check if cross origin isolation has been successful, you can test against the {{domxref("Window.crossOriginIsolated")}} property available to window and worker contexts:
+To check if cross-origin isolation has been successful, you can test against the {{domxref("Window.crossOriginIsolated")}} property available to window and worker contexts:
 
 ```js
 const myWorker = new Worker("worker.js");

--- a/files/en-us/web/http/guides/authentication/index.md
+++ b/files/en-us/web/http/guides/authentication/index.md
@@ -114,7 +114,7 @@ The "Basic" HTTP authentication scheme is defined in {{rfc(7617)}}, which transm
 As the user ID and password are passed over the network as clear text (it is base64 encoded, but base64 is a reversible encoding), the basic authentication scheme is not secure.
 HTTPS/TLS should be used with basic authentication to prevent credential interception.
 
-In addition, sites that use HTTP Basic Auth are particularly vulnerable to [Cross-Site Request Forgery (CSRF)](/en-US/docs/Glossary/CSRF) attacks because the user credentials are sent in all requests regardless of origin (this differs cookie-based credential mechanisms, because cookies are commonly blocked in cross site requests).
+In addition, sites that use HTTP Basic Auth are particularly vulnerable to [Cross-Site Request Forgery (CSRF)](/en-US/docs/Glossary/CSRF) attacks because the user credentials are sent in all requests regardless of origin (this differs cookie-based credential mechanisms, because cookies are commonly blocked in cross-site requests).
 Sites should always use the POST requests when changing data, and include [CSRF tokens](/en-US/docs/Web/Security/Attacks/CSRF).
 
 Without these security enhancements, basic authentication should not be used to protect sensitive or valuable information.

--- a/files/en-us/web/http/reference/headers/cross-origin-embedder-policy/index.md
+++ b/files/en-us/web/http/reference/headers/cross-origin-embedder-policy/index.md
@@ -157,7 +157,7 @@ if (crossOriginIsolated) {
 
 ### Avoiding COEP blockage with CORS
 
-If you enable COEP using `require-corp` and want to embed a cross origin resource that supports [CORS](/en-US/docs/Web/HTTP/Guides/CORS), you will need to explicitly specify that it is requested in `cors` mode.
+If you enable COEP using `require-corp` and want to embed a cross-origin resource that supports [CORS](/en-US/docs/Web/HTTP/Guides/CORS), you will need to explicitly specify that it is requested in `cors` mode.
 
 For example, to fetch an image declared in HTML from a third-party site that supports CORS, you can use the [`crossorigin`](/en-US/docs/Web/HTML/Reference/Attributes/crossorigin) attribute so that it is requested in `cors` mode:
 

--- a/files/en-us/web/http/reference/headers/referrer-policy/index.md
+++ b/files/en-us/web/http/reference/headers/referrer-policy/index.md
@@ -45,7 +45,7 @@ Referrer-Policy: unsafe-url
   - : Send only the {{glossary("origin")}} in the {{HTTPHeader("Referer")}} header.
     For example, a document at `https://example.com/page.html` will send the referrer `https://example.com/`.
 - `origin-when-cross-origin`
-  - : When performing a {{glossary("Same-origin_policy", "same-origin")}} request, send the {{glossary("origin")}}, path, and query string. Send only the origin for cross origin requests and requests to less secure destinations (HTTPS→HTTP).
+  - : When performing a {{glossary("Same-origin_policy", "same-origin")}} request, send the {{glossary("origin")}}, path, and query string. Send only the origin for cross-origin requests and requests to less secure destinations (HTTPS→HTTP).
 - `same-origin`
   - : Send the {{glossary("origin")}}, path, and query string for {{glossary("Same-origin_policy", "same-origin")}} requests. Don't send the {{HTTPHeader("Referer")}} header for cross-origin requests.
 - `strict-origin`

--- a/files/en-us/web/media/guides/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: mediasidebar
 ---
 
-In other articles we looked at how to [build a cross browser video player](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/cross_browser_video_player) using the {{ domxref("HTMLMediaElement") }} and {{ domxref("Window.fullScreen") }} APIs, and also at how to [style the player](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Video_player_styling_basics). This article will take the same player and show how to add captions and subtitles to it, using [the WebVTT format](/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format) and the {{ htmlelement("track") }} element.
+In other articles we looked at how to [build a cross-browser video player](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/cross_browser_video_player) using the {{ domxref("HTMLMediaElement") }} and {{ domxref("Window.fullScreen") }} APIs, and also at how to [style the player](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Video_player_styling_basics). This article will take the same player and show how to add captions and subtitles to it, using [the WebVTT format](/en-US/docs/Web/API/WebVTT_API/Web_Video_Text_Tracks_Format) and the {{ htmlelement("track") }} element.
 
 In this article, our example uses an excerpt from the [Sintel open movie](https://durian.blender.org/), created by the [Blender Foundation](https://www.blender.org/about/foundation/).
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/index.md
@@ -37,7 +37,7 @@ The code above will create an audio player that attempts to preload as much audi
 > [!NOTE]
 > The `preload` attribute may be ignored by some mobile browsers.
 
-For further info see [Cross Browser Audio Basics (HTML Audio In Detail)](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Cross-browser_audio_basics#html_audio_in_detail)
+For further info see [Cross-browser Audio Basics (HTML Audio In Detail)](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Cross-browser_audio_basics#html_audio_in_detail)
 
 ### HTML video
 
@@ -483,7 +483,7 @@ A number of audio and video JavaScript libraries exist. The most popular librari
 ## Guides
 
 - [Creating a cross-browser video player](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/cross_browser_video_player)
-  - : A guide to creating a basic cross browser video player using the {{ htmlelement("video") }} element.
+  - : A guide to creating a basic cross-browser video player using the {{ htmlelement("video") }} element.
 - [Video player styling basics](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Video_player_styling_basics)
   - : With the cross-browser video player put in place in the previous article, this article now looks at providing some basic, responsive styling for the player.
 - [Adding captions and subtitles to HTML video](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video)
@@ -508,8 +508,8 @@ A number of audio and video JavaScript libraries exist. The most popular librari
 
 ### Advanced topics
 
-- [Web Audio API cross browser support](/en-US/docs/Web/API/Web_Audio_API/Best_practices#cross_browser_legacy_support)
-  - : A guide to writing cross browser Web Audio API code.
+- [Web Audio API cross-browser support](/en-US/docs/Web/API/Web_Audio_API/Best_practices#cross_browser_legacy_support)
+  - : A guide to writing cross-browser Web Audio API code.
 - [Easy audio capture with the MediaRecorder API](https://hacks.mozilla.org/2014/06/easy-audio-capture-with-the-mediarecorder-api/)
   - : Explains the basics of using the MediaStream Recording API to directly record a media stream.
 

--- a/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: mediasidebar
 ---
 
-In the previous [Cross browser video player article](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/cross_browser_video_player) we described how to build a cross-browser HTML video player using the Media and Fullscreen APIs. This follow-up article looks at how to style this custom player, including making it responsive.
+In the previous [Cross-browser video player article](/en-US/docs/Web/Media/Guides/Audio_and_video_delivery/cross_browser_video_player) we described how to build a cross-browser HTML video player using the Media and Fullscreen APIs. This follow-up article looks at how to style this custom player, including making it responsive.
 
 ## HTML markup
 

--- a/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
+++ b/files/en-us/web/media/guides/audio_and_video_manipulation/index.md
@@ -105,7 +105,7 @@ This is an example showing how to manipulate video frames using a canvas. For ef
 You can achieve the same result by applying the {{cssxref("filter-function/grayscale", "grayscale()")}} CSS function to the source `<video>` element.
 
 > [!NOTE]
-> Due to potential security issues if your video is on a different domain than your code, you'll need to enable [CORS (Cross Origin Resource Sharing)](/en-US/docs/Web/HTTP/Guides/CORS) on your video server.
+> Due to potential security issues if your video is on a different domain than your code, you'll need to enable [CORS (Cross-Origin Resource Sharing)](/en-US/docs/Web/HTTP/Guides/CORS) on your video server.
 
 ### Video and WebGL
 

--- a/files/en-us/web/privacy/guides/referer_header_colon__privacy_and_security_concerns/index.md
+++ b/files/en-us/web/privacy/guides/referer_header_colon__privacy_and_security_concerns/index.md
@@ -35,7 +35,7 @@ You can also mitigate such risks using:
 
 Security-conscious server-side frameworks tend to have built in mitigations for such problems, for example:
 
-- [Security in Django](https://docs.djangoproject.com/en/stable/topics/security/) (especially see [Cross site request forgery (CSRF) protection](https://docs.djangoproject.com/en/stable/topics/security/#cross-site-request-forgery-csrf-protection)).
+- [Security in Django](https://docs.djangoproject.com/en/stable/topics/security/) (especially see [Cross-site request forgery (CSRF) protection](https://docs.djangoproject.com/en/stable/topics/security/#cross-site-request-forgery-csrf-protection)).
 - [Helmet referrer-policy](https://github.com/helmetjs/helmet/tree/main/middlewares/referrer-policy) — middleware for setting Referrer-Policy in Node.js/Express apps (see also [Helmet](https://github.com/helmetjs) for more security provisions).
 
 ## Policy and requirements


### PR DESCRIPTION
### Description

Hyphenates "cross-browser", "cross-site" and "cross-origin" in the 30 places where they modify a following noun.

### Motivation

Used before a noun these are compound modifiers and take a hyphen. The repository already writes cross-origin about 1028 times and cross-site about 355, so the unhyphenated ones are outliers.

The clearest case is the testing module, whose own page is titled "Introduction to cross-browser testing" while three pages link to it with the text "principles of cross browser testing" and "an overview of the topic of cross browser testing". Also included are "reduce cross browser errors", "the most common cross browser HTML and CSS problems", "build a cross browser video player", "cross origin isolation", "embed a cross origin resource", and "Cross Origin Resource Sharing", whose specification name is hyphenated.

Three section headings are included: "Cross site scripting (XSS)" and "Cross site request forgery (CSRF) protection" in the Django security article, and "Common cross browser problems". Nothing in the repository links to their anchors, so the renames are self-contained. The heading "Cross browser & legacy support" is deliberately left unchanged, because a page does link to its `#cross_browser_legacy_support` anchor.

External titles are quoted as published and left alone, including OWASP's "Cross Site Scripting Prevention Cheat Sheet" and web.dev's "Cross Origin Opener Policy", as is the alt text describing a chart's own labels on the SQL injection page.
