### PR TITLE
Remove `Deprecated_Header` macro calls

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/onbrowserupdateavailable/index.md
@@ -8,8 +8,6 @@ browser-compat: webextensions.api.runtime.onBrowserUpdateAvailable
 sidebar: addonsidebar
 ---
 
-{{Deprecated_header}}
-
 Fired when an update for the browser is available, but it isn't installed immediately because a browser restart is required.
 
 ## Syntax

--- a/files/en-us/web/api/htmlallcollection/index.md
+++ b/files/en-us/web/api/htmlallcollection/index.md
@@ -7,7 +7,7 @@ status:
 browser-compat: api.HTMLAllCollection
 ---
 
-{{APIRef("DOM")}}{{Deprecated_Header}}
+{{APIRef("DOM")}}
 
 The **`HTMLAllCollection`** interface represents a collection of _all_ of the document's elements, accessible by index (like an array) and by the element's [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id). It is returned by the {{domxref("document.all")}} property.
 

--- a/files/en-us/web/http/reference/status/102/index.md
+++ b/files/en-us/web/http/reference/status/102/index.md
@@ -2,11 +2,11 @@
 title: 102 Processing
 slug: Web/HTTP/Reference/Status/102
 page-type: http-status-code
+status:
+  - deprecated
 spec-urls: https://www.rfc-editor.org/info/rfc2518/#section-10.1
 sidebar: http
 ---
-
-{{deprecated_header}}
 
 The HTTP **`102 Processing`** [informational response](/en-US/docs/Web/HTTP/Reference/Status#informational_responses) status code indicates to client that a full request has been received and the server is working on it.
 This status code is only sent if the server expects the request to take significant time.


### PR DESCRIPTION
### Description

Remove the `Deprecated_Header` macro from the three content pages that still call it, and add `status: deprecated` front matter to `102 Processing`, which has no `browser-compat` key to derive the banner from. The other two pages already carry the front matter property.

### Motivation

The macro is no longer required to generate the **Deprecated status** banner: the platform generates it from the `status` front matter property or from web-features data.

### Additional details

Two remaining occurrences are intentionally left in place:

- `files/en-us/mdn/writing_guidelines/page_structures/feature_status/index.md` documents the deprecation and escapes the macro (`\{{Deprecated_Header}}`).
- `files/en-us/mdn/kitchensink/index.md` exists to exercise every Rari macro, so it should be cleaned up together with the macro itself.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.