### PR TITLE
replace other instances of anyfunc with funcref

### DIFF
--- a/files/en-us/webassembly/guides/exported_functions/index.md
+++ b/files/en-us/webassembly/guides/exported_functions/index.md
@@ -23,7 +23,7 @@ Either way, you get the same kind of wrapper for the underlying function. From a
 Let's look at an example to clear things up (you can find this on GitHub as [table-set.html](https://github.com/mdn/webassembly-examples/blob/main/other-examples/table-set.html); see it [running live also](https://mdn.github.io/webassembly-examples/other-examples/table-set.html), and check out the Wasm [text representation](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table.wat)):
 
 ```js
-const otherTable = new WebAssembly.Table({ element: "anyfunc", initial: 2 });
+const otherTable = new WebAssembly.Table({ element: "funcref", initial: 2 });
 
 WebAssembly.instantiateStreaming(fetch("table.wasm")).then((obj) => {
   const tbl = obj.instance.exports.tbl;

--- a/files/en-us/webassembly/guides/understanding_the_text_format/index.md
+++ b/files/en-us/webassembly/guides/understanding_the_text_format/index.md
@@ -607,9 +607,9 @@ To see why tables are needed, we need to observe that the `call` instruction we 
 
 WebAssembly needed a type of call instruction to achieve this, so we gave it `call_indirect`, which takes a dynamic function operand. The problem is that the only types we can give operands in WebAssembly are (currently) `i32`/`i64`/`f32`/`f64`.
 
-WebAssembly could add an `anyfunc` type ("any" because the type could hold functions of any signature), but unfortunately, this `anyfunc` type couldn't be stored in linear memory for security reasons. Linear memory exposes the raw contents of stored values as bytes, therefore, Wasm content could arbitrarily observe and corrupt raw function addresses, which is something that cannot be allowed on the web.
+WebAssembly has a [`funcref`](/en-US/docs/WebAssembly/Reference/Value_types/funcref) type (which can hold functions of any signature), but unfortunately, `funcref` types cann't be stored in linear memory for security reasons. Linear memory exposes the raw contents of stored values as bytes, therefore, Wasm content could arbitrarily observe and corrupt raw function addresses, which is something that cannot be allowed on the web.
 
-The solution was to store function references in a table and pass around table indices instead, which are just i32 values. `call_indirect`'s operand can therefore be an i32 index value.
+The solution is to store function references in a table and pass around table indices instead, which are just `i32` values. `call_indirect`'s operand can therefore be an `i32` index value.
 
 #### Defining a table in Wasm
 
@@ -640,7 +640,7 @@ In JavaScript, the equivalent calls to create such a table instance would look s
 ```js
 function module() {
   // table section
-  const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
+  const tbl = new WebAssembly.Table({ initial: 2, element: "funcref" });
 
   // function sections:
   const f1 = () => 42; /* some imported WebAssembly function */
@@ -785,7 +785,7 @@ After converting to a WebAssembly binary (Wasm), we then use `shared0.wasm` and 
 const importObj = {
   js: {
     memory: new WebAssembly.Memory({ initial: 1 }),
-    table: new WebAssembly.Table({ initial: 1, element: "anyfunc" }),
+    table: new WebAssembly.Table({ initial: 1, element: "funcref" }),
   },
 };
 

--- a/files/en-us/webassembly/reference/javascript_interface/table/grow/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/table/grow/index.md
@@ -44,7 +44,7 @@ The following example creates a new WebAssembly Table instance with an initial s
 
 ```js
 const table = new WebAssembly.Table({
-  element: "anyfunc",
+  element: "funcref",
   initial: 2,
   maximum: 10,
 });

--- a/files/en-us/webassembly/reference/javascript_interface/table/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/table/index.md
@@ -37,7 +37,7 @@ The **`WebAssembly.Table`** object is a JavaScript wrapper object — an array-l
 The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of 2 elements. We then print out the table length and contents of the two indexes (retrieved via [`Table.prototype.get()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table/get) to show that the length is two and both elements are [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
-const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
+const tbl = new WebAssembly.Table({ initial: 2, element: "funcref" });
 console.log(tbl.length); // "2"
 console.log(tbl.get(0)); // "null"
 console.log(tbl.get(1)); // "null"

--- a/files/en-us/webassembly/reference/javascript_interface/table/length/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/table/length/index.md
@@ -17,7 +17,7 @@ The following example creates a new WebAssembly Table instance with an initial s
 
 ```js
 const table = new WebAssembly.Table({
-  element: "anyfunc",
+  element: "funcref",
   initial: 2,
   maximum: 10,
 });

--- a/files/en-us/webassembly/reference/javascript_interface/table/set/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/table/set/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/main/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of two references. We then print out the table length and contents of the two indexes (retrieved via [`Table.prototype.get()`](/en-US/docs/WebAssembly/Reference/JavaScript_interface/Table/get)) to show that the length is two, and the indexes currently contain no function references (they currently return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
 
 ```js
-const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });
+const tbl = new WebAssembly.Table({ initial: 2, element: "funcref" });
 console.log(tbl.length);
 console.log(tbl.get(0));
 console.log(tbl.get(1));

--- a/files/en-us/webassembly/reference/javascript_interface/table/table/index.md
+++ b/files/en-us/webassembly/reference/javascript_interface/table/table/index.md
@@ -20,7 +20,7 @@ new WebAssembly.Table(tableDescriptor, value)
 - `tableDescriptor`
   - : An object that can contain the following members:
     - `element`
-      - : A string representing the type of value to be stored in the table. This can have a value of `"anyfunc"` (functions) or `"externref"` (host references).
+      - : A string representing the type of value to be stored in the table. This can have a value of `"funcref"` (functions) or `"externref"` (host references).
     - `initial`
       - : The initial number of elements of the WebAssembly Table.
     - `maximum` {{optional_inline}}
@@ -55,7 +55,7 @@ In `table2.html`, we create a `WebAssembly.Table`:
 ```js
 const tbl = new WebAssembly.Table({
   initial: 2,
-  element: "anyfunc",
+  element: "funcref",
 });
 ```
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

As per https://github.com/mdn/content/pull/45485#issuecomment-5537712106, we should replace all the other instances of `anyfunc` in the Wasm docs with `funcref`. This PR does that.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
