### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/opensearchresultsinnewtabs/index.md
@@ -10,7 +10,7 @@ A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object whose underl
 
 If set to `true`, then when the user selects a term in the browser's search box, the search results are displayed in a new tab. If set to `false` (the default) the search results are shown in the current tab.
 
-Note that this does not affect the behavior when selecting items from the omnibox/awesomebar,only the dedicated search box.
+Note that this does not affect the behavior when selecting items from the omnibox/awesomebar, only the dedicated search box.
 
 ## Examples
 

--- a/files/en-us/mozilla/firefox/releases/45/index.md
+++ b/files/en-us/mozilla/firefox/releases/45/index.md
@@ -35,7 +35,7 @@ Highlights:
   - The implied minimum size of grid Items, that is the special {{cssxref("min-width")}} and {{cssxref("min-height")}} `auto` behavior has been implemented ([Firefox bug 1176775](https://bugzil.la/1176775)).
   - {{cssxref("align-self")}} and {{cssxref("justify-self")}} are now supported on grid layouts ([Firefox bug 1151213](https://bugzil.la/1151213)).
   - {{cssxref("align-content")}} and {{cssxref("justify-content")}} are now supported on grid layouts ([Firefox bug 1151214](https://bugzil.la/1151214)).
-  - Resolved value of grid-template-columns,grid-template-rows in px units ([Firefox bug 978212](https://bugzil.la/978212)).
+  - Resolved value of grid-template-columns, grid-template-rows in px units ([Firefox bug 978212](https://bugzil.la/978212)).
   - The related feature {{cssxref("display")}}: contents has been supported since [Firefox 37](/en-US/docs/Mozilla/Firefox/Releases/37)
 
 - Implement full support for CSS Box Alignment for CSS Grid, support the missing values: `start`, `end`, `self-start`, `self-end`, `left`, `right`, `last-baseline`, `space-evenly` ([Firefox bug 1176782](https://bugzil.la/1176782)). CSS Box Alignment currently applies only to CSS Flexbox and CSS Grid.

--- a/files/en-us/mozilla/firefox/releases/68/index.md
+++ b/files/en-us/mozilla/firefox/releases/68/index.md
@@ -164,7 +164,7 @@ _No changes._
 ### API changes
 
 - The [`proxy.register()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy) and [`proxy.unregister()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy) functions have been deprecated and will be removed from Firefox 71 ([Firefox bug 1545811](https://bugzil.la/1545811)).
-- A `boolean` flag, `incognito`, has been added to the [proxy.RequestDetails](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails). object. When `true`, it indicates that this was a private browsing request ([Firefox bug 1545163](https://bugzil.la/1545163)).
+- A `boolean` flag, `incognito`, has been added to the [proxy.RequestDetails](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails) object. When `true`, it indicates that this was a private browsing request ([Firefox bug 1545163](https://bugzil.la/1545163)).
 - The [webRequest.RequestFilter](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter) parameters can include an incognito parameter. If provided, requests that do not match the incognito state (`true` or `false`) will be filtered out ([Firefox bug 1548177](https://bugzil.la/1548177)).
 - A `string` value, `cookieStoreId`, representing the cookie store ID of the current context, has been added to the [proxy.RequestDetails](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/RequestDetails). object ([Firefox bug 1545420](https://bugzil.la/1545420)).
 - When an add-on attempts to add a bookmark folder to the root folder, the resulting error message is now much more intuitive ([Firefox bug 1512171](https://bugzil.la/1512171)).

--- a/files/en-us/web/accessibility/guides/information_for_web_authors/index.md
+++ b/files/en-us/web/accessibility/guides/information_for_web_authors/index.md
@@ -45,4 +45,4 @@ Tools to integrate into your build process, programmatically adding accessibilit
 
 - [AccessLint](https://www.accesslint.com/)
 
-While best to test your web applications with real users, you can simulate color blindness, low vision, low and contrast, and zooming. You should always test your site with out a mouse and touch to test keyboard navigation. You may also want to try your site using voice commands. Try disabling your mouse and using browser extensions like [Web Disability Simulator](https://chromewebstore.google.com/detail/web-disability-simulator/olioanlbgbpmdlgjnnampnnlohigkjla)
+While best to test your web applications with real users, you can simulate color blindness, low vision, low contrast, and zooming. You should always test your site without a mouse and touch to test keyboard navigation. You may also want to try your site using voice commands. Try disabling your mouse and using browser extensions like [Web Disability Simulator](https://chromewebstore.google.com/detail/web-disability-simulator/olioanlbgbpmdlgjnnampnnlohigkjla)

--- a/files/en-us/web/api/rtcremoteinboundrtpstreamstats/fractionlost/index.md
+++ b/files/en-us/web/api/rtcremoteinboundrtpstreamstats/fractionlost/index.md
@@ -13,7 +13,7 @@ The **`fractionLost`** property of the {{domxref("RTCRemoteInboundRtpStreamStats
 To convert the value to a percentage, divide it by 256 and multiply by 100.
 For example, a value of 20 indicates a 7.8% packet loss.
 
-Note that the value may not be precisely accurate due to the way that it is calculated, but it does provides a quick and convenient measure of the link quality.
+Note that the value may not be precisely accurate due to the way that it is calculated, but it does provide a quick and convenient measure of the link quality.
 
 ## Value
 

--- a/files/en-us/web/css/reference/values/if/index.md
+++ b/files/en-us/web/css/reference/values/if/index.md
@@ -518,7 +518,7 @@ body {
 }
 ```
 
-We then set the `--scheme` custom property to match the `<article>` element's `class` name. The class will set by our JavaScript when a new value is selected in our `<select>` element. You'll see the significance of the custom element value in the next CSS block.
+We then set the `--scheme` custom property to match the `<article>` element's `class` name. The class will be set by our JavaScript when a new value is selected in our `<select>` element. You'll see the significance of the custom element value in the next CSS block.
 
 ```css live-sample___color-scheme
 .ice {

--- a/files/en-us/web/http/reference/headers/service-worker-navigation-preload/index.md
+++ b/files/en-us/web/http/reference/headers/service-worker-navigation-preload/index.md
@@ -38,7 +38,7 @@ Service-Worker-Navigation-Preload: <value>
 - `<value>`
   - : An arbitrary value that indicates what data should be sent in the response to the preload request.
     This defaults to `true`.
-    It maybe set to any other string value in the service worker, using {{domxref("NavigationPreloadManager.setHeaderValue()")}}.
+    It may be set to any other string value in the service worker, using {{domxref("NavigationPreloadManager.setHeaderValue()")}}.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Fixes seven unrelated typos in prose.

- `information_for_web_authors`: "test your site with out a mouse" → "without"; the same sentence lists "low vision, low and contrast" → "low contrast".
- `RTCRemoteInboundRtpStreamStats.fractionLost`: "it does provides a quick and convenient measure" → "does provide".
- `Service-Worker-Navigation-Preload`: "It maybe set to any other string value" → "may be set".
- `if()`: "The class will set by our JavaScript" → "will be set".
- `browserSettings.openSearchResultsInNewTabs`: missing space after a comma in "omnibox/awesomebar,only".
- Firefox 45 release notes: missing space after a comma in "grid-template-columns,grid-template-rows".
- Firefox 68 release notes: a stray period between a link and the word it modifies, "[proxy.RequestDetails](…). object" → "…) object".

### Motivation

These are straightforward mechanical errors rather than wording preferences, and each one is visible in the rendered page.
