### PR TITLE
Add missing space after sentence-ending period

### DIFF
--- a/files/en-us/glossary/layout_mode/index.md
+++ b/files/en-us/glossary/layout_mode/index.md
@@ -10,7 +10,7 @@ A **layout mode**, sometimes called _layout_, is a [CSS](/en-US/docs/Web/CSS) al
 There are several layout modes:
 
 - **[Flow layout or normal flow](/en-US/docs/Web/CSS/Guides/Display/Flow_layout)**
-  - : All elements are part of normal flow until you do something to take them out of it.Normal flow includes:
+  - : All elements are part of normal flow until you do something to take them out of it. Normal flow includes:
     - **[Block layout](/en-US/docs/Web/CSS/Guides/Display/Block_and_inline_layout)**
       - : Designed for laying out boxes such as paragraphs.
     - **[Inline layout](/en-US/docs/Web/CSS/Guides/Inline_layout)**

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -69,7 +69,7 @@ For video tracks only:
 - `width`
   - : A range object, containing a `min` and a `max` property (both containing a non-negative integer), describing the supported width range in pixels.
 - `resizeMode`
-  - : An array of strings that indicates how the user agent may derive the desired resolution from the camera resolution.See {{domxref("MediaTrackConstraints.resizeMode")}} for supported values. The value `"none"` is always included.
+  - : An array of strings that indicates how the user agent may derive the desired resolution from the camera resolution. See {{domxref("MediaTrackConstraints.resizeMode")}} for supported values. The value `"none"` is always included.
 
 For more information about what each property means, see {{domxref("MediaTrackConstraints")}}.
 

--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -172,7 +172,7 @@ _Modifiers_ are special keys which are used to generate special characters or ca
     <tr>
       <td><code>"FnLock"</code></td>
       <td>
-        The <kbd>FnLock</kbd> or <kbd>F-Lock</kbd> (Function Lock) key.Toggles
+        The <kbd>FnLock</kbd> or <kbd>F-Lock</kbd> (Function Lock) key. Toggles
         the function key mode described by <code>"Fn"</code> on and off. Often
         handled in hardware so that events aren't generated for this key.
       </td>

--- a/files/en-us/web/css/guides/custom_highlight_api/index.md
+++ b/files/en-us/web/css/guides/custom_highlight_api/index.md
@@ -13,7 +13,7 @@ The CSS Custom Highlight API extends the concept of other highlight pseudo-eleme
 
 ## Custom highlight API in action
 
-To enable styling text ranges on a webpage using the CSS Custom Highlight API, you create a {{domxref("Range")}} object, then a {{domxref("Highlight")}} object for the range. After registering the highlight using the {{domxref("HighlightRegistry.set()")}} method, you can then select the range using the {{cssxref("::highlight()")}} pseudo-element. The name defined in the `set()` method is used as the parameter of the `::highlight()` pseudo-element selector to select that range.The range selected by the `::highlight()` pseudo-element can be styled using a [limited number of properties](/en-US/docs/Web/CSS/Reference/Selectors/::highlight#allowable_properties).
+To enable styling text ranges on a webpage using the CSS Custom Highlight API, you create a {{domxref("Range")}} object, then a {{domxref("Highlight")}} object for the range. After registering the highlight using the {{domxref("HighlightRegistry.set()")}} method, you can then select the range using the {{cssxref("::highlight()")}} pseudo-element. The name defined in the `set()` method is used as the parameter of the `::highlight()` pseudo-element selector to select that range. The range selected by the `::highlight()` pseudo-element can be styled using a [limited number of properties](/en-US/docs/Web/CSS/Reference/Selectors/::highlight#allowable_properties).
 
 ```html-nolint hidden
 <h1>Directions</h1>

--- a/files/en-us/web/css/reference/properties/font-variation-settings/index.md
+++ b/files/en-us/web/css/reference/properties/font-variation-settings/index.md
@@ -141,7 +141,7 @@ You can find a number of other variable font examples in our [Variable fonts](/e
 
 ### Controlling variable font weight (wght)
 
-Click "Play" in the code blocks below to edit the example in the MDN Playground.Edit the CSS to play with different font weight values. See what happens when you specify a value outside the weight range.
+Click "Play" in the code blocks below to edit the example in the MDN Playground. Edit the CSS to play with different font weight values. See what happens when you specify a value outside the weight range.
 
 ```html hidden live-sample___variable-fonts-weight-example
 <div>
@@ -226,7 +226,7 @@ angle.addEventListener("input", (e) => {
 
 ### Controlling variable font slant (slnt)
 
-Click "Play" in the code blocks below to edit the example in the MDN Playground.Edit the CSS to play with different font slant/oblique values.
+Click "Play" in the code blocks below to edit the example in the MDN Playground. Edit the CSS to play with different font slant/oblique values.
 
 ```html hidden live-sample___variable-fonts-slant-example
 <div>


### PR DESCRIPTION
### Description

Adds the missing space after a sentence-ending period in six places.

- `Glossary/Layout_mode`: "take them out of it.Normal flow includes:"
- `MediaStreamTrack.getCapabilities()`: "from the camera resolution.See {{domxref(…)}} for supported values."
- `Keyboard event key values`: "(Function Lock) key.Toggles"
- `CSS custom highlight API`: "to select that range.The range selected by the `::highlight()` pseudo-element…"
- `font-variation-settings`: "in the MDN Playground.Edit the CSS…" — twice, in two different examples.

### Motivation

In each case two sentences render as one run-on word, which is visible in the built page.
