### PR TITLE
Add missing period to the abbreviation etc.

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/apache_configuration_htaccess/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/apache_configuration_htaccess/index.md
@@ -396,7 +396,7 @@ To make your CSP implementation easier, you can use an online [CSP header genera
 This CSP:
 
 1. Restricts all fetches by default to the origin of the current website by setting the `default-src` directive to `'self'` - which acts as a fallback to all [Fetch directives](/en-US/docs/Glossary/Fetch_directive).
-   - This is convenient as you do not have to specify all Fetch directives that apply to your site, for example: `connect-src 'self'; font-src 'self'; script-src 'self'; style-src 'self'`, etc
+   - This is convenient as you do not have to specify all Fetch directives that apply to your site, for example: `connect-src 'self'; font-src 'self'; script-src 'self'; style-src 'self'`, etc.
    - This restriction also means that you must explicitly define from which site(s) your website is allowed to load resources from. Otherwise, it will be restricted to the same origin as the page making the request
 
 2. Disallows the `<base>` element on the website. This is to prevent attackers from changing the locations of resources loaded from relative URLs

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/deployment/index.md
@@ -557,7 +557,7 @@ Select the **New** button, which is used to add services to the current project.
 
 Select **Database** when prompted about the type of service to add:
 
-![Railway popup showing options for a new service, such as database, GitHub repo, empty service etc](railway_database_add.png)
+![Railway popup showing options for a new service, such as database, GitHub repo, empty service, etc.](railway_database_add.png)
 
 Then select **Add MongoDB** to start adding the database
 

--- a/files/en-us/mozilla/firefox/releases/46/index.md
+++ b/files/en-us/mozilla/firefox/releases/46/index.md
@@ -38,7 +38,7 @@ Highlights:
 - Added support for [`@media (-webkit-transform-3d)`](/en-US/docs/Web/CSS/Reference/At-rules/@media/-webkit-transform-3d) as a media query for 3D transform support, if about:config pref `layout.css.prefixes.webkit` is set to `true` ([Firefox bug 1239799](https://bugzil.la/1239799)).
 - {{cssxref("gradient/linear-gradient", "linear-gradient()")}} support for the omission of `0deg` units ([Firefox bug 1239153](https://bugzil.la/1239153)).
 - Added `-webkit-filter` for web compatibility, behind the preference `layout.css.prefixes.webkit`, defaulting to `false` ([Firefox bug 1236506](https://bugzil.la/1236506)).
-- \[css-align] "unsafe start" (formerly "true start") should serialize to "start" etc ([Firefox bug 1230398](https://bugzil.la/1230398)).
+- \[css-align] "unsafe start" (formerly "true start") should serialize to "start", etc. ([Firefox bug 1230398](https://bugzil.la/1230398)).
 
 ### JavaScript
 

--- a/files/en-us/web/api/baseaudiocontext/index.md
+++ b/files/en-us/web/api/baseaudiocontext/index.md
@@ -35,7 +35,7 @@ _Also implements methods from the interface_ {{domxref("EventTarget")}}.
 - {{domxref("BaseAudioContext.createAnalyser()")}}
   - : Creates an {{domxref("AnalyserNode")}}, which can be used to expose audio time and frequency data and for example to create data visualizations.
 - {{domxref("BaseAudioContext.createBiquadFilter()")}}
-  - : Creates a {{domxref("BiquadFilterNode")}}, which represents a second order filter configurable as several different common filter types: high-pass, low-pass, band-pass, etc
+  - : Creates a {{domxref("BiquadFilterNode")}}, which represents a second order filter configurable as several different common filter types: high-pass, low-pass, band-pass, etc.
 - {{domxref("BaseAudioContext.createBuffer()")}}
   - : Creates a new, empty {{ domxref("AudioBuffer") }} object, which can then be populated by data and played via an {{ domxref("AudioBufferSourceNode") }}.
 - {{domxref("BaseAudioContext.createBufferSource()")}}

--- a/files/en-us/web/css/reference/selectors/attribute_selectors/index.md
+++ b/files/en-us/web/css/reference/selectors/attribute_selectors/index.md
@@ -59,7 +59,7 @@ a[class~="logo"] {
 ### Values
 
 - `<attr>`
-  - : An {{cssxref("ident")}}, that is, the unquoted name of the attribute. This can be any valid language-specific attribute (SVG, HTML, XML, etc), a [`data-*` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/data-*), or an author-created attribute.
+  - : An {{cssxref("ident")}}, that is, the unquoted name of the attribute. This can be any valid language-specific attribute (SVG, HTML, XML, etc.), a [`data-*` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/data-*), or an author-created attribute.
 - `<value>`
   - : An {{cssxref("ident")}} or {{cssxref("string")}}, representing the attribute value. The value must be quoted if it contains spaces or special characters.
 - `s` or `i`

--- a/files/en-us/web/css/reference/values/attr/index.md
+++ b/files/en-us/web/css/reference/values/attr/index.md
@@ -90,7 +90,7 @@ The parameters are:
 - `<attr-type>`
   - : Specifies how the attribute value is parsed into a CSS value. This can be the `raw-string` keyword, a {{cssxref("type()")}} function, or a CSS dimension unit (specified using an `<attr-unit>` identifier). When omitted, it defaults to `raw-string`.
     - `raw-string`
-      - : The `raw-string` keyword causes the attribute's literal value to be treated as the value of a CSS string, with no CSS parsing performed (including CSS escapes, whitespace removal, comments, etc). The `<fallback-value>` is only used if the attribute is omitted; specifying an empty value doesn't trigger the fallback.
+      - : The `raw-string` keyword causes the attribute's literal value to be treated as the value of a CSS string, with no CSS parsing performed (including CSS escapes, whitespace removal, comments, etc.). The `<fallback-value>` is only used if the attribute is omitted; specifying an empty value doesn't trigger the fallback.
 
         ```css
         attr(data-name raw-string, "stranger")

--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -102,7 +102,7 @@ Because elements are also properties, you can access them using [property access
 const myArray = ["Wind", "Rain", "Fire"];
 ```
 
-You can refer to the first element of the array as `myArray[0]`, the second element of the array as `myArray[1]`, etc… The index of the elements begins with zero.
+You can refer to the first element of the array as `myArray[0]`, the second element of the array as `myArray[1]`, etc. The index of the elements begins with zero.
 
 > [!NOTE]
 > You can also use [property accessors](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors) to access other properties of the array, like with an object.


### PR DESCRIPTION
### Description

Adds the missing period to seven occurrences of `etc` in prose, and a missing serial comma before two of them.

Affects the `.htaccess` configuration guide, the Express deployment guide, the Firefox 46 release notes, `BaseAudioContext`, attribute selectors, `attr()`, and the indexed collections guide. The last one also drops a trailing ellipsis, so "`myArray[1]`, etc… The index of" becomes "`myArray[1]`, etc. The index of".

Instances inside code blocks are left alone.

### Motivation

The writing style guide asks for the period explicitly:

> **Latin abbreviations**: You can use common Latin abbreviations (etc., i.e., e.g.) in parenthetical expressions and notes. Use periods in these abbreviations, followed by a comma or other appropriate punctuation.

The rest of the repository already follows it — `etc.` appears about 1080 times, so these seven are outliers.
