### PR TITLE
font-style: note that left/right values are unimplemented

### DIFF
--- a/files/en-us/web/css/reference/properties/font-style/index.md
+++ b/files/en-us/web/css/reference/properties/font-style/index.md
@@ -85,6 +85,9 @@ This property is specified as one of the following keyword values. The `oblique`
 
     In general, for a requested angle of 14 degrees or greater, larger angles are preferred; otherwise, smaller angles are preferred (see the spec's [font matching section](https://drafts.csswg.org/css-fonts-4/#font-matching-algorithm) for the precise algorithm).
 
+> [!NOTE]
+> The [CSS fonts](/en-US/docs/Web/CSS/Guides/Fonts) module defines `left` and `right` values for the `font-style` property to select an italic or oblique face with a specific slant direction, however, this is not supported in any browsers.
+
 ### Variable fonts
 
 Variable fonts can offer a fine control over the degree to which an oblique face is slanted. You can select this using the `<angle>` modifier for the `oblique` keyword.

--- a/files/en-us/web/css/reference/properties/font-style/index.md
+++ b/files/en-us/web/css/reference/properties/font-style/index.md
@@ -85,8 +85,7 @@ This property is specified as one of the following keyword values. The `oblique`
 
     In general, for a requested angle of 14 degrees or greater, larger angles are preferred; otherwise, smaller angles are preferred (see the spec's [font matching section](https://drafts.csswg.org/css-fonts-4/#font-matching-algorithm) for the precise algorithm).
 
-> [!NOTE]
-> The [CSS fonts](/en-US/docs/Web/CSS/Guides/Fonts) module defines `left` and `right` values for the `font-style` property to select an italic or oblique face with a specific slant direction, however, this is not supported in any browsers.
+The [CSS fonts](/en-US/docs/Web/CSS/Guides/Fonts) module also defines `left` and `right` values to select an italic or oblique face with a specific slant direction; however, these values are not supported in any browsers.
 
 ### Variable fonts
 


### PR DESCRIPTION
### Description

Adds a note to the `font-style` property page stating that the spec-defined `left` and `right` values are not supported in any browser.

### Motivation

`left` and `right` appear in the formal syntax but aren't explained anywhere on the page, and no browser implements them (confirmed against `mdn/browser-compat-data`, which has no compat entries for these values). This leaves readers unable to tell whether the values are usable. The note mirrors the existing "not supported in any browsers" pattern used on other property pages (e.g. `caption-side`, `text-combine-upright`) and leaves the formal syntax untouched, since the values are legitimately defined in CSS Fonts Module Level 4.

### Additional details

- CSS Fonts Module Level 4, §2.4 defines `left`/`right` as slant-direction matches for italic/oblique faces.
- No BCD entries exist for these values under `css/properties/font-style.json`.

### Related issues and pull requests

Fixes #45460