### PR TITLE
Geometry interfaces: note they are not a linear algebra library

### DIFF
--- a/files/en-us/web/api/geometry_interfaces/index.md
+++ b/files/en-us/web/api/geometry_interfaces/index.md
@@ -18,6 +18,9 @@ browser-compat:
 
 As a web developer, you don't always use the geometry interfaces directly, but instead use other features that rely on them behind the scenes: parts of [CSS Transforms](/en-US/docs/Web/CSS/Guides/Transforms), the [Canvas API](/en-US/docs/Web/API/Canvas_API), the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API), and (more directly) {{domxref('VideoFrame.visibleRect')}}, {{domxref('Element.getClientRects()')}}, and {{domxref('Element.getBoundingClientRect()')}}.
 
+> [!NOTE]
+> The geometry interfaces are designed for convenience and for integrating with DOM rendering, not as a general-purpose linear algebra library. Because of the overhead of native bindings, methods such as {{domxref('DOMMatrix.transformPoint()')}} can be slower than the equivalent math written directly in JavaScript. If you're doing a large amount of geometry computation on a hot path, consider doing the math manually instead.
+
 ## Interfaces
 
 - {{domxref('DOMMatrix')}}

--- a/files/en-us/web/api/geometry_interfaces/index.md
+++ b/files/en-us/web/api/geometry_interfaces/index.md
@@ -19,7 +19,7 @@ browser-compat:
 As a web developer, you don't always use the geometry interfaces directly, but instead use other features that rely on them behind the scenes: parts of [CSS Transforms](/en-US/docs/Web/CSS/Guides/Transforms), the [Canvas API](/en-US/docs/Web/API/Canvas_API), the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API), and (more directly) {{domxref('VideoFrame.visibleRect')}}, {{domxref('Element.getClientRects()')}}, and {{domxref('Element.getBoundingClientRect()')}}.
 
 > [!NOTE]
-> The geometry interfaces are intended for interacting with web graphics APIs, not as a general-purpose linear algebra library. For operations such as {{domxref("DOMMatrixReadOnly.transformPoint()")}}, the overhead of converting inputs, creating result objects, and accessing them through native bindings may outweigh the cost of the math itself. For computation-intensive code, profile different approaches and consider using plain JavaScript objects or arrays for intermediate calculations.
+> The geometry interfaces are intended for other web APIs like the ones listed above, rather than as a general-purpose linear algebra library. The transformation methods, such as {{domxref("DOMMatrixReadOnly.transformPoint()")}}, are provided for convenience and may be significantly slower than equivalent hand-written JavaScript due to internal overhead. For computation-intensive code, profile different approaches and consider using plain JavaScript objects or arrays for intermediate calculations.
 
 ## Interfaces
 

--- a/files/en-us/web/api/geometry_interfaces/index.md
+++ b/files/en-us/web/api/geometry_interfaces/index.md
@@ -19,7 +19,7 @@ browser-compat:
 As a web developer, you don't always use the geometry interfaces directly, but instead use other features that rely on them behind the scenes: parts of [CSS Transforms](/en-US/docs/Web/CSS/Guides/Transforms), the [Canvas API](/en-US/docs/Web/API/Canvas_API), the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API), and (more directly) {{domxref('VideoFrame.visibleRect')}}, {{domxref('Element.getClientRects()')}}, and {{domxref('Element.getBoundingClientRect()')}}.
 
 > [!NOTE]
-> The geometry interfaces are designed for convenience and for integrating with DOM rendering, not as a general-purpose linear algebra library. Because of the overhead of native bindings, methods such as {{domxref('DOMMatrix.transformPoint()')}} can be slower than the equivalent math written directly in JavaScript. If you're doing a large amount of geometry computation on a hot path, consider doing the math manually instead.
+> The geometry interfaces are intended for interacting with web graphics APIs, not as a general-purpose linear algebra library. For operations such as {{domxref("DOMMatrixReadOnly.transformPoint()")}}, the overhead of converting inputs, creating result objects, and accessing them through native bindings may outweigh the cost of the math itself. For computation-intensive code, profile different approaches and consider using plain JavaScript objects or arrays for intermediate calculations.
 
 ## Interfaces
 


### PR DESCRIPTION
### Description

Adds a note to the Geometry interfaces overview explaining that these interfaces (DOMMatrix, DOMPoint, DOMRect, DOMQuad) prioritize DOM-rendering integration and native-binding convenience over raw computational throughput.

### Motivation

The issue reported that `DOMMatrix.transformPoint()` can be 40-160x slower than equivalent hand-written JS math across engines. As discussed on the issue, this isn't a browser bug to fix but an inherent tradeoff of the API's design, so a documentation note is the right response. The note is scoped to that inherent-complexity framing per maintainer feedback, rather than citing implementation-specific benchmark numbers or browser bug trackers.

### Additional details

See discussion on the linked issue for the maintainer's framing of what the note should (and shouldn't) say.

### Related issues and pull requests

Fixes #45490