### PR TITLE
Document SDP's role in WebRTC negotiation

### DIFF
--- a/files/en-us/glossary/sdp/index.md
+++ b/files/en-us/glossary/sdp/index.md
@@ -25,6 +25,8 @@ a=rtpmap:32 MPV/90000
 
 SDP is used together with protocols such as {{Glossary("RTP")}} and {{Glossary("RTSP")}}. It is also used by {{Glossary("WebRTC")}} to describe multimedia sessions.
 
+During WebRTC [session negotiation](/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling#session_negotiation), peers exchange offers and answers through a signaling channel. Each offer or answer is a session description containing SDP that describes the proposed connection configuration, as represented by {{domxref("RTCSessionDescription")}}. An application uses {{domxref("RTCPeerConnection.setLocalDescription()")}} to apply its own description and {{domxref("RTCPeerConnection.setRemoteDescription()")}} to apply a description received from the other peer.
+
 ## See also
 
 - {{domxref("RTCSessionDescription")}}


### PR DESCRIPTION
### Description

Adds concise context for how WebRTC uses SDP during session negotiation and links the relevant session-description APIs where they are introduced.

### Motivation

The glossary entry currently says that WebRTC uses SDP but does not explain where it is used or why the linked APIs are relevant. This completes the residual scope identified after #44621 without turning the glossary page into a protocol reference.

### Additional details

The existing definition, sample message, RTP/RTSP relationship, RFC 8866 reference, and WebRTC protocol link remain intact. The target-scoped Rari build, filecheck, Markdownlint, and Prettier checks are required on the exact proposed diff.

### Related issues and pull requests

Fixes #36500
Relates to #44621