### PR TITLE
Fix typos

### DIFF
--- a/files/en-us/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
@@ -143,7 +143,7 @@ Pseudo-elements start with a double colon `::`. `::before` is an example of a ps
 > [!NOTE]
 > Some early pseudo-elements used the single colon syntax, so you may sometimes see this in code or examples. Modern browsers support the early pseudo-elements with single- or double-colon syntax for backwards compatibility.
 
-For example, if you wanted to select the first line of a paragraph you could wrap it in a `<span>` element and use an element selector; however, that would fail if the number of words you had wrapped were longer or shorter than the parent element's width. As we tend not to know how many words will fit on a line — as that will change if the screen width or font-size changes — it is impossible to robustly do this by adding HTML.
+For example, if you wanted to select the first line of a paragraph you could wrap it in a `<span>` element and use an element selector; however, that would fail if the number of words you had wrapped was longer or shorter than the parent element's width. As we tend not to know how many words will fit on a line — as that will change if the screen width or font-size changes — it is impossible to robustly do this by adding HTML.
 
 The `::first-line` pseudo-element selector will do this for you reliably — if the number of words increases or decreases it will still only select the first line.
 

--- a/files/en-us/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
+++ b/files/en-us/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
@@ -143,7 +143,7 @@ Pseudo-elements start with a double colon `::`. `::before` is an example of a ps
 > [!NOTE]
 > Some early pseudo-elements used the single colon syntax, so you may sometimes see this in code or examples. Modern browsers support the early pseudo-elements with single- or double-colon syntax for backwards compatibility.
 
-For example, if you wanted to select the first line of a paragraph you could wrap it in a `<span>` element and use an element selector; however, that would fail if the number of words you had wrapped was longer or shorter than the parent element's width. As we tend not to know how many words will fit on a line — as that will change if the screen width or font-size changes — it is impossible to robustly do this by adding HTML.
+For example, if you wanted to select the first line of a paragraph, you could wrap it in a `<span>` element and use an element selector; however, that would fail if the words you had wrapped were longer or shorter than the parent element's width. As we tend not to know how many words will fit on a line — as that will change if the screen width or font-size changes — it is impossible to robustly do this by adding HTML.
 
 The `::first-line` pseudo-element selector will do this for you reliably — if the number of words increases or decreases it will still only select the first line.
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -67,7 +67,7 @@ canvas specified. The coordinates of the rectangle's top-left corner are
 ### Exceptions
 
 - `IndexSizeError` {{domxref("DOMException")}}
-  - : Thrown if either `sw` or `sh` are zero.
+  - : Thrown if either `sw` or `sh` is zero.
 - `SecurityError` {{domxref("DOMException")}}
   - : The canvas contains or may contain pixels which were loaded from an origin other
     than the one from which the document itself was loaded.

--- a/files/en-us/web/css/guides/cascade/specificity/index.md
+++ b/files/en-us/web/css/guides/cascade/specificity/index.md
@@ -72,7 +72,7 @@ input:focus {
 
 ### Three-column comparison
 
-Once the specificity values of the relevant selectors are determined, the number of selector components in each column are compared, from left to right.
+Once the specificity values of the relevant selectors are determined, the number of selector components in each column is compared, from left to right.
 
 ```css
 #myElement {

--- a/files/en-us/web/javascript/reference/global_objects/atomics/or/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/or/index.md
@@ -37,7 +37,7 @@ The old value at the given position (`typedArray[index]`).
 
 ## Description
 
-The bitwise OR operation yields 1, if either `a` or `b` are 1. The truth table for the OR operation is:
+The bitwise OR operation yields 1, if either `a` or `b` is 1. The truth table for the OR operation is:
 
 | `a` | `b` | `a \| b` |
 | --- | --- | -------- |


### PR DESCRIPTION
### Description

Fixes four subject-verb agreement typos.

- `Cascade/Specificity`: "the number of selector components in each column are compared" → "is compared". The subject is "the number", not "components".
- `Pseudo-classes and pseudo-elements`: "that would fail if the number of words you had wrapped were longer or shorter" → "was longer or shorter".
- `CanvasRenderingContext2D.getImageData()`: "Thrown if either `sw` or `sh` are zero." → "is zero."
- `Atomics.or()`: "The bitwise OR operation yields 1, if either `a` or `b` are 1." → "is 1."

### Motivation

In the first two, "the number of …" is a singular subject and takes a singular verb; the plural noun in between is part of the prepositional phrase. In the last two, `either … or` presents the alternatives one at a time, so the verb agrees with the nearer singular subject.
