### PR TITLE
Remove empty header from Firefox 155 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -133,8 +133,6 @@ No notable changes.
 - Fixed the `browsingContext.reload` command failing when used for frames. ([Firefox bug 2030909](https://bugzil.la/2030909)).
 - Removed support for the `contexts` argument in the `session.unsubscribe` command. From now on, clients can unsubscribe only by event name or subscription ID. ([Firefox bug 1988723](https://bugzil.la/1988723)).
 
-## Changes for add-on developers
-
 ## Experimental web features
 
 These features are shipping in Firefox 155 but are disabled by default.


### PR DESCRIPTION
### Description

Removes empty Add-one section from release notes.

### Motivation

<img width="573" height="1280" alt="IMG_5638" src="https://github.com/user-attachments/assets/ff012a4a-de3a-49e4-9e4a-009738d857c3" />
