### PR TITLE
Clarify Android PWA install support (Firefox adds a shortcut, not a WebAPK)

### DIFF
--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -116,7 +116,7 @@ On desktop:
 
 On mobile:
 
-- On Android, Firefox, Chrome, Edge, Opera, and Samsung Internet Browser all support installing PWAs.
+- On Android, the Chromium-based browsers — Chrome, Edge, Opera, and Samsung Internet Browser — install PWAs as WebAPKs, so they appear in the app drawer and app switcher and behave like platform-specific apps. Firefox for Android instead only adds a home screen shortcut that opens the site in the browser, rather than installing it as a separate app.
 - On iOS 16.3 and earlier, PWAs can only be installed with Safari.
 - On iOS 16.4 and later, PWAs can be installed from the Share menu in Safari, Chrome, Edge, Firefox, and Orion.
 

--- a/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
+++ b/files/en-us/web/progressive_web_apps/guides/making_pwas_installable/index.md
@@ -116,7 +116,9 @@ On desktop:
 
 On mobile:
 
-- On Android, the Chromium-based browsers — Chrome, Edge, Opera, and Samsung Internet Browser — install PWAs as WebAPKs, so they appear in the app drawer and app switcher and behave like platform-specific apps. Firefox for Android instead only adds a home screen shortcut that opens the site in the browser, rather than installing it as a separate app.
+- On Android, the only browsers that [install PWAs as WebAPKs](https://web.dev/learn/pwa/installation#webapks) are: Chrome on devices with Google Mobile Services (GMS), and Samsung Internet on Samsung devices.
+  This gives them a real entry in the app launcher and switcher, and in the system settings.
+  Firefox, Edge, Opera, and other browsers including Chrome on devices where GMS is not present, instead add a browser-badged home-screen shortcut that opens the site in the browser.
 - On iOS 16.3 and earlier, PWAs can only be installed with Safari.
 - On iOS 16.4 and later, PWAs can be installed from the Share menu in Safari, Chrome, Edge, Firefox, and Orion.
 


### PR DESCRIPTION
Fixes #36444.

The *Browser support* section stated that "On Android, Firefox, Chrome, Edge, Opera, and Samsung Internet Browser all support installing PWAs." That overstates Firefox's behavior: only the Chromium-based browsers install a PWA as a WebAPK (it lands in the app drawer / app switcher and behaves like a platform-specific app). Firefox for Android only adds a home-screen **shortcut** that opens the site in the browser — no separate installed app.

This updates the bullet to distinguish the two behaviors.
