### PR TITLE
Do not pair both with as well as

### DIFF
--- a/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
+++ b/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
@@ -79,4 +79,4 @@ If someone wants to donate an article to MDN that they previously published on t
 
 ## Linking to MDN Web Docs articles
 
-We regularly get users asking us questions about how to link to MDN Web Docs and whether or not it is even allowed. The short answer is: **yes, you can link to MDN Web Docs!** Not only is the hypertext link the essence of the web, it is both a way to point your users to valuable resources as well as a show of trust toward the work our community does.
+We regularly get users asking us questions about how to link to MDN Web Docs and whether or not it is even allowed. The short answer is: **yes, you can link to MDN Web Docs!** Not only is the hypertext link the essence of the web, it is both a way to point your users to valuable resources and a show of trust toward the work our community does.

--- a/files/en-us/mdn/writing_guidelines/criteria_for_inclusion/index.md
+++ b/files/en-us/mdn/writing_guidelines/criteria_for_inclusion/index.md
@@ -106,7 +106,7 @@ To ensure that your project for documenting the new technology on MDN Web Docs i
 
 ### Dedicated team
 
-Make sure you have a dedicated team in place that will be there to both write the initial documentation as well as maintain it in future with the required updates.
+Make sure you have a dedicated team in place that will be there to both write the initial documentation and maintain it in future with the required updates.
 
 Have a think about how much work there is and how many people you might need for that.
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -174,7 +174,7 @@ The following checklist is good to keep in mind while writing and reviewing cont
   It's important, then, to ensure that every page has its own content. The following suggestions can help you accomplish that:
   - **Explain more unique concepts**: Consider use cases where there might be more differences than one would think. For instance, in the case of documenting `width` and `height` properties, perhaps write about the ways horizontal space and vertical space are used differently, and provide a discussion about the appropriate concepts. Perhaps you can mention the use of `width` in terms of making room for a sidebar, while using `height` to handle vertical scrolling or footers. Including information about accessibility issues is a useful and important idea as well.
   - **Use different examples**: Examples in these situations are often even more similar than the body text because the examples may use both (or all) of the similar methods or properties to begin with, thereby requiring no real changes when reused. So throw out the example and write a new one, or at least provide multiple examples, with at least some of them different.
-  - **Add descriptions for examples**: Both an overview of what the example does as well as coverage of how it works, in an appropriate level of detail given the complexity of the topic and the target audience, should be included.
+  - **Add descriptions for examples**: Both an overview of what the example does and coverage of how it works, in an appropriate level of detail given the complexity of the topic and the target audience, should be included.
 
   The easiest way to avoid being overly similar is of course to write each article from scratch if time allows.
 

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.md
@@ -23,7 +23,7 @@ If the intrinsic height is not available—either because the image does not spe
 
 ## Examples
 
-This example displays both the natural, density-adjusted size of an image as well as its rendered size as altered by the page's CSS and other factors.
+This example displays both the natural, density-adjusted size of an image and its rendered size as altered by the page's CSS and other factors.
 
 ### HTML
 

--- a/files/en-us/web/api/htmlslotelement/assignedelements/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignedelements/index.md
@@ -12,7 +12,7 @@ The **`assignedElements()`** method of the {{domxref("HTMLSlotElement")}}
 interface returns a sequence of the elements assigned to this slot (and no
 other nodes).
 
-If the `flatten` option is set to `true`, it returns a sequence of both the elements assigned to this slot, as well as the elements assigned to any other slots that are descendants of this slot. If no assigned elements are found, it returns the slot's fallback content.
+If the `flatten` option is set to `true`, it returns a sequence of both the elements assigned to this slot and the elements assigned to any other slots that are descendants of this slot. If no assigned elements are found, it returns the slot's fallback content.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlslotelement/assignednodes/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignednodes/index.md
@@ -10,7 +10,7 @@ browser-compat: api.HTMLSlotElement.assignedNodes
 
 The **`assignedNodes()`** method of the {{domxref("HTMLSlotElement")}} interface returns a sequence of the nodes assigned to this slot.
 
-If the `flatten` option is set to `true`, it returns a sequence of both the nodes assigned to this slot, as well as the nodes assigned to any other slots that are descendants of this slot. If no assigned nodes are found, it returns the slot's fallback content.
+If the `flatten` option is set to `true`, it returns a sequence of both the nodes assigned to this slot and the nodes assigned to any other slots that are descendants of this slot. If no assigned nodes are found, it returns the slot's fallback content.
 
 ## Syntax
 

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -92,7 +92,7 @@ None ({{jsxref("undefined")}}).
 
 To remove a previously-established action handler, call `setActionHandler()` again, specifying `null` as the `callback`.
 
-The action handler receives as input a single parameter: an object which provides both the action type (so the same function can handle multiple action types), as well as data needed in order to perform the action.
+The action handler receives as input a single parameter: an object which provides both the action type (so the same function can handle multiple action types) and data needed in order to perform the action.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/index.md
@@ -156,7 +156,7 @@ Listen to these events using {{domxref("EventTarget.addEventListener", "addEvent
     This indicates whether ICE negotiation has not yet begun (`new`), has begun gathering candidates (`gathering`), or has completed (`complete`).
 - {{domxref("RTCPeerConnection.negotiationneeded_event", "negotiationneeded")}}
   - : Sent when negotiation or renegotiation of the {{Glossary("ICE")}} connection needs to be performed;
-    this can happen both when first opening a connection as well as when it is necessary to adapt to changing network conditions.
+    this can happen both when first opening a connection and when it is necessary to adapt to changing network conditions.
     The receiver should respond by creating an offer and sending it to the other peer.
 - {{domxref("RTCPeerConnection.signalingstatechange_event", "signalingstatechange")}}
   - : Sent when the connection's {{Glossary("ICE")}} signaling state changes.

--- a/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.md
@@ -9,7 +9,7 @@ browser-compat: api.RTCPeerConnection.negotiationneeded_event
 {{APIRef("WebRTC")}}
 
 A **`negotiationneeded`** event is sent to the {{domxref("RTCPeerConnection")}} when negotiation of the connection through the signaling channel is required.
-This occurs both during the initial setup of the connection as well as any time a change to the communication environment requires reconfiguring the connection.
+This occurs both during the initial setup of the connection and any time a change to the communication environment requires reconfiguring the connection.
 
 The `negotiationneeded` event is first dispatched to the {{domxref("RTCPeerConnection")}} when media is first added to the connection. This starts the process of {{Glossary("ICE")}} negotiation by instructing your code to begin exchanging ICE candidates through the signaling server. See [Signaling transaction flow](/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling#signaling_transaction_flow) for a description of the signaling process that begins with a `negotiationneeded` event.
 

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -65,7 +65,7 @@ function startCapture(displayMediaOptions) {
 
 Either way, the {{Glossary("user agent")}} responds by presenting a user interface that prompts the user to choose the screen area to share. Both of these implementations of `startCapture()` return the {{domxref("MediaStream")}} containing the captured display imagery.
 
-See [Options and constraints](#options_and_constraints), below, for more on both how to specify the type of surface you want as well as other ways to adjust the resulting stream.
+See [Options and constraints](#options_and_constraints), below, for more on both how to specify the type of surface you want and other ways to adjust the resulting stream.
 
 ### Example of a window allowing the user to select a display surface to capture
 

--- a/files/en-us/web/api/svganimationelement/beginevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/beginevent_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.SVGAnimationElement.beginEvent_event
 
 The **`beginEvent`** event of the {{domxref("SVGAnimationElement")}} interface is fired when the element local timeline begins to play. It will be raised each time the element begins the active duration (i.e., when it restarts, but not when it repeats).
 
-It may be raised both in the course of normal (i.e., scheduled or interactive) timeline play, as well as in the case that the element was begun with a DOM method.
+It may be raised both in the course of normal (i.e., scheduled or interactive) timeline play and in the case that the element was begun with a DOM method.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/svganimationelement/endevent_event/index.md
+++ b/files/en-us/web/api/svganimationelement/endevent_event/index.md
@@ -11,7 +11,7 @@ browser-compat: api.SVGAnimationElement.endEvent_event
 The **`endEvent`** event of the {{domxref("SVGAnimationElement")}} interface is fired when at the active end of the animation is reached.
 
 > [!NOTE]
-> This event is not raised at the simple end of each animation repeat. This event may be raised both in the course of normal (i.e., scheduled or interactive) timeline play, as well as in the case that the element was ended with a DOM method.
+> This event is not raised at the simple end of each animation repeat. This event may be raised both in the course of normal (i.e., scheduled or interactive) timeline play and in the case that the element was ended with a DOM method.
 
 This event is not cancelable and does not bubble.
 

--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -303,7 +303,7 @@ xrSession.addEventListener("select", (event) => {
 });
 ```
 
-Some actions may send these events very quickly, one after the other. The time that elapses between these events depends on both the hardware apparatus that causes the action as well as the software drivers that interpret the hardware action and turn it into a series of events. Do not presume these events will happen with any particular amount of time between them.
+Some actions may send these events very quickly, one after the other. The time that elapses between these events depends on both the hardware apparatus that causes the action and the software drivers that interpret the hardware action and turn it into a series of events. Do not presume these events will happen with any particular amount of time between them.
 
 For example, if the hardware that causes the primary action to occur is a button, you would receive `selectstart` when the user presses the button, then `select` and `selectend` when the user releases it.
 

--- a/files/en-us/web/http/reference/headers/index.md
+++ b/files/en-us/web/http/reference/headers/index.md
@@ -536,7 +536,7 @@ See the [Topics API](/en-US/docs/Web/API/Topics_API) documentation for more info
 - {{HTTPHeader("X-Forwarded-Proto")}} {{non-standard_inline}}
   - : Identifies the protocol (HTTP or HTTPS) that a client used to connect to your proxy or load balancer.
 - {{HTTPHeader("X-DNS-Prefetch-Control")}} {{non-standard_inline}}
-  - : Controls DNS prefetching, a feature by which browsers proactively perform domain name resolution on both links that the user may choose to follow as well as URLs for items referenced by the document, including images, CSS, JavaScript, and so forth.
+  - : Controls DNS prefetching, a feature by which browsers proactively perform domain name resolution on both links that the user may choose to follow and URLs for items referenced by the document, including images, CSS, JavaScript, and so forth.
 - {{HTTPHeader("X-Robots-Tag")}} {{non-standard_inline}}
   - : The [`X-Robots-Tag`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag) HTTP header is used to indicate how a web page is to be indexed within public search engine results. The header is equivalent to [`<meta name="robots">`](/en-US/docs/Web/HTML/Reference/Elements/meta/name/robots) elements.
 

--- a/files/en-us/web/media/guides/autoplay/index.md
+++ b/files/en-us/web/media/guides/autoplay/index.md
@@ -11,7 +11,7 @@ Autoplay blocking is _not_ applied to {{HTMLElement("video")}} elements when the
 
 ## Autoplay and autoplay blocking
 
-The term **autoplay** refers to any feature that causes media to begin to play without the user specifically requesting that playback begin. This includes both the use of HTML attributes to autoplay media as well as the use of JavaScript code to start playback outside the context of handling user input.
+The term **autoplay** refers to any feature that causes media to begin to play without the user specifically requesting that playback begin. This includes both the use of HTML attributes to autoplay media and the use of JavaScript code to start playback outside the context of handling user input.
 
 That means that both of the following are considered autoplay behavior, and are therefore subject to the browser's autoplay blocking policy:
 


### PR DESCRIPTION
### Description

Replaces `as well as` with `and` in the 15 places where it follows `both`, so each correlative has its proper partner.

Examples:

- `HTMLSlotElement.assignedNodes()`: "a sequence of both the nodes assigned to this slot, as well as the nodes assigned to any other slots" → "both the nodes assigned to this slot and the nodes assigned to any other slots"
- `RTCPeerConnection`: "this can happen both when first opening a connection as well as when it is necessary to adapt" → "both when first opening a connection and when it is necessary to adapt"
- `Media autoplay guide`: "includes both the use of HTML attributes to autoplay media as well as the use of JavaScript code" → "both the use of HTML attributes to autoplay media and the use of JavaScript code"

Lines where `both` already has its own `and` are left alone, because the trailing `as well as` there introduces a genuine third item — for example `XRSystem.requestSession()`'s "both CPU- and GPU-optimized usage, as well as …", and `<img>`'s "both leading and trailing space, as well as …". So are the places where `both` is a plain pronoun or determiner, such as "if `frame-ancestors` and `X-Frame-Options` are both set".

### Motivation

`both` pairs with `and`. Following it with `as well as` states the pairing twice, and the reader has to backtrack to see which items are being joined.
