### PR TITLE
docs: clarify language and direction inheritance in shadow DOM

### DIFF
--- a/files/en-us/web/api/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/api/web_components/using_shadow_dom/index.md
@@ -66,9 +66,22 @@ Before shadow DOM was made available to web developers, browsers were already us
 
 ### Attribute inheritance
 
-Language and text directionality, set using [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) and [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir), are generally inherited from an element's DOM parent. When that parent is a shadow root, inheritance comes from the shadow host instead. Elements within the shadow tree can specify their own language and direction; see the attribute references for details and exceptions.
+Language and text directionality, set using [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) and [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir), are generally inherited from an element's parent node. When that parent is a shadow root, they are inherited from the shadow host instead.
 
-Assigning an element to a {{HTMLElement("slot")}} does not change its DOM parent. When an assigned element inherits language and directionality, it inherits them from its light-DOM parent, not from the slot. The slot itself follows the inheritance rules within the shadow tree, as does its fallback content. For example, a slot without its own `lang` or `dir` attributes inside a shadow-tree element with `lang="ar"` and `dir="rtl"` inherits those settings, while an assigned {{HTMLElement("span")}} without these attributes still inherits from its light-DOM parent.
+Assigning an element to a {{HTMLElement("slot")}} does not change its parent node, so an assigned element inherits from its parent outside the shadow tree, not from the slot. The slot and its fallback content inherit within the shadow tree, like any other element there:
+
+```html
+<div dir="rtl" lang="ar">
+  <!-- my-element's shadow tree:
+    <div dir="ltr" lang="en"><slot></slot></div> -->
+  <my-element><span>Assigned content</span></my-element>
+</div>
+```
+
+The `<span>` matches `:dir(rtl)` and `:lang(ar)`, inherited from the `<div>` containing `<my-element>`. The `<slot>` matches `:dir(ltr)` and `:lang(en)`, inherited from its parent in the shadow tree.
+
+> [!NOTE]
+> CSS inherits the {{cssxref("direction")}} property through the flattened tree, so an assigned element with no `dir` attribute of its own is _rendered_ using the direction in effect at the slot, even though {{cssxref(":dir")}} reports the direction inherited from its parent node.
 
 ## Creating a shadow DOM
 

--- a/files/en-us/web/api/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/api/web_components/using_shadow_dom/index.md
@@ -66,7 +66,9 @@ Before shadow DOM was made available to web developers, browsers were already us
 
 ### Attribute inheritance
 
-The shadow tree and {{ HTMLElement("slot") }} elements inherit the [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir) and [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attributes from their shadow host.
+Language and text directionality, set using [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) and [`dir`](/en-US/docs/Web/HTML/Reference/Global_attributes/dir), are generally inherited from an element's DOM parent. When that parent is a shadow root, inheritance comes from the shadow host instead. Elements within the shadow tree can specify their own language and direction; see the attribute references for details and exceptions.
+
+Assigning an element to a {{HTMLElement("slot")}} does not change its DOM parent. When an assigned element inherits language and directionality, it inherits them from its light-DOM parent, not from the slot. The slot itself follows the inheritance rules within the shadow tree, as does its fallback content. For example, a slot without its own `lang` or `dir` attributes inside a shadow-tree element with `lang="ar"` and `dir="rtl"` inherits those settings, while an assigned {{HTMLElement("span")}} without these attributes still inherits from its light-DOM parent.
 
 ## Creating a shadow DOM
 

--- a/files/en-us/web/html/reference/global_attributes/dir/index.md
+++ b/files/en-us/web/html/reference/global_attributes/dir/index.md
@@ -42,7 +42,7 @@ If unspecified or invalid, the direction is generally [inherited](#inheritance) 
 
 ### Inheritance
 
-If an element has no `dir` attribute, it generally inherits the direction of its [parent element](/en-US/docs/Web/API/Node/parentElement). If no ancestor sets a direction, the default is left-to-right.
+If an element has no `dir` attribute, it generally inherits the direction of its [parent element](/en-US/docs/Web/API/Node/parentElement), or the {{domxref("ShadowRoot/host", "host")}} if the parent node is a {{domxref("ShadowRoot")}}. If no ancestor sets a direction, the default is left-to-right.
 
 There are exceptions:
 

--- a/files/en-us/web/html/reference/global_attributes/lang/index.md
+++ b/files/en-us/web/html/reference/global_attributes/lang/index.md
@@ -10,7 +10,7 @@ sidebar: htmlsidebar
 The **`lang`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user. The attribute contains a single {{glossary("BCP 47 language tag")}}.
 
 > [!NOTE]
-> If the value of `lang` is set to an empty string, the language is explicitly unknown. Therefore, it is recommended to always specify an appropriate value for this attribute.
+> The language is in an unknown state if there's no indication of language anywhere. It is recommended to always specify an appropriate value for this attribute, especially due to [accessibility concerns](#accessibility_concerns).
 
 {{InteractiveExample("HTML Demo: lang", "tabbed-shorter")}}
 
@@ -36,11 +36,17 @@ p::before {
 }
 ```
 
-If the attribute value is the _empty string_ (`lang=""`), the language is set to _unknown_; if the language tag is not valid according to BCP47, it is set to _invalid_.
+## Values
 
-Even if the `lang` attribute is set, it may not be taken into account, as the `xml:lang` attribute has priority.
+The attribute contains a single {{glossary("BCP 47 language tag")}}. If the attribute value is the _empty string_ (`lang=""`), the language is set to _unknown_; if the language tag is not valid according to BCP47, it is set to _invalid_.
+
+If the `xml:lang` attribute is also specified, the HTML spec requires the `lang` and `xml:lang` attributes' values to be equal case-insensitively. The `xml:lang` attribute takes priority.
 
 For the CSS pseudo-class {{cssxref(":lang")}}, two invalid language names are different if their names are different. So while `:lang(es)` matches both `lang="es-ES"` and `lang="es-419"`, `:lang(xyzzy)` would _not_ match `lang="xyzzy-Zorp!"`.
+
+### Inheritance
+
+If an element has no `lang` or `xml:lang` attribute, it inherits the language of its [parent element](/en-US/docs/Web/API/Node/parentElement), or the {{domxref("ShadowRoot/host", "host")}} if the parent node is a {{domxref("ShadowRoot")}}. If no ancestor sets a language, the language can also be specified by [`<meta http-equiv="content-language">`](/en-US/docs/Web/HTML/Reference/Elements/meta/http-equiv#content-language) or the HTTP {{HTTPHeader("Content-Language")}} header. If no single content language can be determined from these cues, the default is the empty string (with _unknown_ as the content language).
 
 ## Accessibility concerns
 
@@ -150,10 +156,6 @@ For example, the language menu on this site (MDN) includes a **`lang`** attribut
   </ul>
 </div>
 ```
-
-## Inheritance
-
-If an element has no `lang` attribute, it will inherit the `lang` value set on its [parent node](/en-US/docs/Glossary/Node/DOM), which in turn may inherit it from its parent, and so on.
 
 ## Specifications
 


### PR DESCRIPTION
### Description

Clarify the existing Attribute inheritance section in the Using shadow DOM guide. Explain parent-based inheritance across a shadow boundary and distinguish a slot's inheritance from that of its assigned light-DOM content.

### Motivation

The current sentence implies that every slot inherits language and directionality directly from the shadow host, overlooking intervening shadow-tree ancestors. The replacement adds a short nested-slot example and retains qualifications and reference links for directionality exceptions, following the [invitation to propose a focused update](https://github.com/mdn/content/issues/45249#issuecomment-5555033430).

### Additional details

The wording follows the HTML Standard's [language rules](https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes) and [parent directionality algorithm](https://html.spec.whatwg.org/multipage/dom.html#parent-directionality), together with the DOM Standard's [slot assignment rules](https://dom.spec.whatwg.org/#assign-slottables).

Validation:

- Changed-file Markdown, Prettier, front-matter, spelling and cross-reference checks passed.
- `npm test`: 12 passed, 0 failed.
- Changed-page Rari build and Fred SSR passed with no reported page issues.
- Local rendered page checked at 1440px and 390px: both paragraphs and links rendered correctly, without horizontal overflow.
- A Chromium experiment checked `:lang()`, `:dir()`, DOM parents and explicit attributes separately for nested slots, fallback content, assigned spans, explicit overrides, and directionality exceptions (`bdi` and telephone inputs).

This is a one-file prose correction: no runtime, dependency or anchor changes. No cross-browser or assistive-technology testing is claimed.

AI assistance: Codex assisted with research, wording, validation and a separate exact-commit review.

### Related issues and pull requests

Fixes #45249
