### PR TITLE
Clarify that const requires an initializer

### DIFF
--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -65,14 +65,20 @@ Comments behave like whitespace, and are discarded during script execution.
 
 ## Declarations
 
-JavaScript has three kinds of variable declarations.
+JavaScript has five kinds of variable declarations.
 
 - {{jsxref("Statements/var", "var")}}
   - : Declares a variable, optionally initializing it to a value.
 - {{jsxref("Statements/let", "let")}}
-  - : Declares a block-scoped, local variable, optionally initializing it to a value.
+  - : Declares a block-scoped variable, optionally initializing it to a value.
 - {{jsxref("Statements/const", "const")}}
-  - : Declares a block-scoped, read-only named constant.
+  - : Declares a block-scoped variable that cannot be re-assigned, which must be initialized at declaration.
+- {{jsxref("Statements/using", "using")}}
+  - : Declares a variable like `const` that is _synchronously disposed_.
+- {{jsxref("Statements/await_using", "await using")}}
+  - : Declares a variable like `const` that is _asynchronously disposed_.
+
+We will only talk about the first three: `var`, `let`, and `const`, in this article. The `using` and `await using` declarations will be introduced in [Resource management](/en-US/docs/Web/JavaScript/Guide/Resource_management).
 
 ### Variables
 

--- a/files/en-us/web/javascript/reference/statements/index.md
+++ b/files/en-us/web/javascript/reference/statements/index.md
@@ -34,13 +34,13 @@ For an alphabetical listing see the sidebar on the left.
 - {{jsxref("Statements/var", "var")}}
   - : Declares a variable, optionally initializing it to a value.
 - {{jsxref("Statements/let", "let")}}
-  - : Declares a block scope local variable, optionally initializing it to a value.
+  - : Declares a block-scoped variable, optionally initializing it to a value.
 - {{jsxref("Statements/const", "const")}}
-  - : Declares a read-only named constant, and must be initialized at declaration.
+  - : Declares a block-scoped variable that cannot be re-assigned, which must be initialized at declaration.
 - {{jsxref("Statements/using", "using")}}
-  - : Declares local variables that are _synchronously disposed_.
+  - : Declares a variable like `const` that is _synchronously disposed_.
 - {{jsxref("Statements/await_using", "await using")}}
-  - : Declares local variables that are _asynchronously disposed_.
+  - : Declares a variable like `const` that is _asynchronously disposed_.
 
 ### Functions and classes
 

--- a/files/en-us/web/javascript/reference/statements/index.md
+++ b/files/en-us/web/javascript/reference/statements/index.md
@@ -36,7 +36,7 @@ For an alphabetical listing see the sidebar on the left.
 - {{jsxref("Statements/let", "let")}}
   - : Declares a block scope local variable, optionally initializing it to a value.
 - {{jsxref("Statements/const", "const")}}
-  - : Declares a read-only named constant.
+  - : Declares a read-only named constant, and must be initialized at declaration.
 - {{jsxref("Statements/using", "using")}}
   - : Declares local variables that are _synchronously disposed_.
 - {{jsxref("Statements/await_using", "await using")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->
<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->
### Description
Clarifies that `const` requires an initializer at declaration time, unlike `var` and `let`, where initialization is optional.

### Motivation
The "Declaring variables" section lists `var`, `let`, and `const` with parallel one-line summaries. `var` and `let` both explicitly state that initializing them is optional, but the `const` entry omitted the fact that its initializer is *mandatory* — attempting to declare `const` without one (`const x;`) throws a `SyntaxError` at parse time. This is an asymmetry readers could easily miss given the otherwise-parallel phrasing of the three entries, so this PR brings `const`'s description in line with the precision already given to `var`/`let`.

### Additional details
Per the ECMAScript specification (§14.3.1.1, Early Errors for `LexicalDeclaration`): a `LexicalBinding` with no `Initializer` is a Syntax Error whenever the declaration `IsConstantDeclaration` — i.e., specifically for `const`, not `let`.
https://tc39.es/ecma262/#sec-let-and-const-declarations-static-semantics-early-errors

### Related issues and pull requests
<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->