### PR TITLE
Update index.md, added QUIC mdn-glossary link

### DIFF
--- a/files/en-us/web/api/webtransport_api/index.md
+++ b/files/en-us/web/api/webtransport_api/index.md
@@ -11,7 +11,7 @@ The **WebTransport API** provides a modern update to {{domxref("WebSockets API",
 
 ## Concepts and usage
 
-[HTTP/3](https://en.wikipedia.org/wiki/HTTP/3) has been in progress since 2018. It is based on Google's QUIC protocol (which is itself based on UDP), and fixes several issues around the classic TCP protocol, on which HTTP and WebSockets are based.
+[HTTP/3](https://en.wikipedia.org/wiki/HTTP/3) has been in progress since 2018. It is based on Google's {{glossary("QUIC", "QUIC")}} protocol (which is itself based on UDP), and fixes several issues around the classic TCP protocol, on which HTTP and WebSockets are based.
 
 These include:
 


### PR DESCRIPTION
### Description

added link to "QUIC" to direct to https://developer.mozilla.org/en-US/docs/Glossary/QUIC

### Motivation

For us readers to be able to faster access important MDN pages