### PR TITLE
fix(PerformanceResourceTiming): clarify startTime is not always fetchStart

### DIFF
--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -38,7 +38,7 @@ The meaning of this property depends on the value of this performance entry's {{
 - `paint`
   - : The time when the paint occurred.
 - `resource`
-  - : The value of this entry's {{domxref("PerformanceResourceTiming.fetchStart", "fetchStart")}} property.
+  - : The time the resource fetch started, including redirects. If there are no HTTP redirects or their timing information is not exposed, this value is equivalent to {{domxref("PerformanceResourceTiming.fetchStart")}}. Otherwise, this value can be earlier than `fetchStart`.
 - `taskattribution`
   - : Always `0`.
 - `visibility-state`

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -10,7 +10,7 @@ browser-compat: api.PerformanceResourceTiming.fetchStart
 
 The **`fetchStart`** read-only property represents a {{domxref("DOMHighResTimeStamp","timestamp")}} immediately before the browser starts to fetch the resource.
 
-If there are HTTP redirects, the property returns the time immediately before the user agent starts to fetch the final resource in the redirection.
+If there are no HTTP redirects or their timing information is not exposed, this value is equivalent to {{domxref("PerformanceEntry.startTime")}}. Otherwise, this value can be later than `startTime`.
 
 Unlike many other `PerformanceResourceTiming` properties, the `fetchStart` property is available for cross-origin requests without the need of the {{HTTPHeader("Timing-Allow-Origin")}} HTTP response header.
 

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -62,7 +62,7 @@ This interface extends the following {{domxref("PerformanceEntry")}} properties 
 - {{domxref("PerformanceEntry.name")}} {{ReadOnlyInline}}
   - : Returns the resource's URL.
 - {{domxref("PerformanceEntry.startTime")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("DOMHighResTimeStamp","timestamp")}} for the time a resource fetch started. If there are no HTTP redirects, this value is equivalent to {{domxref("PerformanceResourceTiming.fetchStart")}}. If there are HTTP redirects, this value is the time the first fetch in the redirection started, whereas `fetchStart` returns the time immediately before the user agent starts to fetch the final resource in the redirection.
+  - : Returns the {{domxref("DOMHighResTimeStamp","timestamp")}} for the time a resource fetch started. If there are no HTTP redirects or their timing information is not exposed, this value is equivalent to {{domxref("PerformanceResourceTiming.fetchStart")}}. Otherwise, this value can be earlier than `fetchStart`.
 
 ### Timestamps
 
@@ -77,7 +77,7 @@ The interface supports the following timestamp properties which you can see in t
 - {{domxref('PerformanceResourceTiming.workerStart')}} {{ReadOnlyInline}}
   - : Returns a {{domxref("DOMHighResTimeStamp")}} immediately before dispatching the {{domxref("FetchEvent")}} if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running. If the resource is not intercepted by a Service Worker the property will always return 0.
 - {{domxref('PerformanceResourceTiming.fetchStart')}} {{ReadOnlyInline}}
-  - : A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts to fetch the resource.
+  - : A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts to fetch the resource. If there are no HTTP redirects or their timing information is not exposed, this value is equivalent to {{domxref("PerformanceEntry.startTime")}}. Otherwise, this value can be later than `startTime`.
 - {{domxref('PerformanceResourceTiming.domainLookupStart')}} {{ReadOnlyInline}}
   - : A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts the domain name lookup for the resource.
 - {{domxref('PerformanceResourceTiming.domainLookupEnd')}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -62,7 +62,7 @@ This interface extends the following {{domxref("PerformanceEntry")}} properties 
 - {{domxref("PerformanceEntry.name")}} {{ReadOnlyInline}}
   - : Returns the resource's URL.
 - {{domxref("PerformanceEntry.startTime")}} {{ReadOnlyInline}}
-  - : Returns the {{domxref("DOMHighResTimeStamp","timestamp")}} for the time a resource fetch started. This value is equivalent to {{domxref("PerformanceResourceTiming.fetchStart")}}.
+  - : Returns the {{domxref("DOMHighResTimeStamp","timestamp")}} for the time a resource fetch started. If there are no HTTP redirects, this value is equivalent to {{domxref("PerformanceResourceTiming.fetchStart")}}. If there are HTTP redirects, this value is the time the first fetch in the redirection started, whereas `fetchStart` returns the time immediately before the user agent starts to fetch the final resource in the redirection.
 
 ### Timestamps
 


### PR DESCRIPTION
### Description

The `PerformanceEntry.startTime` bullet on the `PerformanceResourceTiming` page stated that the value is equivalent to `PerformanceResourceTiming.fetchStart`. It now explains that the two are equal only when there are no HTTP redirects.

### Motivation

The claim contradicted the timestamp diagram directly below it, which places `startTime` before the redirect phase and `fetchStart` after it. Readers had no way to tell which one was right.

Per the Resource Timing spec, a resource entry's `startTime` comes from the fetch timing info's start time, while `fetchStart` returns the post-redirect start time, so the values diverge as soon as a redirect is involved. The new text reuses the redirect caveat already documented on the `fetchStart` subpage.

### Additional details

- Spec: https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-fetchstart ("The `fetchStart` getter steps are to convert fetch timestamp for this's timing info's post-redirect start time")
- Existing wording reused from `files/en-us/web/api/performanceresourcetiming/fetchstart/index.md`

### Related issues and pull requests

Fixes #43903
