### PR TITLE
Update disposition to enforce when using content-security-policy

### DIFF
--- a/files/en-us/web/http/reference/headers/content-security-policy/report-uri/index.md
+++ b/files/en-us/web/http/reference/headers/content-security-policy/report-uri/index.md
@@ -121,7 +121,7 @@ A browser capable of enforcing CSP would send the following violation report as 
 {
   "csp-report": {
     "blocked-uri": "http://example.com/css/style.css",
-    "disposition": "report",
+    "disposition": "enforce",
     "document-uri": "http://example.com/signup.html",
     "effective-directive": "style-src-elem",
     "original-policy": "default-src 'none'; style-src cdn.example.com; report-uri /_/csp-reports",


### PR DESCRIPTION
The docs are using a "report" value for the "disposition" key in the csp-report payload for both content-security-policy and content-security-policy-report-only headers.

### Description
When using "content-security-policy-report-only" the disposition value will be "report"; but when using "content-security-policy" the asset will be blocked and the disposition value should be "enforce".

### Motivation
Showing the correct value. Now it's confusing when reading these examples.

### Additional details
- https://www.w3.org/TR/CSP3/#content-security-policy-object-disposition
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/report-uri#examples