### PR TITLE
Fix layout containment live sample so the float overlaps card 3 in all browsers

### DIFF
--- a/files/en-us/web/css/reference/properties/contain/index.md
+++ b/files/en-us/web/css/reference/properties/contain/index.md
@@ -231,6 +231,7 @@ div {
 
 .float {
   float: left;
+  height: 40px;
   margin: 10px;
   background: aquamarine;
 }


### PR DESCRIPTION
### Description

The [Layout containment](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/contain#layout_containment) section says:

> A float overlaps the second card's bounds causing the third card to have unexpected layout shift that's visible in the positioning of the `<h2>` element.

That shift only appears in Firefox.

`.float` has no explicit `height`, so its height is one line of text in the browser's default font plus fixed padding and margins. Card 3's heading moves only if the float escaping card 2 reaches it. As authored the float stops within about a pixel or so of it and that difference in float height between engines is enough to decide the outcome.

This PR adds an explicit `height` to `.float` so the overlap no longer depends on font metrics:

```diff
 .float {
   float: left;
+  height: 40px;
   margin: 10px;
   background: aquamarine;
 }
```

### Motivation

The live sample doesn't demonstrate what the prose describes. In Chrome and Safari card 3's heading isn't shifted at all, so the point of the example isn't visible.

Measured on macOS 26, before and after:

| Browser | Heading displaced (before) | `.float` height (before) | Heading displaced (after) | `.float` height (after) |
| --- | --- | --- | --- | --- |
| Firefox 155.0.1 | yes | 47.2px | yes | 52px |
| Chrome 152.0.7977.76 | no | 46.5px | yes | 52px |
| Safari 26.6.2 | no | 46px | yes | 52px |
| Safari TP 251 | no | 46px | yes | 52px |

### Additional details

I chose 40px to put the result well clear of the boundary rather than just past it. I checked that it still fits the `EmbedLiveSample` height of 350, so that argument is unchanged.

Screenshots below, both Safari: before (no shift) and after (heading indented).

<img width="1440" height="900" alt="before-safari" src="https://github.com/user-attachments/assets/e6907d13-317f-42a7-9a6d-dbf4842b9e14" />
<img width="1440" height="900" alt="after-safari" src="https://github.com/user-attachments/assets/f0dc6ff3-1a58-4b05-b6e4-e656e24e68ef" />

### Related issues and pull requests

None
