### PR TITLE
Update reset and position-anchor:auto information relating to implicit anchor association

### DIFF
--- a/files/en-us/web/api/popover_api/using/index.md
+++ b/files/en-us/web/api/popover_api/using/index.md
@@ -477,13 +477,13 @@ Or you could use a {{cssxref("position-area")}} property:
 
 ```css
 .my-popover {
-  margin: 0;
-  inset: auto;
   position-area: top;
 }
 ```
 
-When using {{cssxref("position-area")}} or {{cssxref("anchor()")}} to position popovers, be aware that [the default styles for popovers](https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3:~:text=%5Bpopover%5D%20%7B) may conflict with the position you're trying to achieve. The usual culprits are the default styles for `margin` and `inset`, so it's advisable to reset those, as in the examples above. The CSS working group is [looking at ways to avoid requiring this workaround](https://github.com/w3c/csswg-drafts/issues/10258).
+When using {{cssxref("anchor()")}} to position popovers, be aware that [the default styles for popovers](https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3:~:text=%5Bpopover%5D%20%7B) may conflict with the position you're trying to achieve. The usual culprits are the default styles for `margin` and `inset`, so it's advisable to reset those, as shown in the first example in this section.
+
+This is not an issue with popovers positioned with {{cssxref("position-area")}} because the used value of `auto` [inset](/en-US/docs/Glossary/Inset_properties) and {{cssxref("margin")}} properties resolves to `0` on any element that has a `position-area` value set other than `none`. This is also the case with boxes positioned with `anchor-center`, provided the box is absolutely-positioned. However, because `anchor-center` values are often used along with `anchor()` values, you'll probably still need the resets in these situations.
 
 See [Using CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning/Using#positioning_elements_relative_to_their_anchor) for more details on associating anchor and positioned elements, and positioning elements relative to their anchor.
 

--- a/files/en-us/web/api/popover_api/using/index.md
+++ b/files/en-us/web/api/popover_api/using/index.md
@@ -460,14 +460,15 @@ There is another useful positioning option that the Popover API provides. If you
 
 [Associating any kind of popover with its invoker](#other_ways_to_set_up_a_popover-invoker_relationship) creates an implicit anchor reference between the two. This causes the invoker to become the popover's **anchor element**, meaning that you can position the popover relative to it using [CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning).
 
-Because the association between the popover and the invoker is implicit, an explicit association does not need to be made using the {{cssxref("anchor-name")}} and {{cssxref("position-anchor")}} properties. However, you still need to specify the positioning CSS.
+Because the association between the popover and the invoker is implicit, you do not need to name the anchor using {{cssxref("anchor-name")}}. The implicit anchor is adopted automatically when you position the popover with {{cssxref("position-area")}}. However, if you position it using {{cssxref("anchor()")}} or `anchor-center`, `position-anchor: auto` is required to opt in. The initial value of {{cssxref("position-anchor")}} is `normal`, which behaves as `none` while `position-area` is `none`.
 
-For example, you could use a combination of {{cssxref("anchor()")}} function values set on {{glossary("inset properties")}}, and `anchor-center` values set on alignment properties:
+For example, you could use a combination of an `anchor()` function value set on an {{glossary("inset properties","inset property")}}, and an `anchor-center` value set on an alignment property:
 
 ```css
 .my-popover {
   margin: 0;
   inset: auto;
+  position-anchor: auto;
   bottom: calc(anchor(top) + 20px);
   justify-self: anchor-center;
 }
@@ -488,10 +489,10 @@ This is not an issue with popovers positioned with {{cssxref("position-area")}} 
 See [Using CSS anchor positioning](/en-US/docs/Web/CSS/Guides/Anchor_positioning/Using#positioning_elements_relative_to_their_anchor) for more details on associating anchor and positioned elements, and positioning elements relative to their anchor.
 
 > [!NOTE]
-> For an example that uses this implicit association, see our [popover hint demo](https://mdn.github.io/dom-examples/popover-api/popover-hint/) ([source](https://github.com/mdn/dom-examples/tree/main/popover-api/popover-hint)). If you check out the CSS code, you'll see that no explicit anchor associations are made using the {{cssxref("anchor-name")}} and {{cssxref("position-anchor")}} properties.
+> For an example that uses this implicit association, see our [popover hint demo](https://mdn.github.io/dom-examples/popover-api/popover-hint/) ([source](https://github.com/mdn/dom-examples/tree/main/popover-api/popover-hint)). If you check out the CSS code, you'll see implicit association examples using both `position-area` and `anchor()`/`anchor-center`.
 
 > [!NOTE]
-> If you want to remove the implicit anchor reference to stop the popover from being anchored to its invoker, you can do so by setting the `position-anchor` property of the popover to an anchor name that doesn't exist in the current document, such as `--not-an-anchor-name`. See also [removing an anchor association](/en-US/docs/Web/CSS/Guides/Anchor_positioning/Using#removing_an_anchor_association).
+> If you want to remove the implicit anchor reference to stop the popover from being anchored to its invoker, you can do so by setting the `position-anchor` property of the popover to `none`, or to an anchor name that doesn't exist in the current document, such as `--not-an-anchor-name`. See also [removing an anchor association](/en-US/docs/Web/CSS/Guides/Anchor_positioning/Using#removing_an_anchor_association).
 
 ## Animating popovers
 

--- a/files/en-us/web/css/guides/anchor_positioning/using/index.md
+++ b/files/en-us/web/css/guides/anchor_positioning/using/index.md
@@ -100,6 +100,9 @@ In some cases, an implicit anchor reference will be made between two elements, d
 - A {{htmlelement("select")}} element and its dropdown picker are opted into [customizable select element](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select) functionality via the {{cssxref("appearance")}} property `base-select` value. In this case, an implicit popover-invoker relationship is created between the two, which also means they'll have an implicit anchor reference.
 
 > [!NOTE]
+> See [Popover anchor positioning](/en-US/docs/Web/API/Popover_API/Using#popover_anchor_positioning) for more information on positioning elements relative to their implicit anchors.
+
+> [!NOTE]
 > The methods above associate an anchor with an element, but they are not yet tethered. To tether them together, the positioned element needs to be positioned relative to its anchor, which is done with CSS.
 
 ### Removing an anchor association
@@ -360,6 +363,9 @@ This gives us the following result:
 {{ EmbedLiveSample("`anchor()` example", "100%", "250") }}
 
 The positioned element is `5px` below and `5px` to the right of the anchor element. If you scroll the document up and down, the positioned element maintains its position relative to the anchor element — it is fixed to the anchor element, not the viewport.
+
+> [!NOTE]
+> When positioning elements relative to [implicit anchors](#implicit_anchor_association) using `anchor()`, some additional steps are required, such as resetting default positioning property values, and setting `position-anchor: auto` to opt-in to the implicit association. See [Popover anchor positioning](/en-US/docs/Web/API/Popover_API/Using#popover_anchor_positioning) for more information.
 
 ### Setting a `position-area`
 

--- a/files/en-us/web/css/reference/properties/position-anchor/index.md
+++ b/files/en-us/web/css/reference/properties/position-anchor/index.md
@@ -59,6 +59,8 @@ To cancel a previously-made association between an anchor-positioned element and
 
 To tether a positioned element to its anchor, it must be placed relative to an anchor element using an anchor positioning feature, such as the {{cssxref("anchor()")}} function (set as a value on {{glossary("inset properties")}}) or the {{cssxref("position-area")}} property.
 
+When positioning elements relative to [implicit anchors](/en-US/docs/Web/CSS/Guides/Anchor_positioning/Using#implicit_anchor_association) using `anchor()`, set `position-anchor: auto` on the anchor-positioned element to opt-in to the implicit association. See [Popover anchor positioning](/en-US/docs/Web/API/Popover_API/Using#popover_anchor_positioning) for more information.
+
 If the associated anchor is hidden, for example with {{cssxref("display", "display: none")}} or {{cssxref("visibility", "visibility: hidden")}}, or if it is part of the [skipped contents](/en-US/docs/Web/CSS/Guides/Containment/Using#skips_its_contents) of another element due to it having {{cssxref("content-visibility", "content-visibility: hidden")}} set on it, the anchor positioned element will not be displayed.
 
 The `position-anchor` property is supported on all elements that are positioned, including [pseudo-elements](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements) like {{cssxref("::before")}} and {{cssxref("::after")}}. Pseudo elements are implicitly anchored to the same element as the pseudo-element's originating element, unless otherwise specified.

--- a/files/en-us/web/css/reference/properties/position-area/index.md
+++ b/files/en-us/web/css/reference/properties/position-area/index.md
@@ -118,16 +118,9 @@ If the positioned element is placed in any other single grid square (say with `p
 
 ### Using `position-area` to position popovers
 
-When using `position-area` to position [popovers](/en-US/docs/Web/HTML/Reference/Global_attributes/popover), be aware that [the default styles for popovers](https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3:~:text=%5Bpopover%5D%20%7B) may conflict with the position you're trying to achieve. The usual culprits are the default styles for `margin` and `inset`, so it's advisable to reset those:
+When using `position-area` to position [popovers](/en-US/docs/Web/HTML/Reference/Global_attributes/popover), be aware that the used value of `auto` [inset](/en-US/docs/Glossary/Inset_properties) and {{cssxref("margin")}} properties resolves to `0` on any element that has a `position-area` value set other than `none`. This means that the [the default styles for popovers](https://html.spec.whatwg.org/multipage/rendering.html#flow-content-3:~:text=%5Bpopover%5D%20%7B) will not conflict with the position you are trying to set via `position-area`.
 
-```css
-.my-popover {
-  margin: 0;
-  inset: auto;
-}
-```
-
-The CSS working group is [looking at ways to avoid requiring this workaround](https://github.com/w3c/csswg-drafts/issues/10258).
+This is not the case with the {{cssxref("anchor()")}} function — see [Using `anchor()` to position popovers](/en-US/docs/Web/CSS/Reference/Values/anchor#using_anchor_to_position_popovers).
 
 ## Formal definition
 

--- a/files/en-us/web/css/reference/values/anchor/index.md
+++ b/files/en-us/web/css/reference/values/anchor/index.md
@@ -143,8 +143,6 @@ When using `anchor()` to position [popovers](/en-US/docs/Web/HTML/Reference/Glob
 }
 ```
 
-The CSS working group is [looking at ways to avoid requiring this workaround](https://github.com/w3c/csswg-drafts/issues/10258).
-
 ### Using `anchor()` inside `calc()`
 
 When the `anchor()` function refers to a side of the default anchor, you can include a {{cssxref("margin")}} to create spacing between the edges of the anchor and the positioned element as needed. Alternatively, you can include the `anchor()` function within a {{cssxref("calc")}} function to add spacing.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

In our docs, we've included information about having to reset the default values set on popover elements, such as inset and margin property values, so that they don't break attempts to position popovers using `anchor()`/`position-area`/`anchor-center`.

However, as per https://github.com/mdn/content/issues/45515, the default behavior has been updated so that the need for these resets is avoided, except for the `anchor()` cases. In addition, https://github.com/mdn/content/issues/45514 points out that `position-anchor: auto` is needed to opt-in to the association, in the `anchor()` cases.

This PR attempts to update our information so that it is no longer out of date.

I wrote some quick demos to test the updated behavior:

- `anchor()`: https://codepen.io/editor/Chris-Mills/pen/01a07b77-d3a7-7f58-b78a-3265437f0047
- `position-area`: https://codepen.io/editor/Chris-Mills/pen/01a07b9e-73d6-75a9-a056-c5b91edadcb4
- `anchor-center`: https://codepen.io/editor/Chris-Mills/pen/01a07b83-0beb-74da-b0c1-cf4f5f566331

<s>Note: Another thing I noticed — even though popovers and their control buttons are meant to have implicit association, meaning that you shouldn't need to associate them with `anchor-name`/`position-anchor`, it seems like I needed to set `position-anchor: auto` in cases where I was doing resets to make the anchor positioning work. I was surprised by this, and I'm not 100% sure what I should say about it in the docs. This is maybe something @mfreed7 could advise me on.</s> -- Update: I've now read the other issue and am now clear on what is going on here. I will fix both in this PR ;-)

See also https://github.com/mdn/dom-examples/pull/396 for a related demo fix.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Fixes https://github.com/mdn/content/issues/45515
Fixes https://github.com/mdn/content/issues/45514

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
