### PR TITLE
fix(api): use `jsxref` instead of `domxref` for JavaScript references

### DIFF
--- a/files/en-us/web/api/prompt_api/multimodal/index.md
+++ b/files/en-us/web/api/prompt_api/multimodal/index.md
@@ -48,7 +48,7 @@ The Prompt API accepts several different formats for audio and image data:
 
 - Audio:
   - {{domxref("AudioBuffer")}}
-  - {{domxref("ArrayBufferView")}}
+  - {{jsxref("TypedArray")}}
   - {{jsxref("ArrayBuffer")}}
   - {{domxref("Blob")}}
 - Image:

--- a/files/en-us/web/api/view_transition_api/using/index.md
+++ b/files/en-us/web/api/view_transition_api/using/index.md
@@ -30,7 +30,7 @@ Let's walk through the process by which a view transition works:
    At this point, the view transition is about to run, and the {{domxref("ViewTransition.ready")}} promise fulfills, allowing you to respond by running a custom JavaScript animation instead of the default, for example.
 
 5. The old snapshots animate "out", while the new snapshots animate "in". By default, the old snapshots animate from {{cssxref("opacity")}} 1 to 0, and the new snapshots animate from `opacity` 0 to 1, which creates a cross-fade.
-6. When the transition animations have reached their end states, the snapshots are destroyed, and the {{domxref("ViewTransition.finished")}} promise fulfills, allowing you to respond. If needed, you can delay a view transition from reaching its finished state until a specified {{domxref("Promise")}} is resolved using the {{domxref("ViewTransition.waitUntil()")}} method.
+6. When the transition animations have reached their end states, the snapshots are destroyed, and the {{domxref("ViewTransition.finished")}} promise fulfills, allowing you to respond. If needed, you can delay a view transition from reaching its finished state until a specified {{jsxref("Promise")}} is resolved using the {{domxref("ViewTransition.waitUntil()")}} method.
 
 > [!NOTE]
 > If the document's [page visibility state](/en-US/docs/Web/API/Page_Visibility_API) is `hidden` (for example if the document is obscured by a window, the browser is minimized, or another browser tab is active) during a {{domxref("Document.startViewTransition()", "document.startViewTransition()")}} call, the view transition is skipped entirely.

--- a/files/en-us/web/api/xrvisibilitymaskchangeevent/indices/index.md
+++ b/files/en-us/web/api/xrvisibilitymaskchangeevent/indices/index.md
@@ -16,7 +16,7 @@ The number of contained values should therefore be a multiple of three. See {{do
 
 ## Value
 
-A {{domxref("Uint32Array")}}.
+A {{jsxref("Uint32Array")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/xrvisibilitymaskchangeevent/vertices/index.md
+++ b/files/en-us/web/api/xrvisibilitymaskchangeevent/vertices/index.md
@@ -14,7 +14,7 @@ The read-only **`vertices`** property of the {{domxref("XRVisibilityMaskChangeEv
 
 ## Value
 
-A {{domxref("Float32Array")}}.
+A {{jsxref("Float32Array")}}.
 
 ## Description
 

--- a/files/en-us/web/api/xrvisibilitymaskchangeevent/xrvisibilitymaskchangeevent/index.md
+++ b/files/en-us/web/api/xrvisibilitymaskchangeevent/xrvisibilitymaskchangeevent/index.md
@@ -29,7 +29,7 @@ new XRVisibilityMaskChangeEvent(type, options)
     - `index`
       - : The index of the current {{domxref("XRView")}} in the {{domxref("XRViewerPose.views")}} array.
     - `indices`
-      - : A {{domxref("Uint32Array")}} of values specifying the index position of each coordinate pair (not individual array index) inside the [`vertices`](#vertices) array that define the triangles used to draw the currently visible part of the scene displayed in the {{domxref("XRView")}}.
+      - : A {{jsxref("Uint32Array")}} of values specifying the index position of each coordinate pair (not individual array index) inside the [`vertices`](#vertices) array that define the triangles used to draw the currently visible part of the scene displayed in the {{domxref("XRView")}}.
     - `session`
       - : The {{domxref("XRSession")}} to which the event belongs.
     - `vertices`

--- a/files/en-us/web/api/xrvisibilitymaskchangeevent/xrvisibilitymaskchangeevent/index.md
+++ b/files/en-us/web/api/xrvisibilitymaskchangeevent/xrvisibilitymaskchangeevent/index.md
@@ -33,7 +33,7 @@ new XRVisibilityMaskChangeEvent(type, options)
     - `session`
       - : The {{domxref("XRSession")}} to which the event belongs.
     - `vertices`
-      - : A {{domxref("Float32Array")}} of coordinates representing the set of possible coordinate values that may be used in a visibility mask. If this array is empty, the whole region of the `XRView` will be drawn.
+      - : A {{jsxref("Float32Array")}} of coordinates representing the set of possible coordinate values that may be used in a visibility mask. If this array is empty, the whole region of the `XRView` will be drawn.
 
 ### Return value
 


### PR DESCRIPTION
### Description

Use `jsxref` instead of `domxref` for JavaScript references in Web API pages, with one commit per replaced argument:

| `domxref` | `jsxref` | Occurrences |
| --- | --- | --: |
| `ArrayBufferView` | `TypedArray` | 1 |
| `Float32Array` | `Float32Array` | 2 |
| `Promise` | `Promise` | 1 |
| `Uint32Array` | `Uint32Array` | 2 |

### Motivation

Ensure these references link to their JavaScript reference pages directly. The `Web/API` URLs they used either redirect there or do not exist at all.

### Additional details

Renamed arguments also update the rendered link text: `ArrayBufferView` becomes `TypedArray`.

### Related issues and pull requests

Part of mdn/fred#1462.
