### PR TITLE
Revise nested promise example in allSettledKeyed docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/allsettledkeyed/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/allsettledkeyed/index.md
@@ -74,9 +74,7 @@ console.log(result);
 // {
 //   a: { status: "fulfilled", value: "a" },
 //   [sym]: { status: "fulfilled", value: "symbol" },
-//   nested: {
-//     b: <Promise>,
-//   },
+//   nested: { status: "fulfilled", value: { b: <Promise> } },
 // }
 ```
 


### PR DESCRIPTION


### Description

Updated the example output for nested promises in the allSettledKeyed documentation.


### Motivation

is was incorrect

### Additional details

you can run example code in Firefox 155

<img width="574" height="342" alt="Screenshot 2026-09-07 at 19 24 15" src="https://github.com/user-attachments/assets/8147440d-7122-4018-8fef-a1546cacbeb6" />


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
