### PR TITLE
Bug 2067229 alarms.clearAll returns undefined

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -8,12 +8,10 @@ sidebar: addonsidebar
 
 Cancels all active alarms.
 
-This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
-
 ## Syntax
 
 ```js-nolint
-let clearAlarms = browser.alarms.clearAll()
+browser.alarms.clearAll()
 ```
 
 ### Parameters
@@ -22,20 +20,22 @@ None.
 
 ### Return value
 
-A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with a boolean. This is `true` if any alarms were cleared, `false` otherwise.
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with `undefined`.
 
 > [!NOTE]
-> Chrome always passes `true` and Safari `undefined`. The return type is subject to change and may always return `undefined` for all browsers in the future. It is best to not rely on the return type.
+> Before Firefox 157, the promise was fulfilled with a boolean: `true` if any alarms were cleared and `false` otherwise. Chrome fulfills the promise with `true` and Safari with `undefined`. Don't rely on the fulfillment value. To check whether any alarms remain, call {{WebExtAPIRef("alarms.getAll()")}}.
 
 ## Examples
 
+Clear all the alarms the extension has scheduled, then log that the alarms are cleared:
+
 ```js
-function onClearedAll(wasCleared) {
-  console.log(wasCleared); // true/false
+async function clearAllAlarms() {
+  await browser.alarms.clearAll();
+  console.log("All alarms cleared");
 }
 
-let clearAlarms = browser.alarms.clearAll();
-clearAlarms.then(onClearedAll);
+clearAllAlarms();
 ```
 
 {{WebExtExamples}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clearall/index.md
@@ -23,7 +23,9 @@ None.
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfilled with `undefined`.
 
 > [!NOTE]
-> Before Firefox 157, the promise was fulfilled with a boolean: `true` if any alarms were cleared and `false` otherwise. Chrome fulfills the promise with `true` and Safari with `undefined`. Don't rely on the fulfillment value. To check whether any alarms remain, call {{WebExtAPIRef("alarms.getAll()")}}.
+> Before Firefox 157, the promise was fulfilled with a boolean: `true` if any alarms were cleared and `false` otherwise. Chrome fulfills the promise with `true` and Safari with `undefined`. Don't rely on the fulfillment value. See [w3c/webextensions#1055](https://github.com/w3c/webextensions/issues/1055) for details.
+>
+> To check whether any alarms remain, call {{WebExtAPIRef("alarms.getAll()")}}.
 
 ## Examples
 

--- a/files/en-us/mozilla/firefox/releases/157/index.md
+++ b/files/en-us/mozilla/firefox/releases/157/index.md
@@ -72,6 +72,8 @@ Firefox 157 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
+- [`alarms.clearAll()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll) now fulfills its promise with `undefined` instead of a boolean. Extensions that relied on the fulfillment value to determine whether any alarms were cleared should call [`alarms.getAll()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll) instead. ([Firefox bug 2067229](https://bugzil.la/2067229))
+
 <!-- ### Removals -->
 
 <!-- ### Other -->

--- a/files/en-us/mozilla/firefox/releases/157/index.md
+++ b/files/en-us/mozilla/firefox/releases/157/index.md
@@ -72,7 +72,7 @@ Firefox 157 is the current [Nightly version of Firefox](https://www.firefox.com/
 
 ## Changes for add-on developers
 
-- [`alarms.clearAll()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll) now fulfills its promise with `undefined` instead of a boolean. Extensions that relied on the fulfillment value to determine whether any alarms were cleared should call [`alarms.getAll()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/getAll) instead. ([Firefox bug 2067229](https://bugzil.la/2067229))
+- [`alarms.clearAll()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll) now fulfills its promise with `undefined` instead of a boolean. ([Firefox bug 2067229](https://bugzil.la/2067229))
 
 <!-- ### Removals -->
 


### PR DESCRIPTION
### Description

Addresses the dev-docs-needed requirements of [Bug 2067229](https://bugzilla.mozilla.org/show_bug.cgi?id=2067229) "alarms.clearAll should return undefined instead of a boolean" with:

- update to alarms.clearAll
- addition of 157 release note

### Related issues and pull requests

BCG changes in https://github.com/mdn/browser-compat-data/pull/30450
