### PR TITLE
Add Firefox experimental features entry for @supports at-rule() function

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -449,6 +449,20 @@ The {{cssxref("view-timeline")}} shorthand property now supports the {{cssxref("
 - `layout.css.scroll-driven-animations.enabled`
   - : Set to `true` to enable.
 
+### `at-rule()` support queries
+
+The [`at-rule()`](/en-US/docs/Web/CSS/Reference/At-rules/@supports#at-rule) function in the {{cssxref("@supports")}} at-rule lets you test whether the browser supports a given CSS at-rule, for example `@supports at-rule(@scope)`. ([Firefox bug 2060754](https://bugzil.la/2060754)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 155           | Yes                 |
+| Developer Edition | 155           | No                  |
+| Beta              | 155           | No                  |
+| Release           | 155           | No                  |
+
+- `layout.css.supports.at-rule.enabled`
+  - : Set to `true` to enable.
+
 ## SVG
 
 **No experimental features in this release cycle.**


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Firefox 155 adds support for the `@supports` [`at-rule()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@supports#at-rule) function, currently only enabled by default in Nightly. In other versions, it is behind the `layout.css.supports.at-rule.enabled` pref. See https://bugzilla.mozilla.org/show_bug.cgi?id=2060754.

This PR adds an [Experimental features](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features) entry for `at-rule()`. It already has an entry in the Firefox 155 rel notes, and the feature is already documented sufficiently.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
