### PR TITLE
Remove redundant back after return and revert

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/authentication/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/authentication/index.md
@@ -481,7 +481,7 @@ You should be taken to the logout/login pages that you defined in the [Template 
 
 ### Testing in views
 
-If you're using function-based views, the easiest way to restrict access to your functions is to apply the `login_required` decorator to your view function, as shown below. If the user is logged in then your view code will execute as normal. If the user is not logged in, this will redirect to the login URL defined in the project settings (`settings.LOGIN_URL`), passing the current absolute path as the `next` URL parameter. If the user succeeds in logging in then they will be returned back to this page, but this time authenticated.
+If you're using function-based views, the easiest way to restrict access to your functions is to apply the `login_required` decorator to your view function, as shown below. If the user is logged in then your view code will execute as normal. If the user is not logged in, this will redirect to the login URL defined in the project settings (`settings.LOGIN_URL`), passing the current absolute path as the `next` URL parameter. If the user succeeds in logging in then they will be returned to this page, but this time authenticated.
 
 ```python
 from django.contrib.auth.decorators import login_required

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
@@ -99,7 +99,7 @@ It's a good idea to save the canvas state before doing any transformations. In m
 
 This example demonstrates some of the benefits of translating the canvas origin. Without the `translate()` method, all of the rectangles would be drawn at the same position (0,0). The `translate()` method also gives us the freedom to place the rectangle anywhere on the canvas without having to manually adjust coordinates in the `fillRect()` function. This makes it a little easier to understand and use.
 
-In the `draw()` function, we call the `fillRect()` function nine times using two `for` loops. In each loop, the canvas is translated, the rectangle is drawn, and the canvas is returned back to its original state. Note how the call to `fillRect()` uses the same coordinates each time, relying on `translate()` to adjust the drawing position.
+In the `draw()` function, we call the `fillRect()` function nine times using two `for` loops. In each loop, the canvas is translated, the rectangle is drawn, and the canvas is returned to its original state. Note how the call to `fillRect()` uses the same coordinates each time, relying on `translate()` to adjust the drawing position.
 
 ```js
 function draw() {

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -33,7 +33,7 @@ We start with some HTML: a paragraph with a link, as well as a definition list t
 
 #### JavaScript
 
-We add JavaScript to grab our unstyled link and return back a definition list of all the default CSS property values impacting the link using `computedStyleMap()`.
+We add JavaScript to grab our unstyled link and return a definition list of all the default CSS property values impacting the link using `computedStyleMap()`.
 
 ```js
 // Get the element

--- a/files/en-us/web/api/element/computedstylemap/index.md
+++ b/files/en-us/web/api/element/computedstylemap/index.md
@@ -50,7 +50,7 @@ a {
 }
 ```
 
-We add JavaScript to grab our link and return back a definition list of all the CSS property values using `computedStyleMap()`.
+We add JavaScript to grab our link and return a definition list of all the CSS property values using `computedStyleMap()`.
 
 ```js
 // get the element

--- a/files/en-us/web/api/highlightregistry/set/index.md
+++ b/files/en-us/web/api/highlightregistry/set/index.md
@@ -41,7 +41,7 @@ CSS.highlights.set("foo", fooHighlight);
 
 ### Using set() with chaining
 
-Since the `set()` method returns back the registry, you can chain the method call like below:
+Since the `set()` method returns the registry, you can chain the method call like below:
 
 ```js
 const fooHighlight = new Highlight();

--- a/files/en-us/web/api/navigationprecommitcontroller/redirect/index.md
+++ b/files/en-us/web/api/navigationprecommitcontroller/redirect/index.md
@@ -32,7 +32,7 @@ redirect(url, options)
             - If the original navigation occurred as a result of a {{domxref("Navigation.navigate()")}} call, the value will be whatever was specified in the `navigate()` call's [`history`](/en-US/docs/Web/API/Navigation/navigate#history) option.
             - Otherwise, the value used is usually `push`, but it will become `replace` if the redirect points to the same URL as the pre-navigation URL.
         - `push`
-          - : Adds a new {{domxref("NavigationHistoryEntry")}} to the navigation history, and clears any available forward navigation (that is, if the user previously navigated to other locations, then used the back button to return back through the history before initiating the navigation that caused the redirect).
+          - : Adds a new {{domxref("NavigationHistoryEntry")}} to the navigation history, and clears any available forward navigation (that is, if the user previously navigated to other locations, then used the back button to return through the history before initiating the navigation that caused the redirect).
         - `replace`
           - : Replaces the {{domxref("Navigation.currentEntry")}} with the resulting new `NavigationHistoryEntry`.
 

--- a/files/en-us/web/api/stylepropertymapreadonly/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/index.md
@@ -57,7 +57,7 @@ p {
 }
 ```
 
-We add JavaScript to grab our paragraph and return back a definition list of all the default CSS property values using {{domxref('Element.computedStyleMap()')}}.
+We add JavaScript to grab our paragraph and return a definition list of all the default CSS property values using {{domxref('Element.computedStyleMap()')}}.
 
 ```js
 // get the element

--- a/files/en-us/web/css/reference/values/transform-function/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/index.md
@@ -128,7 +128,7 @@ However, one major transformation is not linear, and therefore must be special-c
 
 The following example provides a 3D cube created from DOM elements and transforms, and a select menu allowing you to choose different transform functions to transform the cube with, so you can compare the effects of the different types.
 
-Choose one, and the transform is applied to the cube; after 2 seconds, the cube reverts back to its starting state. The cube's starting state is slightly rotated using `transform3d()`, to allow you to see the effect of all the transforms.
+Choose one, and the transform is applied to the cube; after 2 seconds, the cube reverts to its starting state. The cube's starting state is slightly rotated using `transform3d()`, to allow you to see the effect of all the transforms.
 
 #### HTML
 

--- a/files/en-us/web/javascript/reference/global_objects/map/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/set/index.md
@@ -56,7 +56,7 @@ myMap.set("bar", "baz");
 
 ### Using the set() with chaining
 
-Since the `set()` method returns back the same `Map` object, you can chain the method call like below:
+Since the `set()` method returns the same `Map` object, you can chain the method call like below:
 
 ```js
 // Add new elements to the map with chaining.


### PR DESCRIPTION
### Description

Drops the redundant `back` after `return` and `revert` in nine places.

- `HighlightRegistry.set()`: "the `set()` method returns back the registry" → "returns the registry"
- `Map.prototype.set()`: "the `set()` method returns back the same `Map` object" → "returns the same `Map` object"
- `CSS Typed OM guide`, `Element.computedStyleMap()`, `StylePropertyMapReadOnly`: "return back a definition list" → "return a definition list"
- `Canvas transformations tutorial`: "the canvas is returned back to its original state" → "is returned to its original state"
- `transform-function`: "the cube reverts back to its starting state" → "reverts to its starting state"
- `NavigationPreCommitController.redirect()`: "used the back button to return back through the history" → "to return through the history" (the "back button" itself is unchanged)
- `Django authentication tutorial`: "returned back to this page" → "returned to this page"

`repeated again and again` on the WebGL boilerplate page is left alone, since "again and again" is idiomatic rather than redundant.

### Motivation

`return` and `revert` already carry the sense of going back, so the particle adds nothing.
