### PR TITLE
Fix linked blogpost title

### DIFF
--- a/files/en-us/web/css/guides/media_queries/using/index.md
+++ b/files/en-us/web/css/guides/media_queries/using/index.md
@@ -71,7 +71,7 @@ Queries involving unknown media types are always false.
 > [!NOTE]
 > A style sheet with a media query attached to its {{HTMLElement("link")}} tag [will still download](https://scottjehl.github.io/CSS-Download-Tests/) even if the query returns `false`, the download will happen but the priority of downloading will be much lower.
 > Nevertheless, its contents will not apply unless and until the result of the query changes to `true`.
-> You can read why this happens in Tomayac's blog [Why Browser Download Stylesheet with Non-Matching Media Queries](https://medium.com/@tomayac/why-browsers-download-stylesheets-with-non-matching-media-queries-eb61b91b85a2).
+> You can read why this happens in Tomayac's blog [Why Browsers Download Stylesheets With Non-Matching Media Queries](https://medium.com/@tomayac/why-browsers-download-stylesheets-with-non-matching-media-queries-eb61b91b85a2).
 
 ## Targeting media types
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Correct typos in title of external document. "Why Browser Download Stylesheet with Non-Matching Media Queries" → "Why Browser**s** Download Stylesheet**s** With Non-Matching Media Queries"

### Motivation

To more accurately refer to the linked document.

### Additional details

https://medium.com/@tomayac/why-browsers-download-stylesheets-with-non-matching-media-queries-eb61b91b85a2

