### PR TITLE
fix: macro syntax errors in three pages

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -248,7 +248,7 @@ This section begins with an introductory sentence explaining how the property's 
 
 > This property is specified as one of the following keyword values. The `oblique` keyword can optionally be followed by an `<angle>`:
 
-In the definition list, wrap each value type in angle brackets and link it to the MDN reference page covering that value type if a page exists for it. For an example, see the "Values" section of {{CSSxRef("list-style-image"}}.
+In the definition list, wrap each value type in angle brackets and link it to the MDN reference page covering that value type if a page exists for it. For an example, see the "Values" section of {{CSSxRef("list-style-image")}}.
 
 #### Formal syntax
 

--- a/files/en-us/web/css/guides/environment_variables/index.md
+++ b/files/en-us/web/css/guides/environment_variables/index.md
@@ -33,7 +33,7 @@ Environment variables provide values that can be used on the page based on infor
 - {{cssxref("var")}}
 - {{domxref("VirtualKeyboard")}} interface
 - [`display_override`](/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/display_override) manifest field
-  [Window Controls Overlay API](/en-US/docs/Web/API/Window_Controls_Overlay_API) and {{domxref("WindowControlsOverlay"))}} interface
+  [Window Controls Overlay API](/en-US/docs/Web/API/Window_Controls_Overlay_API) and {{domxref("WindowControlsOverlay")}} interface
 
 ## Specifications
 

--- a/files/en-us/web/css/reference/values/calc/index.md
+++ b/files/en-us/web/css/reference/values/calc/index.md
@@ -102,7 +102,7 @@ When an {{cssxref("&lt;integer&gt;")}} is expected, the `calc()` expression can 
 
 ### Input considerations
 
-- `calc()` cannot perform calculations on [intrinsic size values](/en-US/docs/Glossary/Intrinsic_Size) such as {{cssxref("width#auto", "auto"}} and {{cssxref("fit-content")}}. Use the {{cssxref("calc-size()")}} function instead.
+- `calc()` cannot perform calculations on [intrinsic size values](/en-US/docs/Glossary/Intrinsic_Size) such as {{cssxref("width#auto", "auto")}} and {{cssxref("fit-content")}}. Use the {{cssxref("calc-size()")}} function instead.
 - The `*` and `/` operators do not require whitespace, but adding it for consistency is recommended.
 - It is permitted to nest `calc()` functions, in which case, the inner ones are treated as simple parentheses.
 - Math expressions involving percentages for widths and heights on table columns, table column groups, table rows, table row groups, and table cells in both auto and fixed layout tables _may_ be treated as if `auto` is specified.


### PR DESCRIPTION
### Description

Fix macro syntax errors (missing or duplicated closing parenthesis) in the following pages:

- MDN/Writing_guidelines/Page_structures/Syntax_sections (`CSSxRef`)
- Web/CSS/Guides/Environment_variables (`domxref`)
- Web/CSS/Reference/Values/calc (`cssxref`)

### Motivation

Ensure the affected macros render as links instead of leaving a syntax error (and raw macro text) in the page.

### Additional details

These errors are newly flagged as `templ-syntax-error` by rari 0.2.34, since https://github.com/mdn/rari/pull/868.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->