### PR TITLE
Speculation Rules: Remove prefetch’s Cache-Control conflict

### DIFF
--- a/files/en-us/web/api/speculation_rules_api/index.md
+++ b/files/en-us/web/api/speculation_rules_api/index.md
@@ -84,10 +84,7 @@ Same-site and cross-site prefetches will work, but cross-site prefetches are lim
 > [!NOTE]
 > In the future an opt-in for cross-site prefetches will be provided via the {{httpheader("Supports-Loading-Mode")}} header, but this was not implemented at the time of writing (only cross-origin, same-site [prerendering](#using_prerendering) opt-in was available).
 
-For browsers that support it, speculation rules prefetch should be preferred over older prefetch mechanisms, namely [`<link rel="prefetch">`](/en-US/docs/Web/HTML/Reference/Attributes/rel/prefetch) and {{domxref("Window/fetch", "fetch()")}} with a `priority: "low"` option set on it. Because we know that speculation rules prefetch is for navigations, not general resource prefetching:
-
-- It can be used for cross-site navigations, whereas `<link rel="prefetch">` cannot.
-- It doesn't get blocked by {{httpheader("Cache-Control")}} headers, whereas `<link rel="prefetch">` often does.
+For browsers that support it, speculation rules prefetch should be preferred over older prefetch mechanisms, namely [`<link rel="prefetch">`](/en-US/docs/Web/HTML/Reference/Attributes/rel/prefetch) and {{domxref("Window/fetch", "fetch()")}} with a `priority: "low"` option set on it. Because we know that speculation rules prefetch is for navigations, not general resource prefetching it can be used for cross-site navigations, whereas `<link rel="prefetch">` cannot.
 
 In addition, speculation rules prefetch:
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

On the Speculation Rules API page, stop saying that link-rel-prefetch is “often” “blocked” by the Cache-Control header.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

That was fixed in Firefox 152 (released 2026-06-16). Chromium never had that problem. Safari doesn’t support link-rel-prefetch.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

[Firefox bug tracker marking it as fixed](https://bugzilla.mozilla.org/show_bug.cgi?id=1527334#c21)

<!--### Related issues and pull requests-->

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
