### PR TITLE
Document the MathML <a> element and MathMLAnchorElement interface

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -469,6 +469,20 @@ When enabled, the [`href`](/en-US/docs/Web/MathML/Reference/Global_attributes/hr
 - `mathml.href_link_on_non_anchor_element.disabled`
   - : Set to `true` to enable.
 
+### Implement the `MathMLAnchorElement` interface
+
+When enabled, the MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element is correctly represented in the DOM by the [`MathMLAnchorElement`](/en-US/docs/Web/API/MathMLAnchorElement) interface rather than the generic [`MathMLElement`](/en-US/docs/Web/API/MathMLElement) interface. ([Firefox bug 2059312](https://bugzil.la/2059312)).
+
+| Release channel   | Version added | Enabled by default? |
+| ----------------- | ------------- | ------------------- |
+| Nightly           | 155           | Yes                 |
+| Developer Edition | 155           | No                  |
+| Beta              | 155           | No                  |
+| Release           | 155           | No                  |
+
+- `mathml.a.element.enabled`
+  - : Set to `true` to enable.
+
 ## JavaScript
 
 ### TC39 Intl.Locale info proposal

--- a/files/en-us/mozilla/firefox/releases/155/index.md
+++ b/files/en-us/mozilla/firefox/releases/155/index.md
@@ -181,3 +181,7 @@ You can find more such features on the [Experimental features](/en-US/docs/Mozil
 - **`view-timeline` includes `view-timeline-inset`**: `layout.css.scroll-driven-animations.enabled`
 
   The {{cssxref("view-timeline")}} shorthand property now supports the {{cssxref("view-timeline-inset")}} property. The shorthand lets you specify start and/or end inset (or outset) values to adjust the position of the view progress timeline. ([Firefox bug 2046602](https://bugzil.la/2046602)).
+
+- **The `MathMLAnchorElement` interface**: `mathml.a.element.enabled`
+
+  The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element is now correctly represented in the DOM by the [`MathMLAnchorElement`](/en-US/docs/Web/API/MathMLAnchorElement) interface rather than the generic [`MathMLElement`](/en-US/docs/Web/API/MathMLElement) interface. ([Firefox bug 2059312](https://bugzil.la/2059312)).

--- a/files/en-us/web/api/htmlanchorelement/protocol/index.md
+++ b/files/en-us/web/api/htmlanchorelement/protocol/index.md
@@ -8,7 +8,7 @@ browser-compat: api.HTMLAnchorElement.protocol
 
 {{ApiRef("HTML DOM")}}
 
-The **`protocol`** property of the {{domxref("HTMLAnchorElement")}} interface is a string containing the protocol or scheme of the `<area>` element's `href`, including the final `":"`.
+The **`protocol`** property of the {{domxref("HTMLAnchorElement")}} interface is a string containing the protocol or scheme of the `<a>` element's `href`, including the final `":"`.
 
 This property can be set to change the protocol of the URL. A `":"` is appended to the provided string if not provided. The provided scheme has to be compatible with the rest of the URL to be considered valid.
 

--- a/files/en-us/web/api/htmlanchorelement/search/index.md
+++ b/files/en-us/web/api/htmlanchorelement/search/index.md
@@ -14,13 +14,7 @@ This property can be set to change the query string of the URL. When setting, a 
 
 The query is {{Glossary("Percent-encoding", "percent-encoded")}} when setting but not percent-decoded when reading.
 
-Modern browsers provide
-[`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examples)
-and
-[`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams#examples)
-to make it easy to parse out the parameters from the query string.
-
-See {{domxref("URL.search")}} for more information.
+The {{domxref("URL.searchParams")}} property is a {{domxref("URLSearchParams")}} object that enables parsing the parameters from the query string. See also {{domxref("URL.search")}}.
 
 ## Value
 

--- a/files/en-us/web/api/htmlanchorelement/target/index.md
+++ b/files/en-us/web/api/htmlanchorelement/target/index.md
@@ -14,10 +14,7 @@ It reflects the [`target`](/en-US/docs/Web/HTML/Reference/Elements/a#target) att
 
 ## Value
 
-A string representing the target. Its value can be:
-
-- The name of a {{HTMLElement("frame")}}.
-- One of the [keyword with specific values](/en-US/docs/Web/HTML/Reference/Elements/a#target): `_blank`, `_self`, `_parent`, or `_top`.
+A string representing the target. Its value can be one of the [keywords](/en-US/docs/Web/HTML/Reference/Elements/a#target) `_blank`, `_self`, `_parent`, or `_top`.
 
 ## Example
 

--- a/files/en-us/web/api/mathmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/hash/index.md
@@ -20,10 +20,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com#examples">...</a>
+</math>
 ```
 
 you can get the `hash` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/hash/index.md
@@ -1,0 +1,46 @@
+---
+title: "MathMLAnchorElement: hash property"
+short-title: hash
+slug: Web/API/MathMLAnchorElement/hash
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.hash
+---
+
+{{APIRef("MathML")}}
+
+The **`hash`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing a `"#"` followed by the fragment identifier of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`. If the URL does not have a fragment identifier, this property contains an empty string, `""`.
+
+See {{domxref("URL.hash")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com#examples"> ... </a>
+```
+
+you can get the `hash` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.hash; // '#examples'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/host/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/host/index.md
@@ -1,0 +1,47 @@
+---
+title: "MathMLAnchorElement: host property"
+short-title: host
+slug: Web/API/MathMLAnchorElement/host
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.host
+---
+
+{{APIRef("MathML")}}
+
+The **`host`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the host, which is the {{domxref("MathMLAnchorElement.hostname", "hostname")}}, and then, if the {{glossary("port")}} of the URL is nonempty, a `":"`, followed by the {{domxref("MathMLAnchorElement.port", "port")}} of the URL. If the URL does not have a `hostname`, this property contains an empty string, `""`.
+
+See {{domxref("URL.host")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+```js
+const mathAnchor = document.querySelector("a");
+
+mathAnchor.href = "https://example.com/subsection";
+mathAnchor.host === "example.com";
+
+mathAnchor.href = "https://example.com:443";
+mathAnchor.host === "example.com";
+// The port number is not included because 443 is the scheme's default port
+
+mathAnchor.href = "https://example.com:4097";
+mathAnchor.host === "example.com:4097";
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/host/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/host/index.md
@@ -20,8 +20,16 @@ A string.
 
 ### Basic usage
 
+Given this MathML:
+
+```html
+<math>
+  <a href="https://example.com#examples">...</a>
+</math>
+```
+
 ```js
-const mathAnchor = document.querySelector("a");
+const mathAnchor = document.querySelector("math a");
 
 mathAnchor.href = "https://example.com/subsection";
 mathAnchor.host === "example.com";

--- a/files/en-us/web/api/mathmlanchorelement/hostname/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/hostname/index.md
@@ -20,10 +20,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com#examples"> ... </a>
+</math>
 ```
 
 you can get the `hostname` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/hostname/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/hostname/index.md
@@ -1,0 +1,46 @@
+---
+title: "MathMLAnchorElement: hostname property"
+short-title: hostname
+slug: Web/API/MathMLAnchorElement/hostname
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.hostname
+---
+
+{{APIRef("MathML")}}
+
+The **`hostname`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing either the {{glossary("domain name")}} or {{glossary("IP address")}} of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`. If the URL does not have a hostname, this property contains an empty string, `""`. IPv4 and IPv6 addresses are normalized, such as stripping leading zeros, and domain names are converted to [IDN](https://en.wikipedia.org/wiki/Internationalized_domain_name).
+
+See {{domxref("URL.hostname")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com#examples"> ... </a>
+```
+
+you can get the `hostname` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.hostname; // returns 'example.com'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/href/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/href/index.md
@@ -1,0 +1,48 @@
+---
+title: "MathMLAnchorElement: href property"
+short-title: href
+slug: Web/API/MathMLAnchorElement/href
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.href
+---
+
+{{APIRef("MathML")}}
+
+The **`href`** property of the {{domxref("MathMLAnchorElement")}} interface is a {{Glossary("stringifier")}} that returns the absolute URL corresponding to the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href` attribute (or an empty string if `href` is unset). Setting this property updates the element's `href` attribute to the provided value.
+
+## Value
+
+A string.
+
+- If the `href` attribute is absent, the value is an empty string (`""`).
+- If the `href` attribute is present but is not a valid relative or absolute URL, the value is the attribute's value as-is.
+- If the `href` attribute is present and is a valid relative or absolute URL, the value is the absolute URL, resolved relative to the document's base URL. The empty string (`""`) is considered a valid relative URL, resolving to the document's base URL.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com#examples"> ... </a>
+```
+
+you can get the `href` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.href; // returns 'https://example.com#examples'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/href/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/href/index.md
@@ -22,10 +22,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com#examples"> ... </a>
+</math>
 ```
 
 you can get the `href` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/hreflang/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/hreflang/index.md
@@ -1,0 +1,50 @@
+---
+title: "MathMLAnchorElement: hreflang property"
+short-title: hreflang
+slug: Web/API/MathMLAnchorElement/hreflang
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.hreflang
+---
+
+{{APIRef("MathML")}}
+
+The **`hreflang`** property of the {{domxref("MathMLAnchorElement")}} interface is a string that is the language of the linked resource.
+
+It reflects the `hreflang` attribute of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element.
+
+Web browsers and search engines may use this information to understand the language of the linked content better, but they are not required to follow it. The value provided for the `hreflang` attribute must adhere to the {{glossary("BCP 47 language tag")}} format. If not, it is ignored.
+
+Web browsers do not rely solely on the `hreflang` attribute after fetching the linked resource. Instead, they use language information directly associated with the resource (e.g., through HTTP headers) to determine its language.
+
+## Value
+
+A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` element.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com#examples" hreflang="en-CA"> ... </a>
+```
+
+you can get the `hreflang` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.hreflang; // returns 'en-CA'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/hreflang/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/hreflang/index.md
@@ -18,7 +18,7 @@ Web browsers do not rely solely on the `hreflang` attribute after fetching the l
 
 ## Value
 
-A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` element.
+A string that contains a language tag, or the empty string (`""`) if there is no `hreflang` attribute.
 
 ## Examples
 

--- a/files/en-us/web/api/mathmlanchorelement/hreflang/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/hreflang/index.md
@@ -24,10 +24,14 @@ A string that contains a language tag, or the empty string (`""`) if there is no
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com#examples" hreflang="en-CA"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com#examples" hreflang="en-CA">
+    ...
+  </a>
+</math>
 ```
 
 you can get the `hreflang` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/index.md
@@ -1,0 +1,184 @@
+---
+title: MathMLAnchorElement
+slug: Web/API/MathMLAnchorElement
+page-type: web-api-interface
+browser-compat: api.MathMLAnchorElement
+---
+
+{{APIRef("MathML")}}
+
+The **`MathMLAnchorElement`** interface represents MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) (hyperlink) elements and provides properties for getting and setting various features of such elements.
+
+{{InheritanceDiagram}}
+
+## Instance properties
+
+_Inherits properties from its parent, {{domxref("MathMLElement")}}._
+
+- {{domxref("MathMLAnchorElement.hash")}}
+  - : A string representing the fragment identifier, including the leading hash mark (`#`), if any, in the referenced URL.
+- {{domxref("MathMLAnchorElement.host")}}
+  - : A string representing the hostname and port (if it's not the default port) in the referenced URL.
+- {{domxref("MathMLAnchorElement.hostname")}}
+  - : A string representing the hostname in the referenced URL.
+- {{domxref("MathMLAnchorElement.href")}}
+  - : A string that is the result of parsing the element's [`href`](/en-US/docs/Web/MathML/Reference/Element/a#href) attribute relative to the document, containing a valid URL of a linked resource.
+- {{domxref("MathMLAnchorElement.hreflang")}}
+  - : A string that reflects the element's [`hreflang`](/en-US/docs/Web/MathML/Reference/Element/a#hreflang) attribute, indicating the language of the linked resource.
+- {{domxref("MathMLAnchorElement.origin")}} {{ReadOnlyInline}}
+  - : Returns a string containing the origin of the URL, that is its scheme, its domain and its port.
+- {{domxref("MathMLAnchorElement.password")}}
+  - : A string containing the password specified before the domain name.
+- {{domxref("MathMLAnchorElement.pathname")}}
+  - : A string containing an initial `/` followed by the path of the URL, not including the query string or fragment.
+- {{domxref("MathMLAnchorElement.port")}}
+  - : A string representing the port component, if any, of the referenced URL.
+- {{domxref("MathMLAnchorElement.protocol")}}
+  - : A string representing the protocol component, including trailing colon (`:`), of the referenced URL.
+- {{domxref("MathMLAnchorElement.search")}}
+  - : A string representing the search element, including leading question mark (`?`), if any, of the referenced URL.
+- {{domxref("MathMLAnchorElement.target")}}
+  - : A string that reflects the element's [`target`](/en-US/docs/Web/MathML/Reference/Element/a#target) attribute, indicating where to display the linked resource.
+- {{domxref("MathMLAnchorElement.type")}}
+  - : A string that reflects the element's [`type`](/en-US/docs/Web/MathML/Reference/Element/a#type) attribute, indicating the MIME type of the linked resource.
+- {{domxref("MathMLAnchorElement.username")}}
+  - : A string containing the username specified before the domain name.
+
+## Examples
+
+### Basic usage
+
+This example marks up the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) in MathML. It includes several nested MathML `<a>` elements and demonstrates how to access their properties in JavaScript via the `MathMLAnchorElement` interface.
+
+#### MathML
+
+The example includes several `<a>` elements that point to various parts of the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) Wikipedia page. We've updated the first one to an `example.com` link that includes several link and URL features that we can target with JavaScript. We also include a {{htmlelement("ul")}} element to output property values to.
+
+```html live-sample___mathmlanchorelement
+<math display="block" xmlns="http://www.w3.org/1998/Math/MathML"
+  ><semantics
+    ><mrow
+      ><a
+        href="https://uname:pwd@example.com:8000/subsection?q=123#fragment"
+        target="_blank"
+        hreflang="en"
+        type="text/html"
+        ><mrow
+          ><mi mathvariant="normal">Γ</mi><mo stretchy="false">(</mo><mi>t</mi
+          ><mo stretchy="false">)</mo></mrow
+        ></a
+      ><mo>=</mo
+      ><a href="https://en.wikipedia.org/wiki/Gamma_function#Main_definition"
+        ><mrow
+          ><msubsup
+            ><mo>∫</mo><mn>0</mn><mrow><mo>+</mo><mn>∞</mn></mrow></msubsup
+          ><msup
+            ><mi>x</mi><mrow><mi>t</mi><mo>−</mo><mn>1</mn></mrow></msup
+          ><msup
+            ><mi>e</mi><mrow><mo>−</mo><mi>x</mi></mrow></msup
+          ><mi>d</mi><mi>x</mi></mrow
+        ></a
+      ><mo>=</mo
+      ><a
+        href="https://en.wikipedia.org/wiki/Gamma_function#Euler's_definition_as_an_infinite_product"
+        ><mrow
+          ><mfrac><mn>1</mn><mi>t</mi></mfrac
+          ><munderover
+            ><mo>∏</mo><mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow
+            ><mn>∞</mn></munderover
+          ><mfrac
+            ><msup
+              ><mrow
+                ><mo>(</mo
+                ><mrow
+                  ><mn>1</mn><mo>+</mo><mfrac><mn>1</mn><mi>n</mi></mfrac></mrow
+                ><mo>)</mo></mrow
+              ><mi>t</mi></msup
+            ><mrow
+              ><mn>1</mn><mo>+</mo><mfrac><mi>t</mi><mi>n</mi></mfrac></mrow
+            ></mfrac
+          ></mrow
+        ></a
+      ><a href="https://en.wikipedia.org/wiki/Asymptotic_analysis#Definition"
+        ><mo>∼</mo></a
+      ><a href="https://en.wikipedia.org/wiki/Gamma_function#Stirling's_formula"
+        ><mrow
+          ><msqrt
+            ><mfrac
+              ><mrow><mn>2</mn><mi>π</mi></mrow
+              ><mi>t</mi></mfrac
+            ></msqrt
+          ><msup
+            ><mrow
+              ><mo>(</mo><mfrac><mi>t</mi><mi>e</mi></mfrac
+              ><mo>)</mo></mrow
+            ><mi>t</mi></msup
+          ></mrow
+        ></a
+      ></mrow
+    ></semantics
+  ></math
+>
+
+<ul></ul>
+```
+
+```css hidden live-sample___mathmlanchorelement
+math {
+  font-size: 4vw;
+}
+```
+
+#### JavaScript
+
+We get references to the first MathML `<a>` element in the document and the `<ul>` element.
+
+```js live-sample___mathmlanchorelement
+const mathAnchor = document.querySelector("math a");
+const list = document.querySelector("ul");
+```
+
+Next, we define a function that takes a string value representing a property of the `MathMLAnchorElement` object and appends an {{htmlelement("li")}} to the `list` containing the property name and property value:
+
+```js live-sample___mathmlanchorelement
+function outputValue(value) {
+  const listItem = document.createElement("li");
+  listItem.textContent = `${value}: ${mathAnchor[value]}`;
+  list.appendChild(listItem);
+}
+```
+
+Finally, we call the function several times to output names and values of properties defined directly on the interface to the list:
+
+```js live-sample___mathmlanchorelement
+outputValue("href");
+outputValue("target");
+outputValue("origin");
+outputValue("protocol");
+outputValue("username");
+outputValue("password");
+outputValue("host");
+outputValue("hostname");
+outputValue("port");
+outputValue("pathname");
+outputValue("search");
+outputValue("hash");
+outputValue("hreflang");
+outputValue("type");
+```
+
+#### Result
+
+{{EmbedLiveSample("mathml-a", "100%", "460")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/index.md
@@ -48,11 +48,11 @@ _Inherits properties from its parent, {{domxref("MathMLElement")}}._
 
 ### Basic usage
 
-This example marks up the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) in MathML. It includes several nested MathML `<a>` elements and demonstrates how to access their properties in JavaScript via the `MathMLAnchorElement` interface.
+This example marks up the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) in MathML. It demonstrates how to access MathML `<a>` properties in JavaScript via the `MathMLAnchorElement` interface.
 
 #### MathML
 
-The example includes several `<a>` elements that point to various parts of the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) Wikipedia page. We've updated the first one to an `example.com` link that includes several link and URL features that we can target with JavaScript. We also include a {{htmlelement("ul")}} element to output property values to.
+The example includes several `<a>` elements. The first one is an `example.com` link that includes several link and URL features that we can target with JavaScript. We also include a {{htmlelement("ul")}} element to output property values to.
 
 ```html live-sample___mathmlanchorelement
 <math display="block" xmlns="http://www.w3.org/1998/Math/MathML"

--- a/files/en-us/web/api/mathmlanchorelement/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/index.md
@@ -169,7 +169,7 @@ outputValue("type");
 
 #### Result
 
-{{EmbedLiveSample("mathml-a", "100%", "460")}}
+{{EmbedLiveSample("mathmlanchorelement", "100%", "460")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/mathmlanchorelement/origin/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/origin/index.md
@@ -28,10 +28,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+</math>
 ```
 
 you can get the `origin` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/origin/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/origin/index.md
@@ -1,0 +1,54 @@
+---
+title: "MathMLAnchorElement: origin property"
+short-title: origin
+slug: Web/API/MathMLAnchorElement/origin
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.origin
+---
+
+{{APIRef("MathML")}}
+
+The **`origin`** read-only property of the {{domxref("MathMLAnchorElement")}} interface returns a string containing the Unicode serialization of the origin of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`.
+
+The exact structure varies depending on the type of URL:
+
+- For URLs using the `ftp:`, `http:`, `https:`, `ws:`, and `wss:` schemes, the {{domxref("MathMLAnchorElement.protocol", "protocol")}} followed by `//`, followed by the {{domxref("MathMLAnchorElement.host", "host")}}. Same as `host`, the {{domxref("MathMLAnchorElement.port", "port")}} is only included if it's not the default for the protocol.
+- For URLs using `file:` scheme, the value is browser dependent.
+- For URLs using the `blob:` scheme, the origin of the URL following `blob:`, but only if that URL uses the `http:`, `https:`, or `file:` scheme. For example, `blob:https://mozilla.org` will have `https://mozilla.org`.
+
+For all other cases, the string `"null"` is returned.
+
+See {{domxref("URL.origin")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+```
+
+you can get the `origin` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.origin; // returns 'https://example.com'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/password/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/password/index.md
@@ -24,10 +24,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://foo:bar@example.com#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://foo:bar@example.com#examples"> ... </a>
+</math>
 ```
 
 you can get the `password` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/password/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/password/index.md
@@ -1,0 +1,50 @@
+---
+title: "MathMLAnchorElement: password property"
+short-title: password
+slug: Web/API/MathMLAnchorElement/password
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.password
+---
+
+{{APIRef("MathML")}}
+
+The **`password`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the password component of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`. If the URL does not have a password, this property contains an empty string, `""`.
+
+This property can be set to change the password of the URL. If the URL has no {{domxref("MathMLAnchorElement.host", "host")}} or its scheme is `file:`, then setting this property has no effect.
+
+The password is {{Glossary("Percent-encoding", "percent-encoded")}} when setting but not percent-decoded when reading.
+
+See {{domxref("URL.password")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://foo:bar@example.com#examples"> ... </a>
+```
+
+you can get the `password` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.password; // returns 'bar'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/pathname/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/pathname/index.md
@@ -10,6 +10,8 @@ browser-compat: api.MathMLAnchorElement.pathname
 
 The **`pathname`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing an initial `'/'` followed by the path of the URL not including the query string or fragment (or the empty string if there is no path).
 
+See {{domxref("URL.pathname")}} for more information.
+
 ## Value
 
 A string.

--- a/files/en-us/web/api/mathmlanchorelement/pathname/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/pathname/index.md
@@ -18,10 +18,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+</math>
 ```
 
 you can get the `pathname` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/pathname/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/pathname/index.md
@@ -1,0 +1,44 @@
+---
+title: "MathMLAnchorElement: pathname property"
+short-title: pathname
+slug: Web/API/MathMLAnchorElement/pathname
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.pathname
+---
+
+{{APIRef("MathML")}}
+
+The **`pathname`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing an initial `'/'` followed by the path of the URL not including the query string or fragment (or the empty string if there is no path).
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+```
+
+you can get the `pathname` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.pathname; // returns '/subsection'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/port/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/port/index.md
@@ -1,0 +1,48 @@
+---
+title: "MathMLAnchorElement: port property"
+short-title: port
+slug: Web/API/MathMLAnchorElement/port
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.port
+---
+
+{{APIRef("MathML")}}
+
+The **`port`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the port number of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`. If the port is the default for the protocol (`80` for `ws:` and `http:`, `443` for `wss:` and `https:`, and `21` for `ftp:`), this property contains an empty string, `""`.
+
+This property can be set to change the port of the URL. If the URL has no {{domxref("MathMLAnchorElement.host", "host")}} or its scheme is `file:`, then setting this property has no effect. It also silently ignores invalid port numbers.
+
+See {{domxref("URL.port")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com:8001/subsection#examples"> ... </a>
+```
+
+you can get the `port` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.port; // returns '8001'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/port/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/port/index.md
@@ -22,10 +22,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com:8001/subsection#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com:8001/subsection#examples"> ... </a>
+</math>
 ```
 
 you can get the `port` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/protocol/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/protocol/index.md
@@ -22,10 +22,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+</math>
 ```
 
 you can get the `protocol` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/protocol/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/protocol/index.md
@@ -8,7 +8,7 @@ browser-compat: api.MathMLAnchorElement.protocol
 
 {{APIRef("MathML")}}
 
-The **`protocol`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the protocol or scheme of the `<area>` element's `href`, including the final `":"`.
+The **`protocol`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the protocol or scheme of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`, including the final `":"`.
 
 This property can be set to change the protocol of the URL. A `":"` is appended to the provided string if not provided. The provided scheme has to be compatible with the rest of the URL to be considered valid.
 

--- a/files/en-us/web/api/mathmlanchorelement/protocol/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/protocol/index.md
@@ -1,0 +1,48 @@
+---
+title: "MathMLAnchorElement: protocol property"
+short-title: protocol
+slug: Web/API/MathMLAnchorElement/protocol
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.protocol
+---
+
+{{APIRef("MathML")}}
+
+The **`protocol`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the protocol or scheme of the `<area>` element's `href`, including the final `":"`.
+
+This property can be set to change the protocol of the URL. A `":"` is appended to the provided string if not provided. The provided scheme has to be compatible with the rest of the URL to be considered valid.
+
+See {{domxref("URL.protocol")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com/subsection#examples"> ... </a>
+```
+
+you can get the `protocol` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.protocol; // returns 'https:'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/search/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/search/index.md
@@ -14,13 +14,7 @@ This property can be set to change the query string of the URL. When setting, a 
 
 The query is {{Glossary("Percent-encoding", "percent-encoded")}} when setting but not percent-decoded when reading.
 
-Modern browsers provide
-[`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examples)
-and
-[`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams#examples)
-to make it easy to parse out the parameters from the query string.
-
-See {{domxref("URL.search")}} for more information.
+The {{domxref("URL.searchParams")}} property is a {{domxref("URLSearchParams")}} object that enables parsing the parameters from the query string. See also {{domxref("URL.search")}}.
 
 ## Value
 

--- a/files/en-us/web/api/mathmlanchorelement/search/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/search/index.md
@@ -1,0 +1,56 @@
+---
+title: "MathMLAnchorElement: search property"
+short-title: search
+slug: Web/API/MathMLAnchorElement/search
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.search
+---
+
+{{APIRef("MathML")}}
+
+The **`search`** property of the {{domxref("MathMLAnchorElement")}} interface is a search string, also called a _query string_, that is a string containing a `"?"` followed by the parameters of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`. If the URL does not have a search query, this property contains an empty string, `""`.
+
+This property can be set to change the query string of the URL. When setting, a single `"?"` prefix is added to the provided value, if not already present. Setting it to `""` removes the query string.
+
+The query is {{Glossary("Percent-encoding", "percent-encoded")}} when setting but not percent-decoded when reading.
+
+Modern browsers provide
+[`URLSearchParams`](/en-US/docs/Web/API/URLSearchParams/get#examples)
+and
+[`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams#examples)
+to make it easy to parse out the parameters from the query string.
+
+See {{domxref("URL.search")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com/subsection?q=123"> ... </a>
+```
+
+you can get the `search` string of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.search; // returns '?q=123'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/search/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/search/index.md
@@ -30,10 +30,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com/subsection?q=123"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com/subsection?q=123"> ... </a>
+</math>
 ```
 
 you can get the `search` string of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/target/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/target/index.md
@@ -10,14 +10,11 @@ browser-compat: api.MathMLAnchorElement.target
 
 The **`target`** property of the {{domxref("MathMLAnchorElement")}} interface is a string that indicates where to display the linked resource.
 
-It reflects the [`target`](/en-US/docs/Web/HTML/Reference/Elements/a#target) attribute of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element.
+It reflects the `target` attribute of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element.
 
 ## Value
 
-A string representing the target. Its value can be:
-
-- The name of a {{HTMLElement("frame")}}.
-- One of the [keyword with specific values](/en-US/docs/Web/HTML/Reference/Elements/a#target): `_blank`, `_self`, `_parent`, or `_top`.
+A string representing the target. Its value can be one of the [keywords](/en-US/docs/Web/MathML/Reference/Element/a#target) `_blank`, `_self`, `_parent`, or `_top`.
 
 ## Examples
 

--- a/files/en-us/web/api/mathmlanchorelement/target/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/target/index.md
@@ -23,10 +23,12 @@ A string representing the target. Its value can be:
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com" target="_blank"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com" target="_blank"> ... </a>
+</math>
 ```
 
 you can get the `target` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/target/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/target/index.md
@@ -1,0 +1,49 @@
+---
+title: "MathMLAnchorElement: target property"
+short-title: target
+slug: Web/API/MathMLAnchorElement/target
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.target
+---
+
+{{APIRef("MathML")}}
+
+The **`target`** property of the {{domxref("MathMLAnchorElement")}} interface is a string that indicates where to display the linked resource.
+
+It reflects the [`target`](/en-US/docs/Web/HTML/Reference/Elements/a#target) attribute of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element.
+
+## Value
+
+A string representing the target. Its value can be:
+
+- The name of a {{HTMLElement("frame")}}.
+- One of the [keyword with specific values](/en-US/docs/Web/HTML/Reference/Elements/a#target): `_blank`, `_self`, `_parent`, or `_top`.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com" target="_blank"> ... </a>
+```
+
+you can get the `target` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.target; // returns '_blank'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/type/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/type/index.md
@@ -1,0 +1,46 @@
+---
+title: "MathMLAnchorElement: type property"
+short-title: type
+slug: Web/API/MathMLAnchorElement/type
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.type
+---
+
+{{APIRef("MathML")}}
+
+The **`type`** property of the {{domxref("MathMLAnchorElement")}} interface is a string that indicates the MIME type of the linked resource.
+
+It reflects the `type` attribute of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://example.com" type="text/html"> ... </a>
+```
+
+you can get the `type` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.type; // returns 'text/html'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/type/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/type/index.md
@@ -20,10 +20,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://example.com" type="text/html"> ... </a>
+<math>
+  <a id="myAnchor" href="https://example.com" type="text/html"> ... </a>
+</math>
 ```
 
 you can get the `type` of the anchor like this:

--- a/files/en-us/web/api/mathmlanchorelement/username/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/username/index.md
@@ -1,0 +1,50 @@
+---
+title: "MathMLAnchorElement: username property"
+short-title: username
+slug: Web/API/MathMLAnchorElement/username
+page-type: web-api-instance-property
+browser-compat: api.MathMLAnchorElement.username
+---
+
+{{APIRef("MathML")}}
+
+The **`username`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the username component of the `<a>` element's `href`. If the URL does not have a username, this property contains an empty string, `""`.
+
+This property can be set to change the username of the URL. If the URL has no {{domxref("MathMLAnchorElement.host", "host")}} or its scheme is `file:`, then setting this property has no effect.
+
+The username is {{Glossary("Percent-encoding", "percent-encoded")}} when setting but not percent-decoded when reading.
+
+See {{domxref("URL.username")}} for more information.
+
+## Value
+
+A string.
+
+## Examples
+
+### Basic usage
+
+Given this HTML:
+
+```html
+<a id="myAnchor" href="https://foo:bar@example.com#examples"> ... </a>
+```
+
+you can get the `username` of the anchor like this:
+
+```js
+const mathAnchor = document.getElementById("myAnchor");
+mathAnchor.username; // returns 'foo'
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- The MathML [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element

--- a/files/en-us/web/api/mathmlanchorelement/username/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/username/index.md
@@ -8,7 +8,7 @@ browser-compat: api.MathMLAnchorElement.username
 
 {{APIRef("MathML")}}
 
-The **`username`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the username component of the `<a>` element's `href`. If the URL does not have a username, this property contains an empty string, `""`.
+The **`username`** property of the {{domxref("MathMLAnchorElement")}} interface is a string containing the username component of the [`<a>`](/en-US/docs/Web/MathML/Reference/Element/a) element's `href`. If the URL does not have a username, this property contains an empty string, `""`.
 
 This property can be set to change the username of the URL. If the URL has no {{domxref("MathMLAnchorElement.host", "host")}} or its scheme is `file:`, then setting this property has no effect.
 

--- a/files/en-us/web/api/mathmlanchorelement/username/index.md
+++ b/files/en-us/web/api/mathmlanchorelement/username/index.md
@@ -24,10 +24,12 @@ A string.
 
 ### Basic usage
 
-Given this HTML:
+Given this MathML:
 
 ```html
-<a id="myAnchor" href="https://foo:bar@example.com#examples"> ... </a>
+<math>
+  <a id="myAnchor" href="https://foo:bar@example.com#examples"> ... </a>
+</math>
 ```
 
 you can get the `username` of the anchor like this:

--- a/files/en-us/web/mathml/reference/element/a/index.md
+++ b/files/en-us/web/mathml/reference/element/a/index.md
@@ -8,6 +8,8 @@ sidebar: mathmlref
 
 The **`<a>`** [MathML](/en-US/docs/Web/MathML) element enables hyperlinks to be created inside MathML formulae, linking different parts to different locations.
 
+MathML's `<a>` element is a container, which means you can create a link around any MathML content. For layout purposes, it behaves like an {{MathMLElement("mrow")}} element.
+
 If the `href` attribute is present, pressing the enter key while focused on the `<a>` element will activate it.
 
 ## Attributes

--- a/files/en-us/web/mathml/reference/element/a/index.md
+++ b/files/en-us/web/mathml/reference/element/a/index.md
@@ -46,7 +46,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 ### Basic usage
 
-This example marks up the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) in MathML. It includes several nested MathML `<a>` elements to link individual parts of the formula to their respective sections on the Wiki page.
+This example marks up the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) in MathML. It includes several MathML `<a>` elements to link individual parts of the formula to their respective sections on the Wiki page.
 
 #### MathML
 

--- a/files/en-us/web/mathml/reference/element/a/index.md
+++ b/files/en-us/web/mathml/reference/element/a/index.md
@@ -1,0 +1,153 @@
+---
+title: <a>
+slug: Web/MathML/Reference/Element/a
+page-type: mathml-element
+browser-compat: mathml.elements.a
+sidebar: mathmlref
+---
+
+The **`<a>`** [MathML](/en-US/docs/Web/MathML) element enables hyperlinks to be created inside MathML formulae, linking different parts to different locations.
+
+If the `href` attribute is present, pressing the enter key while focused on the `<a>` element will activate it.
+
+## Attributes
+
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Reference/Global_attributes) as well as the following attributes:
+
+- `href`
+  - : The URL that the hyperlink points to. Links are not restricted to HTTP-based URLs — they can use any URL scheme supported by browsers:
+    - Telephone numbers with `tel:` URLs
+    - Email addresses with `mailto:` URLs
+    - SMS text messages with `sms:` URLs
+    - Executable code with [`javascript:` URLs](/en-US/docs/Web/URI/Reference/Schemes/javascript)
+    - While web browsers may not support other URL schemes, websites can with [`registerProtocolHandler()`](/en-US/docs/Web/API/Navigator/registerProtocolHandler)
+
+    Moreover other URL features can locate specific parts of the resource, including:
+    - Sections of a page with document fragments
+    - Specific text portions with [text fragments](/en-US/docs/Web/URI/Reference/Fragment/Text_fragments)
+    - Pieces of media files with media fragments
+
+- `hreflang`
+  - : Hints at the human language of the linked URL. No built-in functionality. Allowed values are the same as [the global `lang` attribute](/en-US/docs/Web/HTML/Reference/Global_attributes/lang).
+
+- `target`
+  - : Where to display the linked URL, as the name for a _browsing context_ (a tab, window, or {{HTMLElement("iframe")}}). The following keywords have special meanings for where to load the URL:
+    - `_self`: The current browsing context. (Default)
+    - `_blank`: Usually a new tab, but users can configure browsers to open a new window instead.
+    - `_parent`: The parent browsing context of the current one. If no parent, behaves as `_self`.
+    - `_top`: The topmost browsing context. To be specific, this means the "highest" context that's an ancestor of the current one. If no ancestors, behaves as `_self`.
+
+- `type`
+  - : Hints at the linked URL's format with a {{Glossary("MIME type")}}. No built-in functionality.
+
+## Examples
+
+### Basic usage
+
+This example marks up the [Gamma function](https://en.wikipedia.org/wiki/Gamma_function) in MathML. It includes several nested MathML `<a>` elements to link individual parts of the formula to their respective sections on the Wiki page.
+
+#### MathML
+
+```html live-sample___mathml-a
+<math display="block" xmlns="http://www.w3.org/1998/Math/MathML"
+  ><semantics
+    ><mrow
+      ><a href="https://en.wikipedia.org/wiki/Gamma_function"
+        ><mrow
+          ><mi mathvariant="normal">Γ</mi><mo stretchy="false">(</mo><mi>t</mi
+          ><mo stretchy="false">)</mo></mrow
+        ></a
+      ><mo>=</mo
+      ><a href="https://en.wikipedia.org/wiki/Gamma_function#Main_definition"
+        ><mrow
+          ><msubsup
+            ><mo>∫</mo><mn>0</mn><mrow><mo>+</mo><mn>∞</mn></mrow></msubsup
+          ><msup
+            ><mi>x</mi><mrow><mi>t</mi><mo>−</mo><mn>1</mn></mrow></msup
+          ><msup
+            ><mi>e</mi><mrow><mo>−</mo><mi>x</mi></mrow></msup
+          ><mi>d</mi><mi>x</mi></mrow
+        ></a
+      ><mo>=</mo
+      ><a
+        href="https://en.wikipedia.org/wiki/Gamma_function#Euler's_definition_as_an_infinite_product"
+        ><mrow
+          ><mfrac><mn>1</mn><mi>t</mi></mfrac
+          ><munderover
+            ><mo>∏</mo><mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow
+            ><mn>∞</mn></munderover
+          ><mfrac
+            ><msup
+              ><mrow
+                ><mo>(</mo
+                ><mrow
+                  ><mn>1</mn><mo>+</mo><mfrac><mn>1</mn><mi>n</mi></mfrac></mrow
+                ><mo>)</mo></mrow
+              ><mi>t</mi></msup
+            ><mrow
+              ><mn>1</mn><mo>+</mo><mfrac><mi>t</mi><mi>n</mi></mfrac></mrow
+            ></mfrac
+          ></mrow
+        ></a
+      ><a href="https://en.wikipedia.org/wiki/Asymptotic_analysis#Definition"
+        ><mo>∼</mo></a
+      ><a href="https://en.wikipedia.org/wiki/Gamma_function#Stirling's_formula"
+        ><mrow
+          ><msqrt
+            ><mfrac
+              ><mrow><mn>2</mn><mi>π</mi></mrow
+              ><mi>t</mi></mfrac
+            ></msqrt
+          ><msup
+            ><mrow
+              ><mo>(</mo><mfrac><mi>t</mi><mi>e</mi></mfrac
+              ><mo>)</mo></mrow
+            ><mi>t</mi></msup
+          ></mrow
+        ></a
+      ></mrow
+    ></semantics
+  ></math
+>
+```
+
+```css hidden live-sample___mathml-a
+math {
+  font-size: 4vw;
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("mathml-a", "100%", "200")}}
+
+## Technical summary
+
+<table class="properties">
+  <tr>
+    <th scope="row">
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles">Implicit ARIA role</a>
+    </th>
+    <td>
+      <a href="/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/generic_role">
+        <code>generic</code>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <th scope="row">DOM interface</th>
+    <td>{{domxref("MathMLAnchorElement")}}</td>
+  </tr>
+</table>
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("MathMLAnchorElement")}}

--- a/files/en-us/web/mathml/reference/element/index.md
+++ b/files/en-us/web/mathml/reference/element/index.md
@@ -6,7 +6,7 @@ page-type: landing-page
 sidebar: mathmlref
 ---
 
-This is an alphabetical list of MathML elements. All of them implement the {{domxref("MathMLElement")}} class.
+This page provides a list of all MathML elements. All of them implement the {{domxref("MathMLElement")}} class, except where otherwise noted.
 
 > [!NOTE]
 > As explained on the main [MathML](/en-US/docs/Web/MathML) page, MDN uses [MathML Core](https://w3c.github.io/mathml-core/) as a reference specification. However, legacy features that are still implemented by some browsers are also documented. You can find further details for these and other features in [MathML 4](https://w3c.github.io/mathml/).
@@ -15,7 +15,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### A
 
-- {{MathMLElement("a")}} (Hyperlink)
+- {{MathMLElement("a")}} (Hyperlink, implements {{domxref("MathMLAnchorElement")}})
 - {{MathMLElement("annotation")}} (Data annotations)
 - {{MathMLElement("annotation-xml")}} (XML annotations)
 
@@ -99,7 +99,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### General layout
 
-- {{MathMLElement("a")}} (Hyperlink)
+- {{MathMLElement("a")}} (Hyperlink, implements {{domxref("MathMLAnchorElement")}})
 - {{MathMLElement("menclose")}} {{non-standard_inline}} (Enclosed contents)
 - {{MathMLElement("merror")}} (Enclosed syntax error messages)
 - {{MathMLElement("mfenced")}} {{non-standard_inline}} {{deprecated_inline}} (Parentheses)

--- a/files/en-us/web/mathml/reference/element/index.md
+++ b/files/en-us/web/mathml/reference/element/index.md
@@ -13,13 +13,9 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ## MathML elements A to Z
 
-### math
-
-- {{MathMLElement("math")}} (Top-level element)
-
 ### A
 
-- {{MathMLElement("maction")}} {{deprecated_inline}} (Bound actions to sub-expressions)
+- {{MathMLElement("a")}} (Hyperlink)
 - {{MathMLElement("annotation")}} (Data annotations)
 - {{MathMLElement("annotation-xml")}} (XML annotations)
 
@@ -39,6 +35,8 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### M
 
+- {{MathMLElement("maction")}} {{deprecated_inline}} (Bound actions to sub-expressions)
+- {{MathMLElement("math")}} (Top-level element)
 - {{MathMLElement("mmultiscripts")}} (Prescripts and tensor indices)
 
 ### N
@@ -101,6 +99,7 @@ This is an alphabetical list of MathML elements. All of them implement the {{dom
 
 ### General layout
 
+- {{MathMLElement("a")}} (Hyperlink)
 - {{MathMLElement("menclose")}} {{non-standard_inline}} (Enclosed contents)
 - {{MathMLElement("merror")}} (Enclosed syntax error messages)
 - {{MathMLElement("mfenced")}} {{non-standard_inline}} {{deprecated_inline}} (Parentheses)

--- a/files/en-us/web/mathml/reference/global_attributes/href/index.md
+++ b/files/en-us/web/mathml/reference/global_attributes/href/index.md
@@ -11,7 +11,7 @@ sidebar: mathmlref
 
 {{Non-standard_header}}
 
-The **`href`** [global attribute](/en-US/docs/Web/MathML/Reference/Global_attributes) creates a hyperlink on the MathML element pointing to the specified URL.
+The **`href`** [global attribute](/en-US/docs/Web/MathML/Reference/Global_attributes) creates a hyperlink on a MathML element pointing to the specified URL. Setting `href` on MathML elements other than {{MathMLElement("a")}} is deprecated; you should use the {{MathMLElement("a")}} element to create hyperlinks within MathML content.
 
 ## Example
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

Firefox 155 adds support for the MathML [`<a>` element's](https://w3c.github.io/mathml-core/#the-a-element) DOM interface, [`MathMLAnchorElement`](https://w3c.github.io/mathml-core/#dom-mathmlanchorelement). It is currently enabled in Nightly only (the pref is `mathml.a.element.enabled`). See https://bugzilla.mozilla.org/show_bug.cgi?id=2059312.

This PR documents both the element and the interface.

<!-- ✍️ Summarize your changes in one or two sentences. -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
