### PR TITLE
Document bracket notation for SVG*List interfaces

### DIFF
--- a/files/en-us/web/api/svglengthlist/index.md
+++ b/files/en-us/web/api/svglengthlist/index.md
@@ -11,7 +11,7 @@ The **`SVGLengthList`** interface defines a list of {{ domxref("SVGLength") }} o
 
 An `SVGLengthList` object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-An `SVGLengthList` object is indexable and can be accessed like an array.
+An `SVGLengthList` object is indexable and can be accessed like an array using [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation). Reading an index is equivalent to calling {{domxref("SVGLengthList.getItem", "getItem()")}}. Assigning to an index is equivalent to calling {{domxref("SVGLengthList.replaceItem", "replaceItem()")}}, including the exceptions it throws.
 
 ## Instance properties
 

--- a/files/en-us/web/api/svglengthlist/replaceitem/index.md
+++ b/files/en-us/web/api/svglengthlist/replaceitem/index.md
@@ -10,6 +10,8 @@ browser-compat: api.SVGLengthList.replaceItem
 
 The **`replaceItem()`** method of the {{domxref("SVGLengthList")}} interface replaces an existing item in the list with a new item. If the new item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. If the item is already in this list, note that the index of the item to replace is before the removal of the item.
 
+Assigning to an index of the list has the same effect as calling this method, except that there is no return value.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/svgnumberlist/index.md
+++ b/files/en-us/web/api/svgnumberlist/index.md
@@ -11,7 +11,7 @@ The **`SVGNumberList`** interface defines a list of numbers.
 
 An `SVGNumberList` object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-An `SVGNumberList` object is indexable and can be accessed like an array.
+An `SVGNumberList` object is indexable and can be accessed like an array using [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation). Reading an index is equivalent to calling {{domxref("SVGNumberList.getItem", "getItem()")}}. Assigning to an index is equivalent to calling {{domxref("SVGNumberList.replaceItem", "replaceItem()")}}, including the exceptions it throws.
 
 ## Instance properties
 

--- a/files/en-us/web/api/svgnumberlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgnumberlist/replaceitem/index.md
@@ -10,6 +10,8 @@ browser-compat: api.SVGNumberList.replaceItem
 
 The **`replaceItem()`** method of the {{domxref("SVGNumberList")}} interface replaces an existing item in the list with a new item. If the new item is already in a list, it is removed from its previous list before it is inserted into this list. The inserted item is the item itself and not a copy. If the item is already in this list, note that the index of the item to replace is before the removal of the item.
 
+Assigning to an index of the list has the same effect as calling this method, except that there is no return value.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/svgpointlist/index.md
+++ b/files/en-us/web/api/svgpointlist/index.md
@@ -11,6 +11,8 @@ The **`SVGPointList`** interface represents a list of {{domxref("DOMPoint")}} ob
 
 An `SVGPointList` can be designated as read-only, which means that attempts to modify the object will result in an exception being thrown.
 
+An `SVGPointList` object is indexable and can be accessed like an array using [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation). Reading an index is equivalent to calling {{domxref("SVGPointList.getItem", "getItem()")}}. Assigning to an index is equivalent to calling {{domxref("SVGPointList.replaceItem", "replaceItem()")}}, including the exceptions it throws.
+
 ## Instance properties
 
 - {{domxref("SVGPointList.length")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.md
@@ -10,6 +10,8 @@ browser-compat: api.SVGPointList.replaceItem
 
 The **`replaceItem()`** method of the {{domxref("SVGPointList")}} interface replaces a {{domxref("DOMPoint")}} in the list.
 
+Assigning to an index of the list has the same effect as calling this method, except that there is no return value.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/svgstringlist/index.md
+++ b/files/en-us/web/api/svgstringlist/index.md
@@ -11,7 +11,7 @@ The **`SVGStringList`** interface defines a list of strings.
 
 An `SVGStringList` object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-An `SVGStringList` object is indexable and can be accessed like an array.
+An `SVGStringList` object is indexable and can be accessed like an array using [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation). Reading an index is equivalent to calling {{domxref("SVGStringList.getItem", "getItem()")}}. Assigning to an index is equivalent to calling {{domxref("SVGStringList.replaceItem", "replaceItem()")}}, including the exceptions it throws.
 
 ## Instance properties
 

--- a/files/en-us/web/api/svgstringlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgstringlist/replaceitem/index.md
@@ -13,6 +13,8 @@ The **`replaceItem()`** method of the {{domxref("SVGStringList")}} interface rep
 - If the new item is already in a list, it is removed from its previous list before it is inserted into this list.
 - If the item is already in this list, note that the index of the item to replace is before the removal of the item.
 
+Assigning to an index of the list has the same effect as calling this method, except that there is no return value.
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/svgtransformlist/index.md
+++ b/files/en-us/web/api/svgtransformlist/index.md
@@ -11,7 +11,7 @@ The **`SVGTransformList`** interface defines a list of {{ domxref("SVGTransform"
 
 An `SVGTransformList` object can be designated as read only, which means that attempts to modify the object will result in an exception being thrown.
 
-An `SVGTransformList` is indexable and can be accessed like an array.
+An `SVGTransformList` is indexable and can be accessed like an array using [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation). Reading an index is equivalent to calling {{domxref("SVGTransformList.getItem", "getItem()")}}. Assigning to an index is equivalent to calling {{domxref("SVGTransformList.replaceItem", "replaceItem()")}}, including the exceptions it throws.
 
 ## Instance properties
 
@@ -102,6 +102,43 @@ document.querySelector("rect").addEventListener("click", transformMe);
 ```
 
 {{EmbedLiveSample("Using_multiple_SVGTransform_objects",300,280)}}
+
+### Replacing a transform using bracket notation
+
+In this example, an item in the list is replaced using bracket notation instead of {{domxref("SVGTransformList.replaceItem", "replaceItem()")}}. Each time the button is pressed, the code reads the current angle from `transformList[0]`, creates a {{domxref("SVGTransform")}} rotated a further 15 degrees, and assigns it back to `transformList[0]`.
+
+```html
+<svg
+  id="my-svg"
+  viewBox="0 0 100 100"
+  width="150"
+  height="150"
+  xmlns="http://www.w3.org/2000/svg">
+  <rect
+    x="30"
+    y="30"
+    width="40"
+    height="40"
+    fill="blue"
+    transform="rotate(0, 50, 50)" />
+</svg>
+<button id="rotate">Rotate by 15 degrees</button>
+```
+
+```js
+const svg = document.getElementById("my-svg");
+const rect = svg.querySelector("rect");
+const transformList = rect.transform.baseVal;
+
+document.getElementById("rotate").addEventListener("click", () => {
+  const rotate = svg.createSVGTransform();
+  rotate.setRotate(transformList[0].angle + 15, 50, 50);
+  // Equivalent to transformList.replaceItem(rotate, 0)
+  transformList[0] = rotate;
+});
+```
+
+{{EmbedLiveSample("Replacing_a_transform_using_bracket_notation", "", "220")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svgtransformlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgtransformlist/replaceitem/index.md
@@ -16,6 +16,8 @@ The inserted item is the item itself and not a copy.
 
 - If the item is already in this list, note that the `index` of the item to replace is before the removal of the item.
 
+Assigning to an index of the list has the same effect as calling this method, except that there is no return value.
+
 ## Syntax
 
 ```js-nolint


### PR DESCRIPTION
### Description

- Documents bracket notation on `SVG*List`
- Adds a note to their `replaceItem()` pages
- Adds a live example to `SVGTransformList`

### Related issues and pull requests

- https://github.com/mdn/content/issues/45189
- https://github.com/mdn/content/pull/45245

### Note

BCD isn’t updated: there’s no subfeature for indexed setters.