### PR TITLE
ci(pr-review-companion): run independent steps in parallel

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -59,38 +59,53 @@ jobs:
       STATUS_CONTEXT: pr-review-companion
       STATUS_TARGET: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: build
-          path: build
-          merge-multiple: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+      - parallel:
+          - name: Download artifact
+            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+            with:
+              pattern: build
+              path: build
+              merge-multiple: true
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+              run-id: ${{ github.event.workflow_run.id }}
+
+          - name: Checkout (mdn/content)
+            uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            with:
+              path: content
+              persist-credentials: false
 
       - name: Check for artifacts
         id: check
         if: hashFiles('build/') != ''
         run: echo "HAS_ARTIFACT=true" >> "$GITHUB_OUTPUT"
 
-      - name: Mark status as pending
-        if: steps.check.outputs.HAS_ARTIFACT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api "$STATUS_PATH" \
-            -f state=pending \
-            -f context="$STATUS_CONTEXT" \
-            -f description='Review deployment pending' \
-            -f target_url="$STATUS_TARGET"
+      - parallel:
+          - name: Mark status as pending
+            if: steps.check.outputs.HAS_ARTIFACT
+            env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            run: |
+              gh api "$STATUS_PATH" \
+                -f state=pending \
+                -f context="$STATUS_CONTEXT" \
+                -f description='Review deployment pending' \
+                -f target_url="$STATUS_TARGET"
 
-      - name: Authenticate with GCP
-        if: steps.check.outputs.HAS_ARTIFACT
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          token_format: access_token
-          service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
-          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+          - name: Authenticate with GCP
+            if: steps.check.outputs.HAS_ARTIFACT
+            uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+            with:
+              token_format: access_token
+              service_account: deploy-mdn-review-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+              workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+          - name: Setup (mdn/content)
+            uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+            if: steps.check.outputs.HAS_ARTIFACT
+            with:
+              node-version-file: "content/.nvmrc"
+              package-manager-cache: false
 
       - name: Setup gcloud
         if: steps.check.outputs.HAS_ARTIFACT
@@ -108,20 +123,6 @@ jobs:
           parent: false
           concurrency: 500
           process_gcloudignore: false
-
-      - name: Checkout (mdn/content)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: steps.check.outputs.HAS_ARTIFACT
-        with:
-          path: content
-          persist-credentials: false
-
-      - name: Setup (mdn/content)
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: steps.check.outputs.HAS_ARTIFACT
-        with:
-          node-version-file: "content/.nvmrc"
-          package-manager-cache: false
 
       - name: Install (mdn/content)
         if: steps.check.outputs.HAS_ARTIFACT


### PR DESCRIPTION
### Description

Update the PR review companion workflow to run independent, network-bound steps in parallel using the GitHub Actions `parallel` step group:

- the artifact download and the `mdn/content` checkout,
- the status update, GCP authentication, and Node setup.

### Motivation

Speed up CI by overlapping independent download, checkout, and setup steps instead of running them serially.

### Additional details

Uses the parallel step keywords introduced in GitHub Actions on 2026-06-25: https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

`parallel` is shorthand for `background: true` on each step followed by an implicit wait: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel

Measured over the last 25 runs of the `review` job, this saves about 4s of a ~48s job (8%), consistently 7-9% per run. Group 1 collapses `Download artifact` (1-3s) into `Checkout (mdn/content)` (4-11s); group 2 collapses `Mark status as pending` (1-4s) and `Authenticate with GCP` (0-1s) into `Setup (mdn/content)` (4-5s).

One behavior change: `Checkout (mdn/content)` is no longer gated on `HAS_ARTIFACT`, because it now precedes the `Check for artifacts` step. It runs concurrently with the artifact download, so there is no wall-clock cost.

The other workflows in this repository were checked and left unchanged. `interfacedata-updater.yml` would save ~8s but only runs weekly, and `pr-reviewdog.yml` saves a median of 0s (its artifact download is under a second, and `Setup reviewdog` executed in only 2 of 25 sampled runs). The rest, including `test.yml`, `markdown-lint.yml`, the `pr-check_*.yml` set, `spelling-check-bot.yml`, and `auto-cleanup-bot.yml`, are strict `checkout` -> `setup-node` chains: `node-version-file: .nvmrc` and `cache: npm` both need the checkout to have finished, so there is nothing independent to overlap.

Note that this workflow triggers on `workflow_run` only, so it does not run on this PR.

### Related issues and pull requests

Part of mdn/fred#1862.

Follows mdn/rari#775.
