### PR TITLE
Issue 45524 Expanded toolbar button details in your second extension tutorial

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -21,7 +21,8 @@ To implement this, you:
 
 - **Define an `action`, which is a [button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) attached to the Firefox toolbar**.
   For the button you supply:
-  - An icon, called "beasts-32.png".
+  - An icon, called "beasts-32.png", and an alternative icon, called "beasts-32-light.png", for use with themes that use light text.
+  - A tooltip.
   - A popup to open when the user presses the button. The popup includes HTML, CSS, and JavaScript.
 
 - **Define an icon for the extension**, called "beasts-48.png". The Add-ons Manager displays this icon with the extension's details.
@@ -99,10 +100,7 @@ Now create a file called "manifest.json", and give it this content:
   - [`id`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#id) defines a unique identifier for the extension. This ID is needed before an extension can be published on addons.mozilla.org (AMO).
   - [`data_collection_permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings#data_collection_permissions) provides information on whether the extension collects and transmits personally identifiable information. This example doesn't collect or transmit any data.
 - [`permissions`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) lists permissions the extension needs. In this example, the extension asks for the [`activeTab` permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#activetab_permission).
-- [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) specifies the toolbar button. You supply three pieces of information here, all of which are optional:
-  - `default_icon` points to the button's icon.
-  - `default_title` provides text for a tooltip displayed for the action button.
-  - `default_popup` points to an HTML file included with the extension that defines the popups content.
+- [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) specifies the toolbar button, its icons, tooltip, and popup. See [The toolbar button](#the_toolbar_button) for details of the properties used in this example.
 - [`web_accessible_resources`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) lists files that you want to make accessible to web pages. As the extension replaces the page's content with images packaged in the extension, you need to make those images accessible to the page.
 
 Note that all paths given are relative to the manifest.json file.
@@ -124,9 +122,19 @@ If you choose to supply an icon, it should be 48x48 pixels. You can supply a 96x
 
 ### The toolbar button
 
-The toolbar button also needs an icon, and manifest.json specifies that it is at "icons/beasts-32.png".
+The [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) key defines the extension's toolbar button, which is the extension's main user interface. All the key's properties are optional. This example uses four of them:
 
-Save an icon named "beasts-32.png" in the "icons" directory. You could use [the one from the example](https://raw.githubusercontent.com/mdn/webextensions-examples/main/beastify/icons/beasts-32.png), which is taken from the [IconBeast Lite icon set](https://www.iconbeast.com/free/) and used under its [license](https://www.iconbeast.com/faq/).
+- `default_icon` points to the button's icon, "icons/beasts-32.png".
+- `theme_icons` provides alternative icons for themes that use light or dark text. Firefox displays the icon in the `light` property, "icons/beasts-32-light.png", when a theme that uses light text is active, such as the Firefox Dark theme. It displays the icon in the `dark` property, "icons/beasts-32.png", when a theme that uses dark text is active, such as the Firefox Light theme. The `size` property defines the icon size in pixels.
+- `default_title` provides the text of the tooltip Firefox displays when the user hovers over the button.
+- `default_popup` points to an HTML file, included with the extension, that defines the popup's content. If you don't supply this property, Firefox dispatches a click event to your extension when the user clicks the button.
+
+Save the two icons in the "icons" directory. You could use the ones from the example:
+
+- [beasts-32.png](https://raw.githubusercontent.com/mdn/webextensions-examples/main/beastify/icons/beasts-32.png)
+- [beasts-32-light.png](https://raw.githubusercontent.com/mdn/webextensions-examples/main/beastify/icons/beasts-32-light.png)
+
+Both icons are taken from the [IconBeast Lite icon set](https://www.iconbeast.com/free/) and used under its [license](https://www.iconbeast.com/faq/).
 
 ### The popup
 
@@ -458,6 +466,7 @@ beastify/
 
     icons/
         beasts-32.png
+        beasts-32-light.png
         beasts-48.png
 
     popup/

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -21,7 +21,7 @@ To implement this, you:
 
 - **Define an `action`, which is a [button](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Toolbar_button) attached to the Firefox toolbar**.
   For the button you supply:
-  - An icon, called "beasts-32.png", and an alternative icon, called "beasts-32-light.png", for use with themes that use light text.
+  - A default icon, and icons to use when Firefox displays light and dark text.
   - A tooltip.
   - A popup to open when the user presses the button. The popup includes HTML, CSS, and JavaScript.
 
@@ -122,25 +122,30 @@ If you choose to supply an icon, it should be 48x48 pixels. You can supply a 96x
 
 ### The toolbar button
 
-The [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) key defines the extension's toolbar button, which is the extension's main user interface. All the key's properties are optional. This example uses four of them:
+You add and customize a toolbar button using the [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) key. The key and all its properties are optional. However, when using a toolbar button, you specify properties to customize the button and, when needed, add a popup that appears when the button is clicked. This example uses:
 
-- `default_icon` points to the button's icon, "icons/beasts-32.png".
-- `theme_icons` provides alternative icons for themes that use light or dark text. Firefox displays the icon in the `light` property, "icons/beasts-32-light.png", when a theme that uses light text is active, such as the Firefox Dark theme. It displays the icon in the `dark` property, "icons/beasts-32.png", when a theme that uses dark text is active, such as the Firefox Light theme. The `size` property defines the icon size in pixels.
+- `default_icon` that points to the button's default icon.
+- `theme_icons` that provides alternative icons for themes:
+  - `light` specifies the icon (`icons/beasts-32-light.png`) used when light text is displayed (usually when a dark theme is active).
+  - `dark` specifies the icon (`icons/beasts-32.png`) used when dark text is displayed (usually when a light theme is active).
+  - `size` specifies the icon's size, in pixels.
 - `default_title` provides the text of the tooltip Firefox displays when the user hovers over the button.
-- `default_popup` points to an HTML file, included with the extension, that defines the popup's content. If you don't supply this property, Firefox dispatches a click event to your extension when the user clicks the button.
+- `default_popup` points to the popup's HTML file. See [The popup](#the_popup) for details.
 
-Save the two icons in the "icons" directory. You could use the ones from the example:
+Save your icons in the "icons" directory or use those from the example source code on GitHub:
 
 - [beasts-32.png](https://raw.githubusercontent.com/mdn/webextensions-examples/main/beastify/icons/beasts-32.png)
 - [beasts-32-light.png](https://raw.githubusercontent.com/mdn/webextensions-examples/main/beastify/icons/beasts-32-light.png)
 
-Both icons are taken from the [IconBeast Lite icon set](https://www.iconbeast.com/free/) and used under its [license](https://www.iconbeast.com/faq/).
+Both icons are based on one from the [IconBeast Lite icon set](https://www.iconbeast.com/free/) and used under its [license](https://www.iconbeast.com/faq/).
 
 ### The popup
 
-If you don't supply a popup, when the user clicks the toolbar button, Firefox dispatches a click event to your extension. If you supply a popup, when the user clicks the toolbar button the popup opens, and Firefox doesn't dispatch a click event.
+Toolbar buttons let you add a popup that opens when the user clicks the toolbar button.
 
-For this example, you want a popup. The function of the popup is to enable the user to choose one of three beasts.
+If you don't supply a popup, clicking the button dispatches a {{WebExtAPIRef("action.onClicked")}} event to your extension. Your extension uses this event to trigger the functionality associated with the button.
+
+For this example, you want a popup. The popup lets the user choose one of three beasts.
 
 Create a directory called "popup" under the extension root. This directory is where you create the popup's code. The popup consists of three files:
 


### PR DESCRIPTION
### Description

This change expands the tool power button section to provide a more detailed explanation of the value set in the action key along with links to the two icons used.

### Motivation

Primarily motivated by a desire to address concerns that links weren't provided for the icons used in the key, but also to provide more complete information on the key's purpose and behavior.

### Additional details

I was curious as to why we were defining both the default icon and theme icons. I did some testing, and as far as I can tell, once you define the theme icons, the default icon is never used. An AI review of the source code says it should occur when the "System theme (default-theme@mozilla.org) [is set and], OS in light mode" but I couldn't reproduce this. But I'm not sure whether that's because I simply didn't have the correct settings. If the theme icons are always used instead of the default, we don't document this in the action key.

### Related issues and pull requests

Fixes #45524