### PR TITLE
docs(WebAPI): call out duplicate keys on FormData iteration methods

### DIFF
--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -11,7 +11,7 @@ browser-compat: api.FormData.entries
 The **`FormData.entries()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all key/value pairs contained in the {{domxref("FormData")}}. The key of each pair is a string, and the value is either a string or a {{domxref("Blob")}}.
 
 > [!NOTE]
-> Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) entries, `FormData` entries are not necessarily unique by key. A form can contain multiple elements with the same name, so the same key may appear in more than one pair while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
+> Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) entries, `FormData` entries are not necessarily unique by key. A form can contain multiple elements with the same name, so the same key may appear in more than one pair while iterating. Past the first entry, the value may differ from the return value of {{domxref("FormData.get()", "get()")}} which returns the first value associated with the key.
 
 ## Syntax
 

--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -10,6 +10,8 @@ browser-compat: api.FormData.entries
 
 The **`FormData.entries()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all key/value pairs contained in the {{domxref("FormData")}}. The key of each pair is a string, and the value is either a string or a {{domxref("Blob")}}.
 
+> **Note:** Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) entries, `FormData` entries are not necessarily unique by key. A form can contain multiple elements with the same name, so the same key may appear in more than one pair while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -10,7 +10,8 @@ browser-compat: api.FormData.entries
 
 The **`FormData.entries()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all key/value pairs contained in the {{domxref("FormData")}}. The key of each pair is a string, and the value is either a string or a {{domxref("Blob")}}.
 
-> **Note:** Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) entries, `FormData` entries are not necessarily unique by key. A form can contain multiple elements with the same name, so the same key may appear in more than one pair while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
+> [!NOTE]
+> Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) entries, `FormData` entries are not necessarily unique by key. A form can contain multiple elements with the same name, so the same key may appear in more than one pair while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
 
 ## Syntax
 

--- a/files/en-us/web/api/formdata/keys/index.md
+++ b/files/en-us/web/api/formdata/keys/index.md
@@ -10,7 +10,8 @@ browser-compat: api.FormData.keys
 
 The **`FormData.keys()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all keys contained in the {{domxref("FormData")}}. The keys are strings.
 
-> **Note:** Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) keys, `FormData` keys are not necessarily unique. A form can contain multiple elements with the same name, so the same key may appear more than once while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
+> [!NOTE]
+> Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) keys, `FormData` keys are not necessarily unique. A form can contain multiple elements with the same name, so the same key may appear more than once while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
 
 ## Syntax
 

--- a/files/en-us/web/api/formdata/keys/index.md
+++ b/files/en-us/web/api/formdata/keys/index.md
@@ -10,6 +10,8 @@ browser-compat: api.FormData.keys
 
 The **`FormData.keys()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all keys contained in the {{domxref("FormData")}}. The keys are strings.
 
+> **Note:** Unlike [`Map`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) keys, `FormData` keys are not necessarily unique. A form can contain multiple elements with the same name, so the same key may appear more than once while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/formdata/values/index.md
+++ b/files/en-us/web/api/formdata/values/index.md
@@ -10,6 +10,8 @@ browser-compat: api.FormData.values
 
 The **`FormData.values()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all values contained in the {{domxref("FormData")}}. The values are strings or {{domxref("Blob")}} objects.
 
+> **Note:** `FormData` keys are not necessarily unique. A form can contain multiple elements with the same name, so values sharing one key each appear while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
+
 ## Syntax
 
 ```js-nolint

--- a/files/en-us/web/api/formdata/values/index.md
+++ b/files/en-us/web/api/formdata/values/index.md
@@ -10,7 +10,8 @@ browser-compat: api.FormData.values
 
 The **`FormData.values()`** method returns an [iterator](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) which iterates through all values contained in the {{domxref("FormData")}}. The values are strings or {{domxref("Blob")}} objects.
 
-> **Note:** `FormData` keys are not necessarily unique. A form can contain multiple elements with the same name, so values sharing one key each appear while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
+> [!NOTE]
+> `FormData` keys are not necessarily unique. A form can contain multiple elements with the same name, so values sharing one key each appear while iterating. To retrieve all values associated with a single key, use the {{domxref("FormData.getAll()", "getAll()")}} method (or {{domxref("FormData.get()", "get()")}} for only the first value).
 
 ## Syntax
 


### PR DESCRIPTION
The issue: a form can hold several elements sharing one name, so FormData iteration can yield the same key many times. Readers coming from Map reasonably assume unique keys, and code like new Map(fd) silently drops values. None of the three iteration pages said keys may repeat.

What I changed, per page:

- keys(): a Note that keys are not necessarily unique, pointing at getAll() for every value of a key and get() for the first value only.
- entries(): the same callout, worded for key/value pairs.
- values(): the same callout, worded for values sharing one key.

I used the two-argument domxref form the get() page already uses, and kept each note to one paragraph right after the intro so the pages read the same as before. Only these three method pages change; examples, front matter, and everything else are untouched. I left the top-level FormData() constructor page alone to keep this small, but I can follow up there if reviewers want it.

Closes #45582

## Verification

- Read all three pages and checked the note wording against the issue's duplicate-name example
- Checked the get()/getAll() targets exist and the domxref form matches existing usage on the get() page
- No trailing whitespace; no front-matter changes