### PR TITLE
[WebExtensions] Chrome 152 limits extension action badge text length

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
@@ -36,6 +36,8 @@ This API is also available as `chrome.action.setBadgeText()`.
 
         If a `windowId` is specified, `null` removes the window-specific badge text so that the tab inherits the global badge text. Otherwise it reverts the global badge text to `""`.
 
+        Since Chrome 152, badge texts longer than 100 bytes are rejected. This limit may be implemented on other browsers. See [Proposal: limit byte length of extension action badge text](https://github.com/w3c/webextensions/issues/960) for more information.
+
     - `tabId` {{optional_inline}}
       - : `integer`. Set the badge text only for the given tab. The text is reset when the user navigates this tab to a new page.
     - `windowId` {{optional_inline}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
@@ -36,7 +36,7 @@ This API is also available as `chrome.action.setBadgeText()`.
 
         If a `windowId` is specified, `null` removes the window-specific badge text so that the tab inherits the global badge text. Otherwise it reverts the global badge text to `""`.
 
-        Since Chrome 152, badge texts longer than 100 bytes are rejected. This limit may be implemented on other browsers. See [Proposal: limit byte length of extension action badge text](https://github.com/w3c/webextensions/issues/960) for more information.
+        From Chrome 152, badge text longer than 100 bytes is rejected. Other browsers may implement this limit. See [Proposal: limit byte length of extension action badge text](https://github.com/w3c/webextensions/issues/960) for more information.
 
     - `tabId` {{optional_inline}}
       - : `integer`. Set the badge text only for the given tab. The text is reset when the user navigates this tab to a new page.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
Chrome 152+ throws an error for calls to `action.setBadgeText()` with `text` longer than 100 bytes.

### Motivation

Inform developers of API limit.
<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
Sources:
 - https://github.com/chromium/chromium/commit/8170d1b52c226e2550811aefdca87ec35ba496e9
 - https://github.com/w3c/webextensions/issues/960

### Related issues and pull requests

MDN BCD PR: https://github.com/mdn/browser-compat-data/pull/30386
WECG Discussion: https://github.com/w3c/webextensions/issues/960
Chrome tracking bug: https://issues.chromium.org/issues/491158086

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
