### PR TITLE
Correct createIndex exception wording

### DIFF
--- a/files/en-us/web/api/idbobjectstore/createindex/index.md
+++ b/files/en-us/web/api/idbobjectstore/createindex/index.md
@@ -58,7 +58,7 @@ An {{domxref("IDBIndex")}} object: the newly created index.
 This method may raise a {{domxref("DOMException")}} of one of the following types:
 
 - `ConstraintError` {{domxref("DOMException")}}
-  - : Thrown if an index with the same name already exists in the database. Index names are case-sensitive.
+  - : Thrown if an index with the same name already exists in the object store. Index names are case-sensitive.
 - `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if the provided key path is a sequence, and `multiEntry` is set to `true` in the `objectParameters` object.
 - `InvalidStateError` {{domxref("DOMException")}}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->

[The spec](https://www.w3.org/TR/IndexedDB/#dom-idbobjectstore-createindex) states: 

> If an [index](https://www.w3.org/TR/IndexedDB/#index-concept) [named](https://www.w3.org/TR/IndexedDB/#index-name) name already exists in store, [throw](https://webidl.spec.whatwg.org/#dfn-throw) a "[ConstraintError](https://webidl.spec.whatwg.org/#constrainterror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException).

I have changed the docs to refer to the object store rather than the database.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

This confused me when reading as a newbie to IndexedDB