### PR TITLE
Move a single-sentence description out of the Try it section on CSS pages

### DIFF
--- a/files/en-us/web/css/reference/properties/flex-wrap/index.md
+++ b/files/en-us/web/css/reference/properties/flex-wrap/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`flex-wrap`** [CSS](/en-US/docs/Web/CSS) property sets whether flex items are forced onto one line or can wrap onto multiple lines. If wrapping is allowed, it sets the direction that lines are stacked.
 
+The {{cssxref("flex-flow")}} property shorthand can be used to set both the {{CSSXRef("flex-direction")}} and `flex-wrap` properties, which define the flex container's main and cross axes, respectively.
+
 {{InteractiveExample("CSS Demo: flex-wrap")}}
 
 ```css interactive-example-choice
@@ -55,8 +57,6 @@ flex-wrap: wrap balance;
   margin: 10px;
 }
 ```
-
-The {{cssxref("flex-flow")}} property shorthand can be used to set both the {{CSSXRef("flex-direction")}} and `flex-wrap` properties, which define the flex container's main and cross axes, respectively.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/font-style/index.md
+++ b/files/en-us/web/css/reference/properties/font-style/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`font-style`** [CSS](/en-US/docs/Web/CSS) property sets whether a font should be styled with a normal, italic, or oblique face from its {{cssxref("font-family")}}.
 
+**Italic** font faces are generally cursive in nature, usually using less horizontal space than their unstyled counterparts, while **oblique** faces are usually just sloped versions of the regular face. When the specified style is not available, both italic and oblique faces are simulated by artificially sloping the glyphs of the regular face (use {{cssxref("font-synthesis")}} to control this behavior).
+
 {{InteractiveExample("CSS Demo: font-style")}}
 
 ```css interactive-example-choice
@@ -51,8 +53,6 @@ section {
   font-family: "Amstelvar", serif;
 }
 ```
-
-**Italic** font faces are generally cursive in nature, usually using less horizontal space than their unstyled counterparts, while **oblique** faces are usually just sloped versions of the regular face. When the specified style is not available, both italic and oblique faces are simulated by artificially sloping the glyphs of the regular face (use {{cssxref("font-synthesis")}} to control this behavior).
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/font-variant-numeric/index.md
+++ b/files/en-us/web/css/reference/properties/font-variant-numeric/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`font-variant-numeric`** [CSS](/en-US/docs/Web/CSS) property controls the usage of alternate glyphs for numbers, fractions, and ordinal markers.
 
+<!-- Source Sans Pro doesn't support stacked-fractions -->
+
 {{InteractiveExample("CSS Demo: font-variant-numeric", "taller")}}
 
 ```css interactive-example-choice
@@ -42,8 +44,6 @@ font-variant-numeric: proportional-nums;
 ```css interactive-example-choice
 font-variant-numeric: diagonal-fractions;
 ```
-
-<!-- Source Sans Pro doesn't support stacked-fractions -->
 
 ```html interactive-example
 <section id="default-example">

--- a/files/en-us/web/css/reference/properties/grid-auto-columns/index.md
+++ b/files/en-us/web/css/reference/properties/grid-auto-columns/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`grid-auto-columns`** [CSS](/en-US/docs/Web/CSS) property specifies the size of an implicitly-created grid column {{glossary("grid tracks", "track")}} or pattern of tracks.
 
+If a grid item is positioned into a column that is not explicitly sized by {{cssxref("grid-template-columns")}}, implicit {{glossary("grid", "grid")}} tracks are created to hold it. This can happen either by explicitly positioning into a column that is out of range, or by the auto-placement algorithm creating additional columns.
+
 {{InteractiveExample("CSS Demo: grid-auto-columns")}}
 
 ```css interactive-example-choice
@@ -63,8 +65,6 @@ grid-auto-columns: minmax(10px, auto);
   grid-column: 2;
 }
 ```
-
-If a grid item is positioned into a column that is not explicitly sized by {{cssxref("grid-template-columns")}}, implicit {{glossary("grid", "grid")}} tracks are created to hold it. This can happen either by explicitly positioning into a column that is out of range, or by the auto-placement algorithm creating additional columns.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/grid-auto-rows/index.md
+++ b/files/en-us/web/css/reference/properties/grid-auto-rows/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`grid-auto-rows`** [CSS](/en-US/docs/Web/CSS) property specifies the size of an implicitly-created grid row {{glossary("grid tracks", "track")}} or pattern of tracks.
 
+If a grid item is positioned into a row that is not explicitly sized by {{cssxref("grid-template-rows")}}, implicit {{glossary("grid", "grid")}} tracks are created to hold it. This can happen either by explicitly positioning into a row that is out of range, or by the auto-placement algorithm creating additional rows.
+
 {{InteractiveExample("CSS Demo: grid-auto-rows")}}
 
 ```css interactive-example-choice
@@ -61,8 +63,6 @@ grid-auto-rows: minmax(30px, auto);
   font-size: 13px;
 }
 ```
-
-If a grid item is positioned into a row that is not explicitly sized by {{cssxref("grid-template-rows")}}, implicit {{glossary("grid", "grid")}} tracks are created to hold it. This can happen either by explicitly positioning into a row that is out of range, or by the auto-placement algorithm creating additional rows.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/grid-template-areas/index.md
+++ b/files/en-us/web/css/reference/properties/grid-template-areas/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`grid-template-areas`** [CSS](/en-US/docs/Web/CSS) property specifies named {{glossary("grid areas")}}, establishing the cells in the grid and assigning them names.
 
+Those areas are not associated with any particular grid item, but can be referenced from the grid-placement properties {{cssxref("grid-row-start")}}, {{cssxref("grid-row-end")}}, {{cssxref("grid-column-start")}}, {{cssxref("grid-column-end")}}, and their shorthands {{cssxref("grid-row")}}, {{cssxref("grid-column")}}, and {{cssxref("grid-area")}}.
+
 {{InteractiveExample("CSS Demo: grid-template-areas")}}
 
 ```css interactive-example-choice
@@ -72,8 +74,6 @@ grid-template-areas:
   grid-area: c;
 }
 ```
-
-Those areas are not associated with any particular grid item, but can be referenced from the grid-placement properties {{cssxref("grid-row-start")}}, {{cssxref("grid-row-end")}}, {{cssxref("grid-column-start")}}, {{cssxref("grid-column-end")}}, and their shorthands {{cssxref("grid-row")}}, {{cssxref("grid-column")}}, and {{cssxref("grid-area")}}.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/image-rendering/index.md
+++ b/files/en-us/web/css/reference/properties/image-rendering/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`image-rendering`** [CSS](/en-US/docs/Web/CSS) property sets an image scaling algorithm. The property applies to an element itself, to any images set in its other properties, and to its descendants.
 
+The {{Glossary("user agent")}} will scale an image when the page author specifies dimensions other than its natural size. Scaling may also occur due to user interaction (zooming). For example, if the natural size of an image is `100×100px`_,_ but its actual dimensions are `200×200px` (or `50×50px`), then the image will be upscaled (or downscaled) using the algorithm specified by `image-rendering`. This property has no effect on non-scaled images.
+
 {{InteractiveExample("CSS Demo: image-rendering")}}
 
 ```css interactive-example-choice
@@ -42,8 +44,6 @@ image-rendering: pixelated;
   object-fit: cover;
 }
 ```
-
-The {{Glossary("user agent")}} will scale an image when the page author specifies dimensions other than its natural size. Scaling may also occur due to user interaction (zooming). For example, if the natural size of an image is `100×100px`_,_ but its actual dimensions are `200×200px` (or `50×50px`), then the image will be upscaled (or downscaled) using the algorithm specified by `image-rendering`. This property has no effect on non-scaled images.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/inset/index.md
+++ b/files/en-us/web/css/reference/properties/inset/index.md
@@ -11,6 +11,8 @@ The **`inset`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guide
 
 This {{glossary("inset properties")}}, including `inset`, have no effect on non-positioned elements.
 
+While part of the [CSS logical properties and values](/en-US/docs/Web/CSS/Guides/Logical_properties_and_values) module, it does not define _logical_ offsets. It defines _physical_ offsets, regardless of the element's writing mode, directionality, and text orientation.
+
 {{InteractiveExample("CSS Demo: inset")}}
 
 ```css interactive-example-choice
@@ -65,8 +67,6 @@ inset: 0;
   inset: 0;
 }
 ```
-
-While part of the [CSS logical properties and values](/en-US/docs/Web/CSS/Guides/Logical_properties_and_values) module, it does not define _logical_ offsets. It defines _physical_ offsets, regardless of the element's writing mode, directionality, and text orientation.
 
 ## Constituent properties
 

--- a/files/en-us/web/css/reference/properties/isolation/index.md
+++ b/files/en-us/web/css/reference/properties/isolation/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`isolation`** [CSS](/en-US/docs/Web/CSS) property determines whether an element must create a new {{glossary("stacking context")}}.
 
+This property is especially helpful when used in conjunction with {{cssxref("mix-blend-mode")}} and {{cssxref("z-index")}}.
+
 {{InteractiveExample("CSS Demo: isolation")}}
 
 ```css interactive-example-choice
@@ -46,8 +48,6 @@ isolation: isolate;
   color: #8245a3;
 }
 ```
-
-This property is especially helpful when used in conjunction with {{cssxref("mix-blend-mode")}} and {{cssxref("z-index")}}.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/margin-right/index.md
+++ b/files/en-us/web/css/reference/properties/margin-right/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`margin-right`** [CSS](/en-US/docs/Web/CSS) property sets the [margin area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#margin_area) on the right side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
 
+The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/Web/CSS/Guides/Box_model/Margin_collapsing).
+
 {{InteractiveExample("CSS Demo: margin-right")}}
 
 ```css interactive-example-choice
@@ -58,8 +60,6 @@ margin-right: 0;
   background-color: rgb(255 244 219 / 0.6);
 }
 ```
-
-The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/Web/CSS/Guides/Box_model/Margin_collapsing).
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/margin-top/index.md
+++ b/files/en-us/web/css/reference/properties/margin-top/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`margin-top`** [CSS](/en-US/docs/Web/CSS) property sets the [margin area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#margin_area) on the top of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
 
+This property has no effect on _non-[replaced](/en-US/docs/Glossary/Replaced_elements)_ inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.
+
 {{InteractiveExample("CSS Demo: margin-top")}}
 
 ```css interactive-example-choice
@@ -60,8 +62,6 @@ margin-top: 0;
   background-color: #2b3a55;
 }
 ```
-
-This property has no effect on _non-[replaced](/en-US/docs/Glossary/Replaced_elements)_ inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/max-height/index.md
+++ b/files/en-us/web/css/reference/properties/max-height/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`max-height`** [CSS](/en-US/docs/Web/CSS) property sets the maximum height of an element. It prevents the [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the {{cssxref("height")}} property from becoming larger than the value specified for `max-height`.
 
+`max-height` overrides {{cssxref("height")}}, but {{cssxref("min-height")}} overrides `max-height`.
+
 {{InteractiveExample("CSS Demo: max-height")}}
 
 ```css interactive-example-choice
@@ -45,8 +47,6 @@ max-height: 10px;
   color: white;
 }
 ```
-
-`max-height` overrides {{cssxref("height")}}, but {{cssxref("min-height")}} overrides `max-height`.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/max-width/index.md
+++ b/files/en-us/web/css/reference/properties/max-width/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`max-width`** [CSS](/en-US/docs/Web/CSS) property sets the maximum width of an element. It prevents the [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the {{cssxref("width")}} property from becoming larger than the value specified by `max-width`.
 
+`max-width` overrides {{cssxref("width")}}, but {{cssxref("min-width")}} overrides `max-width`.
+
 {{InteractiveExample("CSS Demo: max-width")}}
 
 ```css interactive-example-choice
@@ -45,8 +47,6 @@ max-width: 20ch;
   color: white;
 }
 ```
-
-`max-width` overrides {{cssxref("width")}}, but {{cssxref("min-width")}} overrides `max-width`.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/min-height/index.md
+++ b/files/en-us/web/css/reference/properties/min-height/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`min-height`** [CSS](/en-US/docs/Web/CSS) property sets the minimum height of an element. It prevents the [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the {{cssxref("height")}} property from becoming smaller than the value specified for `min-height`.
 
+The element's height is set to the value of `min-height` whenever `min-height` is larger than {{cssxref("max-height")}} or {{cssxref("height")}}.
+
 {{InteractiveExample("CSS Demo: min-height")}}
 
 ```css interactive-example-choice
@@ -46,8 +48,6 @@ min-height: 10px;
   color: white;
 }
 ```
-
-The element's height is set to the value of `min-height` whenever `min-height` is larger than {{cssxref("max-height")}} or {{cssxref("height")}}.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/min-width/index.md
+++ b/files/en-us/web/css/reference/properties/min-width/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`min-width`** [CSS](/en-US/docs/Web/CSS) property sets the minimum width of an element. It prevents the [used value](/en-US/docs/Web/CSS/Guides/Cascade/Property_value_processing#used_value) of the {{cssxref("width")}} property from becoming smaller than the value specified for `min-width`.
 
+The element's width is set to the value of `min-width` whenever `min-width` is larger than {{Cssxref("max-width")}} or {{Cssxref("width")}}.
+
 {{InteractiveExample("CSS Demo: min-width")}}
 
 ```css interactive-example-choice
@@ -45,8 +47,6 @@ min-width: 40ch;
   color: white;
 }
 ```
-
-The element's width is set to the value of `min-width` whenever `min-width` is larger than {{Cssxref("max-width")}} or {{Cssxref("width")}}.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/outline-style/index.md
+++ b/files/en-us/web/css/reference/properties/outline-style/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`outline-style`** [CSS](/en-US/docs/Web/CSS) property sets the style of an element's outline. An outline is a line that is drawn around an element, outside the {{cssxref("border")}}.
 
+It is often more convenient to use the shorthand property {{cssxref("outline")}} when defining the appearance of an outline.
+
 {{InteractiveExample("CSS Demo: outline-style")}}
 
 ```css interactive-example-choice
@@ -47,8 +49,6 @@ outline-style: inset;
   height: 100px;
 }
 ```
-
-It is often more convenient to use the shorthand property {{cssxref("outline")}} when defining the appearance of an outline.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/outline-width/index.md
+++ b/files/en-us/web/css/reference/properties/outline-width/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The [CSS](/en-US/docs/Web/CSS) **`outline-width`** property sets the thickness of an element's outline. An outline is a line that is drawn around an element, outside the {{cssxref("border")}}.
 
+It is often more convenient to use the shorthand property {{cssxref("outline")}} when defining the appearance of an outline.
+
 {{InteractiveExample("CSS Demo: outline-width")}}
 
 ```css interactive-example-choice
@@ -43,8 +45,6 @@ outline-width: thick;
   height: 100px;
 }
 ```
-
-It is often more convenient to use the shorthand property {{cssxref("outline")}} when defining the appearance of an outline.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/perspective-origin/index.md
+++ b/files/en-us/web/css/reference/properties/perspective-origin/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`perspective-origin`** [CSS](/en-US/docs/Web/CSS) property determines the position at which the viewer is looking. It is used as the _vanishing point_ by the {{cssxref("perspective")}} property.
 
+The **`perspective-origin`** and {{cssxref('perspective')}} properties are attached to the parent of a child transformed in 3-dimensional space, unlike the [`perspective()`](/en-US/docs/Web/CSS/Reference/Values/transform-function/perspective) transform function which is placed on the element being transformed.
+
 {{InteractiveExample("CSS Demo: perspective-origin")}}
 
 ```css interactive-example-choice
@@ -99,8 +101,6 @@ perspective-origin: 500% 200%;
   transform: rotateX(-90deg) translateZ(50px);
 }
 ```
-
-The **`perspective-origin`** and {{cssxref('perspective')}} properties are attached to the parent of a child transformed in 3-dimensional space, unlike the [`perspective()`](/en-US/docs/Web/CSS/Reference/Values/transform-function/perspective) transform function which is placed on the element being transformed.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/quotes/index.md
+++ b/files/en-us/web/css/reference/properties/quotes/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The [CSS](/en-US/docs/Web/CSS) **`quotes`** property sets how the browser should render quotation marks that are automatically added to the HTML {{HTMLElement("q")}} element or added using the `open-quotes` or `close-quotes` (or omitted using the `no-open-quote` and `no-close-quote`) values of the of the CSS {{cssxref("content")}} property.
 
+Browsers insert quotation marks at the opening and closing of `<q>` elements and for the `open-quote` and `close-quote` values of the `content` property. Each opening or closing quote is replaced by one of the strings from the value of `quotes`, based on the depth of nesting, or, if `quotes` is explicitly set to or otherwise resolves to `auto`, the quotation marks used are language dependent.
+
 {{InteractiveExample("CSS Demo: quotes")}}
 
 ```css interactive-example-choice
@@ -45,8 +47,6 @@ q {
   font-size: 1.2rem;
 }
 ```
-
-Browsers insert quotation marks at the opening and closing of `<q>` elements and for the `open-quote` and `close-quote` values of the `content` property. Each opening or closing quote is replaced by one of the strings from the value of `quotes`, based on the depth of nesting, or, if `quotes` is explicitly set to or otherwise resolves to `auto`, the quotation marks used are language dependent.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/scroll-padding-block/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-padding-block/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`scroll-padding-block`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties) property sets the scroll padding of an element in the block dimension.
 
+The scroll-padding properties define offsets for the _optimal viewing region_ of the scrollport: the region used as the target region for placing things in view of the user. This allows the author to exclude regions of the scrollport that are obscured by other content (such as fixed-positioned toolbars or sidebars) or to put more breathing room between a targeted element and the edges of the scrollport.
+
 {{InteractiveExample("CSS Demo: scroll-padding-block")}}
 
 ```css interactive-example-choice
@@ -70,8 +72,6 @@ scroll-padding-block: 2em;
   color: rebeccapurple;
 }
 ```
-
-The scroll-padding properties define offsets for the _optimal viewing region_ of the scrollport: the region used as the target region for placing things in view of the user. This allows the author to exclude regions of the scrollport that are obscured by other content (such as fixed-positioned toolbars or sidebars) or to put more breathing room between a targeted element and the edges of the scrollport.
 
 ## Constituent properties
 

--- a/files/en-us/web/css/reference/properties/scroll-padding-inline/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-padding-inline/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`scroll-padding-inline`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties) property sets the scroll padding of an element in the inline dimension.
 
+The scroll-padding properties define offsets for the _optimal viewing region_ of the scrollport: the region used as the target region for placing things in view of the user. This allows the author to exclude regions of the scrollport that are obscured by other content (such as fixed-positioned toolbars or sidebars) or to put more breathing room between a targeted element and the edges of the scrollport.
+
 {{InteractiveExample("CSS Demo: scroll-padding-inline")}}
 
 ```css interactive-example-choice
@@ -73,8 +75,6 @@ scroll-padding-inline: 2em;
   color: rebeccapurple;
 }
 ```
-
-The scroll-padding properties define offsets for the _optimal viewing region_ of the scrollport: the region used as the target region for placing things in view of the user. This allows the author to exclude regions of the scrollport that are obscured by other content (such as fixed-positioned toolbars or sidebars) or to put more breathing room between a targeted element and the edges of the scrollport.
 
 ## Constituent properties
 

--- a/files/en-us/web/css/reference/properties/shape-image-threshold/index.md
+++ b/files/en-us/web/css/reference/properties/shape-image-threshold/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`shape-image-threshold`** [CSS](/en-US/docs/Web/CSS) property sets the alpha channel threshold used to extract the shape using an image as the value for {{cssxref("shape-outside")}}.
 
+Any pixels whose alpha component's value is greater than the threshold are considered to be part of the shape for the purposes of determining its boundaries. For example, a value of `0.5` means that the shape will enclose all the pixels that are more than 50% opaque.
+
 {{InteractiveExample("CSS Demo: shape-image-threshold")}}
 
 ```css interactive-example-choice
@@ -76,8 +78,6 @@ shape-image-threshold: 0.6;
   );
 }
 ```
-
-Any pixels whose alpha component's value is greater than the threshold are considered to be part of the shape for the purposes of determining its boundaries. For example, a value of `0.5` means that the shape will enclose all the pixels that are more than 50% opaque.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/shape-margin/index.md
+++ b/files/en-us/web/css/reference/properties/shape-margin/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`shape-margin`** [CSS](/en-US/docs/Web/CSS) property sets a margin for a CSS shape created using {{cssxref("shape-outside")}}.
 
+The margin lets you adjust the distance between the edges of the shape (the **float element**) and the surrounding content.
+
 {{InteractiveExample("CSS Demo: shape-margin")}}
 
 ```css interactive-example-choice
@@ -59,8 +61,6 @@ shape-margin: 5%;
   shape-outside: circle(50%);
 }
 ```
-
-The margin lets you adjust the distance between the edges of the shape (the **float element**) and the surrounding content.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/text-decoration-color/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-color/index.md
@@ -11,6 +11,8 @@ The **`text-decoration-color`** [CSS](/en-US/docs/Web/CSS) property sets the col
 
 The color applies to decorations, such as underlines, overlines, strikethroughs, and wavy lines like those used to mark misspellings, in the scope of the property's value.
 
+CSS does not provide a direct mechanism for specifying a unique color for each line type. This effect can nevertheless be achieved by nesting elements, applying a different line type to each element (with the {{cssxref("text-decoration-line")}} property), and specifying the line color (with `text-decoration-color`) on a per-element basis.
+
 {{InteractiveExample("CSS Demo: text-decoration-color")}}
 
 ```css interactive-example-choice
@@ -52,8 +54,6 @@ p {
   text-decoration-line: underline;
 }
 ```
-
-CSS does not provide a direct mechanism for specifying a unique color for each line type. This effect can nevertheless be achieved by nesting elements, applying a different line type to each element (with the {{cssxref("text-decoration-line")}} property), and specifying the line color (with `text-decoration-color`) on a per-element basis.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/text-decoration-line/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-line/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`text-decoration-line`** [CSS](/en-US/docs/Web/CSS) property sets the kind of decoration that is used on text in an element, such as an underline or overline.
 
+When setting multiple line-decoration properties at once, it may be more convenient to use the {{cssxref("text-decoration")}} shorthand property instead.
+
 {{InteractiveExample("CSS Demo: text-decoration-line")}}
 
 ```css interactive-example-choice
@@ -58,8 +60,6 @@ p {
   font: 1.5em sans-serif;
 }
 ```
-
-When setting multiple line-decoration properties at once, it may be more convenient to use the {{cssxref("text-decoration")}} shorthand property instead.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/text-decoration-skip-ink/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-skip-ink/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`text-decoration-skip-ink`** [CSS](/en-US/docs/Web/CSS) property specifies how overlines and underlines are drawn when they pass over glyph ascenders and descenders.
 
+`text-decoration-skip-ink` is not part of the {{cssxref("text-decoration")}} shorthand.
+
 {{InteractiveExample("CSS Demo: text-decoration-skip-ink")}}
 
 ```css interactive-example-choice
@@ -35,8 +37,6 @@ p {
   text-decoration: underline;
 }
 ```
-
-`text-decoration-skip-ink` is not part of the {{cssxref("text-decoration")}} shorthand.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/text-decoration/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`text-decoration`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties) property sets the appearance of decorative lines on text. It is a shorthand for {{cssxref("text-decoration-line")}}, {{cssxref("text-decoration-color")}}, {{cssxref("text-decoration-style")}}, and the newer {{cssxref("text-decoration-thickness")}} property.
 
+Text decorations are drawn across descendant text elements. This means that if an element specifies a text decoration, then a child element can't remove the decoration. For example, in the markup `<p>This text has <em>some emphasized words</em> in it.</p>`, the style rule `p { text-decoration: underline; }` would cause the entire paragraph to be underlined. The style rule `em { text-decoration: none; }` would not cause any change; the entire paragraph would still be underlined. However, the rule `em { text-decoration: overline; }` would cause a second decoration to appear on "some emphasized words".
+
 {{InteractiveExample("CSS Demo: text-decoration")}}
 
 ```css interactive-example-choice
@@ -46,8 +48,6 @@ p {
   font: 1.5em sans-serif;
 }
 ```
-
-Text decorations are drawn across descendant text elements. This means that if an element specifies a text decoration, then a child element can't remove the decoration. For example, in the markup `<p>This text has <em>some emphasized words</em> in it.</p>`, the style rule `p { text-decoration: underline; }` would cause the entire paragraph to be underlined. The style rule `em { text-decoration: none; }` would not cause any change; the entire paragraph would still be underlined. However, the rule `em { text-decoration: overline; }` would cause a second decoration to appear on "some emphasized words".
 
 ## Constituent properties
 

--- a/files/en-us/web/css/reference/properties/text-underline-offset/index.md
+++ b/files/en-us/web/css/reference/properties/text-underline-offset/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`text-underline-offset`** [CSS](/en-US/docs/Web/CSS) property sets the offset distance of an underline text decoration line (applied using {{cssxref("text-decoration")}}) from its original position.
 
+`text-underline-offset` is not part of the {{cssxref('text-decoration')}} shorthand. While an element can have multiple `text-decoration` lines, `text-underline-offset` only impacts underlining, and **not** other possible line decoration options such as `overline` or `line-through`.
+
 {{InteractiveExample("CSS Demo: text-underline-offset")}}
 
 ```css interactive-example-choice
@@ -36,8 +38,6 @@ p {
   text-decoration-color: red;
 }
 ```
-
-`text-underline-offset` is not part of the {{cssxref('text-decoration')}} shorthand. While an element can have multiple `text-decoration` lines, `text-underline-offset` only impacts underlining, and **not** other possible line decoration options such as `overline` or `line-through`.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/transition-duration/index.md
+++ b/files/en-us/web/css/reference/properties/transition-duration/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`transition-duration`** [CSS](/en-US/docs/Web/CSS) property sets the length of time a transition animation should take to complete. By default, the value is `0s`, meaning that no animation will occur.
 
+You may specify multiple durations; each duration will be applied to the corresponding property as specified by the {{ cssxref("transition-property") }} property, which acts as a master list. If the number of specified durations is less than in the master list, the user agent repeats the list of durations. If the number of specified durations is more than in the master list, the list is truncated to the right size. In both the cases, the CSS declaration stays valid.
+
 {{InteractiveExample("CSS Demo: transition-duration")}}
 
 ```css interactive-example-choice
@@ -54,8 +56,6 @@ transition-property: margin-right, color;
   margin-right: 40%;
 }
 ```
-
-You may specify multiple durations; each duration will be applied to the corresponding property as specified by the {{ cssxref("transition-property") }} property, which acts as a master list. If the number of specified durations is less than in the master list, the user agent repeats the list of durations. If the number of specified durations is more than in the master list, the list is truncated to the right size. In both the cases, the CSS declaration stays valid.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/transition-property/index.md
+++ b/files/en-us/web/css/reference/properties/transition-property/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`transition-property`** [CSS](/en-US/docs/Web/CSS) property sets the CSS properties to which a [transition effect](/en-US/docs/Web/CSS/Guides/Transitions/Using) should be applied.
 
+If you specify a shorthand property (e.g., {{cssxref("background")}}), all of its longhand sub-properties that can be animated will be.
+
 {{InteractiveExample("CSS Demo: transition-property")}}
 
 ```css interactive-example-choice
@@ -50,8 +52,6 @@ transition-property: none;
   margin-right: 40%;
 }
 ```
-
-If you specify a shorthand property (e.g., {{cssxref("background")}}), all of its longhand sub-properties that can be animated will be.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/transition/index.md
+++ b/files/en-us/web/css/reference/properties/transition/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`transition`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties) property for {{ cssxref("transition-property") }}, {{ cssxref("transition-duration") }}, {{ cssxref("transition-timing-function") }}, {{ cssxref("transition-delay") }}, and {{ cssxref("transition-behavior") }}.
 
+Transitions enable you to define the transition between two states of an element. Different states may be defined using [pseudo-classes](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) like {{cssxref(":hover")}} or {{cssxref(":active")}} or dynamically set using JavaScript.
+
 {{InteractiveExample("CSS Demo: transition")}}
 
 ```css interactive-example-choice
@@ -60,8 +62,6 @@ transition: all 1s ease-out;
   margin-right: 40%;
 }
 ```
-
-Transitions enable you to define the transition between two states of an element. Different states may be defined using [pseudo-classes](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) like {{cssxref(":hover")}} or {{cssxref(":active")}} or dynamically set using JavaScript.
 
 ## Constituent properties
 

--- a/files/en-us/web/css/reference/properties/visibility/index.md
+++ b/files/en-us/web/css/reference/properties/visibility/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`visibility`** [CSS](/en-US/docs/Web/CSS) property shows or hides an element without changing the layout of a document. The property can also hide rows or columns in a {{HTMLElement("table")}}.
 
+To both hide an element _and remove it from the document layout_, set the {{cssxref("display")}} property to `none` instead of using `visibility`.
+
 {{InteractiveExample("CSS Demo: visibility")}}
 
 ```css interactive-example-choice
@@ -54,8 +56,6 @@ visibility: collapse;
   border: 3px solid rebeccapurple;
 }
 ```
-
-To both hide an element _and remove it from the document layout_, set the {{cssxref("display")}} property to `none` instead of using `visibility`.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_focus-visible/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:focus-visible`** pseudo-class applies while an element matches the {{CSSxRef(":focus")}} pseudo-class and the UA ({{glossary("User Agent")}}) determines via heuristics that the focus should be made evident on the element. (Many browsers show a "focus ring" by default in this case.)
 
+This selector is useful to provide a different focus indicator based on the user's input modality (mouse vs. keyboard).
+
 {{InteractiveExample("CSS Demo: :focus-visible", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -44,8 +46,6 @@ select:focus-visible {
   </label>
 </form>
 ```
-
-This selector is useful to provide a different focus indicator based on the user's input modality (mouse vs. keyboard).
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_focus-within/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_focus-within/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:focus-within`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) matches an element if the element or any of its descendants are focused. In other words, it represents an element that is itself matched by the {{CSSxRef(":focus")}} pseudo-class or has a descendant that is matched by `:focus`. (This includes descendants in [shadow trees](/en-US/docs/Web/API/Web_components/Using_shadow_DOM).)
 
+This selector is useful, to take a common example, for highlighting an entire {{HTMLElement("form")}} container when the user focuses on one of its {{HTMLElement("input")}} fields.
+
 {{InteractiveExample("CSS Demo: :focus-within", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -37,8 +39,6 @@ label:focus-within {
   </label>
 </form>
 ```
-
-This selector is useful, to take a common example, for highlighting an entire {{HTMLElement("form")}} container when the user focuses on one of its {{HTMLElement("input")}} fields.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_invalid/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_invalid/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:invalid`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents any {{HTMLElement("form")}}, {{HTMLElement("fieldset")}}, {{HTMLElement("input")}} or other {{HTMLElement("form")}} element whose contents fail to [validate](/en-US/docs/Web/HTML/Guides/Constraint_validation).
 
+This pseudo-class is useful for highlighting field errors for the user.
+
 {{InteractiveExample("CSS Demo: :invalid", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -42,8 +44,6 @@ input:invalid {
   >
 </form>
 ```
-
-This pseudo-class is useful for highlighting field errors for the user.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_not/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_not/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:not()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents elements that do not match a list of selectors. Since it prevents specific items from being selected, it is known as the _negation pseudo-class_.
 
+The `:not()` pseudo-class has a number of [quirks, tricks, and unexpected results](#description) that you should be aware of before using it.
+
 {{InteractiveExample("CSS Demo: :not", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -38,8 +40,6 @@ p > :not(strong, b.important) {
   and atmospheric pressure.
 </p>
 ```
-
-The `:not()` pseudo-class has a number of [quirks, tricks, and unexpected results](#description) that you should be aware of before using it.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_valid/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_valid/index.md
@@ -44,8 +44,6 @@ input:valid {
 </form>
 ```
 
-This pseudo-class is useful for highlighting correct fields for the user.
-
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/reference/selectors/_colon_visited/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_visited/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:visited`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) applies once the link has been visited by the user. For privacy reasons, the styles that can be modified using this selector are very limited. The `:visited` pseudo-class applies only to {{htmlelement("a")}} and {{htmlelement("area")}} elements that have an `href` attribute.
 
+Styles defined by the `:visited` and unvisited {{cssxref(":link")}} pseudo-classes can be overridden by any subsequent user-action pseudo-classes ({{cssxref(":hover")}} or {{cssxref(":active")}}) that have at least equal specificity. To style links appropriately, put the `:visited` rule after the `:link` rule but before the `:hover` and `:active` rules, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`. The `:visited` pseudo-class and `:link` pseudo-class are mutually exclusive.
+
 {{InteractiveExample("CSS Demo: :visited", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -42,8 +44,6 @@ a:visited {
   </li>
 </ul>
 ```
-
-Styles defined by the `:visited` and unvisited {{cssxref(":link")}} pseudo-classes can be overridden by any subsequent user-action pseudo-classes ({{cssxref(":hover")}} or {{cssxref(":active")}}) that have at least equal specificity. To style links appropriately, put the `:visited` rule after the `:link` rule but before the `:hover` and `:active` rules, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`. The `:visited` pseudo-class and `:link` pseudo-class are mutually exclusive.
 
 ## Privacy restrictions
 

--- a/files/en-us/web/css/reference/values/color_value/hsl/index.md
+++ b/files/en-us/web/css/reference/values/color_value/hsl/index.md
@@ -15,6 +15,8 @@ sidebar: cssref
 
 The **`hsl()`** functional notation expresses a color in the {{glossary("RGB", "sRGB")}} {{glossary("color space")}} according to its _hue_, _saturation_, and _lightness_ components. An optional _alpha_ component represents the color's transparency.
 
+Defining _complementary colors_ with `hsl()` can be done by adding or subtracting 180 degrees from the hue value, as they are positioned on the same diameter of the {{glossary("color wheel")}}. For example, if the hue angle of a color is `10deg`, its complementary has `190deg` as its hue angle.
+
 {{InteractiveExample("CSS Demo: hsl()")}}
 
 ```css interactive-example-choice
@@ -46,8 +48,6 @@ background: hsl(0 80% 50% / 25%);
   padding: 10%;
 }
 ```
-
-Defining _complementary colors_ with `hsl()` can be done by adding or subtracting 180 degrees from the hue value, as they are positioned on the same diameter of the {{glossary("color wheel")}}. For example, if the hue angle of a color is `10deg`, its complementary has `190deg` as its hue angle.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/gradient/index.md
+++ b/files/en-us/web/css/reference/values/gradient/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`<gradient>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/Reference/Values/Data_types) is a special type of {{cssxref("image")}} that consists of a progressive transition between two or more colors.
 
+A CSS gradient has [no intrinsic dimensions](/en-US/docs/Web/CSS/Reference/Values/image#description); i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element to which it applies.
+
 {{InteractiveExample("CSS Demo: &lt;gradient&gt;")}}
 
 ```css interactive-example-choice
@@ -42,8 +44,6 @@ background: conic-gradient(#f69d3c, #3f87a6);
   min-height: 100%;
 }
 ```
-
-A CSS gradient has [no intrinsic dimensions](/en-US/docs/Web/CSS/Reference/Values/image#description); i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element to which it applies.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/var/index.md
+++ b/files/en-us/web/css/reference/values/var/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`var()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) can be used to insert the value of a [custom property](/en-US/docs/Web/CSS/Reference/Properties/--*) (sometimes called a "CSS variable") instead of any part of a value of another property.
 
+The `var()` function cannot be used in property names, selectors or anything else besides property values. (Doing so usually produces invalid syntax, or else a value whose meaning has no connection to the variable.)
+
 {{InteractiveExample("CSS Demo: var()")}}
 
 ```css interactive-example-choice
@@ -44,8 +46,6 @@ border-color: var(--color-c);
   padding: 10px;
 }
 ```
-
-The `var()` function cannot be used in property names, selectors or anything else besides property values. (Doing so usually produces invalid syntax, or else a value whose meaning has no connection to the variable.)
 
 ## Syntax
 


### PR DESCRIPTION
### Description

This is the first of four PRs splitting up #45563, which was closed so it could be reviewed in smaller pieces. It covers the CSS pages where exactly one sentence sits after the `{{InteractiveExample}}` macro.

Because the macro generates the "Try it" heading, that sentence renders *inside* the "Try it" section, after the demo's code. Each one moves up to follow the introductory paragraph. For example, on `max-width`:

```diff
 The **`max-width`** CSS property sets the maximum width of an element. …

+`max-width` overrides {{cssxref("width")}}, but {{cssxref("min-width")}} overrides `max-width`.
+
 {{InteractiveExample("CSS Demo: max-width")}}

 …interactive-example code blocks…

-`max-width` overrides {{cssxref("width")}}, but {{cssxref("min-width")}} overrides `max-width`.
-
 ## Syntax
```

Every change is the same single line moved, with no rewording. The one exception is `:valid`, which keeps @Josh-Cena's edit from the original PR deleting the sentence as redundant rather than moving it.

Pages where the sentence refers back to the example ("In the above example…") are left alone, as requested in the previous review.

I confirmed the effect by building `max-width` with `rari` before and after: beforehand the sentence appears in the section with `id="try_it"`; afterwards it appears in the introduction and `try_it` contains only the example.

### Motivation

A single sentence of description belongs with the introduction, above the demo — [as described in review](https://github.com/mdn/content/pull/45563#issuecomment-3389310786), the interactive example should come after a short summary of the feature. Most pages already do this: of the pages using `interactive-example-choice` blocks, 314 have nothing after the macro.

The longer, multi-paragraph cases are the ones where the intro could get too long, so they are split into separate PRs rather than mixed in here.
