### PR TITLE
Move a single-sentence description out of the Try it section on HTML and WebAssembly pages

### DIFF
--- a/files/en-us/web/html/reference/elements/article/index.md
+++ b/files/en-us/web/html/reference/elements/article/index.md
@@ -55,13 +55,13 @@ The **`<article>`** [HTML](/en-US/docs/Web/HTML) element represents a self-conta
 }
 ```
 
-A given document can have multiple articles in it; for example, on a blog that shows the text of each article one after another as the reader scrolls, each post would be contained in an `<article>` element, possibly with one or more `<section>`s within.
-
 ## Attributes
 
 This element only includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 
 ## Usage notes
+
+A given document can have multiple articles in it; for example, on a blog that shows the text of each article one after another as the reader scrolls, each post would be contained in an `<article>` element, possibly with one or more `<section>`s within.
 
 - Each `<article>` should be identified, typically by including a heading ([`<h1>` - `<h6>`](/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements) element) as a child of the `<article>` element.
 - When an `<article>` element is nested, the inner element represents an article related to the outer element. For example, the comments of a blog post can be `<article>` elements nested in the `<article>` representing the blog post.

--- a/files/en-us/web/html/reference/elements/bdo/index.md
+++ b/files/en-us/web/html/reference/elements/bdo/index.md
@@ -37,8 +37,6 @@ bdo {
 }
 ```
 
-The text's characters are drawn from the starting point in the given direction; the individual characters' orientation is not affected (so characters don't get drawn backward, for example).
-
 ## Attributes
 
 This element's attributes include the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -61,6 +59,8 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/R
 {{EmbedLiveSample('Examples')}}
 
 ## Notes
+
+The text's characters are drawn from the starting point in the given direction; the individual characters' orientation is not affected (so characters don't get drawn backward, for example).
 
 The HTML 4 specification did not specify events for this element; they were added in XHTML. This is most likely an oversight.
 

--- a/files/en-us/web/html/reference/elements/bdo/index.md
+++ b/files/en-us/web/html/reference/elements/bdo/index.md
@@ -46,6 +46,10 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/R
     - `ltr`: Indicates that the text should go in a left-to-right direction.
     - `rtl`: Indicates that the text should go in a right-to-left direction.
 
+## Usage notes
+
+The text's characters are drawn from the starting point in the given direction; the individual characters' orientation is not affected (so characters don't get drawn backward, for example).
+
 ## Examples
 
 ```html
@@ -57,12 +61,6 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/R
 ### Result
 
 {{EmbedLiveSample('Examples')}}
-
-## Notes
-
-The text's characters are drawn from the starting point in the given direction; the individual characters' orientation is not affected (so characters don't get drawn backward, for example).
-
-The HTML 4 specification did not specify events for this element; they were added in XHTML. This is most likely an oversight.
 
 ## Technical summary
 

--- a/files/en-us/web/html/reference/elements/del/index.md
+++ b/files/en-us/web/html/reference/elements/del/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`<del>`** [HTML](/en-US/docs/Web/HTML) element represents a range of text that has been deleted from a document. This can be used when rendering "track changes" or source code diff information, for example. The {{HTMLElement("ins")}} element can be used for the opposite purpose: to indicate text that has been added to the document.
 
+This element is often (but need not be) rendered by applying a strike-through style to the text.
+
 {{InteractiveExample("HTML Demo: &lt;del&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -36,8 +38,6 @@ blockquote {
   font-size: 1rem;
 }
 ```
-
-This element is often (but need not be) rendered by applying a strike-through style to the text.
 
 ## Attributes
 

--- a/files/en-us/web/html/reference/elements/div/index.md
+++ b/files/en-us/web/html/reference/elements/div/index.md
@@ -39,8 +39,6 @@ The **`<div>`** [HTML](/en-US/docs/Web/HTML) element is the generic container fo
 }
 ```
 
-As a "pure" container, the `<div>` element does not inherently represent anything. Instead, it's used to group content so it can be easily styled using the [`class`](/en-US/docs/Web/HTML/Reference/Global_attributes/class) or [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attributes, marking a section of a document as being written in a different language (using the [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute), and so on.
-
 ## Attributes
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -49,6 +47,8 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 > The `align` attribute is obsolete; do not use it anymore. Instead, you should use CSS properties or techniques such as [CSS Grid](/en-US/docs/Web/CSS/Guides/Grid_layout) or [CSS Flexbox](/en-US/docs/Learn_web_development/Core/CSS_layout/Flexbox) to align and position `<div>` elements on the page.
 
 ## Usage notes
+
+As a "pure" container, the `<div>` element does not inherently represent anything. Instead, it's used to group content so it can be easily styled using the [`class`](/en-US/docs/Web/HTML/Reference/Global_attributes/class) or [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attributes, marking a section of a document as being written in a different language (using the [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute), and so on.
 
 - The `<div>` element should be used only when no other semantic element (such as {{HTMLElement("article")}} or {{HTMLElement("nav")}}) is appropriate.
 

--- a/files/en-us/web/html/reference/elements/div/index.md
+++ b/files/en-us/web/html/reference/elements/div/index.md
@@ -50,7 +50,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
 As a "pure" container, the `<div>` element does not inherently represent anything. Instead, it's used to group content so it can be easily styled using the [`class`](/en-US/docs/Web/HTML/Reference/Global_attributes/class) or [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attributes, marking a section of a document as being written in a different language (using the [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute), and so on.
 
-- The `<div>` element should be used only when no other semantic element (such as {{HTMLElement("article")}} or {{HTMLElement("nav")}}) is appropriate.
+The `<div>` element should be used only when no other semantic element (such as {{HTMLElement("article")}} or {{HTMLElement("nav")}}) is appropriate.
 
 ## Accessibility
 

--- a/files/en-us/web/html/reference/elements/form/index.md
+++ b/files/en-us/web/html/reference/elements/form/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`<form>`** [HTML](/en-US/docs/Web/HTML) element represents a document section containing interactive controls for submitting information.
 
+It is possible to use the {{cssxref(':valid')}} and {{cssxref(':invalid')}} CSS [pseudo-classes](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) to style a `<form>` element based on whether the {{domxref("HTMLFormElement.elements", "elements")}} inside the form are valid.
+
 {{InteractiveExample("HTML Demo: &lt;form&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -46,8 +48,6 @@ label {
   padding-right: 10px;
 }
 ```
-
-It is possible to use the {{cssxref(':valid')}} and {{cssxref(':invalid')}} CSS [pseudo-classes](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) to style a `<form>` element based on whether the {{domxref("HTMLFormElement.elements", "elements")}} inside the form are valid.
 
 ## Attributes
 

--- a/files/en-us/web/html/reference/elements/input/datetime-local/index.md
+++ b/files/en-us/web/html/reference/elements/input/datetime-local/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 {{htmlelement("input")}} elements of type **`datetime-local`** create input controls that let the user easily enter both a date and a time, including the year, month, and day as well as the time in hours and minutes.
 
+The control's UI varies in general from browser to browser. The control is intended to represent _a local date and time_, not necessarily _the user's local date and time_. In other words, the input allows any valid combination of year, month, day, hour, and minute—even if such a combination is invalid in the user's local time zone (such as the one hour within a daylight saving time spring-forward transition gap).
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;datetime-local&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -36,8 +38,6 @@ label {
   margin: 0.4rem 0;
 }
 ```
-
-The control's UI varies in general from browser to browser. The control is intended to represent _a local date and time_, not necessarily _the user's local date and time_. In other words, the input allows any valid combination of year, month, day, hour, and minute—even if such a combination is invalid in the user's local time zone (such as the one hour within a daylight saving time spring-forward transition gap).
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/input/email/index.md
+++ b/files/en-us/web/html/reference/elements/input/email/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`email`** are used to let the user enter and edit an email address, or, if the [`multiple`](/en-US/docs/Web/HTML/Reference/Attributes/multiple) attribute is specified, a list of email addresses.
 
+The input value is automatically validated to ensure that it's either empty or a properly-formatted email address (or list of addresses) before the form can be submitted. The {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS pseudo-classes are automatically applied as appropriate to visually denote whether the current value of the field is a valid email address or not.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;email&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -30,8 +32,6 @@ label {
   margin: 0.4rem 0;
 }
 ```
-
-The input value is automatically validated to ensure that it's either empty or a properly-formatted email address (or list of addresses) before the form can be submitted. The {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS pseudo-classes are automatically applied as appropriate to visually denote whether the current value of the field is a valid email address or not.
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/input/number/index.md
+++ b/files/en-us/web/html/reference/elements/input/number/index.md
@@ -11,6 +11,8 @@ sidebar: htmlsidebar
 
 The browser may opt to provide stepper arrows to let the user increase and decrease the value using their mouse or by tapping with a fingertip.
 
+On browsers that don't support inputs of type `number`, a `number` input falls back to type `text`.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;number&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -32,8 +34,6 @@ label {
   margin: 0.4rem 0;
 }
 ```
-
-On browsers that don't support inputs of type `number`, a `number` input falls back to type `text`.
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/input/range/index.md
+++ b/files/en-us/web/html/reference/elements/input/range/index.md
@@ -11,6 +11,8 @@ sidebar: htmlsidebar
 
 Because this kind of widget is imprecise, it should only be used if the control's exact value isn't important.
 
+If the user's browser doesn't support type `range`, it will fall back and treat it as a `{{HTMLElement('input/text', 'text')}}` input.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;range&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -46,8 +48,6 @@ input {
   margin: 0.4rem;
 }
 ```
-
-If the user's browser doesn't support type `range`, it will fall back and treat it as a `{{HTMLElement('input/text', 'text')}}` input.
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/input/url/index.md
+++ b/files/en-us/web/html/reference/elements/input/url/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`url`** are used to let the user enter and edit a URL.
 
+The input value is automatically validated to ensure that it's either empty or a properly-formatted URL before the form can be submitted. The {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS pseudo-classes are automatically applied as appropriate to visually denote whether the current value of the field is a valid URL or not.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;url&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -38,8 +40,6 @@ label {
   margin: 0.4rem 0;
 }
 ```
-
-The input value is automatically validated to ensure that it's either empty or a properly-formatted URL before the form can be submitted. The {{cssxref(":valid")}} and {{cssxref(":invalid")}} CSS pseudo-classes are automatically applied as appropriate to visually denote whether the current value of the field is a valid URL or not.
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/main/index.md
+++ b/files/en-us/web/html/reference/elements/main/index.md
@@ -35,13 +35,13 @@ header {
 }
 ```
 
-A document mustn't have more than one `<main>` element that doesn't have the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute specified.
-
 ## Attributes
 
 This element only includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 
 ## Usage notes
+
+A document mustn't have more than one `<main>` element that doesn't have the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute specified.
 
 The content of a `<main>` element should be unique to the document. Content that is repeated across a set of documents or document sections such as sidebars, navigation links, copyright information, site logos, and search forms shouldn't be included unless the search form is the main function of the page.
 

--- a/files/en-us/web/html/reference/elements/rt/index.md
+++ b/files/en-us/web/html/reference/elements/rt/index.md
@@ -23,8 +23,6 @@ ruby {
 }
 ```
 
-See the article about the {{HTMLElement("ruby")}} element for more examples.
-
 ## Attributes
 
 This element only includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -48,6 +46,8 @@ body {
 #### Result
 
 {{EmbedLiveSample("Using_ruby_annotations", 600, 60)}}
+
+See the {{HTMLElement("ruby")}} element for more examples.
 
 ## Technical summary
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_s/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_s/index.md
@@ -9,6 +9,8 @@ sidebar: webassemblysidebar
 
 The **`trunc_sat_f32x4_s`** [SIMD conversion instruction](/en-US/docs/WebAssembly/Reference/SIMD/conversion) performs a [saturating](https://en.wikipedia.org/wiki/Saturation_arithmetic) conversion of the lanes of a [`v128`](/en-US/docs/WebAssembly/Reference/Value_types/v128) `f32x4` value interpretation into a signed `i32x4` value interpretation, clamping the output to the range allowed by the value type.
 
+Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `−2,147,483,648` to `2,147,483,647` (the full range of a signed 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
+
 {{InteractiveExample("Wat Demo: trunc_sat_f32x4_s", "tabbed-taller")}}
 
 ```wat interactive-example
@@ -28,8 +30,6 @@ The **`trunc_sat_f32x4_s`** [SIMD conversion instruction](/en-US/docs/WebAssembl
 ```js interactive-example
 WebAssembly.instantiateStreaming(fetch("{%wasm-url%}"), { console });
 ```
-
-Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `−2,147,483,648` to `2,147,483,647` (the full range of a signed 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
 
 ## Syntax
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_u/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f32x4_u/index.md
@@ -9,6 +9,8 @@ sidebar: webassemblysidebar
 
 The **`trunc_sat_f32x4_u`** [SIMD conversion instruction](/en-US/docs/WebAssembly/Reference/SIMD/conversion) performs a [saturating](https://en.wikipedia.org/wiki/Saturation_arithmetic) conversion of the lanes of a [`v128`](/en-US/docs/WebAssembly/Reference/Value_types/v128) `f32x4` value interpretation into an unsigned `i32x4` value interpretation, clamping the output to the range allowed by the value type.
 
+Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `0` to `4,294,967,295` (the full range of an unsigned 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
+
 {{InteractiveExample("Wat Demo: trunc_sat_f32x4_u", "tabbed-taller")}}
 
 ```wat interactive-example
@@ -28,8 +30,6 @@ The **`trunc_sat_f32x4_u`** [SIMD conversion instruction](/en-US/docs/WebAssembl
 ```js interactive-example
 WebAssembly.instantiateStreaming(fetch("{%wasm-url%}"), { console });
 ```
-
-Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `0` to `4,294,967,295` (the full range of an unsigned 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
 
 ## Syntax
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_s_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_s_zero/index.md
@@ -9,6 +9,8 @@ sidebar: webassemblysidebar
 
 The **`trunc_sat_f64x2_s_zero`** [SIMD conversion instruction](/en-US/docs/WebAssembly/Reference/SIMD/conversion) performs a [saturating](https://en.wikipedia.org/wiki/Saturation_arithmetic) conversion of the lanes of a [`v128`](/en-US/docs/WebAssembly/Reference/Value_types/v128) `f64x2` value interpretation into a signed `i32x4` value interpretation, clamping the output to the range allowed by the value type. The two higher lanes of the result are initialized to zero.
 
+Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `−2,147,483,648` to `2,147,483,647` (the full range of a signed 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
+
 {{InteractiveExample("Wat Demo: trunc_sat_f64x2_s_zero", "tabbed-taller")}}
 
 ```wat interactive-example
@@ -28,8 +30,6 @@ The **`trunc_sat_f64x2_s_zero`** [SIMD conversion instruction](/en-US/docs/WebAs
 ```js interactive-example
 WebAssembly.instantiateStreaming(fetch("{%wasm-url%}"), { console });
 ```
-
-Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `−2,147,483,648` to `2,147,483,647` (the full range of a signed 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
 
 ## Syntax
 

--- a/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_u_zero/index.md
+++ b/files/en-us/webassembly/reference/simd/conversion/trunc_sat_f64x2_u_zero/index.md
@@ -9,6 +9,8 @@ sidebar: webassemblysidebar
 
 The **`trunc_sat_f64x2_u_zero`** [SIMD conversion instruction](/en-US/docs/WebAssembly/Reference/SIMD/conversion) performs a [saturating](https://en.wikipedia.org/wiki/Saturation_arithmetic) conversion of the lanes of a [`v128`](/en-US/docs/WebAssembly/Reference/Value_types/v128) `f64x2` value interpretation into an unsigned `i32x4` value interpretation, clamping the output to the range allowed by the value type. The two higher lanes of the result are initialized to zero.
 
+Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `0` to `4,294,967,295` (the full range of an unsigned 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
+
 {{InteractiveExample("Wat Demo: trunc_sat_f64x2_u_zero", "tabbed-taller")}}
 
 ```wat interactive-example
@@ -28,8 +30,6 @@ The **`trunc_sat_f64x2_u_zero`** [SIMD conversion instruction](/en-US/docs/WebAs
 ```js interactive-example
 WebAssembly.instantiateStreaming(fetch("{%wasm-url%}"), { console });
 ```
-
-Saturation means that the output values are clamped to the upper and lower values allowed by the value interpretation. Allowed output values are `0` to `4,294,967,295` (the full range of an unsigned 32-bit integer). {{jsxref("NaN")}} values are converted to `0`.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

The second of four PRs splitting up #45563. Same change as #45601, applied to the HTML, WebAssembly and JavaScript pages: 17 pages where exactly one sentence sits after the `{{InteractiveExample}}` macro and therefore renders inside the "Try it" section.

Examples of the sentences moved:

- `<del>` — "This element is often (but need not be) rendered by applying a strike-through style to the text."
- `<input type="number">` — "On browsers that don't support inputs of type `number`, a `number` input falls back to type `text`."
- `<main>` — "A document mustn't have more than one `<main>` element that doesn't have the `hidden` attribute specified."

Every change is the same single line moved, with no rewording. The one exception is `<rt>`, which keeps @Josh-Cena's edit from the original PR relocating the sentence below the example and rewording it.

Pages where the sentence refers back to the example are left alone, as requested in the previous review.

### Motivation

Same as #45601: a single sentence of description belongs with the introduction, above the demo, rather than rendering inside the "Try it" section after the demo's code.
