### PR TITLE
Move multi-paragraph descriptions out of the Try it section on CSS pages

### DIFF
--- a/files/en-us/web/css/reference/properties/float/index.md
+++ b/files/en-us/web/css/reference/properties/float/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`float`** [CSS](/en-US/docs/Web/CSS) property places an element on the left or right side of its container, allowing text and inline elements to wrap around it. The element is removed from the normal flow of the page, though still remaining a part of the flow (in contrast to [absolute positioning](/en-US/docs/Web/CSS/Reference/Properties/position#absolute_positioning)).
 
+A _floating element_ is one where the computed value of `float` is not `none`.
+
 {{InteractiveExample("CSS Demo: float")}}
 
 ```css interactive-example-choice
@@ -59,8 +61,6 @@ float: inline-end;
   width: 40%;
 }
 ```
-
-A _floating element_ is one where the computed value of `float` is not `none`.
 
 As `float` implies the use of the block layout, it modifies the computed value of the {{cssxref("display")}} values, in some cases:
 

--- a/files/en-us/web/css/reference/properties/font-family/index.md
+++ b/files/en-us/web/css/reference/properties/font-family/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`font-family`** [CSS](/en-US/docs/Web/CSS) property specifies a prioritized list of one or more font family names and/or generic family names for the selected element.
 
+Values are separated by commas to indicate that they are alternatives. The browser will select the first font in the list that is installed or that can be downloaded using a {{CSSxRef("@font-face")}} at-rule.
+
 {{InteractiveExample("CSS Demo: font-family")}}
 
 ```css interactive-example-choice
@@ -52,8 +54,6 @@ section {
   font-size: 1.2em;
 }
 ```
-
-Values are separated by commas to indicate that they are alternatives. The browser will select the first font in the list that is installed or that can be downloaded using a {{CSSxRef("@font-face")}} at-rule.
 
 It is often convenient to use the shorthand property {{CSSxRef("font")}} to set `font-size` and other font related properties all at once.
 

--- a/files/en-us/web/css/reference/properties/font-kerning/index.md
+++ b/files/en-us/web/css/reference/properties/font-kerning/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`font-kerning`** [CSS](/en-US/docs/Web/CSS) property sets the use of the kerning information stored in a font.
 
+_Kerning_ affects how letters are spaced. In _well-kerned_ fonts, this feature makes character spacing more uniform and pleasant to read by reducing white space between certain character combinations.
+
 {{InteractiveExample("CSS Demo: font-kerning")}}
 
 ```css interactive-example-choice
@@ -36,8 +38,6 @@ section {
   font-family: serif;
 }
 ```
-
-_Kerning_ affects how letters are spaced. In _well-kerned_ fonts, this feature makes character spacing more uniform and pleasant to read by reducing white space between certain character combinations.
 
 In the image below, for instance, the examples on the left do not use kerning, while the ones on the right do:
 

--- a/files/en-us/web/css/reference/properties/grid-area/index.md
+++ b/files/en-us/web/css/reference/properties/grid-area/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`grid-area`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties) property specifies a grid item's size and location within a {{glossary("grid", "grid")}} by contributing a line, a span, or nothing (automatic) to its grid placement, thereby specifying the edges of its {{glossary("grid areas", "grid area")}}.
 
+If four `<grid-line>` values are specified, `grid-row-start` is set to the first value, `grid-column-start` is set to the second value, `grid-row-end` is set to the third value, and `grid-column-end` is set to the fourth value.
+
 {{InteractiveExample("CSS Demo: grid-area")}}
 
 ```css interactive-example-choice
@@ -59,8 +61,6 @@ grid-area: 2 / 1 / 2 / 4;
   border: 3px solid rebeccapurple;
 }
 ```
-
-If four `<grid-line>` values are specified, `grid-row-start` is set to the first value, `grid-column-start` is set to the second value, `grid-row-end` is set to the third value, and `grid-column-end` is set to the fourth value.
 
 When `grid-column-end` is omitted, if `grid-column-start` is a {{cssxref("&lt;custom-ident&gt;")}}, `grid-column-end` is set to that `<custom-ident>`; otherwise, it is set to `auto`.
 

--- a/files/en-us/web/css/reference/properties/grid/index.md
+++ b/files/en-us/web/css/reference/properties/grid/index.md
@@ -11,6 +11,9 @@ The **`grid`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides
 
 Using `grid` you specify one axis using {{cssxref("grid-template-rows")}} or {{cssxref("grid-template-columns")}}, you then specify how content should auto-repeat in the other axis using the implicit grid properties: {{cssxref("grid-auto-rows")}}, {{cssxref("grid-auto-columns")}}, and {{cssxref("grid-auto-flow")}}.
 
+> [!NOTE]
+> The sub-properties you don't specify are set to their initial value, as normal for shorthands. Also, the gutter properties are NOT reset by this shorthand.
+
 {{InteractiveExample("CSS Demo: grid")}}
 
 ```css interactive-example-choice
@@ -63,9 +66,6 @@ grid: repeat(3, 80px) / auto-flow;
   grid-column: auto / span 2;
 }
 ```
-
-> [!NOTE]
-> The sub-properties you don't specify are set to their initial value, as normal for shorthands. Also, the gutter properties are NOT reset by this shorthand.
 
 ## Constituent properties
 

--- a/files/en-us/web/css/reference/properties/height/index.md
+++ b/files/en-us/web/css/reference/properties/height/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`height`** [CSS](/en-US/docs/Web/CSS) property specifies the height of an element. By default, the property defines the height of the [content area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#content_area). If {{cssxref("box-sizing")}} is set to `border-box`, however, it instead determines the height of the [border area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#border_area).
 
+The {{cssxref("min-height")}} and {{cssxref("max-height")}} properties override `height`.
+
 {{InteractiveExample("CSS Demo: height")}}
 
 ```css interactive-example-choice
@@ -44,8 +46,6 @@ height: auto;
   color: white;
 }
 ```
-
-The {{cssxref("min-height")}} and {{cssxref("max-height")}} properties override `height`.
 
 > [!NOTE]
 > As a geometric property, `height` also applies to the {{SVGElement("svg")}}, {{SVGElement("rect")}}, {{SVGElement("image")}}, and {{SVGElement("foreignObject")}} SVG elements, with `auto` resolving to `0` and percent values being relative to the SVG viewport height for `<rect>`. The CSS `height` property value overrides any SVG {{SVGAttr("height")}} attribute value set on the SVG element.

--- a/files/en-us/web/css/reference/properties/list-style-image/index.md
+++ b/files/en-us/web/css/reference/properties/list-style-image/index.md
@@ -11,6 +11,9 @@ The **`list-style-image`** [CSS](/en-US/docs/Web/CSS) property sets an image to 
 
 It is often more convenient to use the shorthand {{ cssxref("list-style") }}.
 
+> [!NOTE]
+> This property is applied to list items, i.e., elements with `{{cssxref("display")}}: list-item;` [by default](https://html.spec.whatwg.org/multipage/rendering.html#lists) this includes {{HTMLElement("li")}} elements. Because this property is inherited, it can be set on the parent element (normally {{HTMLElement("ol")}} or {{HTMLElement("ul")}}) to let it apply to all list items.
+
 {{InteractiveExample("CSS Demo: list-style-image")}}
 
 ```css interactive-example-choice
@@ -71,9 +74,6 @@ hr {
   suffix: " ";
 }
 ```
-
-> [!NOTE]
-> This property is applied to list items, i.e., elements with `{{cssxref("display")}}: list-item;` [by default](https://html.spec.whatwg.org/multipage/rendering.html#lists) this includes {{HTMLElement("li")}} elements. Because this property is inherited, it can be set on the parent element (normally {{HTMLElement("ol")}} or {{HTMLElement("ul")}}) to let it apply to all list items.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/margin-bottom/index.md
+++ b/files/en-us/web/css/reference/properties/margin-bottom/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`margin-bottom`** [CSS](/en-US/docs/Web/CSS) property sets the [margin area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#margin_area) on the bottom of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
 
+![The effect of the CSS margin-bottom property on the element box](margin-bottom.svg)
+
 {{InteractiveExample("CSS Demo: margin-bottom")}}
 
 ```css interactive-example-choice
@@ -60,8 +62,6 @@ margin-bottom: 0;
   background-color: #2b3a55;
 }
 ```
-
-![The effect of the CSS margin-bottom property on the element box](margin-bottom.svg)
 
 This property has no effect on _non-[replaced](/en-US/docs/Glossary/Replaced_elements)_ inline elements, such as {{HTMLElement("span")}} or {{HTMLElement("code")}}.
 

--- a/files/en-us/web/css/reference/properties/margin-left/index.md
+++ b/files/en-us/web/css/reference/properties/margin-left/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`margin-left`** [CSS](/en-US/docs/Web/CSS) property sets the [margin area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#margin_area) on the left side of an element. A positive value places it farther from its neighbors, while a negative value places it closer.
 
+The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/Web/CSS/Guides/Box_model/Margin_collapsing).
+
 {{InteractiveExample("CSS Demo: margin-left")}}
 
 ```css interactive-example-choice
@@ -58,8 +60,6 @@ margin-left: 0;
   background-color: rgb(255 244 219 / 0.6);
 }
 ```
-
-The vertical margins of two adjacent boxes may fuse. This is called [_margin collapsing_](/en-US/docs/Web/CSS/Guides/Box_model/Margin_collapsing).
 
 In the rare cases where width is overconstrained (i.e., when all of `width`, `margin-left`, `border`, `padding`, the content area, and `margin-right` are defined), `margin-left` is ignored, and will have the same calculated value as if the `auto` value was specified.
 

--- a/files/en-us/web/css/reference/properties/offset-rotate/index.md
+++ b/files/en-us/web/css/reference/properties/offset-rotate/index.md
@@ -9,6 +9,9 @@ sidebar: cssref
 
 The **`offset-rotate`** [CSS](/en-US/docs/Web/CSS) property defines the orientation/direction of the element as it is positioned along the {{cssxref("offset-path")}}.
 
+> [!NOTE]
+> Early versions of the spec called this property `motion-rotation`.
+
 {{InteractiveExample("CSS Demo: offset-rotate")}}
 
 ```css interactive-example-choice
@@ -88,9 +91,6 @@ button.addEventListener("click", () => {
   }
 });
 ```
-
-> [!NOTE]
-> Early versions of the spec called this property `motion-rotation`.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/overflow-wrap/index.md
+++ b/files/en-us/web/css/reference/properties/overflow-wrap/index.md
@@ -12,6 +12,9 @@ The **`overflow-wrap`** [CSS](/en-US/docs/Web/CSS) property applies to text, set
 > [!NOTE]
 > The property was originally a nonstandard and unprefixed Microsoft extension called `word-wrap`, and was implemented by most browsers with the same name. It has since been renamed to `overflow-wrap`, with `word-wrap` being an alias.
 
+> [!NOTE]
+> In contrast to {{cssxref("word-break")}}, `overflow-wrap` will only create a break if an entire word cannot be placed on its own line without overflowing.
+
 {{InteractiveExample("CSS Demo: overflow-wrap")}}
 
 ```css interactive-example-choice
@@ -48,9 +51,6 @@ overflow-wrap: break-word;
   height: 200px;
 }
 ```
-
-> [!NOTE]
-> In contrast to {{cssxref("word-break")}}, `overflow-wrap` will only create a break if an entire word cannot be placed on its own line without overflowing.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/properties/padding-bottom/index.md
+++ b/files/en-us/web/css/reference/properties/padding-bottom/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`padding-bottom`** [CSS](/en-US/docs/Web/CSS) property sets the height of the [padding area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#padding_area) on the bottom of an element.
 
+An element's padding area is the space between its content and its border.
+
 {{InteractiveExample("CSS Demo: padding-bottom")}}
 
 ```css interactive-example-choice
@@ -53,8 +55,6 @@ padding-bottom: 0;
   border: dashed 1px;
 }
 ```
-
-An element's padding area is the space between its content and its border.
 
 ![The effect of the CSS padding-bottom property on the element box](padding-bottom.svg)
 

--- a/files/en-us/web/css/reference/properties/padding-left/index.md
+++ b/files/en-us/web/css/reference/properties/padding-left/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`padding-left`** [CSS](/en-US/docs/Web/CSS) property sets the width of the [padding area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#padding_area) to the left of an element.
 
+An element's padding area is the space between its content and its border.
+
 {{InteractiveExample("CSS Demo: padding-left")}}
 
 ```css interactive-example-choice
@@ -53,8 +55,6 @@ padding-left: 0;
   border: dashed 1px;
 }
 ```
-
-An element's padding area is the space between its content and its border.
 
 > [!NOTE]
 > The {{cssxref("padding")}} property can be used to set paddings on all four sides of an element with a single declaration.

--- a/files/en-us/web/css/reference/properties/padding-right/index.md
+++ b/files/en-us/web/css/reference/properties/padding-right/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`padding-right`** [CSS](/en-US/docs/Web/CSS) property sets the width of the [padding area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#padding_area) on the right of an element.
 
+An element's padding area is the space between its content and its border.
+
 {{InteractiveExample("CSS Demo: padding-right")}}
 
 ```css interactive-example-choice
@@ -53,8 +55,6 @@ padding-right: 0;
   border: dashed 1px;
 }
 ```
-
-An element's padding area is the space between its content and its border.
 
 > [!NOTE]
 > The {{cssxref("padding")}} property can be used to set paddings on all four sides of an element with a single declaration.

--- a/files/en-us/web/css/reference/properties/padding-top/index.md
+++ b/files/en-us/web/css/reference/properties/padding-top/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`padding-top`** [CSS](/en-US/docs/Web/CSS) property sets the height of the [padding area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#padding_area) on the top of an element.
 
+An element's padding area is the space between its content and its border.
+
 {{InteractiveExample("CSS Demo: padding-top")}}
 
 ```css interactive-example-choice
@@ -53,8 +55,6 @@ padding-top: 0;
   border: dashed 1px;
 }
 ```
-
-An element's padding area is the space between its content and its border.
 
 ![The effect of the CSS padding-top property on the element box](padding-top.svg)
 

--- a/files/en-us/web/css/reference/properties/padding/index.md
+++ b/files/en-us/web/css/reference/properties/padding/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`padding`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties) property sets the [padding area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#padding_area) on all four sides of an element at once.
 
+An element's padding area is the space between its content and its border.
+
 {{InteractiveExample("CSS Demo: padding")}}
 
 ```css interactive-example-choice
@@ -53,8 +55,6 @@ padding: 0;
   border: dashed 1px;
 }
 ```
-
-An element's padding area is the space between its content and its border.
 
 > [!NOTE]
 > Padding creates extra space within an element. In contrast, {{cssxref("margin")}} creates extra space _around_ an element.

--- a/files/en-us/web/css/reference/properties/scroll-behavior/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-behavior/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`scroll-behavior`** [CSS](/en-US/docs/Web/CSS) property sets the behavior for a scrolling box when scrolling is triggered by the navigation or CSSOM scrolling APIs.
 
+Note that any other scrolls, such as those performed by the user, are not affected by this property. When this property is specified on the root element, it applies to the viewport instead. This property specified on the `body` element will _not_ propagate to the viewport.
+
 {{InteractiveExample("CSS Demo: scroll-behavior")}}
 
 ```css interactive-example-choice
@@ -62,8 +64,6 @@ scroll-page {
   justify-content: center;
 }
 ```
-
-Note that any other scrolls, such as those performed by the user, are not affected by this property. When this property is specified on the root element, it applies to the viewport instead. This property specified on the `body` element will _not_ propagate to the viewport.
 
 User agents are allowed to ignore this property.
 

--- a/files/en-us/web/css/reference/properties/scroll-snap-type/index.md
+++ b/files/en-us/web/css/reference/properties/scroll-snap-type/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`scroll-snap-type`** [CSS](/en-US/docs/Web/CSS) property is set on a {{glossary("scroll container")}}, opting it into scroll snapping by setting the direction and strictness of snap point enforcement within the [snap port](/en-US/docs/Glossary/Scroll_snap#snapport).
 
+If the content in the scroll port changes — for example, if content is added, moved, deleted, or resized — the scroll container will re-snap to the previously snapped content if that content is still present.
+
 {{InteractiveExample("CSS Demo: scroll-snap-type")}}
 
 ```css interactive-example-choice
@@ -72,8 +74,6 @@ scroll-snap-type: x proximity;
   color: rebeccapurple;
 }
 ```
-
-If the content in the scroll port changes — for example, if content is added, moved, deleted, or resized — the scroll container will re-snap to the previously snapped content if that content is still present.
 
 If the value of a scroll snap-related property, such as `scroll-snap-type` or {{cssxref("scroll-margin")}}, is changed, the scroll container will re-snap based on the current value of `scroll-snap-type`.
 

--- a/files/en-us/web/css/reference/properties/text-decoration-style/index.md
+++ b/files/en-us/web/css/reference/properties/text-decoration-style/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`text-decoration-style`** [CSS](/en-US/docs/Web/CSS) property sets the style of the lines specified by {{ cssxref("text-decoration-line") }}. The style applies to all lines that are set with `text-decoration-line`.
 
+If the specified decoration has a specific semantic meaning, like a line-through line meaning that some text has been deleted, authors are encouraged to denote this meaning using an HTML tag, like {{ HTMLElement("del") }} or {{ HTMLElement("s") }}. As browsers can disable styling in some cases, the semantic meaning won't disappear in such a situation.
+
 {{InteractiveExample("CSS Demo: text-decoration-style")}}
 
 ```css interactive-example-choice
@@ -50,8 +52,6 @@ p {
   text-decoration-line: underline;
 }
 ```
-
-If the specified decoration has a specific semantic meaning, like a line-through line meaning that some text has been deleted, authors are encouraged to denote this meaning using an HTML tag, like {{ HTMLElement("del") }} or {{ HTMLElement("s") }}. As browsers can disable styling in some cases, the semantic meaning won't disappear in such a situation.
 
 When setting multiple line-decoration properties at once, it may be more convenient to use the {{cssxref("text-decoration")}} shorthand property instead.
 

--- a/files/en-us/web/css/reference/properties/text-emphasis/index.md
+++ b/files/en-us/web/css/reference/properties/text-emphasis/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`text-emphasis`** [CSS](/en-US/docs/Web/CSS) [shorthand](/en-US/docs/Web/CSS/Guides/Cascade/Shorthand_properties) property applies emphasis marks to text (except spaces and control characters).
 
+The `text-emphasis` property is quite different from {{cssxref("text-decoration")}}. The `text-decoration` property does not inherit, and the decoration specified is applied across the whole element. However, text-emphasis does inherit, which means it is possible to change emphasis marks for descendants.
+
 {{InteractiveExample("CSS Demo: text-emphasis")}}
 
 ```css interactive-example-choice
@@ -42,8 +44,6 @@ p {
   font: 1.5em sans-serif;
 }
 ```
-
-The `text-emphasis` property is quite different from {{cssxref("text-decoration")}}. The `text-decoration` property does not inherit, and the decoration specified is applied across the whole element. However, text-emphasis does inherit, which means it is possible to change emphasis marks for descendants.
 
 The size of the emphasis symbol, like ruby symbols, is about 50% of the size of the font, and `text-emphasis` may affect line height when the current leading is not enough for the marks.
 

--- a/files/en-us/web/css/reference/properties/transform-style/index.md
+++ b/files/en-us/web/css/reference/properties/transform-style/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`transform-style`** [CSS](/en-US/docs/Web/CSS) property sets whether children of an element are positioned in the 3D space or are flattened in the plane of the element.
 
+If flattened, the element's children will not exist on their own in the 3D-space.
+
 {{InteractiveExample("CSS Demo: transform-style")}}
 
 ```css interactive-example-choice
@@ -45,8 +47,6 @@ transform-style: preserve-3d;
   transform: rotate3d(1, 1, 1, 45deg);
 }
 ```
-
-If flattened, the element's children will not exist on their own in the 3D-space.
 
 As this property is not inherited, it must be set for all non-leaf descendants of the element.
 

--- a/files/en-us/web/css/reference/properties/transition-timing-function/index.md
+++ b/files/en-us/web/css/reference/properties/transition-timing-function/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`transition-timing-function`** [CSS](/en-US/docs/Web/CSS) property sets how intermediate values are calculated for CSS properties being affected by a [transition effect](/en-US/docs/Web/CSS/Guides/Transitions/Using).
 
+This, in essence, lets you establish an acceleration curve so that the speed of the transition can vary over its duration.
+
 {{InteractiveExample("CSS Demo: transition-timing-function")}}
 
 ```css interactive-example-choice
@@ -50,8 +52,6 @@ transition-timing-function: cubic-bezier(0.29, 1.01, 1, -0.68);
   margin-right: 40%;
 }
 ```
-
-This, in essence, lets you establish an acceleration curve so that the speed of the transition can vary over its duration.
 
 This acceleration curve is defined using one {{cssxref("easing-function")}} for each property to be transitioned.
 

--- a/files/en-us/web/css/reference/properties/unicode-bidi/index.md
+++ b/files/en-us/web/css/reference/properties/unicode-bidi/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`unicode-bidi`** [CSS](/en-US/docs/Web/CSS) property, together with the {{cssxref("direction")}} property, determines how bidirectional text in a document is handled. For example, if a block of content contains both left-to-right and right-to-left text, the user-agent uses a complex Unicode algorithm to decide how to display the text. The `unicode-bidi` property overrides this algorithm and allows the developer to control the text embedding.
 
+The `unicode-bidi` and {{cssxref("direction")}} properties are the only properties that are not affected by the {{cssxref("all")}} shorthand.
+
 {{InteractiveExample("CSS Demo: unicode-bidi")}}
 
 ```css interactive-example-choice
@@ -34,8 +36,6 @@ unicode-bidi: isolate-override;
   </p>
 </section>
 ```
-
-The `unicode-bidi` and {{cssxref("direction")}} properties are the only properties that are not affected by the {{cssxref("all")}} shorthand.
 
 > [!WARNING]
 > This property is intended for Document Type Definition (DTD) designers. Web designers and similar authors **should not** override it.

--- a/files/en-us/web/css/reference/properties/width/index.md
+++ b/files/en-us/web/css/reference/properties/width/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`width`** [CSS](/en-US/docs/Web/CSS) property sets an element's width. By default, it sets the width of the [content area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#content_area), but if {{cssxref("box-sizing")}} is set to `border-box`, it sets the width of the [border area](/en-US/docs/Web/CSS/Guides/Box_model/Introduction#border_area).
 
+The specified value of `width` applies to the content area so long as its value remains within the values defined by {{cssxref("min-width")}} and {{cssxref("max-width")}}.
+
 {{InteractiveExample("CSS Demo: width")}}
 
 ```css interactive-example-choice
@@ -45,8 +47,6 @@ width: auto;
   color: white;
 }
 ```
-
-The specified value of `width` applies to the content area so long as its value remains within the values defined by {{cssxref("min-width")}} and {{cssxref("max-width")}}.
 
 - If the value for `width` is less than the value for `min-width`, then `min-width` overrides `width`.
 - If the value for `width` is greater than the value for `max-width`, then `max-width` overrides `width`.

--- a/files/en-us/web/css/reference/selectors/_colon_active/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_active/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:active`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents an element (such as a button) that is being activated by the user. When using a mouse, "activation" typically starts when the user presses down the primary mouse button.
 
+The `:active` pseudo-class is commonly used on {{HTMLElement("a")}} and {{HTMLElement("button")}} elements. Other common targets of this pseudo-class include elements that are _contained in_ an activated element, and form elements that are being activated through their associated {{HTMLElement("label")}}.
+
 {{InteractiveExample("CSS Demo: :active", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -32,8 +34,6 @@ The **`:active`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/
 <p>Would you like to subscribe to our channel?</p>
 <button class="joinBtn">Subscribe</button>
 ```
-
-The `:active` pseudo-class is commonly used on {{HTMLElement("a")}} and {{HTMLElement("button")}} elements. Other common targets of this pseudo-class include elements that are _contained in_ an activated element, and form elements that are being activated through their associated {{HTMLElement("label")}}.
 
 Styles defined by the `:active` pseudo-class will be overridden by any subsequent link-related pseudo-class ({{cssxref(":link")}}, {{cssxref(":hover")}}, or {{cssxref(":visited")}}) that has at least equal specificity. To style links appropriately, put the `:active` rule after all other link-related rules, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`.
 

--- a/files/en-us/web/css/reference/selectors/_colon_checked/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_checked/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:checked`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) selector represents any **radio** ([`<input type="radio">`](/en-US/docs/Web/HTML/Reference/Elements/input/radio)), **checkbox** ([`<input type="checkbox">`](/en-US/docs/Web/HTML/Reference/Elements/input/checkbox)), or **option** ({{HTMLElement("option")}} in a {{HTMLElement("select")}} element) that is checked or toggled to an `on` state.
 
+The user can engage this state by checking/selecting an element, or disengage it by unchecking/deselecting the element.
+
 {{InteractiveExample("CSS Demo: :checked", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -46,8 +48,6 @@ input:checked {
   <input type="submit" value="Submit form" />
 </form>
 ```
-
-The user can engage this state by checking/selecting an element, or disengage it by unchecking/deselecting the element.
 
 > [!NOTE]
 > Because browsers often treat `<option>`s as {{ glossary("replaced elements")}}, the extent to which they can be styled with the `:checked` pseudo-class varies from browser to browser. [Customizable select element](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select) functionality can be used to enable full customization of `<option>` elements just like any regular DOM element, in supporting browsers.

--- a/files/en-us/web/css/reference/selectors/_colon_empty/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_empty/index.md
@@ -9,6 +9,9 @@ sidebar: cssref
 
 The **`:empty`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents any element that has no children. Children can be either element nodes or text (including whitespace). Comments, processing instructions, and CSS {{cssxref("content")}} do not affect whether an element is considered empty.
 
+> [!NOTE]
+> In [Selectors Level 4](https://drafts.csswg.org/selectors-4/#the-empty-pseudo), the `:empty` pseudo-class was changed to act like {{CSSxRef(":-moz-only-whitespace")}}, but no browser currently supports this yet.
+
 {{InteractiveExample("CSS Demo: :empty", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -28,9 +31,6 @@ div:empty {
 <p>Element with nested empty element:</p>
 <div><p></p></div>
 ```
-
-> [!NOTE]
-> In [Selectors Level 4](https://drafts.csswg.org/selectors-4/#the-empty-pseudo), the `:empty` pseudo-class was changed to act like {{CSSxRef(":-moz-only-whitespace")}}, but no browser currently supports this yet.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_focus/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_focus/index.md
@@ -9,6 +9,9 @@ sidebar: cssref
 
 The **`:focus`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents an element (such as a form input) that has received focus. It is generally triggered when the user clicks or taps on an element or selects it with the keyboard's <kbd>Tab</kbd> key.
 
+> [!NOTE]
+> This pseudo-class applies only to the focused element itself. Use {{CSSxRef(":focus-within")}} if you want to select an element that _contains_ a focused element.
+
 {{InteractiveExample("CSS Demo: :focus", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -41,9 +44,6 @@ select:focus {
   </label>
 </form>
 ```
-
-> [!NOTE]
-> This pseudo-class applies only to the focused element itself. Use {{CSSxRef(":focus-within")}} if you want to select an element that _contains_ a focused element.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_hover/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_hover/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:hover`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) matches an element when a user interacts with it using a pointing device. The pseudo-class is generally triggered when the user moves the cursor (mouse pointer) over an element without pressing the mouse button.
 
+Styles defined by the `:hover` pseudo-class will be overridden by any subsequent link-related pseudo-class ({{ cssxref(":link") }}, {{ cssxref(":visited") }}, or {{ cssxref(":active") }}) that has at least equal specificity. To style links appropriately, put the `:hover` rule after the `:link` and `:visited` rules but before the `:active` one, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`.
+
 {{InteractiveExample("CSS Demo: :hover", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -32,8 +34,6 @@ The **`:hover`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/R
 <p>Would you like to join our quest?</p>
 <button class="joinBtn">Confirm</button>
 ```
-
-Styles defined by the `:hover` pseudo-class will be overridden by any subsequent link-related pseudo-class ({{ cssxref(":link") }}, {{ cssxref(":visited") }}, or {{ cssxref(":active") }}) that has at least equal specificity. To style links appropriately, put the `:hover` rule after the `:link` and `:visited` rules but before the `:active` one, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`.
 
 > [!NOTE]
 > The `:hover` pseudo-class is problematic on touchscreens. Depending on the browser, the `:hover` pseudo-class might never match, match only for a moment after touching an element, or continue to match even after the user has stopped touching and until the user touches another element. Web developers should make sure that content is accessible on devices with limited or non-existent hovering capabilities.

--- a/files/en-us/web/css/reference/selectors/_colon_in-range/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_in-range/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:in-range`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents an {{htmlelement("input")}} element whose current value is within the range limits specified by the [`min`](/en-US/docs/Web/HTML/Reference/Elements/input#min) and [`max`](/en-US/docs/Web/HTML/Reference/Elements/input#max) attributes.
 
+This pseudo-class is useful for giving the user a visual indication that a field's current value is within the permitted limits.
+
 {{InteractiveExample("CSS Demo: :in-range", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -40,8 +42,6 @@ input:in-range {
   <input id="ret" name="ret" type="date" min="2022-01-01" max="2022-12-31" />
 </form>
 ```
-
-This pseudo-class is useful for giving the user a visual indication that a field's current value is within the permitted limits.
 
 > [!NOTE]
 > This pseudo-class only applies to elements that have (and can take) a range limitation. In the absence of such a limitation, the element can neither be "in-range" nor "out-of-range."

--- a/files/en-us/web/css/reference/selectors/_colon_lang/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_lang/index.md
@@ -9,6 +9,9 @@ sidebar: cssref
 
 The **`:lang()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) matches elements based on the language they are determined to be in.
 
+> [!NOTE]
+> In HTML, the language is determined by a combination of the [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute, the {{HTMLElement("meta")}} element, and possibly by information from the protocol (such as HTTP headers). For other document types there may be other document methods for determining the language.
+
 {{InteractiveExample("CSS Demo: :lang()", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -28,9 +31,6 @@ The **`:lang()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/
   <strong lang="en-US">DANGER</strong> to lepiej nie wchodzić do środka.
 </p>
 ```
-
-> [!NOTE]
-> In HTML, the language is determined by a combination of the [`lang`](/en-US/docs/Web/HTML/Reference/Global_attributes/lang) attribute, the {{HTMLElement("meta")}} element, and possibly by information from the protocol (such as HTTP headers). For other document types there may be other document methods for determining the language.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_link/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_link/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:link`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents an element that has not yet been visited. It matches every unvisited {{HTMLElement("a")}} or {{HTMLElement("area")}} element that has an `href` attribute.
 
+Styles defined by the `:link` and {{cssxref(":visited")}} pseudo-classes can be overridden by any subsequent user-action pseudo-classes ({{cssxref(":hover")}} or {{cssxref(":active")}}) that have at least equal specificity. To style links appropriately, put the `:link` rule before all other link-related rules, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`. The `:visited` pseudo-class and `:link` pseudo-class are mutually exclusive.
+
 {{InteractiveExample("CSS Demo: :link", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -42,8 +44,6 @@ a:link {
   </li>
 </ul>
 ```
-
-Styles defined by the `:link` and {{cssxref(":visited")}} pseudo-classes can be overridden by any subsequent user-action pseudo-classes ({{cssxref(":hover")}} or {{cssxref(":active")}}) that have at least equal specificity. To style links appropriately, put the `:link` rule before all other link-related rules, as defined by the _LVHA-order_: `:link` — `:visited` — `:hover` — `:active`. The `:visited` pseudo-class and `:link` pseudo-class are mutually exclusive.
 
 > [!NOTE]
 > Use {{cssxref(":any-link")}} to select an element independent of whether it has been visited or not.

--- a/files/en-us/web/css/reference/selectors/_colon_nth-child/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_nth-child/index.md
@@ -9,6 +9,9 @@ sidebar: cssref
 
 The **`:nth-child()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) matches elements based on the indexes of the elements in the child list of their parents. In other words, the `:nth-child()` selector selects child elements according to their position among all the sibling elements within a parent element.
 
+> [!NOTE]
+> In the `element:nth-child()` syntax, the child count includes sibling children of any element type; but it is considered a match only if the element _at that child position_ matches the other components of the selector.
+
 {{InteractiveExample("CSS Demo: :nth-child", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -49,9 +52,6 @@ li:nth-child(even) {
   <li>Usain Bolt</li>
 </ul>
 ```
-
-> [!NOTE]
-> In the `element:nth-child()` syntax, the child count includes sibling children of any element type; but it is considered a match only if the element _at that child position_ matches the other components of the selector.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/selectors/_colon_optional/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_optional/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:optional`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents any {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element that does not have the [`required`](/en-US/docs/Web/HTML/Reference/Elements/input#required) attribute set on it.
 
+This pseudo-class is useful for styling fields that are not required to submit a form.
+
 {{InteractiveExample("CSS Demo: :optional", "tabbed-standard")}}
 
 ```css interactive-example
@@ -45,8 +47,6 @@ label {
   <p><span class="req">*</span> - Required field</p>
 </form>
 ```
-
-This pseudo-class is useful for styling fields that are not required to submit a form.
 
 > [!NOTE]
 > The {{cssxref(":required")}} pseudo-class selects _required_ form fields.

--- a/files/en-us/web/css/reference/selectors/_colon_out-of-range/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_out-of-range/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:out-of-range`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents an {{htmlelement("input")}} element whose current value is outside the range limits specified by the [`min`](/en-US/docs/Web/HTML/Reference/Elements/input#min) and [`max`](/en-US/docs/Web/HTML/Reference/Elements/input#max) attributes.
 
+This pseudo-class is useful for giving the user a visual indication that a field's current value is outside the permitted limits.
+
 {{InteractiveExample("CSS Demo: :out-of-range", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -40,8 +42,6 @@ input:out-of-range {
   <input id="ret" name="ret" type="date" min="2022-01-01" max="2022-12-31" />
 </form>
 ```
-
-This pseudo-class is useful for giving the user a visual indication that a field's current value is outside the permitted limits.
 
 > [!NOTE]
 > This pseudo-class only applies to elements that have (and can take) a range limitation. In the absence of such a limitation, the element can neither be "in-range" nor "out-of-range."

--- a/files/en-us/web/css/reference/selectors/_colon_required/index.md
+++ b/files/en-us/web/css/reference/selectors/_colon_required/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`:required`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes) represents any {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element that has the [`required`](/en-US/docs/Web/HTML/Reference/Elements/input#required) attribute set on it.
 
+This pseudo-class is useful for highlighting fields that must have valid data before a form can be submitted.
+
 {{InteractiveExample("CSS Demo: :required", "tabbed-standard")}}
 
 ```css interactive-example
@@ -45,8 +47,6 @@ label {
   <p><span class="req">*</span> - Required field</p>
 </form>
 ```
-
-This pseudo-class is useful for highlighting fields that must have valid data before a form can be submitted.
 
 > [!NOTE]
 > The {{cssxref(":optional")}} pseudo-class selects _optional_ form fields.

--- a/files/en-us/web/css/reference/selectors/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_first-line/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`::first-line`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements) applies styles to the first line of a [block container](/en-US/docs/Web/CSS/Guides/Display/Visual_formatting_model#block_containers).
 
+The effects of `::first-line` are limited by the length and content of the first line of text in the element. The length of the first line depends on many factors, including the width of the element, the width of the document, and the font size of the text. `::first-line` has no effect when the first child of the element, which would be the first part of the first line, is an inline block-level element, such as an inline table.
+
 {{InteractiveExample("CSS Demo: ::first-line", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -28,8 +30,6 @@ p::first-line {
   fish Exocoetidae.
 </p>
 ```
-
-The effects of `::first-line` are limited by the length and content of the first line of text in the element. The length of the first line depends on many factors, including the width of the element, the width of the document, and the font size of the text. `::first-line` has no effect when the first child of the element, which would be the first part of the first line, is an inline block-level element, such as an inline table.
 
 > [!NOTE]
 > [Selectors Level 3](https://drafts.csswg.org/selectors-3/#first-line) introduced the double-colon notation (`::`) to distinguish [pseudo-elements](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements) from the single-colon (`:`) [pseudo-classes](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes). Browsers accept both `::first-line` and `:first-line`, which was introduced in CSS2.

--- a/files/en-us/web/css/reference/selectors/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/reference/selectors/_doublecolon_placeholder/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`::placeholder`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-elements) represents the [placeholder text](/en-US/docs/Web/HTML/Reference/Elements/input#placeholder) in an {{HTMLElement("input")}} or {{HTMLElement("textarea")}} element.
 
+Only the subset of CSS properties that apply to the {{cssxref("::first-line")}} pseudo-element can be used in a rule using `::placeholder` in its selector.
+
 {{InteractiveExample("CSS Demo: ::placeholder", "tabbed-shorter")}}
 
 ```css interactive-example
@@ -34,8 +36,6 @@ input::placeholder {
   maxlength="9"
   placeholder="It must be 9 digits" />
 ```
-
-Only the subset of CSS properties that apply to the {{cssxref("::first-line")}} pseudo-element can be used in a rule using `::placeholder` in its selector.
 
 > [!NOTE]
 > In most browsers, the appearance of placeholder text is a translucent or light gray color by default.

--- a/files/en-us/web/css/reference/values/filter-function/drop-shadow/index.md
+++ b/files/en-us/web/css/reference/values/filter-function/drop-shadow/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`drop-shadow()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) applies a drop shadow effect to the input image. Its result is a {{cssxref("filter-function")}}.
 
+A drop shadow is effectively a blurred, offset version of the input image's alpha mask, drawn in a specific color and composited below the image.
+
 {{InteractiveExample("CSS Demo: drop-shadow()")}}
 
 ```css interactive-example-choice
@@ -32,8 +34,6 @@ filter: drop-shadow(0 0 0.75rem crimson);
     width="200" />
 </section>
 ```
-
-A drop shadow is effectively a blurred, offset version of the input image's alpha mask, drawn in a specific color and composited below the image.
 
 > [!NOTE]
 > This function is somewhat similar to the {{Cssxref("box-shadow")}} property. The `box-shadow` property creates a rectangular shadow behind an element's _entire box_, while the `drop-shadow()` filter function creates a shadow that conforms to the shape (alpha channel) of the _image itself_.

--- a/files/en-us/web/css/reference/values/filter-function/opacity/index.md
+++ b/files/en-us/web/css/reference/values/filter-function/opacity/index.md
@@ -9,6 +9,9 @@ sidebar: cssref
 
 The **`opacity()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) applies transparency to the samples in the input image. Its result is a {{cssxref("filter-function")}}.
 
+> [!NOTE]
+> This function is similar to the more established {{Cssxref("opacity")}} property. The difference is that with filters, some browsers provide hardware acceleration for better performance.
+
 {{InteractiveExample("CSS Demo: opacity()")}}
 
 ```css interactive-example-choice
@@ -40,9 +43,6 @@ filter: opacity(0);
     width="200" />
 </section>
 ```
-
-> [!NOTE]
-> This function is similar to the more established {{Cssxref("opacity")}} property. The difference is that with filters, some browsers provide hardware acceleration for better performance.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/fit-content_function/index.md
+++ b/files/en-us/web/css/reference/values/fit-content_function/index.md
@@ -14,6 +14,8 @@ The **`fit-content()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CS
 It is distinct from the {{cssxref("fit-content")}} keyword, which takes no argument and sizes a box based on its content within the available space.
 Only `fit-content()` is valid in grid track sizing properties such as {{cssxref("grid-template-columns")}}.
 
+The function can be used as a track size in [CSS grid](/en-US/docs/Web/CSS/Guides/Grid_layout) properties, where the maximum size is defined by `max-content` and the minimum size by `auto`, which is calculated similar to `auto` (i.e., [`minmax(auto, max-content)`](/en-US/docs/Web/CSS/Reference/Values/minmax)), except that the track size is clamped at _argument_ if it is greater than the `auto` minimum.
+
 {{InteractiveExample("CSS Demo: fit-content()")}}
 
 ```css interactive-example-choice
@@ -56,8 +58,6 @@ grid-template-columns: fit-content(40%) fit-content(40%) 1fr;
   text-align: left;
 }
 ```
-
-The function can be used as a track size in [CSS grid](/en-US/docs/Web/CSS/Guides/Grid_layout) properties, where the maximum size is defined by `max-content` and the minimum size by `auto`, which is calculated similar to `auto` (i.e., [`minmax(auto, max-content)`](/en-US/docs/Web/CSS/Reference/Values/minmax)), except that the track size is clamped at _argument_ if it is greater than the `auto` minimum.
 
 See the {{cssxref("grid-template-columns")}} page for more information on the `max-content` and `auto` keywords.
 

--- a/files/en-us/web/css/reference/values/gradient/repeating-linear-gradient/index.md
+++ b/files/en-us/web/css/reference/values/gradient/repeating-linear-gradient/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`repeating-linear-gradient()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) creates an image consisting of repeating linear gradients. It is similar to {{cssxref("gradient/linear-gradient", "linear-gradient()")}} and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container. The function's result is an object of the {{cssxref("gradient")}} data type, which is a special kind of {{cssxref("image")}}.
 
+The length of the gradient that repeats is the distance between the first and last color stop. If the first color does not have a color-stop-length, the color-stop-length defaults to 0. With each repetition, the positions of the color stops are shifted by a multiple of the length of the basic linear gradient. Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition. This can be altered with repeating the first color again as the last color.
+
 {{InteractiveExample("CSS Demo: repeating-linear-gradient()")}}
 
 ```css interactive-example-choice
@@ -41,8 +43,6 @@ background:
   min-height: 100%;
 }
 ```
-
-The length of the gradient that repeats is the distance between the first and last color stop. If the first color does not have a color-stop-length, the color-stop-length defaults to 0. With each repetition, the positions of the color stops are shifted by a multiple of the length of the basic linear gradient. Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition. This can be altered with repeating the first color again as the last color.
 
 As with any gradient, a repeating linear gradient has [no intrinsic dimensions](/en-US/docs/Web/CSS/Reference/Values/image#description); i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.
 

--- a/files/en-us/web/css/reference/values/gradient/repeating-radial-gradient/index.md
+++ b/files/en-us/web/css/reference/values/gradient/repeating-radial-gradient/index.md
@@ -9,6 +9,8 @@ sidebar: cssref
 
 The **`repeating-radial-gradient()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) creates an image consisting of repeating gradients that radiate from an origin. It is similar to {{cssxref("gradient/radial-gradient", "radial-gradient()")}} and takes the same arguments, but it repeats the color stops infinitely in all directions so as to cover its entire container, similar to {{cssxref("gradient/repeating-linear-gradient", "repeating-linear-gradient()")}}. The function's result is an object of the {{cssxref("gradient")}} data type, which is a special kind of {{cssxref("image")}}.
 
+With each repetition, the positions of the color stops are shifted by a multiple of the dimensions of the basic radial gradient (the distance between the last color stop and the first). Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition, which can be mitigated by repeating the first color as the last color.
+
 {{InteractiveExample("CSS Demo: repeating-radial-gradient()")}}
 
 ```css interactive-example-choice
@@ -40,8 +42,6 @@ background: repeating-radial-gradient(
   min-height: 100%;
 }
 ```
-
-With each repetition, the positions of the color stops are shifted by a multiple of the dimensions of the basic radial gradient (the distance between the last color stop and the first). Thus, the position of each ending color stop coincides with a starting color stop; if the color values are different, this will result in a sharp visual transition, which can be mitigated by repeating the first color as the last color.
 
 As with any gradient, a repeating radial gradient has [no intrinsic dimensions](/en-US/docs/Web/CSS/Reference/Values/image#description); i.e., it has no natural or preferred size, nor a preferred ratio. Its concrete size will match the size of the element it applies to.
 

--- a/files/en-us/web/css/reference/values/transform-function/perspective/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/perspective/index.md
@@ -11,6 +11,10 @@ The **`perspective()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CS
 user and the z=0 plane, the perspective from which the viewer would be if the 2-dimensional interface were
 3-dimensional. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+The `perspective()` transform function is part of the {{cssxref('transform')}} value applied on the
+element being transformed. This differs from the {{cssxref('perspective')}} and {{cssxref('perspective-origin')}}
+properties which are attached to the parent of a child transformed in 3-dimensional space.
+
 {{InteractiveExample("CSS Demo: perspective()")}}
 
 ```css interactive-example-choice
@@ -102,10 +106,6 @@ transform: perspective(6.5cm);
   transform: rotateX(-90deg) translateZ(50px);
 }
 ```
-
-The `perspective()` transform function is part of the {{cssxref('transform')}} value applied on the
-element being transformed. This differs from the {{cssxref('perspective')}} and {{cssxref('perspective-origin')}}
-properties which are attached to the parent of a child transformed in 3-dimensional space.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/transform-function/rotate3d/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/rotate3d/index.md
@@ -10,6 +10,12 @@ sidebar: cssref
 The **`rotate3d()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that rotates an element around a
 fixed axis in 3D space, without deforming it. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+In 3D space, rotations have three degrees of freedom, which together describe a single axis of rotation. The axis of
+rotation is defined by an \[x, y, z] vector and pass by the origin (as defined by the {{ cssxref("transform-origin") }}
+property). If, as specified, the vector is not _normalized_ (i.e., if the sum of the square of its three
+coordinates is not 1), the {{glossary("user agent")}} will normalize it internally. A non-normalizable vector, such as
+the null vector, \[0, 0, 0], will cause the rotation to be ignored, but without invalidating the whole CSS property.
+
 {{InteractiveExample("CSS Demo: rotate3d()")}}
 
 ```css interactive-example-choice
@@ -95,12 +101,6 @@ transform: rotate3d(0, 1, 0.5, 3.142rad);
   transform: rotateX(-90deg) translateZ(50px);
 }
 ```
-
-In 3D space, rotations have three degrees of freedom, which together describe a single axis of rotation. The axis of
-rotation is defined by an \[x, y, z] vector and pass by the origin (as defined by the {{ cssxref("transform-origin") }}
-property). If, as specified, the vector is not _normalized_ (i.e., if the sum of the square of its three
-coordinates is not 1), the {{glossary("user agent")}} will normalize it internally. A non-normalizable vector, such as
-the null vector, \[0, 0, 0], will cause the rotation to be ignored, but without invalidating the whole CSS property.
 
 > [!NOTE]
 > Unlike rotations in the 2D plane, the composition of 3D rotations is usually

--- a/files/en-us/web/css/reference/values/transform-function/rotatex/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/rotatex/index.md
@@ -10,6 +10,8 @@ sidebar: cssref
 The **`rotateX()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that rotates an element around the
 x-axis (horizontal) without deforming it. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+The axis of rotation passes through an origin, defined by the {{ cssxref("transform-origin") }} CSS property.
+
 {{InteractiveExample("CSS Demo: rotateX()")}}
 
 ```css interactive-example-choice
@@ -37,8 +39,6 @@ transform: rotateX(3.142rad);
     width="200" />
 </section>
 ```
-
-The axis of rotation passes through an origin, defined by the {{ cssxref("transform-origin") }} CSS property.
 
 > [!NOTE]
 > `rotateX(a)` is equivalent to

--- a/files/en-us/web/css/reference/values/transform-function/rotatey/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/rotatey/index.md
@@ -10,6 +10,8 @@ sidebar: cssref
 The **`rotateY()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that rotates an element around the
 y-axis (vertical) without deforming it. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+The axis of rotation passes through an origin, defined by the {{ cssxref("transform-origin") }} CSS property.
+
 {{InteractiveExample("CSS Demo: rotateY()")}}
 
 ```css interactive-example-choice
@@ -37,8 +39,6 @@ transform: rotateY(3.142rad);
     width="200" />
 </section>
 ```
-
-The axis of rotation passes through an origin, defined by the {{ cssxref("transform-origin") }} CSS property.
 
 > [!NOTE]
 > `rotateY(a)` is equivalent to

--- a/files/en-us/web/css/reference/values/transform-function/rotatez/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/rotatez/index.md
@@ -10,6 +10,8 @@ sidebar: cssref
 The **`rotateZ()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that rotates an element around the
 z-axis without deforming it. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+The axis of rotation passes through an origin, defined by the {{ cssxref("transform-origin") }} CSS property.
+
 {{InteractiveExample("CSS Demo: rotateZ()")}}
 
 ```css interactive-example-choice
@@ -37,8 +39,6 @@ transform: rotateZ(3.142rad);
     width="200" />
 </section>
 ```
-
-The axis of rotation passes through an origin, defined by the {{ cssxref("transform-origin") }} CSS property.
 
 > [!NOTE]
 > `rotateZ(a)` is equivalent to

--- a/files/en-us/web/css/reference/values/transform-function/scale/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/scale/index.md
@@ -11,6 +11,10 @@ The **`scale()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Refe
 plane. Because the amount of scaling is defined by a vector [sx, sy], it can resize the horizontal and vertical dimensions at
 different scales. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+This scaling transformation is characterized by a two-dimensional vector. Its coordinates define how much scaling is
+done in each direction. If both coordinates are equal, the scaling is uniform (_isotropic_) and the aspect
+ratio of the element is preserved (this is a [homothetic transformation](https://en.wikipedia.org/wiki/Homothetic_transformation)).
+
 {{InteractiveExample("CSS Demo: scale()")}}
 
 ```css interactive-example-choice
@@ -38,10 +42,6 @@ transform: scale(-0.5, 1);
     width="200" />
 </section>
 ```
-
-This scaling transformation is characterized by a two-dimensional vector. Its coordinates define how much scaling is
-done in each direction. If both coordinates are equal, the scaling is uniform (_isotropic_) and the aspect
-ratio of the element is preserved (this is a [homothetic transformation](https://en.wikipedia.org/wiki/Homothetic_transformation)).
 
 When a coordinate value is outside the \[-1, 1] range, the element grows along that dimension; when inside, it
 shrinks. A negative value results in a [point reflection](https://en.wikipedia.org/wiki/Point_reflection)

--- a/files/en-us/web/css/reference/values/transform-function/scale3d/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/scale3d/index.md
@@ -11,6 +11,10 @@ The **`scale3d()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Re
 Because the amount of scaling is defined by a vector [sx, sy, sz], it can resize different dimensions at different scales. Its
 result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+This scaling transformation is characterized by a three-dimensional vector. Its coordinates define how much scaling
+is done in each direction. If all three coordinates are equal, the scaling is uniform (_isotropic_) and the
+{{glossary("aspect ratio")}} of the element is preserved (this is a [homothetic transformation](https://en.wikipedia.org/wiki/Homothetic_transformation)).
+
 {{InteractiveExample("CSS Demo: scale3d()")}}
 
 ```css interactive-example-choice
@@ -98,10 +102,6 @@ transform: scale3d(-1.4, 0.4, 0.7);
   transform: rotateX(-90deg) translateZ(50px);
 }
 ```
-
-This scaling transformation is characterized by a three-dimensional vector. Its coordinates define how much scaling
-is done in each direction. If all three coordinates are equal, the scaling is uniform (_isotropic_) and the
-{{glossary("aspect ratio")}} of the element is preserved (this is a [homothetic transformation](https://en.wikipedia.org/wiki/Homothetic_transformation)).
 
 When a coordinate value is outside the \[-1, 1] range, the element grows along that dimension; when inside, it
 shrinks. If it is negative, the result is a [point reflection](https://en.wikipedia.org/wiki/Point_reflection)

--- a/files/en-us/web/css/reference/values/transform-function/scalex/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/scalex/index.md
@@ -10,6 +10,11 @@ sidebar: cssref
 The **`scaleX()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that resizes an element along the
 x-axis (horizontally). Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+It modifies the abscissa (horizontal, x-coordinate) of each element point by a constant factor, except when the scale factor is 1, in which case
+the function is the identity transform. The scaling is not isotropic, and the angles of the element are generally not conserved, except for multiples of 90 degrees.
+`scaleX(-1)` defines an [axial symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a vertical axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
+property).
+
 {{InteractiveExample("CSS Demo: scaleX()")}}
 
 ```css interactive-example-choice
@@ -37,11 +42,6 @@ transform: scaleX(-0.5);
     width="200" />
 </section>
 ```
-
-It modifies the abscissa (horizontal, x-coordinate) of each element point by a constant factor, except when the scale factor is 1, in which case
-the function is the identity transform. The scaling is not isotropic, and the angles of the element are generally not conserved, except for multiples of 90 degrees.
-`scaleX(-1)` defines an [axial symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a vertical axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
-property).
 
 > [!NOTE]
 > `scaleX(sx)` is equivalent to

--- a/files/en-us/web/css/reference/values/transform-function/scaley/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/scaley/index.md
@@ -10,6 +10,11 @@ sidebar: cssref
 The **`scaleY()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that resizes an element along the
 y-axis (vertically). Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+It modifies the ordinate (vertical, y-coordinate) of each element point by a constant factor, except when the scale factor is 1, in which case
+the function is the identity transform. The scaling is not isotropic, and the angles of the element are not conserved.
+`scaleY(-1)` defines an [axial symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a horizontal axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
+property).
+
 {{InteractiveExample("CSS Demo: scaleY()")}}
 
 ```css interactive-example-choice
@@ -37,11 +42,6 @@ transform: scaleY(-0.5);
     width="200" />
 </section>
 ```
-
-It modifies the ordinate (vertical, y-coordinate) of each element point by a constant factor, except when the scale factor is 1, in which case
-the function is the identity transform. The scaling is not isotropic, and the angles of the element are not conserved.
-`scaleY(-1)` defines an [axial symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a horizontal axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
-property).
 
 > [!NOTE]
 > `scaleY(sy)` is equivalent to

--- a/files/en-us/web/css/reference/values/transform-function/skew/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/skew/index.md
@@ -10,6 +10,10 @@ sidebar: cssref
 The **`skew()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that skews an element on the 2D
 plane. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+This transformation is a shear mapping ([transvection](https://en.wikipedia.org/wiki/Shear_mapping)) that distorts
+each point within an element by a certain angle in the horizontal and vertical directions. The effect is as if you
+grabbed each corner of the element and pulled them along a certain angle.
+
 {{InteractiveExample("CSS Demo: skew()")}}
 
 ```css interactive-example-choice
@@ -37,10 +41,6 @@ transform: skew(0.312rad);
     width="200" />
 </section>
 ```
-
-This transformation is a shear mapping ([transvection](https://en.wikipedia.org/wiki/Shear_mapping)) that distorts
-each point within an element by a certain angle in the horizontal and vertical directions. The effect is as if you
-grabbed each corner of the element and pulled them along a certain angle.
 
 The coordinates of each point are modified by a value proportionate to the specified angle and the distance to the
 origin. Thus, the farther from the origin a point is, the greater the value added to it.

--- a/files/en-us/web/css/reference/values/transform-function/skewx/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/skewx/index.md
@@ -10,6 +10,11 @@ sidebar: cssref
 The **`skewX()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that skews an element in the
 horizontal direction on the 2D plane. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+This transformation is a shear mapping ([transvection](https://en.wikipedia.org/wiki/Shear_mapping)) that distorts
+each point within an element by a certain angle in the horizontal direction. The abscissa (horizontal, x-coordinate) of each point is
+modified by a value proportionate to the specified angle and the distance to the origin; thus, the farther from the
+origin a point is, the greater will be the value added it.
+
 {{InteractiveExample("CSS Demo: skewX()")}}
 
 ```css interactive-example-choice
@@ -37,11 +42,6 @@ transform: skewX(0.352rad);
     width="200" />
 </section>
 ```
-
-This transformation is a shear mapping ([transvection](https://en.wikipedia.org/wiki/Shear_mapping)) that distorts
-each point within an element by a certain angle in the horizontal direction. The abscissa (horizontal, x-coordinate) of each point is
-modified by a value proportionate to the specified angle and the distance to the origin; thus, the farther from the
-origin a point is, the greater will be the value added it.
 
 > [!NOTE]
 > `skewX(a)` is equivalent to

--- a/files/en-us/web/css/reference/values/transform-function/skewy/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/skewy/index.md
@@ -10,6 +10,11 @@ sidebar: cssref
 The **`skewY()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) defines a transformation that skews an element in the vertical
 direction on the 2D plane. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+This transformation is a shear mapping ([transvection](https://en.wikipedia.org/wiki/Shear_mapping)) that distorts
+each point within an element by a certain angle in the vertical direction. The ordinate (vertical, y-coordinate) of each point is
+modified by a value proportionate to the specified angle and the distance to the origin; thus, the farther from the
+origin a point is, the greater will be the value added it.
+
 {{InteractiveExample("CSS Demo: skewY()")}}
 
 ```css interactive-example-choice
@@ -37,11 +42,6 @@ transform: skewY(0.352rad);
     width="200" />
 </section>
 ```
-
-This transformation is a shear mapping ([transvection](https://en.wikipedia.org/wiki/Shear_mapping)) that distorts
-each point within an element by a certain angle in the vertical direction. The ordinate (vertical, y-coordinate) of each point is
-modified by a value proportionate to the specified angle and the distance to the origin; thus, the farther from the
-origin a point is, the greater will be the value added it.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/transform-function/translate/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/translate/index.md
@@ -10,6 +10,9 @@ sidebar: cssref
 The **`translate()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) repositions an element in the horizontal and/or vertical
 directions. Its result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+This transformation is characterized by a two-dimensional vector [tx, ty]. Its coordinates define how much the element moves
+in each direction.
+
 {{InteractiveExample("CSS Demo: translate()")}}
 
 ```css interactive-example-choice
@@ -53,9 +56,6 @@ transform: translate(3ch, 3mm);
   position: absolute;
 }
 ```
-
-This transformation is characterized by a two-dimensional vector [tx, ty]. Its coordinates define how much the element moves
-in each direction.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/transform-function/translate3d/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/translate3d/index.md
@@ -10,6 +10,9 @@ sidebar: cssref
 The **`translate3d()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) repositions an element in 3D space. Its result is a
 {{cssxref("&lt;transform-function&gt;")}} data type.
 
+This transformation is characterized by a three-dimensional vector [tx, ty, tz]. Its coordinates define how much the element moves
+in each direction.
+
 {{InteractiveExample("CSS Demo: translate3d()")}}
 
 ```css interactive-example-choice
@@ -97,9 +100,6 @@ transform: translate3d(5ch, 0.4in, 5em);
   transform: rotateX(-90deg) translateZ(50px);
 }
 ```
-
-This transformation is characterized by a three-dimensional vector [tx, ty, tz]. Its coordinates define how much the element moves
-in each direction.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/transform-function/translatex/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/translatex/index.md
@@ -10,6 +10,11 @@ sidebar: cssref
 The **`translateX()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) repositions an element horizontally on the 2D plane. Its
 result is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+> [!NOTE]
+> `translateX(tx)` is equivalent to
+> `translate(tx, 0)` or
+> `translate3d(tx, 0, 0)`.
+
 {{InteractiveExample("CSS Demo: translateX()")}}
 
 ```css interactive-example-choice
@@ -53,11 +58,6 @@ transform: translateX(3ch);
   position: absolute;
 }
 ```
-
-> [!NOTE]
-> `translateX(tx)` is equivalent to
-> `translate(tx, 0)` or
-> `translate3d(tx, 0, 0)`.
 
 ## Syntax
 

--- a/files/en-us/web/css/reference/values/transform-function/translatey/index.md
+++ b/files/en-us/web/css/reference/values/transform-function/translatey/index.md
@@ -10,6 +10,11 @@ sidebar: cssref
 The **`translateY()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/Reference/Values/Functions) repositions an element vertically on the 2D plane. Its result
 is a {{cssxref("&lt;transform-function&gt;")}} data type.
 
+> [!NOTE]
+> `translateY(ty)` is equivalent to
+> `translate(0, ty)` or
+> `translate3d(0, ty, 0)`.
+
 {{InteractiveExample("CSS Demo: translateY()")}}
 
 ```css interactive-example-choice
@@ -53,11 +58,6 @@ transform: translateY(3ch);
   position: absolute;
 }
 ```
-
-> [!NOTE]
-> `translateY(ty)` is equivalent to
-> `translate(0, ty)` or
-> `translate3d(0, ty, 0)`.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

The third of four PRs splitting up #45563. Draft until #45601 and #45602 are resolved, since this one raises a question those two don't.

These are the 70 CSS pages where **more than one paragraph** sits after the `{{InteractiveExample}}` macro and therefore renders inside the "Try it" section. As currently written, this PR moves each block up above the macro, the same way as the single-sentence PRs.

**The open question:** [in review on the previous PR](https://github.com/mdn/content/pull/45563#issuecomment-3389310786) @wbamberg noted that the interactive example should come after a very short, preferably one-sentence summary, and that longer descriptions belong after the demo in a `## Description` section. @Josh-Cena agreed that discretion is needed, and that an intro which gets too long should be broken off into `## Description`.

That applies to this PR rather than to #45601/#45602. So before this is reviewed in detail, it would help to know which you'd prefer:

1. Move the paragraphs above the macro, as currently written.
2. Add a `## Description` section after the demo and put them there.
3. Decide per page, based on how long the intro becomes.

Only 4 of these 70 pages currently have a `## Description` section, so option 2 means adding the heading in most cases.

For what it's worth, `list-style-type` was fixed upstream while this was in progress by adding a `## Description` section — so that appears to be the preferred shape. I have left that page and `list-style` out of this PR since they are already done.

### Motivation

Same underlying issue as #45601: prose placed after the `{{InteractiveExample}}` macro renders inside the "Try it" section, after the demo's code, instead of reading as part of the page's description.
