### PR TITLE
Move multi-paragraph descriptions out of the Try it section on HTML and WebAssembly pages

### DIFF
--- a/files/en-us/web/html/reference/elements/address/index.md
+++ b/files/en-us/web/html/reference/elements/address/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`<address>`** [HTML](/en-US/docs/Web/HTML) element indicates that the enclosed HTML provides contact information for a person or people, or for an organization.
 
+The contact information provided by an `<address>` element's contents can take whatever form is appropriate for the context, and may include any type of contact information that is needed, such as a physical address, URL, email address, phone number, social media handle, geographic coordinates, and so forth. The `<address>` element should include the name of the person, people, or organization to which the contact information refers.
+
 {{InteractiveExample("HTML Demo: &lt;address&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -29,8 +31,6 @@ a[href^="tel"]::before {
   content: "📞 ";
 }
 ```
-
-The contact information provided by an `<address>` element's contents can take whatever form is appropriate for the context, and may include any type of contact information that is needed, such as a physical address, URL, email address, phone number, social media handle, geographic coordinates, and so forth. The `<address>` element should include the name of the person, people, or organization to which the contact information refers.
 
 `<address>` can be used in a variety of contexts, such as providing a business's contact information in the page header, or indicating the author of an article by including an `<address>` element within the {{HTMLElement("article")}}.
 

--- a/files/en-us/web/html/reference/elements/address/index.md
+++ b/files/en-us/web/html/reference/elements/address/index.md
@@ -9,8 +9,6 @@ sidebar: htmlsidebar
 
 The **`<address>`** [HTML](/en-US/docs/Web/HTML) element indicates that the enclosed HTML provides contact information for a person or people, or for an organization.
 
-The contact information provided by an `<address>` element's contents can take whatever form is appropriate for the context, and may include any type of contact information that is needed, such as a physical address, URL, email address, phone number, social media handle, geographic coordinates, and so forth. The `<address>` element should include the name of the person, people, or organization to which the contact information refers.
-
 {{InteractiveExample("HTML Demo: &lt;address&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -32,13 +30,15 @@ a[href^="tel"]::before {
 }
 ```
 
-`<address>` can be used in a variety of contexts, such as providing a business's contact information in the page header, or indicating the author of an article by including an `<address>` element within the {{HTMLElement("article")}}.
-
 ## Attributes
 
 This element only includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
 
 ## Usage notes
+
+The contact information provided by an `<address>` element's contents can take whatever form is appropriate for the context, and may include any type of contact information that is needed, such as a physical address, URL, email address, phone number, social media handle, geographic coordinates, and so forth. The `<address>` element should include the name of the person, people, or organization to which the contact information refers.
+
+`<address>` can be used in a variety of contexts, such as providing a business's contact information in the page header, or indicating the author of an article by including an `<address>` element within the {{HTMLElement("article")}}.
 
 - The `<address>` element can only be used to represent the contact information for its nearest {{HTMLElement("article")}} or {{HTMLElement("body")}} element ancestor.
 - This element should not contain more information than the contact information, like a publication date (which belongs in a {{HTMLElement("time")}} element).

--- a/files/en-us/web/html/reference/elements/datalist/index.md
+++ b/files/en-us/web/html/reference/elements/datalist/index.md
@@ -9,6 +9,9 @@ sidebar: htmlsidebar
 
 The **`<datalist>`** [HTML](/en-US/docs/Web/HTML) element contains a set of {{HTMLElement("option")}} elements that represent the permissible or recommended options available to choose from within other controls.
 
+To bind the `<datalist>` element to the control, we give it a unique identifier in the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attribute, and then add the [`list`](/en-US/docs/Web/HTML/Reference/Elements/input#list) attribute to the {{HTMLElement("input")}} element with the same identifier as value.
+Only certain types of {{HTMLElement("input")}} support this behavior, and it can also vary from browser to browser.
+
 {{InteractiveExample("HTML Demo: &lt;datalist&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -30,9 +33,6 @@ label {
   margin-bottom: 10px;
 }
 ```
-
-To bind the `<datalist>` element to the control, we give it a unique identifier in the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attribute, and then add the [`list`](/en-US/docs/Web/HTML/Reference/Elements/input#list) attribute to the {{HTMLElement("input")}} element with the same identifier as value.
-Only certain types of {{HTMLElement("input")}} support this behavior, and it can also vary from browser to browser.
 
 Each `<option>` element should have a `value` attribute, which represents a suggestion to be entered into the input. It can also have a `label` attribute, or, missing that, some text content, which may be displayed by the browser instead of `value` (Firefox), or in addition to `value` (Chrome and Safari, as supplemental text). The exact content of the drop-down menu depends on the browser, but when clicked, content entered into control field will always come from the `value` attribute.
 

--- a/files/en-us/web/html/reference/elements/datalist/index.md
+++ b/files/en-us/web/html/reference/elements/datalist/index.md
@@ -9,9 +9,6 @@ sidebar: htmlsidebar
 
 The **`<datalist>`** [HTML](/en-US/docs/Web/HTML) element contains a set of {{HTMLElement("option")}} elements that represent the permissible or recommended options available to choose from within other controls.
 
-To bind the `<datalist>` element to the control, we give it a unique identifier in the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attribute, and then add the [`list`](/en-US/docs/Web/HTML/Reference/Elements/input#list) attribute to the {{HTMLElement("input")}} element with the same identifier as value.
-Only certain types of {{HTMLElement("input")}} support this behavior, and it can also vary from browser to browser.
-
 {{InteractiveExample("HTML Demo: &lt;datalist&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -34,14 +31,19 @@ label {
 }
 ```
 
+## Attributes
+
+This element has no other attributes than the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes), common to all elements.
+
+## Usage notes
+
+To bind the `<datalist>` element to the control, we give it a unique identifier in the [`id`](/en-US/docs/Web/HTML/Reference/Global_attributes/id) attribute, and then add the [`list`](/en-US/docs/Web/HTML/Reference/Elements/input#list) attribute to the {{HTMLElement("input")}} element with the same identifier as value.
+Only certain types of {{HTMLElement("input")}} support this behavior, and it can also vary from browser to browser.
+
 Each `<option>` element should have a `value` attribute, which represents a suggestion to be entered into the input. It can also have a `label` attribute, or, missing that, some text content, which may be displayed by the browser instead of `value` (Firefox), or in addition to `value` (Chrome and Safari, as supplemental text). The exact content of the drop-down menu depends on the browser, but when clicked, content entered into control field will always come from the `value` attribute.
 
 > [!NOTE]
 > `<datalist>` is not a replacement for {{HTMLElement("select")}}. A `<datalist>` does not represent an input itself; it is a list of suggested values for an associated control. The control can still accept any value that passes validation, even if it is not in this suggestion list.
-
-## Attributes
-
-This element has no other attributes than the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes), common to all elements.
 
 ## Accessibility
 

--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -11,6 +11,8 @@ The **`<details>`** [HTML](/en-US/docs/Web/HTML) element creates a disclosure wi
 
 A disclosure widget is typically presented onscreen using a small triangle that rotates (or twists) to indicate open/closed state, with a label next to the triangle. The contents of the `<summary>` element are used as the label for the disclosure widget. The contents of the `<details>` provide the {{glossary("accessible description")}} for the `<summary>`.
 
+A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside `<summary>` (or a {{Glossary("user agent")}}-defined default string if no `<summary>`).
+
 {{InteractiveExample("HTML Demo: &lt;details&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -42,8 +44,6 @@ details[open] summary {
   margin-bottom: 0.5em;
 }
 ```
-
-A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside `<summary>` (or a {{Glossary("user agent")}}-defined default string if no `<summary>`).
 
 When the user clicks on the widget or focuses it then presses the space bar, it "twists" open, revealing its contents. The common use of a triangle which rotates or twists around to represent opening or closing the widget is why these are sometimes called "twisty".
 

--- a/files/en-us/web/html/reference/elements/details/index.md
+++ b/files/en-us/web/html/reference/elements/details/index.md
@@ -11,8 +11,6 @@ The **`<details>`** [HTML](/en-US/docs/Web/HTML) element creates a disclosure wi
 
 A disclosure widget is typically presented onscreen using a small triangle that rotates (or twists) to indicate open/closed state, with a label next to the triangle. The contents of the `<summary>` element are used as the label for the disclosure widget. The contents of the `<details>` provide the {{glossary("accessible description")}} for the `<summary>`.
 
-A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside `<summary>` (or a {{Glossary("user agent")}}-defined default string if no `<summary>`).
-
 {{InteractiveExample("HTML Demo: &lt;details&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -45,14 +43,6 @@ details[open] summary {
 }
 ```
 
-When the user clicks on the widget or focuses it then presses the space bar, it "twists" open, revealing its contents. The common use of a triangle which rotates or twists around to represent opening or closing the widget is why these are sometimes called "twisty".
-
-You can use CSS to style the disclosure widget, and you can programmatically open and close the widget by setting/removing its [`open`](#open) attribute. Unfortunately, at this time, there's no built-in way to animate the transition between open and closed.
-
-By default when closed, the widget is only tall enough to display the disclosure triangle and summary. When open, it expands to display the details contained within.
-
-Fully standards-compliant implementations automatically apply the CSS `{{cssxref("display")}}: list-item` to the {{HTMLElement("summary")}} element. You can use this or the {{cssxref("::marker")}} pseudo-element to [customize the disclosure widget](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
-
 ## Attributes
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -70,6 +60,18 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
     > [!NOTE]
     > `<details>` elements don't have to be adjacent to one another in the source to be part of the same group.
+
+## Usage notes
+
+A `<details>` widget can be in one of two states. The default _closed_ state displays only the triangle and the label inside `<summary>` (or a {{Glossary("user agent")}}-defined default string if no `<summary>`).
+
+When the user clicks on the widget or focuses it then presses the space bar, it "twists" open, revealing its contents. The common use of a triangle which rotates or twists around to represent opening or closing the widget is why these are sometimes called "twisty".
+
+You can use CSS to style the disclosure widget, and you can programmatically open and close the widget by setting/removing its [`open`](#open) attribute. Unfortunately, at this time, there's no built-in way to animate the transition between open and closed.
+
+By default when closed, the widget is only tall enough to display the disclosure triangle and summary. When open, it expands to display the details contained within.
+
+Fully standards-compliant implementations automatically apply the CSS `{{cssxref("display")}}: list-item` to the {{HTMLElement("summary")}} element. You can use this or the {{cssxref("::marker")}} pseudo-element to [customize the disclosure widget](/en-US/docs/Web/HTML/Reference/Elements/summary#changing_the_summarys_icon).
 
 ## Events
 

--- a/files/en-us/web/html/reference/elements/embed/index.md
+++ b/files/en-us/web/html/reference/elements/embed/index.md
@@ -9,9 +9,6 @@ sidebar: htmlsidebar
 
 The **`<embed>`** [HTML](/en-US/docs/Web/HTML) element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in.
 
-> [!NOTE]
-> This topic documents only the element that is defined as part of the [HTML Living Standard](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element). It does not address earlier, non-standardized implementation of the element.
-
 {{InteractiveExample("HTML Demo: &lt;embed&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -21,8 +18,6 @@ The **`<embed>`** [HTML](/en-US/docs/Web/HTML) element embeds external content a
   width="250"
   height="200" />
 ```
-
-Keep in mind that most modern browsers have deprecated and removed support for browser plug-ins, so relying upon `<embed>` is generally not wise if you want your site to be operable on the average user's browser.
 
 ## Attributes
 
@@ -38,6 +33,11 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/R
   - : The displayed width of the resource, in [CSS pixels](https://drafts.csswg.org/css-values/#px). This must be an absolute value; percentages are _not_ allowed.
 
 ## Usage notes
+
+> [!NOTE]
+> This topic documents only the element that is defined as part of the [HTML Living Standard](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element). It does not address earlier, non-standardized implementation of the element.
+
+Keep in mind that most modern browsers have deprecated and removed support for browser plug-ins, so relying upon `<embed>` is generally not wise if you want your site to be operable on the average user's browser.
 
 You can use the {{cssxref("object-position")}} property to adjust the positioning of the embedded object within the element's frame.
 

--- a/files/en-us/web/html/reference/elements/embed/index.md
+++ b/files/en-us/web/html/reference/elements/embed/index.md
@@ -9,6 +9,9 @@ sidebar: htmlsidebar
 
 The **`<embed>`** [HTML](/en-US/docs/Web/HTML) element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in.
 
+> [!NOTE]
+> This topic documents only the element that is defined as part of the [HTML Living Standard](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element). It does not address earlier, non-standardized implementation of the element.
+
 {{InteractiveExample("HTML Demo: &lt;embed&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -18,9 +21,6 @@ The **`<embed>`** [HTML](/en-US/docs/Web/HTML) element embeds external content a
   width="250"
   height="200" />
 ```
-
-> [!NOTE]
-> This topic documents only the element that is defined as part of the [HTML Living Standard](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element). It does not address earlier, non-standardized implementation of the element.
 
 Keep in mind that most modern browsers have deprecated and removed support for browser plug-ins, so relying upon `<embed>` is generally not wise if you want your site to be operable on the average user's browser.
 

--- a/files/en-us/web/html/reference/elements/hr/index.md
+++ b/files/en-us/web/html/reference/elements/hr/index.md
@@ -9,8 +9,6 @@ sidebar: htmlsidebar
 
 The **`<hr>`** [HTML](/en-US/docs/Web/HTML) element represents a thematic break between elements: for example, a change of scene in a story, or a shift of topic within a section.
 
-Historically, the `<hr>` element has always been presented as a horizontal rule or line. While it may still be displayed as a horizontal rule in visual browsers, this element is now defined in semantic terms, rather than presentational terms. Therefore, if you wish to draw a horizontal line, you should do so by adding a border to an existing element using CSS.
-
 {{InteractiveExample("HTML Demo: &lt;hr&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -40,8 +38,6 @@ hr::after {
 }
 ```
 
-The `border-*` properties (for example, {{cssxref("border-style")}} and {{cssxref("border-color")}}) allow you to significantly customize a line's appearance, whether you are customizing an `<hr>` element or a border drawn on a different element.
-
 ## Attributes
 
 This element's attributes include the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -56,6 +52,12 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/R
   - : Sets the height, in pixels, of the rule.
 - `width` {{deprecated_inline}} {{Non-standard_Inline}}
   - : Sets the length of the rule on the page through a pixel or percentage value.
+
+## Usage notes
+
+Historically, the `<hr>` element has always been presented as a horizontal rule or line. While it may still be displayed as a horizontal rule in visual browsers, this element is now defined in semantic terms, rather than presentational terms. Therefore, if you wish to draw a horizontal line, you should do so by adding a border to an existing element using CSS.
+
+The `border-*` properties (for example, {{cssxref("border-style")}} and {{cssxref("border-color")}}) allow you to significantly customize a line's appearance, whether you are customizing an `<hr>` element or a border drawn on a different element.
 
 ## Example
 

--- a/files/en-us/web/html/reference/elements/hr/index.md
+++ b/files/en-us/web/html/reference/elements/hr/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`<hr>`** [HTML](/en-US/docs/Web/HTML) element represents a thematic break between elements: for example, a change of scene in a story, or a shift of topic within a section.
 
+Historically, the `<hr>` element has always been presented as a horizontal rule or line. While it may still be displayed as a horizontal rule in visual browsers, this element is now defined in semantic terms, rather than presentational terms. Therefore, if you wish to draw a horizontal line, you should do so by adding a border to an existing element using CSS.
+
 {{InteractiveExample("HTML Demo: &lt;hr&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -37,8 +39,6 @@ hr::after {
   top: -13px;
 }
 ```
-
-Historically, the `<hr>` element has always been presented as a horizontal rule or line. While it may still be displayed as a horizontal rule in visual browsers, this element is now defined in semantic terms, rather than presentational terms. Therefore, if you wish to draw a horizontal line, you should do so by adding a border to an existing element using CSS.
 
 The `border-*` properties (for example, {{cssxref("border-style")}} and {{cssxref("border-color")}}) allow you to significantly customize a line's appearance, whether you are customizing an `<hr>` element or a border drawn on a different element.
 

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`<iframe>`** [HTML](/en-US/docs/Web/HTML) element represents a nested {{Glossary("browsing context")}}, embedding another HTML page into the current one.
 
+Each embedded browsing context has its own [document](/en-US/docs/Web/API/Document) and allows URL navigations. The navigations of each embedded browsing context are linearized into the [session history](/en-US/docs/Web/API/History) of the _topmost_ browsing context. The browsing context that embeds the others is called the _parent browsing context_. The _topmost_ browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
+
 {{InteractiveExample("HTML Demo: &lt;iframe&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -27,8 +29,6 @@ iframe {
   width: 100%; /* takes precedence over the width set with the HTML width attribute */
 }
 ```
-
-Each embedded browsing context has its own [document](/en-US/docs/Web/API/Document) and allows URL navigations. The navigations of each embedded browsing context are linearized into the [session history](/en-US/docs/Web/API/History) of the _topmost_ browsing context. The browsing context that embeds the others is called the _parent browsing context_. The _topmost_ browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
 
 > [!WARNING]
 > Because each browsing context is a complete document environment, every `<iframe>` in a page requires increased memory and other computing resources. While theoretically you can use as many `<iframe>`s as you like, check for performance problems.

--- a/files/en-us/web/html/reference/elements/iframe/index.md
+++ b/files/en-us/web/html/reference/elements/iframe/index.md
@@ -9,8 +9,6 @@ sidebar: htmlsidebar
 
 The **`<iframe>`** [HTML](/en-US/docs/Web/HTML) element represents a nested {{Glossary("browsing context")}}, embedding another HTML page into the current one.
 
-Each embedded browsing context has its own [document](/en-US/docs/Web/API/Document) and allows URL navigations. The navigations of each embedded browsing context are linearized into the [session history](/en-US/docs/Web/API/History) of the _topmost_ browsing context. The browsing context that embeds the others is called the _parent browsing context_. The _topmost_ browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
-
 {{InteractiveExample("HTML Demo: &lt;iframe&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -29,9 +27,6 @@ iframe {
   width: 100%; /* takes precedence over the width set with the HTML width attribute */
 }
 ```
-
-> [!WARNING]
-> Because each browsing context is a complete document environment, every `<iframe>` in a page requires increased memory and other computing resources. While theoretically you can use as many `<iframe>`s as you like, check for performance problems.
 
 ## Attributes
 
@@ -182,6 +177,13 @@ These attributes are deprecated and may no longer be supported by all user agent
       - : Always show a scrollbar.
     - `no`
       - : Never show a scrollbar.
+
+## Usage notes
+
+Each embedded browsing context has its own [document](/en-US/docs/Web/API/Document) and allows URL navigations. The navigations of each embedded browsing context are linearized into the [session history](/en-US/docs/Web/API/History) of the _topmost_ browsing context. The browsing context that embeds the others is called the _parent browsing context_. The _topmost_ browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
+
+> [!WARNING]
+> Because each browsing context is a complete document environment, every `<iframe>` in a page requires increased memory and other computing resources. While theoretically you can use as many `<iframe>`s as you like, check for performance problems.
 
 ## Scripting
 

--- a/files/en-us/web/html/reference/elements/input/button/index.md
+++ b/files/en-us/web/html/reference/elements/input/button/index.md
@@ -75,8 +75,6 @@ If you don't specify a `value`, you get an empty button:
 > [!NOTE]
 > While `<input>` elements of type `button` are still perfectly valid HTML, the newer {{HTMLElement("button")}} element is now the favored way to create buttons. Given that a {{HTMLElement("button")}}'s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.
 
-## Using buttons
-
 `<input type="button">` elements have no default behavior (their cousins, `<input type="submit">` and [`<input type="reset">`](/en-US/docs/Web/HTML/Reference/Elements/input/reset) are used to submit and reset forms, respectively). To make buttons do anything, you have to write JavaScript code to do the work.
 
 ### A basic button

--- a/files/en-us/web/html/reference/elements/input/button/index.md
+++ b/files/en-us/web/html/reference/elements/input/button/index.md
@@ -9,9 +9,6 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`button`** are rendered as push buttons, which can be programmed to control custom functionality anywhere on a webpage as required when assigned an event handler function (typically for the {{domxref("Element/click_event", "click")}} event).
 
-> [!NOTE]
-> While `<input>` elements of type `button` are still perfectly valid HTML, the newer {{HTMLElement("button")}} element is now the favored way to create buttons. Given that a {{HTMLElement("button")}}'s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.
-
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;button&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -72,6 +69,11 @@ If you don't specify a `value`, you get an empty button:
 ```
 
 {{EmbedLiveSample("Button_without_a_value", 650, 30)}}
+
+## Usage notes
+
+> [!NOTE]
+> While `<input>` elements of type `button` are still perfectly valid HTML, the newer {{HTMLElement("button")}} element is now the favored way to create buttons. Given that a {{HTMLElement("button")}}'s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.
 
 ## Using buttons
 

--- a/files/en-us/web/html/reference/elements/input/button/index.md
+++ b/files/en-us/web/html/reference/elements/input/button/index.md
@@ -9,6 +9,9 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`button`** are rendered as push buttons, which can be programmed to control custom functionality anywhere on a webpage as required when assigned an event handler function (typically for the {{domxref("Element/click_event", "click")}} event).
 
+> [!NOTE]
+> While `<input>` elements of type `button` are still perfectly valid HTML, the newer {{HTMLElement("button")}} element is now the favored way to create buttons. Given that a {{HTMLElement("button")}}'s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;button&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -47,9 +50,6 @@ sidebar: htmlsidebar
     inset 2px 2px 3px rgb(0 0 0 / 60%);
 }
 ```
-
-> [!NOTE]
-> While `<input>` elements of type `button` are still perfectly valid HTML, the newer {{HTMLElement("button")}} element is now the favored way to create buttons. Given that a {{HTMLElement("button")}}'s label text is inserted between the opening and closing tags, you can include HTML in the label, even images.
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/input/checkbox/index.md
+++ b/files/en-us/web/html/reference/elements/input/checkbox/index.md
@@ -11,9 +11,6 @@ sidebar: htmlsidebar
 
 {{htmlelement("input")}} elements of type **`checkbox`** are rendered by default as boxes that are checked (ticked) when activated, like you might see in an official government paper form. The exact appearance depends upon the operating system configuration under which the browser is running. Generally this is a square but it may have rounded corners. A checkbox allows you to select single values for submission in a form (or not).
 
-> [!NOTE]
-> [Radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio) are similar to checkboxes, but with an important distinction — [same-named radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio#defining_a_radio_group) are grouped into a set in which only one radio button can be selected at a time, whereas checkboxes allow you to turn single values on and off. Where multiple same-named controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
-
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;checkbox&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -71,6 +68,11 @@ If the `value` attribute was omitted, the default value for the checkbox is `on`
 
 > [!NOTE]
 > If a checkbox is unchecked when its form is submitted, neither the name nor the value is submitted to the server. There is no HTML-only method of representing a checkbox's unchecked state (e.g., `value=unchecked`). If you wanted to submit a default value for the checkbox when it is unchecked, you could include JavaScript to create an {{HTMLElement("input/hidden", '&lt;input type="hidden"&gt;')}} within the form with a value indicating an unchecked state.
+
+## Usage notes
+
+> [!NOTE]
+> [Radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio) are similar to checkboxes, but with an important distinction — [same-named radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio#defining_a_radio_group) are grouped into a set in which only one radio button can be selected at a time, whereas checkboxes allow you to turn single values on and off. Where multiple same-named controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
 
 ## Additional attributes
 

--- a/files/en-us/web/html/reference/elements/input/checkbox/index.md
+++ b/files/en-us/web/html/reference/elements/input/checkbox/index.md
@@ -74,30 +74,6 @@ If the `value` attribute was omitted, the default value for the checkbox is `on`
 > [!NOTE]
 > [Radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio) are similar to checkboxes, but with an important distinction — [same-named radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio#defining_a_radio_group) are grouped into a set in which only one radio button can be selected at a time, whereas checkboxes allow you to turn single values on and off. Where multiple same-named controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
 
-## Additional attributes
-
-In addition to the [common attributes](/en-US/docs/Web/HTML/Reference/Elements/input#attributes) shared by all {{HTMLElement("input")}} elements, `checkbox` inputs support the following attributes.
-
-- `checked`
-  - : A [boolean](/en-US/docs/Glossary/Boolean/HTML) attribute indicating whether this checkbox is checked by default (when the page loads). It does _not_ indicate whether this checkbox is currently checked: if the checkbox's state is changed, this content attribute does not reflect the change. (Only the {{domxref("HTMLInputElement")}}'s `checked` IDL attribute is updated.)
-    > [!NOTE]
-    > Unlike other input controls, a checkbox's value is only included in the submitted data if the checkbox is currently `checked`. If it is, then the value of the checkbox's `value` attribute is reported as the input's value, or `on` if no `value` is set.
-    > Unlike other browsers, Firefox by default [persists the dynamic checked state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` across page loads. Use the [`autocomplete`](/en-US/docs/Web/HTML/Reference/Elements/input#autocomplete) attribute to control this feature.
-
-- `value`
-  - : The `value` attribute is one which all {{HTMLElement("input")}}s share; however, it serves a special purpose for inputs of type `checkbox`: when a form is submitted, only checkboxes which are currently checked are submitted to the server, and the reported value is the value of the `value` attribute. If the `value` is not otherwise specified, it is the string `on` by default. This is demonstrated in the section [Value](#value) above.
-
-- `switch`
-  - : A [boolean](/en-US/docs/Glossary/Boolean/HTML) attribute that applies only to `checkbox` inputs. When present, it indicates that the `checkbox` represents an on/off `switch` rather than a normal `checkbox`. It alters the appearance of the `checkbox` control, but the underlying behavior remains the same as that of a normal `checkbox`.
-
-    > [!NOTE]
-    > This attribute allows user agents to expose `switch` ARIA semantics to assistive technologies — without requiring documents to explicitly specify `role="switch"`. The markup and API are similar to those of checkboxes, except that the `:indeterminate` pseudo-class never matches.
-
-    > [!WARNING]
-    > This attribute is still experimental and has limited browser support. The attribute is ignored on unsupported browsers.
-
-## Using checkbox inputs
-
 We already covered the most basic use of checkboxes above. Let's now look at the other common checkbox-related features and techniques you'll need.
 
 ### Handling multiple checkboxes
@@ -267,6 +243,28 @@ function updateDisplay() {
 ```
 
 {{EmbedLiveSample("indeterminate_state", "", 200)}}
+
+## Additional attributes
+
+In addition to the [common attributes](/en-US/docs/Web/HTML/Reference/Elements/input#attributes) shared by all {{HTMLElement("input")}} elements, `checkbox` inputs support the following attributes.
+
+- `checked`
+  - : A [boolean](/en-US/docs/Glossary/Boolean/HTML) attribute indicating whether this checkbox is checked by default (when the page loads). It does _not_ indicate whether this checkbox is currently checked: if the checkbox's state is changed, this content attribute does not reflect the change. (Only the {{domxref("HTMLInputElement")}}'s `checked` IDL attribute is updated.)
+    > [!NOTE]
+    > Unlike other input controls, a checkbox's value is only included in the submitted data if the checkbox is currently `checked`. If it is, then the value of the checkbox's `value` attribute is reported as the input's value, or `on` if no `value` is set.
+    > Unlike other browsers, Firefox by default [persists the dynamic checked state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` across page loads. Use the [`autocomplete`](/en-US/docs/Web/HTML/Reference/Elements/input#autocomplete) attribute to control this feature.
+
+- `value`
+  - : The `value` attribute is one which all {{HTMLElement("input")}}s share; however, it serves a special purpose for inputs of type `checkbox`: when a form is submitted, only checkboxes which are currently checked are submitted to the server, and the reported value is the value of the `value` attribute. If the `value` is not otherwise specified, it is the string `on` by default. This is demonstrated in the section [Value](#value) above.
+
+- `switch`
+  - : A [boolean](/en-US/docs/Glossary/Boolean/HTML) attribute that applies only to `checkbox` inputs. When present, it indicates that the `checkbox` represents an on/off `switch` rather than a normal `checkbox`. It alters the appearance of the `checkbox` control, but the underlying behavior remains the same as that of a normal `checkbox`.
+
+    > [!NOTE]
+    > This attribute allows user agents to expose `switch` ARIA semantics to assistive technologies — without requiring documents to explicitly specify `role="switch"`. The markup and API are similar to those of checkboxes, except that the `:indeterminate` pseudo-class never matches.
+
+    > [!WARNING]
+    > This attribute is still experimental and has limited browser support. The attribute is ignored on unsupported browsers.
 
 ## Validation
 

--- a/files/en-us/web/html/reference/elements/input/checkbox/index.md
+++ b/files/en-us/web/html/reference/elements/input/checkbox/index.md
@@ -11,6 +11,9 @@ sidebar: htmlsidebar
 
 {{htmlelement("input")}} elements of type **`checkbox`** are rendered by default as boxes that are checked (ticked) when activated, like you might see in an official government paper form. The exact appearance depends upon the operating system configuration under which the browser is running. Generally this is a square but it may have rounded corners. A checkbox allows you to select single values for submission in a form (or not).
 
+> [!NOTE]
+> [Radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio) are similar to checkboxes, but with an important distinction — [same-named radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio#defining_a_radio_group) are grouped into a set in which only one radio button can be selected at a time, whereas checkboxes allow you to turn single values on and off. Where multiple same-named controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;checkbox&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -41,9 +44,6 @@ input {
   margin: 0.4rem;
 }
 ```
-
-> [!NOTE]
-> [Radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio) are similar to checkboxes, but with an important distinction — [same-named radio buttons](/en-US/docs/Web/HTML/Reference/Elements/input/radio#defining_a_radio_group) are grouped into a set in which only one radio button can be selected at a time, whereas checkboxes allow you to turn single values on and off. Where multiple same-named controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/input/month/index.md
+++ b/files/en-us/web/html/reference/elements/input/month/index.md
@@ -10,9 +10,6 @@ sidebar: htmlsidebar
 {{HTMLElement("input")}} elements of type **`month`** create input fields that let the user enter a month and year allowing a month and year to be easily entered.
 The value is a string whose value is in the format `YYYY-MM`, where `YYYY` is the four-digit year and `MM` is the month number.
 
-The control's UI varies in general from browser to browser; at the moment support is patchy, with only Chrome/Opera and Edge on desktop — and most modern mobile browser versions — having usable implementations.
-In browsers that don't support `month` inputs, the control degrades gracefully to [`<input type="text">`](/en-US/docs/Web/HTML/Reference/Elements/input/text), although there may be automatic validation of the entered text to ensure it's formatted as expected.
-
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;month&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -34,15 +31,6 @@ label {
   margin: 0.4rem 0;
 }
 ```
-
-For those of you using a browser that doesn't support `month`, the screenshot below shows what it looks like in Chrome and Opera.
-Clicking the down arrow on the right-hand side brings up a date picker that lets you select the month and year.
-
-![Month control on Chrome browser](month-control-chrome.png)
-
-The Microsoft Edge `month` control looks like this:
-
-![Month control on Edge browser](month-control-edge.png)
 
 ## Value
 
@@ -79,6 +67,20 @@ monthControl.value = "2001-06";
 ```
 
 {{EmbedLiveSample("Setting_the_value_using_JavaScript", 600, 60)}}
+
+## Usage notes
+
+The control's UI varies in general from browser to browser; at the moment support is patchy, with only Chrome/Opera and Edge on desktop — and most modern mobile browser versions — having usable implementations.
+In browsers that don't support `month` inputs, the control degrades gracefully to [`<input type="text">`](/en-US/docs/Web/HTML/Reference/Elements/input/text), although there may be automatic validation of the entered text to ensure it's formatted as expected.
+
+For those of you using a browser that doesn't support `month`, the screenshot below shows what it looks like in Chrome and Opera.
+Clicking the down arrow on the right-hand side brings up a date picker that lets you select the month and year.
+
+![Month control on Chrome browser](month-control-chrome.png)
+
+The Microsoft Edge `month` control looks like this:
+
+![Month control on Edge browser](month-control-edge.png)
 
 ## Additional attributes
 

--- a/files/en-us/web/html/reference/elements/input/month/index.md
+++ b/files/en-us/web/html/reference/elements/input/month/index.md
@@ -10,6 +10,9 @@ sidebar: htmlsidebar
 {{HTMLElement("input")}} elements of type **`month`** create input fields that let the user enter a month and year allowing a month and year to be easily entered.
 The value is a string whose value is in the format `YYYY-MM`, where `YYYY` is the four-digit year and `MM` is the month number.
 
+The control's UI varies in general from browser to browser; at the moment support is patchy, with only Chrome/Opera and Edge on desktop — and most modern mobile browser versions — having usable implementations.
+In browsers that don't support `month` inputs, the control degrades gracefully to [`<input type="text">`](/en-US/docs/Web/HTML/Reference/Elements/input/text), although there may be automatic validation of the entered text to ensure it's formatted as expected.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;month&quot;&gt;", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -31,9 +34,6 @@ label {
   margin: 0.4rem 0;
 }
 ```
-
-The control's UI varies in general from browser to browser; at the moment support is patchy, with only Chrome/Opera and Edge on desktop — and most modern mobile browser versions — having usable implementations.
-In browsers that don't support `month` inputs, the control degrades gracefully to [`<input type="text">`](/en-US/docs/Web/HTML/Reference/Elements/input/text), although there may be automatic validation of the entered text to ensure it's formatted as expected.
 
 For those of you using a browser that doesn't support `month`, the screenshot below shows what it looks like in Chrome and Opera.
 Clicking the down arrow on the right-hand side brings up a date picker that lets you select the month and year.

--- a/files/en-us/web/html/reference/elements/input/month/index.md
+++ b/files/en-us/web/html/reference/elements/input/month/index.md
@@ -82,54 +82,6 @@ The Microsoft Edge `month` control looks like this:
 
 ![Month control on Edge browser](month-control-edge.png)
 
-## Additional attributes
-
-In addition to the attributes common to {{HTMLElement("input")}} elements, month inputs offer the following attributes.
-
-### list
-
-The values of the list attribute is the {{domxref("Element.id", "id")}} of a {{HTMLElement("datalist")}} element located in the same document.
-The {{HTMLElement("datalist")}} provides a list of predefined values to suggest to the user for this input.
-Any values in the list that are not compatible with the [`type`](/en-US/docs/Web/HTML/Reference/Elements/input#type) are not included in the suggested options.
-The values provided are suggestions, not requirements: users can select from this predefined list or provide a different value.
-
-### max
-
-The latest year and month, in the string format discussed in the [Value](#value) section above, to accept.
-If the [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) entered into the element exceeds this, the element fails [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation).
-If the value of the `max` attribute isn't a valid string in `yyyy-MM` format, then the element has no maximum value.
-
-This value must specify a year-month pairing later than or equal to the one specified by the `min` attribute.
-
-### min
-
-The earliest year and month to accept, in the same `yyyy-MM` format described above.
-If the [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) of the element is less than this, the element fails [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation).
-If a value is specified for `min` that isn't a valid year and month string, the input has no minimum value.
-
-This value must be a year-month pairing which is earlier than or equal to the one specified by the `max` attribute.
-
-### readonly
-
-A Boolean attribute which, if present, means this field cannot be edited by the user.
-Its `value` can, however, still be changed from JavaScript code that directly sets the value of the {{domxref("HTMLInputElement.value")}} property.
-
-> [!NOTE]
-> Because a read-only field cannot have a value, `required` does not have any effect on inputs with the `readonly` attribute also specified.
-
-### step
-
-The `step` attribute is a number that specifies the granularity that the value must adhere to, or the special value `any`, which is described below. Only values which are a whole number of steps from the step base are valid. The step base is [`min`](#min) if specified, [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) otherwise, or `0` (the Unix epoch, `1970-01`) if neither is provided.
-
-For `month` inputs, the value of `step` is given in months. The default value of `step` is 1, indicating 1 month.
-
-A string value of `any` means that no stepping is implied, and any value is allowed (barring other constraints, such as [`min`](#min) and [`max`](#max)). In reality, it has the same effect as `1` for `month` inputs because the picker UI only allows selecting whole months.
-
-> [!NOTE]
-> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.
-
-## Using month inputs
-
 Date-related inputs (including `month`) sound convenient at first glance; they promise an easy UI for choosing dates, and they normalize the data format sent to the server, regardless of the user's locale.
 However, there are issues with `<input type="month">` because at this time, many major browsers don't yet support it.
 
@@ -176,6 +128,52 @@ The result here is that:
 
 `<input type="month">` doesn't support form sizing attributes such as [`size`](/en-US/docs/Web/HTML/Reference/Elements/input#size).
 You'll have to resort to [CSS](/en-US/docs/Web/CSS) for sizing needs.
+
+## Additional attributes
+
+In addition to the attributes common to {{HTMLElement("input")}} elements, month inputs offer the following attributes.
+
+### list
+
+The values of the list attribute is the {{domxref("Element.id", "id")}} of a {{HTMLElement("datalist")}} element located in the same document.
+The {{HTMLElement("datalist")}} provides a list of predefined values to suggest to the user for this input.
+Any values in the list that are not compatible with the [`type`](/en-US/docs/Web/HTML/Reference/Elements/input#type) are not included in the suggested options.
+The values provided are suggestions, not requirements: users can select from this predefined list or provide a different value.
+
+### max
+
+The latest year and month, in the string format discussed in the [Value](#value) section above, to accept.
+If the [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) entered into the element exceeds this, the element fails [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation).
+If the value of the `max` attribute isn't a valid string in `yyyy-MM` format, then the element has no maximum value.
+
+This value must specify a year-month pairing later than or equal to the one specified by the `min` attribute.
+
+### min
+
+The earliest year and month to accept, in the same `yyyy-MM` format described above.
+If the [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) of the element is less than this, the element fails [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation).
+If a value is specified for `min` that isn't a valid year and month string, the input has no minimum value.
+
+This value must be a year-month pairing which is earlier than or equal to the one specified by the `max` attribute.
+
+### readonly
+
+A Boolean attribute which, if present, means this field cannot be edited by the user.
+Its `value` can, however, still be changed from JavaScript code that directly sets the value of the {{domxref("HTMLInputElement.value")}} property.
+
+> [!NOTE]
+> Because a read-only field cannot have a value, `required` does not have any effect on inputs with the `readonly` attribute also specified.
+
+### step
+
+The `step` attribute is a number that specifies the granularity that the value must adhere to, or the special value `any`, which is described below. Only values which are a whole number of steps from the step base are valid. The step base is [`min`](#min) if specified, [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) otherwise, or `0` (the Unix epoch, `1970-01`) if neither is provided.
+
+For `month` inputs, the value of `step` is given in months. The default value of `step` is 1, indicating 1 month.
+
+A string value of `any` means that no stepping is implied, and any value is allowed (barring other constraints, such as [`min`](#min) and [`max`](#max)). In reality, it has the same effect as `1` for `month` inputs because the picker UI only allows selecting whole months.
+
+> [!NOTE]
+> When the data entered by the user doesn't adhere to the stepping configuration, the {{Glossary("user agent")}} may round to the nearest valid value, preferring numbers in the positive direction when there are two equally close options.
 
 ## Validation
 

--- a/files/en-us/web/html/reference/elements/input/password/index.md
+++ b/files/en-us/web/html/reference/elements/input/password/index.md
@@ -58,60 +58,6 @@ Both approaches help a user check that they entered the intended password, which
 > Any forms involving sensitive information like passwords (such as login forms) should be served over HTTPS.
 > Many browsers now implement mechanisms to warn against insecure login forms.
 
-## Additional attributes
-
-In addition to the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, password field inputs support the following attributes.
-
-> [!NOTE]
-> The [`autocorrect`](/en-US/docs/Web/HTML/Reference/Global_attributes/autocorrect) global attribute can be added to password inputs, but the stored state is always `off`.
-
-### maxlength
-
-The maximum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the password field. This must be an integer value of 0 or higher. If no `maxlength` is specified, or an invalid value is specified, the password field has no maximum length. This value must also be greater than or equal to the value of `minlength`.
-
-The input will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is greater than `maxlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
-
-### minlength
-
-The minimum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the password entry field. This must be a non-negative integer value smaller than or equal to the value specified by `maxlength`. If no `minlength` is specified, or an invalid value is specified, the password input has no minimum length.
-
-The input will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is fewer than `minlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
-
-### pattern
-
-The `pattern` attribute, when specified, is a regular expression that the input's [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) must match for the value to pass [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation). It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our [guide on regular expressions](/en-US/docs/Web/JavaScript/Guide/Regular_expressions); the `'u'` flag is specified when compiling the regular expression, so that the pattern is treated as a sequence of Unicode code points, instead of as {{Glossary("ASCII")}}. No forward slashes should be specified around the pattern text.
-
-If the specified pattern is not specified or is invalid, no regular expression is applied and this attribute is ignored completely.
-
-> [!NOTE]
-> Use the [`title`](/en-US/docs/Web/HTML/Reference/Elements/input#title) attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You should also include other explanatory text nearby.
-
-Use of a pattern is strongly recommended for password inputs, in order to help ensure that valid passwords using a wide assortment of character classes are selected and used by your users. With a pattern, you can mandate case rules, require the use of some number of digits and/or punctuation characters, and so forth. See the section [Validation](#validation) for details and an example.
-
-### placeholder
-
-The `placeholder` attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field. It should be a word or short phrase that demonstrates the expected type of data, rather than an explanatory message. The text _must not_ include carriage returns or line feeds.
-
-If the control's content has one directionality ({{Glossary("LTR")}} or {{Glossary("RTL")}}) but needs to present the placeholder in the opposite directionality, you can use Unicode bidirectional algorithm formatting characters to override directionality within the placeholder; see [How to use Unicode controls for bidi text](https://www.w3.org/International/questions/qa-bidi-unicode-controls) for more information.
-
-> [!NOTE]
-> Avoid using the `placeholder` attribute if you can. It is not as semantically useful as other ways to explain your form, and can cause unexpected technical issues with your content. See [`<input>` labels](/en-US/docs/Web/HTML/Reference/Elements/input#labels) for more information.
-
-### readonly
-
-A Boolean attribute which, if present, means this field cannot be edited by the user. Its `value` can, however, still be changed from JavaScript code that directly sets the value of the {{domxref("HTMLInputElement","HTMLInputElement.value")}} property.
-
-> [!NOTE]
-> Because a read-only field cannot have a value, `required` does not have any effect on inputs with the `readonly` attribute also specified.
-
-### size
-
-The `size` attribute is a numeric value indicating how many characters wide the input field should be. The value must be a number greater than zero, and the default value is 20. Since character widths vary, this may or may not be exact and should not be relied upon to be so; the resulting input may be narrower or wider than the specified number of characters, depending on the characters and the font ({{cssxref("font")}} settings in use).
-
-This does _not_ set a limit on how many characters the user can enter into the field. It only specifies approximately how many can be seen at a time. To set an upper limit on the length of the input data, use the [`maxlength`](#maxlength) attribute.
-
-## Using password inputs
-
 Password input boxes generally work just like other textual input boxes; the main difference is the obscuring of the content to prevent people near the user from reading the password.
 
 ### A basic password input
@@ -210,6 +156,58 @@ document.getElementById("selectAll").onclick = () => {
 {{EmbedLiveSample("Selecting_text", 600, 40)}}
 
 You can also use {{domxref("HTMLInputElement.selectionStart", "selectionStart")}} and {{domxref("HTMLInputElement.selectionEnd", "selectionEnd")}} to get (or set) what range of characters in the control are currently selected, and {{domxref("HTMLInputElement.selectionDirection", "selectionDirection")}} to know which direction selection occurred in (or will be extended in, depending on your platform; see its documentation for an explanation). However, given that the text is obscured, the usefulness of these is somewhat limited.
+
+## Additional attributes
+
+In addition to the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes), and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, password field inputs support the following attributes.
+
+> [!NOTE]
+> The [`autocorrect`](/en-US/docs/Web/HTML/Reference/Global_attributes/autocorrect) global attribute can be added to password inputs, but the stored state is always `off`.
+
+### maxlength
+
+The maximum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the password field. This must be an integer value of 0 or higher. If no `maxlength` is specified, or an invalid value is specified, the password field has no maximum length. This value must also be greater than or equal to the value of `minlength`.
+
+The input will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is greater than `maxlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
+
+### minlength
+
+The minimum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the password entry field. This must be a non-negative integer value smaller than or equal to the value specified by `maxlength`. If no `minlength` is specified, or an invalid value is specified, the password input has no minimum length.
+
+The input will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is fewer than `minlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
+
+### pattern
+
+The `pattern` attribute, when specified, is a regular expression that the input's [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) must match for the value to pass [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation). It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our [guide on regular expressions](/en-US/docs/Web/JavaScript/Guide/Regular_expressions); the `'u'` flag is specified when compiling the regular expression, so that the pattern is treated as a sequence of Unicode code points, instead of as {{Glossary("ASCII")}}. No forward slashes should be specified around the pattern text.
+
+If the specified pattern is not specified or is invalid, no regular expression is applied and this attribute is ignored completely.
+
+> [!NOTE]
+> Use the [`title`](/en-US/docs/Web/HTML/Reference/Elements/input#title) attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You should also include other explanatory text nearby.
+
+Use of a pattern is strongly recommended for password inputs, in order to help ensure that valid passwords using a wide assortment of character classes are selected and used by your users. With a pattern, you can mandate case rules, require the use of some number of digits and/or punctuation characters, and so forth. See the section [Validation](#validation) for details and an example.
+
+### placeholder
+
+The `placeholder` attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field. It should be a word or short phrase that demonstrates the expected type of data, rather than an explanatory message. The text _must not_ include carriage returns or line feeds.
+
+If the control's content has one directionality ({{Glossary("LTR")}} or {{Glossary("RTL")}}) but needs to present the placeholder in the opposite directionality, you can use Unicode bidirectional algorithm formatting characters to override directionality within the placeholder; see [How to use Unicode controls for bidi text](https://www.w3.org/International/questions/qa-bidi-unicode-controls) for more information.
+
+> [!NOTE]
+> Avoid using the `placeholder` attribute if you can. It is not as semantically useful as other ways to explain your form, and can cause unexpected technical issues with your content. See [`<input>` labels](/en-US/docs/Web/HTML/Reference/Elements/input#labels) for more information.
+
+### readonly
+
+A Boolean attribute which, if present, means this field cannot be edited by the user. Its `value` can, however, still be changed from JavaScript code that directly sets the value of the {{domxref("HTMLInputElement","HTMLInputElement.value")}} property.
+
+> [!NOTE]
+> Because a read-only field cannot have a value, `required` does not have any effect on inputs with the `readonly` attribute also specified.
+
+### size
+
+The `size` attribute is a numeric value indicating how many characters wide the input field should be. The value must be a number greater than zero, and the default value is 20. Since character widths vary, this may or may not be exact and should not be relied upon to be so; the resulting input may be narrower or wider than the specified number of characters, depending on the characters and the font ({{cssxref("font")}} settings in use).
+
+This does _not_ set a limit on how many characters the user can enter into the field. It only specifies approximately how many can be seen at a time. To set an upper limit on the length of the input data, use the [`maxlength`](#maxlength) attribute.
 
 ## Validation
 

--- a/files/en-us/web/html/reference/elements/input/password/index.md
+++ b/files/en-us/web/html/reference/elements/input/password/index.md
@@ -12,10 +12,6 @@ sidebar: htmlsidebar
 The element is presented as a one-line plain text editor control in which the text is obscured so that it cannot be read, usually by replacing each character with a symbol such as the asterisk ("\*") or a dot ("•").
 This character will vary depending on the {{Glossary("user agent")}} and operating system.
 
-The precise behavior of the entry process may vary from browser to browser.
-Some browsers display the typed character for a moment before obscuring it, while others allow the user to toggle the display of plain-text on and off.
-Both approaches help a user check that they entered the intended password, which can be particularly difficult on mobile devices.
-
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;password&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -43,10 +39,6 @@ label {
 }
 ```
 
-> [!NOTE]
-> Any forms involving sensitive information like passwords (such as login forms) should be served over HTTPS.
-> Many browsers now implement mechanisms to warn against insecure login forms.
-
 ## Value
 
 The [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) attribute contains a string whose value is the current contents of the text editing control being used to enter the password. If the user hasn't entered anything yet, this value is an empty string (`""`). If the [`required`](/en-US/docs/Web/HTML/Reference/Elements/input#required) property is specified, then the password edit box must contain a value other than an empty string to be valid.
@@ -55,6 +47,16 @@ If the [`pattern`](/en-US/docs/Web/HTML/Reference/Elements/input#pattern) attrib
 
 > [!NOTE]
 > The line feed (U+000A) and carriage return (U+000D) characters are not permitted in a `password` value. When setting the value of a password control, line feed and carriage return characters are stripped out of the value.
+
+## Usage notes
+
+The precise behavior of the entry process may vary from browser to browser.
+Some browsers display the typed character for a moment before obscuring it, while others allow the user to toggle the display of plain-text on and off.
+Both approaches help a user check that they entered the intended password, which can be particularly difficult on mobile devices.
+
+> [!NOTE]
+> Any forms involving sensitive information like passwords (such as login forms) should be served over HTTPS.
+> Many browsers now implement mechanisms to warn against insecure login forms.
 
 ## Additional attributes
 

--- a/files/en-us/web/html/reference/elements/input/password/index.md
+++ b/files/en-us/web/html/reference/elements/input/password/index.md
@@ -12,6 +12,10 @@ sidebar: htmlsidebar
 The element is presented as a one-line plain text editor control in which the text is obscured so that it cannot be read, usually by replacing each character with a symbol such as the asterisk ("\*") or a dot ("•").
 This character will vary depending on the {{Glossary("user agent")}} and operating system.
 
+The precise behavior of the entry process may vary from browser to browser.
+Some browsers display the typed character for a moment before obscuring it, while others allow the user to toggle the display of plain-text on and off.
+Both approaches help a user check that they entered the intended password, which can be particularly difficult on mobile devices.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;password&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -38,10 +42,6 @@ label {
   margin-top: 1rem;
 }
 ```
-
-The precise behavior of the entry process may vary from browser to browser.
-Some browsers display the typed character for a moment before obscuring it, while others allow the user to toggle the display of plain-text on and off.
-Both approaches help a user check that they entered the intended password, which can be particularly difficult on mobile devices.
 
 > [!NOTE]
 > Any forms involving sensitive information like passwords (such as login forms) should be served over HTTPS.

--- a/files/en-us/web/html/reference/elements/input/radio/index.md
+++ b/files/en-us/web/html/reference/elements/input/radio/index.md
@@ -11,6 +11,8 @@ sidebar: htmlsidebar
 
 Only one radio button in a given group can be selected at the same time. Radio buttons are typically rendered as small circles, which are filled or highlighted when selected.
 
+They are called radio buttons because they look and operate in a similar manner to the push buttons on old-fashioned radios, such as the one shown below.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;radio&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -46,8 +48,6 @@ input {
   margin: 0.4rem;
 }
 ```
-
-They are called radio buttons because they look and operate in a similar manner to the push buttons on old-fashioned radios, such as the one shown below.
 
 ![Shows what radio buttons looked like in the olden days.](old-radio.jpg)
 

--- a/files/en-us/web/html/reference/elements/input/radio/index.md
+++ b/files/en-us/web/html/reference/elements/input/radio/index.md
@@ -11,8 +11,6 @@ sidebar: htmlsidebar
 
 Only one radio button in a given group can be selected at the same time. Radio buttons are typically rendered as small circles, which are filled or highlighted when selected.
 
-They are called radio buttons because they look and operate in a similar manner to the push buttons on old-fashioned radios, such as the one shown below.
-
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;radio&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -48,11 +46,6 @@ input {
   margin: 0.4rem;
 }
 ```
-
-![Shows what radio buttons looked like in the olden days.](old-radio.jpg)
-
-> [!NOTE]
-> [Checkboxes](/en-US/docs/Web/HTML/Reference/Elements/input/checkbox) are similar to radio buttons, but with an important distinction: radio buttons are designed for selecting one value out of a set, whereas checkboxes let you turn individual values on and off. Where multiple controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
 
 ## Value
 
@@ -148,6 +141,15 @@ form.addEventListener("submit", (event) => {
 Try this example out and see how there's never more than one result for the `contact` group.
 
 {{EmbedLiveSample("Data_representation_of_a_radio_group", 600, 130)}}
+
+## Usage notes
+
+Radio buttons look and operate in a similar manner to the push buttons on old-fashioned radios, such as the one shown below.
+
+![Shows what radio buttons looked like in the olden days.](old-radio.jpg)
+
+> [!NOTE]
+> [Checkboxes](/en-US/docs/Web/HTML/Reference/Elements/input/checkbox) are similar to radio buttons, but with an important distinction: radio buttons are designed for selecting one value out of a set, whereas checkboxes let you turn individual values on and off. Where multiple controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
 
 ## Additional attributes
 

--- a/files/en-us/web/html/reference/elements/input/radio/index.md
+++ b/files/en-us/web/html/reference/elements/input/radio/index.md
@@ -151,23 +151,6 @@ Radio buttons look and operate in a similar manner to the push buttons on old-fa
 > [!NOTE]
 > [Checkboxes](/en-US/docs/Web/HTML/Reference/Elements/input/checkbox) are similar to radio buttons, but with an important distinction: radio buttons are designed for selecting one value out of a set, whereas checkboxes let you turn individual values on and off. Where multiple controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
 
-## Additional attributes
-
-In addition to the common attributes shared by all {{HTMLElement("input")}} elements, `radio` inputs support the following attributes.
-
-- `checked`
-  - : A Boolean attribute which, if present, indicates that this radio button is the default selected one in the group.
-
-    Unlike other browsers, Firefox by default [persists the dynamic checked state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` across page loads. Use the [`autocomplete`](/en-US/docs/Web/HTML/Reference/Elements/input#autocomplete) attribute to control this feature.
-
-- `value`
-  - : The `value` attribute is one which all {{HTMLElement("input")}}s share; however, it serves a special purpose for inputs of type `radio`: when a form is submitted, only radio buttons which are currently checked are submitted to the server, and the reported value is the value of the `value` attribute. If the `value` is not otherwise specified, it is the string `on` by default. This is demonstrated in the section [Value](#value) above.
-
-- [`required`](/en-US/docs/Web/HTML/Reference/Attributes/required)
-  - : The `required` attribute is one which most {{HTMLElement("input")}}s share. If any radio button in a same-named group of radio buttons has the `required` attribute, a radio button in that group must be checked, although it doesn't have to be the one with the attribute applied.
-
-## Using radio inputs
-
 We already covered the fundamentals of radio buttons above. Let's now look at the other common radio-button-related features and techniques you may need to know about.
 
 ### Selecting a radio button by default
@@ -212,6 +195,21 @@ In this case, the first radio button is now selected by default.
 In the above examples, you may have noticed that you can select a radio button by clicking on its associated {{htmlelement("label")}} element, as well as on the radio button itself. This is a really useful feature of HTML form labels that makes it easier for users to click the option they want, especially on small-screen devices like smartphones.
 
 Beyond accessibility, this is another good reason to properly set up `<label>` elements on your forms.
+
+## Additional attributes
+
+In addition to the common attributes shared by all {{HTMLElement("input")}} elements, `radio` inputs support the following attributes.
+
+- `checked`
+  - : A Boolean attribute which, if present, indicates that this radio button is the default selected one in the group.
+
+    Unlike other browsers, Firefox by default [persists the dynamic checked state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` across page loads. Use the [`autocomplete`](/en-US/docs/Web/HTML/Reference/Elements/input#autocomplete) attribute to control this feature.
+
+- `value`
+  - : The `value` attribute is one which all {{HTMLElement("input")}}s share; however, it serves a special purpose for inputs of type `radio`: when a form is submitted, only radio buttons which are currently checked are submitted to the server, and the reported value is the value of the `value` attribute. If the `value` is not otherwise specified, it is the string `on` by default. This is demonstrated in the section [Value](#value) above.
+
+- [`required`](/en-US/docs/Web/HTML/Reference/Attributes/required)
+  - : The `required` attribute is one which most {{HTMLElement("input")}}s share. If any radio button in a same-named group of radio buttons has the `required` attribute, a radio button in that group must be checked, although it doesn't have to be the one with the attribute applied.
 
 ## Validation
 

--- a/files/en-us/web/html/reference/elements/input/reset/index.md
+++ b/files/en-us/web/html/reference/elements/input/reset/index.md
@@ -81,8 +81,6 @@ If you don't specify a `value`, you get a button with the default label (typical
 > [!NOTE]
 > You should usually avoid including reset buttons in your forms. They're rarely useful, and are instead more likely to frustrate users who click them by mistake (often while trying to click the [submit button](/en-US/docs/Web/HTML/Reference/Elements/input/submit)).
 
-## Using reset buttons
-
 `<input type="reset">` buttons are used to reset forms. If you want to create a custom button and then customize the behavior using JavaScript, you need to use [`<input type="button">`](/en-US/docs/Web/HTML/Reference/Elements/input/button), or better still, a {{htmlelement("button")}} element.
 
 ### A basic reset button

--- a/files/en-us/web/html/reference/elements/input/reset/index.md
+++ b/files/en-us/web/html/reference/elements/input/reset/index.md
@@ -9,9 +9,6 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`reset`** are rendered as buttons, with a default {{domxref("Element/click_event", "click")}} event handler that resets all inputs in the form to their initial values.
 
-> [!NOTE]
-> You should usually avoid including reset buttons in your forms. They're rarely useful, and are instead more likely to frustrate users who click them by mistake (often while trying to click the [submit button](/en-US/docs/Web/HTML/Reference/Elements/input/submit)).
-
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;reset&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -78,6 +75,11 @@ If you don't specify a `value`, you get a button with the default label (typical
 ```
 
 {{EmbedLiveSample("Omitting_the_value_attribute", 650, 30)}}
+
+## Usage notes
+
+> [!NOTE]
+> You should usually avoid including reset buttons in your forms. They're rarely useful, and are instead more likely to frustrate users who click them by mistake (often while trying to click the [submit button](/en-US/docs/Web/HTML/Reference/Elements/input/submit)).
 
 ## Using reset buttons
 

--- a/files/en-us/web/html/reference/elements/input/reset/index.md
+++ b/files/en-us/web/html/reference/elements/input/reset/index.md
@@ -9,6 +9,9 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`reset`** are rendered as buttons, with a default {{domxref("Element/click_event", "click")}} event handler that resets all inputs in the form to their initial values.
 
+> [!NOTE]
+> You should usually avoid including reset buttons in your forms. They're rarely useful, and are instead more likely to frustrate users who click them by mistake (often while trying to click the [submit button](/en-US/docs/Web/HTML/Reference/Elements/input/submit)).
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;reset&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -53,9 +56,6 @@ input[type="submit"] {
   grid-row: 3;
 }
 ```
-
-> [!NOTE]
-> You should usually avoid including reset buttons in your forms. They're rarely useful, and are instead more likely to frustrate users who click them by mistake (often while trying to click the [submit button](/en-US/docs/Web/HTML/Reference/Elements/input/submit)).
 
 ## Value
 

--- a/files/en-us/web/html/reference/elements/input/tel/index.md
+++ b/files/en-us/web/html/reference/elements/input/tel/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`tel`** are used to let the user enter and edit a telephone number. Unlike [`<input type="email">`](/en-US/docs/Web/HTML/Reference/Elements/input/email) and [`<input type="url">`](/en-US/docs/Web/HTML/Reference/Elements/input/url), the input value is not automatically validated to a particular format before the form can be submitted, because formats for telephone numbers vary so much around the world.
 
+Despite the fact that inputs of type `tel` are functionally identical to standard `text` inputs, they do serve useful purposes; the most quickly apparent of these is that mobile browsers — especially on mobile phones — may opt to present a custom keypad optimized for entering phone numbers. Using a specific input type for telephone numbers also makes adding custom validation and handling of phone numbers more convenient.
+
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;tel&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -38,8 +40,6 @@ label {
   margin: 0.4rem 0;
 }
 ```
-
-Despite the fact that inputs of type `tel` are functionally identical to standard `text` inputs, they do serve useful purposes; the most quickly apparent of these is that mobile browsers — especially on mobile phones — may opt to present a custom keypad optimized for entering phone numbers. Using a specific input type for telephone numbers also makes adding custom validation and handling of phone numbers more convenient.
 
 > [!NOTE]
 > Browsers that don't support type `tel` fall back to being a standard {{HTMLElement("input/text", "text")}} input.

--- a/files/en-us/web/html/reference/elements/input/tel/index.md
+++ b/files/en-us/web/html/reference/elements/input/tel/index.md
@@ -50,61 +50,6 @@ Despite the fact that inputs of type `tel` are functionally identical to standar
 > [!NOTE]
 > Browsers that don't support type `tel` fall back to being a standard {{HTMLElement("input/text", "text")}} input.
 
-## Additional attributes
-
-In addition to the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes) and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, telephone number inputs support the following attributes.
-
-### list
-
-The values of the list attribute is the {{domxref("Element.id", "id")}} of a {{HTMLElement("datalist")}} element located in the same document. The {{HTMLElement("datalist")}} provides a list of predefined values to suggest to the user for this input. Any values in the list that are not compatible with the [`type`](/en-US/docs/Web/HTML/Reference/Elements/input#type) are not included in the suggested options. The values provided are suggestions, not requirements: users can select from this predefined list or provide a different value.
-
-### maxlength
-
-The maximum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the telephone number field. This must be an integer value of 0 or higher. If no `maxlength` is specified, or an invalid value is specified, the telephone number field has no maximum length. This value must also be greater than or equal to the value of `minlength`.
-
-The input will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is greater than `maxlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
-
-### minlength
-
-The minimum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the telephone number field. This must be a non-negative integer value smaller than or equal to the value specified by `maxlength`. If no `minlength` is specified, or an invalid value is specified, the telephone number input has no minimum length.
-
-The telephone number field will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is fewer than `minlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
-
-### pattern
-
-The `pattern` attribute, when specified, is a regular expression that the input's [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) must match for the value to pass [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation). It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our [guide on regular expressions](/en-US/docs/Web/JavaScript/Guide/Regular_expressions); the `'u'` flag is specified when compiling the regular expression so that the pattern is treated as a sequence of Unicode code points, instead of as {{Glossary("ASCII")}}. No forward slashes should be specified around the pattern text.
-
-If the specified pattern is not specified or is invalid, no regular expression is applied and this attribute is ignored completely.
-
-> [!NOTE]
-> Use the [`title`](/en-US/docs/Web/HTML/Reference/Elements/input#title) attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You should also include other explanatory text nearby.
-
-See [Pattern validation](#pattern_validation) below for details and an example.
-
-### placeholder
-
-The `placeholder` attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field. It should be a word or short phrase that demonstrates the expected type of data, rather than an explanatory message. The text _must not_ include carriage returns or line feeds.
-
-If the control's content has one directionality ({{Glossary("LTR")}} or {{Glossary("RTL")}}) but needs to present the placeholder in the opposite directionality, you can use Unicode bidirectional algorithm formatting characters to override directionality within the placeholder; see [How to use Unicode controls for bidi text](https://www.w3.org/International/questions/qa-bidi-unicode-controls) for more information.
-
-> [!NOTE]
-> Avoid using the `placeholder` attribute if you can. It is not as semantically useful as other ways to explain your form, and can cause unexpected technical issues with your content. See [`<input>` labels](/en-US/docs/Web/HTML/Reference/Elements/input#labels) for more information.
-
-### readonly
-
-A Boolean attribute which, if present, means this field cannot be edited by the user. Its `value` can, however, still be changed by JavaScript code directly setting the {{domxref("HTMLInputElement")}} `value` property.
-
-> [!NOTE]
-> Because a read-only field cannot have a value, `required` does not have any effect on inputs with the `readonly` attribute also specified.
-
-### size
-
-The `size` attribute is a numeric value indicating how many characters wide the input field should be. The value must be a number greater than zero, and the default value is 20. Since character widths vary, this may or may not be exact and should not be relied upon to be so; the resulting input may be narrower or wider than the specified number of characters, depending on the characters and the font ({{cssxref("font")}} settings in use).
-
-This does _not_ set a limit on how many characters the user can enter into the field. It only specifies approximately how many can be seen at a time. To set an upper limit on the length of the input data, use the [`maxlength`](#maxlength) attribute.
-
-## Using tel inputs
-
 Telephone numbers are a very commonly collected type of data on the web. When creating any kind of registration or e-commerce site, for example, you will likely need to ask the user for a telephone number, whether for business purposes or for emergency contact purposes. Given how commonly-entered phone numbers are, it's unfortunate that a "one size fits all" solution for validating phone numbers is not practical.
 
 Fortunately, you can consider the requirements of your own site and implement an appropriate level of validation yourself. See [Validation](#validation), below, for details.
@@ -212,6 +157,59 @@ With the {{HTMLElement("datalist")}} element and its {{HTMLElement("option")}}s 
 Here's a screenshot of what that might look like:
 
 ![An input box has focus with a blue focus ring. The input has a drop-down menu showing four phone numbers the user can select.](phone-number-with-options.png)
+
+## Additional attributes
+
+In addition to the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes) and the attributes that operate on all {{HTMLElement("input")}} elements regardless of their type, telephone number inputs support the following attributes.
+
+### list
+
+The values of the list attribute is the {{domxref("Element.id", "id")}} of a {{HTMLElement("datalist")}} element located in the same document. The {{HTMLElement("datalist")}} provides a list of predefined values to suggest to the user for this input. Any values in the list that are not compatible with the [`type`](/en-US/docs/Web/HTML/Reference/Elements/input#type) are not included in the suggested options. The values provided are suggestions, not requirements: users can select from this predefined list or provide a different value.
+
+### maxlength
+
+The maximum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the telephone number field. This must be an integer value of 0 or higher. If no `maxlength` is specified, or an invalid value is specified, the telephone number field has no maximum length. This value must also be greater than or equal to the value of `minlength`.
+
+The input will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is greater than `maxlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
+
+### minlength
+
+The minimum string length (measured in {{glossary("UTF-16", "UTF-16 code units")}}) that the user can enter into the telephone number field. This must be a non-negative integer value smaller than or equal to the value specified by `maxlength`. If no `minlength` is specified, or an invalid value is specified, the telephone number input has no minimum length.
+
+The telephone number field will fail [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation) if the length of the text entered into the field is fewer than `minlength` {{glossary("UTF-16", "UTF-16 code units")}} long. Constraint validation is only applied when the value is changed by the user.
+
+### pattern
+
+The `pattern` attribute, when specified, is a regular expression that the input's [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) must match for the value to pass [constraint validation](/en-US/docs/Web/HTML/Guides/Constraint_validation). It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our [guide on regular expressions](/en-US/docs/Web/JavaScript/Guide/Regular_expressions); the `'u'` flag is specified when compiling the regular expression so that the pattern is treated as a sequence of Unicode code points, instead of as {{Glossary("ASCII")}}. No forward slashes should be specified around the pattern text.
+
+If the specified pattern is not specified or is invalid, no regular expression is applied and this attribute is ignored completely.
+
+> [!NOTE]
+> Use the [`title`](/en-US/docs/Web/HTML/Reference/Elements/input#title) attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You should also include other explanatory text nearby.
+
+See [Pattern validation](#pattern_validation) below for details and an example.
+
+### placeholder
+
+The `placeholder` attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field. It should be a word or short phrase that demonstrates the expected type of data, rather than an explanatory message. The text _must not_ include carriage returns or line feeds.
+
+If the control's content has one directionality ({{Glossary("LTR")}} or {{Glossary("RTL")}}) but needs to present the placeholder in the opposite directionality, you can use Unicode bidirectional algorithm formatting characters to override directionality within the placeholder; see [How to use Unicode controls for bidi text](https://www.w3.org/International/questions/qa-bidi-unicode-controls) for more information.
+
+> [!NOTE]
+> Avoid using the `placeholder` attribute if you can. It is not as semantically useful as other ways to explain your form, and can cause unexpected technical issues with your content. See [`<input>` labels](/en-US/docs/Web/HTML/Reference/Elements/input#labels) for more information.
+
+### readonly
+
+A Boolean attribute which, if present, means this field cannot be edited by the user. Its `value` can, however, still be changed by JavaScript code directly setting the {{domxref("HTMLInputElement")}} `value` property.
+
+> [!NOTE]
+> Because a read-only field cannot have a value, `required` does not have any effect on inputs with the `readonly` attribute also specified.
+
+### size
+
+The `size` attribute is a numeric value indicating how many characters wide the input field should be. The value must be a number greater than zero, and the default value is 20. Since character widths vary, this may or may not be exact and should not be relied upon to be so; the resulting input may be narrower or wider than the specified number of characters, depending on the characters and the font ({{cssxref("font")}} settings in use).
+
+This does _not_ set a limit on how many characters the user can enter into the field. It only specifies approximately how many can be seen at a time. To set an upper limit on the length of the input data, use the [`maxlength`](#maxlength) attribute.
 
 ## Validation
 

--- a/files/en-us/web/html/reference/elements/input/tel/index.md
+++ b/files/en-us/web/html/reference/elements/input/tel/index.md
@@ -9,8 +9,6 @@ sidebar: htmlsidebar
 
 {{HTMLElement("input")}} elements of type **`tel`** are used to let the user enter and edit a telephone number. Unlike [`<input type="email">`](/en-US/docs/Web/HTML/Reference/Elements/input/email) and [`<input type="url">`](/en-US/docs/Web/HTML/Reference/Elements/input/url), the input value is not automatically validated to a particular format before the form can be submitted, because formats for telephone numbers vary so much around the world.
 
-Despite the fact that inputs of type `tel` are functionally identical to standard `text` inputs, they do serve useful purposes; the most quickly apparent of these is that mobile browsers — especially on mobile phones — may opt to present a custom keypad optimized for entering phone numbers. Using a specific input type for telephone numbers also makes adding custom validation and handling of phone numbers more convenient.
-
 {{InteractiveExample("HTML Demo: &lt;input type=&quot;tel&quot;&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -41,12 +39,16 @@ label {
 }
 ```
 
-> [!NOTE]
-> Browsers that don't support type `tel` fall back to being a standard {{HTMLElement("input/text", "text")}} input.
-
 ## Value
 
 The {{HTMLElement("input")}} element's [`value`](/en-US/docs/Web/HTML/Reference/Elements/input#value) attribute contains a string that either represents a telephone number or is an empty string (`""`).
+
+## Usage notes
+
+Despite the fact that inputs of type `tel` are functionally identical to standard `text` inputs, they do serve useful purposes; the most quickly apparent of these is that mobile browsers — especially on mobile phones — may opt to present a custom keypad optimized for entering phone numbers. Using a specific input type for telephone numbers also makes adding custom validation and handling of phone numbers more convenient.
+
+> [!NOTE]
+> Browsers that don't support type `tel` fall back to being a standard {{HTMLElement("input/text", "text")}} input.
 
 ## Additional attributes
 

--- a/files/en-us/web/html/reference/elements/optgroup/index.md
+++ b/files/en-us/web/html/reference/elements/optgroup/index.md
@@ -11,6 +11,9 @@ The **`<optgroup>`** [HTML](/en-US/docs/Web/HTML) element creates a grouping of 
 
 In [customizable `<select>` elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select), the {{htmlelement("legend")}} element is allowed as a child of `<optgroup>`, to provide a label that is easy to target and style. This replaces any text set in the `<optgroup>` element's `label` attribute, and it has the same semantics.
 
+> [!NOTE]
+> Optgroup elements may not be nested.
+
 {{InteractiveExample("HTML Demo: &lt;optgroup&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -35,9 +38,6 @@ label {
   margin-bottom: 10px;
 }
 ```
-
-> [!NOTE]
-> Optgroup elements may not be nested.
 
 ## Attributes
 

--- a/files/en-us/web/html/reference/elements/optgroup/index.md
+++ b/files/en-us/web/html/reference/elements/optgroup/index.md
@@ -11,9 +11,6 @@ The **`<optgroup>`** [HTML](/en-US/docs/Web/HTML) element creates a grouping of 
 
 In [customizable `<select>` elements](/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select), the {{htmlelement("legend")}} element is allowed as a child of `<optgroup>`, to provide a label that is easy to target and style. This replaces any text set in the `<optgroup>` element's `label` attribute, and it has the same semantics.
 
-> [!NOTE]
-> Optgroup elements may not be nested.
-
 {{InteractiveExample("HTML Demo: &lt;optgroup&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -47,6 +44,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
   - : If this Boolean attribute is set, none of the items in this option group is selectable. Often browsers gray out such control and it won't receive any browsing events, like mouse clicks or focus-related ones.
 - `label`
   - : The name of the group of options, which the browser can use when labeling the options in the user interface. This attribute is mandatory if this element is used.
+
+## Usage notes
+
+> [!NOTE]
+> Optgroup elements may not be nested.
 
 ## Examples
 

--- a/files/en-us/web/html/reference/elements/picture/index.md
+++ b/files/en-us/web/html/reference/elements/picture/index.md
@@ -11,6 +11,8 @@ The **`<picture>`** [HTML](/en-US/docs/Web/HTML) element contains zero or more {
 
 The browser will consider each child `<source>` element and choose the best match among them. If no matches are found—or the browser doesn't support the `<picture>` element—the URL of the `<img>` element's [`src`](/en-US/docs/Web/HTML/Reference/Elements/img#src) attribute is selected. The selected image is then presented in the space occupied by the `<img>` element.
 
+To decide which URL to load, the {{Glossary("user agent")}} examines each `<source>`'s [`srcset`](/en-US/docs/Web/HTML/Reference/Elements/source#srcset), [`media`](/en-US/docs/Web/HTML/Reference/Elements/source#media), and [`type`](/en-US/docs/Web/HTML/Reference/Elements/source#type) attributes to select a compatible image that best matches the current layout and capabilities of the display device.
+
 {{InteractiveExample("HTML Demo: &lt;picture&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -23,8 +25,6 @@ The browser will consider each child `<source>` element and choose the best matc
   <img src="/shared-assets/images/examples/painted-hand.jpg" alt="" />
 </picture>
 ```
-
-To decide which URL to load, the {{Glossary("user agent")}} examines each `<source>`'s [`srcset`](/en-US/docs/Web/HTML/Reference/Elements/source#srcset), [`media`](/en-US/docs/Web/HTML/Reference/Elements/source#media), and [`type`](/en-US/docs/Web/HTML/Reference/Elements/source#type) attributes to select a compatible image that best matches the current layout and capabilities of the display device.
 
 The `<img>` element serves two purposes:
 

--- a/files/en-us/web/html/reference/elements/picture/index.md
+++ b/files/en-us/web/html/reference/elements/picture/index.md
@@ -11,8 +11,6 @@ The **`<picture>`** [HTML](/en-US/docs/Web/HTML) element contains zero or more {
 
 The browser will consider each child `<source>` element and choose the best match among them. If no matches are found—or the browser doesn't support the `<picture>` element—the URL of the `<img>` element's [`src`](/en-US/docs/Web/HTML/Reference/Elements/img#src) attribute is selected. The selected image is then presented in the space occupied by the `<img>` element.
 
-To decide which URL to load, the {{Glossary("user agent")}} examines each `<source>`'s [`srcset`](/en-US/docs/Web/HTML/Reference/Elements/source#srcset), [`media`](/en-US/docs/Web/HTML/Reference/Elements/source#media), and [`type`](/en-US/docs/Web/HTML/Reference/Elements/source#type) attributes to select a compatible image that best matches the current layout and capabilities of the display device.
-
 {{InteractiveExample("HTML Demo: &lt;picture&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -25,6 +23,14 @@ To decide which URL to load, the {{Glossary("user agent")}} examines each `<sour
   <img src="/shared-assets/images/examples/painted-hand.jpg" alt="" />
 </picture>
 ```
+
+## Attributes
+
+This element includes only [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
+
+## Usage notes
+
+To decide which URL to load, the {{Glossary("user agent")}} examines each `<source>`'s [`srcset`](/en-US/docs/Web/HTML/Reference/Elements/source#srcset), [`media`](/en-US/docs/Web/HTML/Reference/Elements/source#media), and [`type`](/en-US/docs/Web/HTML/Reference/Elements/source#type) attributes to select a compatible image that best matches the current layout and capabilities of the display device.
 
 The `<img>` element serves two purposes:
 
@@ -42,12 +48,6 @@ Common use cases for `<picture>`:
 - **Saving bandwidth and speeding page load times** by loading the most appropriate image for the viewer's display.
 
 If providing higher-density versions of an image for high-DPI (Retina) display, use [`srcset`](/en-US/docs/Web/HTML/Reference/Elements/img#srcset) on the `<img>` element instead. This lets browsers opt for lower-density versions in data-saving modes, and you don't have to write explicit `media` conditions.
-
-## Attributes
-
-This element includes only [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
-
-## Usage notes
 
 You can use the {{cssxref("object-position")}} property to adjust the positioning of the image within the element's frame, and the {{cssxref("object-fit")}} property to control how the image is resized to fit within the frame.
 

--- a/files/en-us/web/html/reference/elements/style/index.md
+++ b/files/en-us/web/html/reference/elements/style/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`<style>`** [HTML](/en-US/docs/Web/HTML) element contains style information for a document, or part of a document. It contains CSS, which is applied to the contents of the document containing the `<style>` element.
 
+The `<style>` element is typically included inside the {{htmlelement("head")}} of the document. It can also be used anywhere metadata content is permitted, such as inside a {{htmlelement("template")}} element.
+
 {{InteractiveExample("HTML Demo: &lt;style&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -36,8 +38,6 @@ p {
   color: red;
 }
 ```
-
-The `<style>` element is typically included inside the {{htmlelement("head")}} of the document. It can also be used anywhere metadata content is permitted, such as inside a {{htmlelement("template")}} element.
 
 If you include multiple `<style>` and `<link>` elements in your document, they will be applied to the DOM in the order they are included in the document — make sure you include them in the correct order, to avoid unexpected cascade issues.
 

--- a/files/en-us/web/html/reference/elements/style/index.md
+++ b/files/en-us/web/html/reference/elements/style/index.md
@@ -9,8 +9,6 @@ sidebar: htmlsidebar
 
 The **`<style>`** [HTML](/en-US/docs/Web/HTML) element contains style information for a document, or part of a document. It contains CSS, which is applied to the contents of the document containing the `<style>` element.
 
-The `<style>` element is typically included inside the {{htmlelement("head")}} of the document. It can also be used anywhere metadata content is permitted, such as inside a {{htmlelement("template")}} element.
-
 {{InteractiveExample("HTML Demo: &lt;style&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -39,10 +37,6 @@ p {
 }
 ```
 
-If you include multiple `<style>` and `<link>` elements in your document, they will be applied to the DOM in the order they are included in the document — make sure you include them in the correct order, to avoid unexpected cascade issues.
-
-In the same manner as `<link>` elements, `<style>` elements can include `media` attributes that contain [media queries](/en-US/docs/Web/CSS/Guides/Media_queries), allowing you to selectively apply internal stylesheets to your document depending on media features such as viewport width.
-
 ## Attributes
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Global_attributes).
@@ -65,6 +59,14 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Reference/Glo
 
 - `type` {{deprecated_inline}}
   - : This attribute should not be provided: if it is, the only permitted values are the empty string or a case-insensitive match for `text/css`.
+
+## Usage notes
+
+The `<style>` element is typically included inside the {{htmlelement("head")}} of the document. It can also be used anywhere metadata content is permitted, such as inside a {{htmlelement("template")}} element.
+
+If you include multiple `<style>` and `<link>` elements in your document, they will be applied to the DOM in the order they are included in the document — make sure you include them in the correct order, to avoid unexpected cascade issues.
+
+In the same manner as `<link>` elements, `<style>` elements can include `media` attributes that contain [media queries](/en-US/docs/Web/CSS/Guides/Media_queries), allowing you to selectively apply internal stylesheets to your document depending on media features such as viewport width.
 
 ## Examples
 

--- a/files/en-us/web/html/reference/global_attributes/style/index.md
+++ b/files/en-us/web/html/reference/global_attributes/style/index.md
@@ -9,6 +9,9 @@ sidebar: htmlsidebar
 
 The **`style`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) contains [CSS](/en-US/docs/Web/CSS) styling declarations to be applied to the element. Note that it is recommended for styles to be defined in a separate file or files. This attribute and the {{HTMLElement("style")}} element have mainly the purpose of allowing for quick styling, for example for testing purposes.
 
+> [!NOTE]
+> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute.
+
 {{InteractiveExample("HTML Demo: style", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -19,11 +22,6 @@ The **`style`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attribu
   </p>
 </div>
 ```
-
-## Description
-
-> [!NOTE]
-> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/style/index.md
+++ b/files/en-us/web/html/reference/global_attributes/style/index.md
@@ -9,6 +9,9 @@ sidebar: htmlsidebar
 
 The **`style`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) contains [CSS](/en-US/docs/Web/CSS) styling declarations to be applied to the element. Note that it is recommended for styles to be defined in a separate file or files. This attribute and the {{HTMLElement("style")}} element have mainly the purpose of allowing for quick styling, for example for testing purposes.
 
+> [!NOTE]
+> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute.
+
 {{InteractiveExample("HTML Demo: style", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -19,9 +22,6 @@ The **`style`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attribu
   </p>
 </div>
 ```
-
-> [!NOTE]
-> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/style/index.md
+++ b/files/en-us/web/html/reference/global_attributes/style/index.md
@@ -9,9 +9,6 @@ sidebar: htmlsidebar
 
 The **`style`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) contains [CSS](/en-US/docs/Web/CSS) styling declarations to be applied to the element. Note that it is recommended for styles to be defined in a separate file or files. This attribute and the {{HTMLElement("style")}} element have mainly the purpose of allowing for quick styling, for example for testing purposes.
 
-> [!NOTE]
-> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute.
-
 {{InteractiveExample("HTML Demo: style", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -22,6 +19,11 @@ The **`style`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attribu
   </p>
 </div>
 ```
+
+## Description
+
+> [!NOTE]
+> This attribute must not be used to convey semantic information. Even if all styling is removed, a page should remain semantically correct. Typically it shouldn't be used to hide irrelevant information; this should be done using the [`hidden`](/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) attribute.
 
 ## Specifications
 

--- a/files/en-us/web/html/reference/global_attributes/title/index.md
+++ b/files/en-us/web/html/reference/global_attributes/title/index.md
@@ -9,8 +9,6 @@ sidebar: htmlsidebar
 
 The **`title`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) contains text representing advisory information related to the element it belongs to.
 
-The main use of the `title` attribute is to label {{HTMLElement("iframe")}} elements for assistive technology.
-
 {{InteractiveExample("HTML Demo: title", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -34,6 +32,10 @@ iframe {
   width: 100%;
 }
 ```
+
+## Description
+
+The main use of the `title` attribute is to label {{HTMLElement("iframe")}} elements for assistive technology.
 
 The `title` attribute may also be used to label controls in [data tables](/en-US/docs/Web/HTML/Reference/Elements/table).
 

--- a/files/en-us/web/html/reference/global_attributes/title/index.md
+++ b/files/en-us/web/html/reference/global_attributes/title/index.md
@@ -9,6 +9,8 @@ sidebar: htmlsidebar
 
 The **`title`** [global attribute](/en-US/docs/Web/HTML/Reference/Global_attributes) contains text representing advisory information related to the element it belongs to.
 
+The main use of the `title` attribute is to label {{HTMLElement("iframe")}} elements for assistive technology.
+
 {{InteractiveExample("HTML Demo: title", "tabbed-shorter")}}
 
 ```html interactive-example
@@ -32,8 +34,6 @@ iframe {
   width: 100%;
 }
 ```
-
-The main use of the `title` attribute is to label {{HTMLElement("iframe")}} elements for assistive technology.
 
 The `title` attribute may also be used to label controls in [data tables](/en-US/docs/Web/HTML/Reference/Elements/table).
 

--- a/files/en-us/web/media/guides/formats/containers/index.md
+++ b/files/en-us/web/media/guides/formats/containers/index.md
@@ -1156,6 +1156,10 @@ This can be used to offer various versions of a video that can be selected depen
 
 In the example shown here, a video is offered to the browser in two formats: WebM and MP4.
 
+The video is offered first in WebM format (with the [`type`](/en-US/docs/Web/HTML/Reference/Elements/source#type) attribute set to `video/webm`).
+If the {{Glossary("user agent")}} can't play that, it moves on to the next option, whose `type` is specified as `video/mp4`.
+If neither of those can be played, the text "This browser does not support the HTML video element." is presented.
+
 {{InteractiveExample("HTML Demo: &lt;source&gt;", "tabbed-standard")}}
 
 ```html interactive-example
@@ -1169,10 +1173,6 @@ In the example shown here, a video is offered to the browser in two formats: Web
   video.
 </video>
 ```
-
-The video is offered first in WebM format (with the [`type`](/en-US/docs/Web/HTML/Reference/Elements/source#type) attribute set to `video/webm`).
-If the {{Glossary("user agent")}} can't play that, it moves on to the next option, whose `type` is specified as `video/mp4`.
-If neither of those can be played, the text "This browser does not support the HTML video element." is presented.
 
 ## Specifications
 

--- a/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
@@ -9,8 +9,6 @@ sidebar: webassemblysidebar
 
 The **`q15mulr_sat_s`** [SIMD arithmetic instruction](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic) performs a lane-wise [saturating](https://en.wikipedia.org/wiki/Saturation_arithmetic) rounding multiplication in Q15 format on two signed [`v128`](/en-US/docs/WebAssembly/Reference/Value_types/v128) `i16x8` value interpretations — clamping the output to the range allowed by the value type (a single `i16x8` value interpretation).
 
-The `q15mulr_sat_s` instruction performs a fixed-point multiplication on 8 pairs of Q15-encoded 16-bit signed integers, simultaneously, with rounding and saturation. Such operations are common in audio processing and machine learning, for example FIR/IIR audio filters and neural network inference.
-
 {{InteractiveExample("Wat Demo: q15mulr_sat_s", "tabbed-taller")}}
 
 ```wat interactive-example
@@ -32,6 +30,10 @@ The `q15mulr_sat_s` instruction performs a fixed-point multiplication on 8 pairs
 WebAssembly.instantiateStreaming(fetch("{%wasm-url%}"), { console });
 ```
 
+## Description
+
+The `q15mulr_sat_s` instruction performs a fixed-point multiplication on 8 pairs of Q15-encoded 16-bit signed integers, simultaneously, with rounding and saturation. Such operations are common in audio processing and machine learning, for example FIR/IIR audio filters and neural network inference.
+
 Q15 is a fixed-point number format where a signed 16-bit integer represents a real number in the range −1.0 to 1.0. The value `32767` (`0x7FFF`) is equivalent to `1.0`, and `−32768` (`0x8000`) is equivalent to `−1.0`. Multiplying two Q15 numbers produces a Q30 result stored as a 32-bit integer. To get back to Q15 (16-bit), you shift right by 15.
 
 Specifically, for each of the corresponding lanes of the two `16x8` input values, the `q15mulr_sat_s` instruction:
@@ -41,7 +43,7 @@ Specifically, for each of the corresponding lanes of the two `16x8` input values
 3. Shifts the result right by 15, converting Q30 back to Q15.
 4. If needed, saturates the result to clamp it to the range −32768 to 32767 and avoid wrapping. This keeps the result inside the allowable range for the Q15 format.
 
-let's look at how we arrive at the result of our example `-8192`, which is the value stored in lane 7 of the output value.
+Let's look at how we arrive at the result of our example `-8192`, which is the value stored in lane 7 of the output value.
 
 1. Lane 7 of the two input values contain `-16384` and `16384`.
 2. Multiplying these values together gives the product `-268435456`.

--- a/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
+++ b/files/en-us/webassembly/reference/simd/arithmetic/q15mulr_sat_s/index.md
@@ -9,6 +9,8 @@ sidebar: webassemblysidebar
 
 The **`q15mulr_sat_s`** [SIMD arithmetic instruction](/en-US/docs/WebAssembly/Reference/SIMD/arithmetic) performs a lane-wise [saturating](https://en.wikipedia.org/wiki/Saturation_arithmetic) rounding multiplication in Q15 format on two signed [`v128`](/en-US/docs/WebAssembly/Reference/Value_types/v128) `i16x8` value interpretations — clamping the output to the range allowed by the value type (a single `i16x8` value interpretation).
 
+The `q15mulr_sat_s` instruction performs a fixed-point multiplication on 8 pairs of Q15-encoded 16-bit signed integers, simultaneously, with rounding and saturation. Such operations are common in audio processing and machine learning, for example FIR/IIR audio filters and neural network inference.
+
 {{InteractiveExample("Wat Demo: q15mulr_sat_s", "tabbed-taller")}}
 
 ```wat interactive-example
@@ -29,8 +31,6 @@ The **`q15mulr_sat_s`** [SIMD arithmetic instruction](/en-US/docs/WebAssembly/Re
 ```js interactive-example
 WebAssembly.instantiateStreaming(fetch("{%wasm-url%}"), { console });
 ```
-
-The `q15mulr_sat_s` instruction performs a fixed-point multiplication on 8 pairs of Q15-encoded 16-bit signed integers, simultaneously, with rounding and saturation. Such operations are common in audio processing and machine learning, for example FIR/IIR audio filters and neural network inference.
 
 Q15 is a fixed-point number format where a signed 16-bit integer represents a real number in the range −1.0 to 1.0. The value `32767` (`0x7FFF`) is equivalent to `1.0`, and `−32768` (`0x8000`) is equivalent to `−1.0`. Multiplying two Q15 numbers produces a Q30 result stored as a 32-bit integer. To get back to Q15 (16-bit), you shift right by 15.
 


### PR DESCRIPTION
### Description

The last of four PRs splitting up #45563. Draft, like #45603.

These are the 28 HTML, WebAssembly and media pages where **more than one paragraph** sits after the `{{InteractiveExample}}` macro and therefore renders inside the "Try it" section. As currently written, each block moves up above the macro.

The same open question as #45603 applies here — whether these belong above the demo or in a `## Description` section after it. Whatever is decided there, I will apply the same treatment to this PR, so it is probably easiest to settle it on #45603 alone.

The largest cases are in this PR: `<picture>` and the `tabindex` global attribute both have eight paragraphs after the macro, which is well past the "very short summary" the template intends before the demo.

### Motivation

Same underlying issue as #45601: prose placed after the `{{InteractiveExample}}` macro renders inside the "Try it" section, after the demo's code, instead of reading as part of the page's description.
