### PR TITLE
Remove browser-specific claims about console.timeStamp()

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -60,7 +60,7 @@ console.log("Failed to open the specified link");
 - {{domxref("console/timeLog_static", "console.timeLog()")}}
   - : Logs the value of the specified [timer](#timers) to the console.
 - {{domxref("console/timeStamp_static", "console.timeStamp()")}} {{Non-standard_inline}}
-  - : Adds a marker to the browser performance tool's timeline ([Chrome](https://developer.chrome.com/docs/devtools/performance/reference) or [Firefox](https://profiler.firefox.com/docs/#/./guide-ui-tour-timeline)).
+  - : Adds a marker to a performance recording in developer tools that support it. Recording and display depend on the browser and profiling tool.
 - {{domxref("console/trace_static", "console.trace()")}}
   - : Outputs a [stack trace](#stack_traces).
 - {{domxref("console/warn_static", "console.warn()")}}

--- a/files/en-us/web/api/console/time_static/index.md
+++ b/files/en-us/web/api/console/time_static/index.md
@@ -28,6 +28,10 @@ console.time(label)
 
 None ({{jsxref("undefined")}}).
 
+## Description
+
+Developer tools may also include the interval between `console.time()` and `console.timeEnd()` in a performance recording. This profiling behavior is separate from the console output and is not specified by the Console API. For standard timing entries accessible to JavaScript, use {{domxref("Performance.mark", "performance.mark()")}} and {{domxref("Performance.measure", "performance.measure()")}}.
+
 ## Specifications
 
 {{Specifications}}
@@ -39,6 +43,9 @@ None ({{jsxref("undefined")}}).
 ## See also
 
 - See {{domxref("console/timeLog_static", "console.timeLog()")}} and {{domxref("console/timeEnd_static", "console.timeEnd()")}} for examples
+- {{domxref("console/timeStamp_static", "console.timeStamp()")}}
+- {{domxref("Performance.mark", "performance.mark()")}}
+- {{domxref("Performance.measure", "performance.measure()")}}
 - [Microsoft Edge's documentation for `console.time()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools/console/api#time)
 - [Node.js documentation for `console.time()`](https://nodejs.org/docs/latest/api/console.html#consoletimelabel)
 - [Google Chrome's documentation for `console.time()`](https://developer.chrome.com/docs/devtools/console/api/#time)

--- a/files/en-us/web/api/console/timeend_static/index.md
+++ b/files/en-us/web/api/console/timeend_static/index.md
@@ -28,6 +28,10 @@ console.timeEnd(label)
 
 None ({{jsxref("undefined")}}).
 
+## Description
+
+Developer tools may also include the interval between `console.time()` and `console.timeEnd()` in a performance recording. This profiling behavior is separate from the console output and is not specified by the Console API. For standard timing entries accessible to JavaScript, use {{domxref("Performance.mark", "performance.mark()")}} and {{domxref("Performance.measure", "performance.measure()")}}.
+
 ## Examples
 
 ```js
@@ -57,6 +61,9 @@ longer tracking time.
 
 - See {{domxref("console/timeLog_static", "console.timeLog()")}} for additional examples
 - {{domxref("console/time_static", "console.time()")}}
+- {{domxref("console/timeStamp_static", "console.timeStamp()")}}
+- {{domxref("Performance.mark", "performance.mark()")}}
+- {{domxref("Performance.measure", "performance.measure()")}}
 - [Microsoft Edge's documentation for `console.timeEnd()`](https://learn.microsoft.com/en-us/microsoft-edge/devtools/console/api#timeend)
 - [Node.js documentation for `console.timeEnd()`](https://nodejs.org/docs/latest/api/console.html#consoletimeendlabel)
 - [Google Chrome's documentation for `console.timeEnd()`](https://developer.chrome.com/docs/devtools/console/api/#timeend)

--- a/files/en-us/web/api/console/timestamp_static/index.md
+++ b/files/en-us/web/api/console/timestamp_static/index.md
@@ -10,11 +10,7 @@ browser-compat: api.console.timeStamp_static
 
 {{APIRef("Console API")}}{{Non-standard_header}} {{AvailableInWorkers}}
 
-The **`console.timeStamp()`** static method adds a single marker to the browser's Performance tool ([Firefox bug 1387528](https://bugzil.la/1387528), [Chrome](https://developer.chrome.com/docs/devtools/performance/reference)). This lets you correlate a point in your code with the other events recorded in the timeline, such as layout and paint events.
-
-You can optionally supply an argument to label the timestamp, and this label will then be shown alongside the marker.
-
-Some browsers have further extended this `console.timeStamp()` method to allow additional, optional parameters to be provided as part of its extensibility API that surfaces these in performances traces. See the [Chrome's extensibility API documentation](https://developer.chrome.com/docs/devtools/performance/extension#inject_your_data_with_consoletimestamp) for more information.
+The **`console.timeStamp()`** static method adds a marker to a performance recording in developer tools that support it, such as the [Chrome Performance panel](https://developer.chrome.com/docs/devtools/performance/reference) and [Firefox Profiler](https://profiler.firefox.com/). This lets you correlate a point in your code with recorded events such as layout and painting.
 
 ## Syntax
 
@@ -52,6 +48,16 @@ console.timeStamp(label, start, end, trackName, trackGroup, color, data);
 ### Return value
 
 None ({{jsxref("undefined")}}).
+
+## Description
+
+To see the marker, start a performance recording before the call occurs. Marker recording and display depend on the browser and its profiling tool; the presence of `console.timeStamp()` does not by itself guarantee a visible marker.
+
+This method does not log elapsed time to the console or create a {{domxref("PerformanceEntry")}}. Use {{domxref("console/time_static", "console.time()")}} and {{domxref("console/timeEnd_static", "console.timeEnd()")}} for console timers, or {{domxref("Performance.mark", "performance.mark()")}} and {{domxref("Performance.measure", "performance.measure()")}} for standard entries that your application can observe and read.
+
+You can optionally supply an argument to label the timestamp, and this label will then be shown alongside the marker.
+
+Some browsers have further extended this `console.timeStamp()` method to allow additional, optional parameters to be provided as part of its extensibility API that surfaces these in performance traces. See the [Chrome's extensibility API documentation](https://developer.chrome.com/docs/devtools/performance/extension#inject_your_data_with_consoletimestamp) for more information.
 
 ## Examples
 
@@ -116,5 +122,4 @@ console.timeStamp(
 - {{domxref("console/timeEnd_static", "console.timeEnd()")}}
 - {{domxref("performance/mark", "performance.mark()")}}
 - {{domxref("performance/measure", "performance.measure()")}}
-- [Adding markers with the console API](https://web.archive.org/web/20211207010020/https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#adding-markers-with-the-console-api)
 - [Chrome DevTools extensibility API](https://developer.chrome.com/docs/devtools/performance/extension#inject_your_data_with_consoletimestamp)

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -131,3 +131,10 @@ performance.mark("navigationStart");
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Performance.measure", "performance.measure()")}}
+- {{domxref("console/timeStamp_static", "console.timeStamp()")}}
+- {{domxref("console/time_static", "console.time()")}}
+- {{domxref("console/timeEnd_static", "console.timeEnd()")}}


### PR DESCRIPTION
Fix https://github.com/mdn/content/issues/22588.

According to BCD, FF 149+ supports `console.timeStamp()` to the profiler, so this content isn't "wrong" per se, but certainly not future-proof. Replaced with handwavy claims that it's implementation dependent, because there's BCD anyway.