### PR TITLE
Document border image sizing with SVG

### DIFF
--- a/files/en-us/web/css/reference/properties/border-image-slice/index.md
+++ b/files/en-us/web/css/reference/properties/border-image-slice/index.md
@@ -91,7 +91,7 @@ The optional `fill` value, if used, can be placed anywhere in the declaration.
 ### Values
 
 - {{cssxref("&lt;number&gt;")}}
-  - : Represents an edge offset in _pixels_ for raster images and _coordinates_ for vector images. For vector images, the number is relative to the element's size, not the size of the source image, so percentages are generally preferable in these cases.
+  - : Represents an edge offset in _pixels_ for raster images and _coordinates_ for vector images. For vector images without natural dimensions, the image is first sized using the border image area as the default object size, so percentages can be easier to use when the slices should follow proportions of the image.
 - {{cssxref("&lt;percentage&gt;")}}
   - : Represents an edge offset as a percentage of the source image's size: the width of the image for horizontal offsets, the height for vertical offsets.
 - `fill`
@@ -210,6 +210,114 @@ sliceSlider.addEventListener("input", () => {
 #### Result
 
 {{EmbedLiveSample('Adjustable_border_width_and_slice', '100%', 400)}}
+
+### Sizing SVG border images
+
+This example compares three SVG border images with identical artwork. The first SVG has neither natural size nor {{SVGAttr("viewBox")}}; the second has no natural size but has `viewBox`; the third has both. All three elements use the same slice offsets and border widths.
+
+```html live-sample___svg-artwork
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="gold" />
+  <rect x="10" width="80" height="10" fill="red" />
+  <rect x="90" y="10" width="10" height="80" fill="green" />
+  <rect x="10" y="90" width="80" height="10" fill="blue" />
+  <rect y="10" width="10" height="80" fill="purple" />
+  <rect width="10" height="10" fill="black" />
+  <rect x="90" width="10" height="10" fill="orange" />
+  <rect x="90" y="90" width="10" height="10" fill="cyan" />
+  <rect y="90" width="10" height="10" fill="deeppink" />
+</svg>
+```
+
+```css hidden live-sample___svg-artwork
+svg {
+  width: 100px;
+  height: 100px;
+}
+```
+
+{{EmbedLiveSample('svg-artwork', '100%', 120)}}
+
+#### HTML
+
+```html live-sample___svg-border-comparison
+<label for="slice">border-image-slice:</label>
+<select id="slice">
+  <option value="10">10</option>
+  <option value="10%">10%</option>
+</select>
+<p class="without-viewbox">Without viewBox</p>
+<p class="with-viewbox">With viewBox</p>
+<p class="with-dimensions">With viewBox and natural dimensions</p>
+```
+
+#### CSS
+
+The SVGs are embedded as data URLs. The slices initially use numeric offsets of `10`; selecting `10%` instead selects the outer tenth of each source image. The resulting slices are stretched to form a `20px` border.
+
+```css live-sample___svg-border-comparison
+p {
+  box-sizing: content-box;
+  width: 200px;
+  height: 100px;
+  padding: 0;
+  border: 20px solid;
+  border-image-slice: 10;
+  border-image-width: 1;
+  border-image-repeat: stretch;
+  overflow: auto;
+  resize: both;
+}
+```
+
+#### JavaScript
+
+We use the same artwork for all three images, changing only the root SVG attributes.
+
+```js live-sample___svg-border-comparison
+const artwork = `
+  <rect width="100" height="100" fill="gold" />
+  <rect x="10" width="80" height="10" fill="red" />
+  <rect x="90" y="10" width="10" height="80" fill="green" />
+  <rect x="10" y="90" width="80" height="10" fill="blue" />
+  <rect y="10" width="10" height="80" fill="purple" />
+  <rect width="10" height="10" fill="black" />
+  <rect x="90" width="10" height="10" fill="orange" />
+  <rect x="90" y="90" width="10" height="10" fill="cyan" />
+  <rect y="90" width="10" height="10" fill="deeppink" />
+`;
+
+const variants = {
+  ".without-viewbox": "",
+  ".with-viewbox": 'viewBox="0 0 100 100"',
+  ".with-dimensions": 'viewBox="0 0 100 100" width="100" height="100"',
+};
+
+for (const [selector, attributes] of Object.entries(variants)) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" ${attributes}>${artwork}</svg>`;
+  const url = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+  document.querySelector(selector).style.borderImageSource = `url("${url}")`;
+}
+
+const sliceSelect = document.querySelector("#slice");
+sliceSelect.addEventListener("change", () => {
+  for (const selector of Object.keys(variants)) {
+    document.querySelector(selector).style.borderImageSlice = sliceSelect.value;
+  }
+});
+```
+
+#### Result
+
+Switch between numeric and percentage slices, and drag the bottom-right corner of each element to resize it.
+
+{{EmbedLiveSample('svg-border-comparison', '100%', 540)}}
+
+Before slicing, the browser determines each image's [concrete size](/en-US/docs/Web/CSS/Reference/Values/image#concrete_size), using the border image area as the default object size. Initially, this area is 240 by 140.
+
+- The first SVG has neither natural dimensions nor a natural aspect ratio, so its source viewport is initially 240 by 140. The artwork remains 100 by 100 in the top-left corner, so the right and bottom borders are initially transparent. Resizing the element changes which parts of the artwork fall inside the slices, but the artwork itself never scales with the element.
+- The second SVG has a square natural aspect ratio due to the `viewBox`, so its source viewport is 140 by 140, and the artwork is scaled to fill that viewport. With `10%`, the slices follow the scaled edges and corners. With `10`, the fixed offsets can cut through the scaled corners, leaving parts of them in the edge slices that are stretched along the border.
+- The third SVG is sized to its natural dimensions of 100 by 100 before slicing, regardless of the element's size. Both `10` and `10%` select a 10-unit edge or corner, so the border stays consistent even as the element resizes.
 
 ## Specifications
 


### PR DESCRIPTION
Fix #43131. Note that Firefox seems to behave differently but not sure if it merits a note.