### PR TITLE
Update Firefox 156 release notes for WebDriver conforming changes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/156/index.md
+++ b/files/en-us/mozilla/firefox/releases/156/index.md
@@ -62,13 +62,20 @@ Firefox 156 is the current [Beta version of Firefox](https://www.firefox.com/en-
 
 <!-- #### Removals -->
 
-<!-- ### WebDriver conformance (WebDriver BiDi, Marionette) -->
+### WebDriver conformance (WebDriver BiDi, Marionette)
 
-<!-- #### General -->
+#### General
 
-<!-- #### WebDriver BiDi -->
+- Marionette and RemoteAgent now both use a custom exit code (69) when their server fails to start. ([Firefox bug 2040974](https://bugzil.la/2040974)).
+- Improved the timing of intermediary events for actions with a duration greater than 0, to be closer to a 16ms interval and avoid inflating the overall duration even if the content process is overloaded. ([Firefox bug 2054442](https://bugzil.la/2054442)).
 
-<!-- #### Marionette -->
+#### WebDriver BiDi
+
+- `browsingContext.startScreencast` will now safely pick a valid download folder and should no longer throw if the default download folder (`DfltDwnld`) is not available. ([Firefox bug 2066782](https://bugzil.la/2066782)).
+
+#### Marionette
+
+- The `WebDriver:GetElementTagName` command was updated to match the [latest specification changes](https://github.com/w3c/webdriver/pull/1968) and now returns the DOM element's [qualified name](https://dom.spec.whatwg.org/#concept-element-qualified-name). This command used to always lowercase the return value. In practice, this change is backward compatible for HTML elements, but it is a non-backward-compatible change for elements with a case-sensitive qualified name, such as SVG elements.([Firefox bug 2026697](https://bugzil.la/2026697)).
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
Changes for WebDriver conformance for the Firefox 156 release based on the [release note worthy bugs in this list](https://bugzilla.mozilla.org/buglist.cgi?include_fields=id,component,resolution,assigned_to,summary,bug_type,whiteboard,mentors&product=Remote%20Protocol&resolution=FIXED&f1=cf_status_firefox156&o1=equals&v1=fixed&f2=cf_status_firefox155&o2=notequals&v2=fixed&f3=status_whiteboard&o3=notsubstring&v3=%5Bwptsync%20downstream%5D&f4=status_whiteboard&o4=substring&v4=%5Bwebdriver%3Arelnote%5D&component=Agent&component=Marionette&component=WebDriver%20BiDi).

@whimboo and @lutien can you please review? Thanks.