### PR TITLE
Fix placeholder example variable name (input → inputElement)

### DIFF
--- a/files/en-us/web/api/htmlinputelement/pattern/index.md
+++ b/files/en-us/web/api/htmlinputelement/pattern/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 const inputElement = document.getElementById("year");
-console.log(input.pattern);
+console.log(inputElement.pattern);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlinputelement/placeholder/index.md
+++ b/files/en-us/web/api/htmlinputelement/placeholder/index.md
@@ -18,7 +18,7 @@ A string.
 
 ```js
 const inputElement = document.getElementById("phone");
-console.log(input.placeholder);
+console.log(inputElement.placeholder);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlinputelement/src/index.md
+++ b/files/en-us/web/api/htmlinputelement/src/index.md
@@ -20,7 +20,7 @@ A string.
 
 ```js
 const inputElement = document.getElementById("imageButton");
-console.log(input.src);
+console.log(inputElement.src);
 ```
 
 ## Specifications


### PR DESCRIPTION
### Description

The Examples snippet declared `const inputElement = ...` but then used `input.placeholder`. This one-line change updates the `console.log` to `inputElement.placeholder` so the variable names match.

### Motivation

As written, the example refers to an undefined `input` variable, so it does not demonstrate the `placeholder` property.

### Additional details

Docs typo only; no other content changes.

Fixes #45605