### PR TITLE
Remove SVGAElement.text from the interface page

### DIFF
--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -51,8 +51,6 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
   - : A string representing the URL's query string, if any, including the leading question mark (`?`).
 - {{domxref("SVGAElement.target")}} {{ReadOnlyInline}}
   - : It corresponds to the {{SVGAttr("target")}} attribute of the given element.
-- {{domxref("SVGAElement.text")}} {{deprecated_inline}}
-  - : A string that is a synonym for the {{domxref("Node.textContent")}} property.
 - {{domxref("SVGAElement.type")}}
   - : A string that reflects the `type` attribute, indicating the MIME type of the linked resource.
 - {{domxref("SVGAElement.username")}} {{experimental_inline}}


### PR DESCRIPTION
### Description

Removes the leftover `SVGAElement.text` entry from the instance properties list on the `SVGAElement` interface page.

### Motivation

- The `text` property was removed from Gecko in Firefox 125 and isn’t implemented anywhere else.
- The page was deleted in #44410, and the `api.SVGAElement.text` BCD entry is gone too.

This was the last remaining reference.

### Additional details

- [Firefox bug 1880689](https://bugzil.la/1880689): Remove `SVGAElement.text`
- Removed from the SVG 2 spec: [`SVGAElement` interface](https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement)

### Related issues and pull requests

Relates to #44410.