### PR TITLE
Fix a typo in the WakeLockSentinel release event

### DIFF
--- a/files/en-us/web/api/wakelocksentinel/release_event/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release_event/index.md
@@ -11,7 +11,7 @@ browser-compat: api.WakeLockSentinel.release_event
 The **`release`** event of the {{domxref("WakeLockSentinel")}} interface is fired when the sentinel object's handle has been released.
 
 A {{domxref("WakeLockSentinel")}} can be released manually via the `release()` method, or automatically via the platform wake lock.
-This can happen if the document becomes inactive or looses visibility, if the device is low on power or the user turns on a power save mode.
+This can happen if the document becomes inactive or loses visibility, if the device is low on power or the user turns on a power save mode.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Fixes `looses` → `loses` on the `WakeLockSentinel` `release` event page.

- The page currently says the lock is released if the document "becomes inactive or **looses** visibility".

### Motivation

`Loose` means not tight. The verb for no longer having something is `lose` / `loses`.