### PR TITLE
Use led as the past tense of lead

### DIFF
--- a/files/en-us/web/http/guides/connection_management_in_http_1.x/index.md
+++ b/files/en-us/web/http/guides/connection_management_in_http_1.x/index.md
@@ -77,7 +77,7 @@ If the server wishes a faster website or application response, it is possible fo
 
 ## Conclusion
 
-Improved connection management allows considerable boosting of performance in HTTP. With HTTP/1.1 or HTTP/1.0, using a persistent connection – at least until it becomes idle – leads to the best performance. However, the failure of pipelining has lead to designing superior connection management models, which have been incorporated into HTTP/2.
+Improved connection management allows considerable boosting of performance in HTTP. With HTTP/1.1 or HTTP/1.0, using a persistent connection – at least until it becomes idle – leads to the best performance. However, the failure of pipelining has led to designing superior connection management models, which have been incorporated into HTTP/2.
 
 ## See also
 

--- a/files/en-us/web/http/reference/resources_and_specifications/index.md
+++ b/files/en-us/web/http/reference/resources_and_specifications/index.md
@@ -5,7 +5,7 @@ page-type: guide
 sidebar: http
 ---
 
-HTTP was first specified in the early 1990s. Designed with extensibility in mind, it has seen numerous additions over the years; this lead to its specification being scattered through numerous specification documents (in the midst of experimental abandoned extensions). This page lists relevant resources about HTTP.
+HTTP was first specified in the early 1990s. Designed with extensibility in mind, it has seen numerous additions over the years; this led to its specification being scattered through numerous specification documents (in the midst of experimental abandoned extensions). This page lists relevant resources about HTTP.
 
 | Specification                                                                                                                                      | Title                                                                                                                                                                                                                                                 | Status                   |
 | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |


### PR DESCRIPTION
### Description

Fixes two past-tense uses of `lead` that should be `led`.

- `connection_management_in_http_1.x`: "the failure of pipelining **has lead** to designing superior connection management models" → "has led"
- `resources_and_specifications`: "it has seen numerous additions over the years; **this lead** to its specification being scattered" → "this led"

### Motivation

The past tense and past participle of `lead` is `led`. Present-tense "lead to" elsewhere in the repo is left alone.