### PR TITLE
Do not pair leftover both with as well as

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/links/index.md
@@ -46,7 +46,7 @@ These macros are:
 
 For the first required parameter, you derive the feature name from the last section of the slug of the document you want to link to.
 For example, to link to the `<select>` element page with the slug `Web/HTML/Reference/Elements/select`, you will write the macro as `\{{HTMLElement("select")}}`.
-This will produce the link "{{HTMLElement("select")}}", which is both code formatted as well as includes the angular brackets.
+This will produce the link "{{HTMLElement("select")}}", which is both code formatted and includes the angular brackets.
 This is because macros add additional feature-specific formatting to the link text.
 So you never have to worry about anything more than the feature name itself when using a macro.
 This is why using macros to add links is quick and easy.

--- a/files/en-us/web/api/document_object_model/building_and_updating_the_dom_tree/index.md
+++ b/files/en-us/web/api/document_object_model/building_and_updating_the_dom_tree/index.md
@@ -9,7 +9,7 @@ page-type: guide
 This article is an overview of some powerful, fundamental DOM level 1 methods and how to use them from JavaScript. You will learn how to create, access and control, and remove HTML elements dynamically. The DOM methods presented here are not specific to HTML; they also apply to XML. The demonstrations provided here will work fine in any modern browser.
 
 > [!NOTE]
-> The DOM methods presented here are part of the Document Object Model (Core) level 1 specification. DOM level 1 includes both methods for generic document access and manipulation (DOM 1 Core) as well as methods specific to HTML documents (DOM 1 HTML).
+> The DOM methods presented here are part of the Document Object Model (Core) level 1 specification. DOM level 1 includes both methods for generic document access and manipulation (DOM 1 Core) and methods specific to HTML documents (DOM 1 HTML).
 
 ## Creating an HTML table dynamically
 

--- a/files/en-us/web/api/document_object_model/building_and_updating_the_dom_tree/index.md
+++ b/files/en-us/web/api/document_object_model/building_and_updating_the_dom_tree/index.md
@@ -9,7 +9,7 @@ page-type: guide
 This article is an overview of some powerful, fundamental DOM level 1 methods and how to use them from JavaScript. You will learn how to create, access and control, and remove HTML elements dynamically. The DOM methods presented here are not specific to HTML; they also apply to XML. The demonstrations provided here will work fine in any modern browser.
 
 > [!NOTE]
-> The DOM methods presented here are part of the Document Object Model (Core) level 1 specification. DOM level 1 includes both methods for generic document access and manipulation (DOM 1 Core) and methods specific to HTML documents (DOM 1 HTML).
+> This guide demonstrates both generic DOM methods and methods specific to HTML elements.
 
 ## Creating an HTML table dynamically
 

--- a/files/en-us/web/media/guides/formats/audio_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/audio_codecs/index.md
@@ -1062,7 +1062,7 @@ For patent reasons, Firefox did not directly support MP3 prior to version 71; in
 
 ### Opus
 
-The [Opus](<https://en.wikipedia.org/wiki/Opus_(audio_format)>) audio format was created by the Xiph.org Foundation as a fully open audio format; it has been standardized by [IETF](https://www.ietf.org/) as {{RFC(6716)}}. It's a good general-purpose audio codec that can efficiently handle both low-complexity audio such as speech as well as music and other high-complexity sounds.
+The [Opus](<https://en.wikipedia.org/wiki/Opus_(audio_format)>) audio format was created by the Xiph.org Foundation as a fully open audio format; it has been standardized by [IETF](https://www.ietf.org/) as {{RFC(6716)}}. It's a good general-purpose audio codec that can efficiently handle both low-complexity audio such as speech and music and other high-complexity sounds.
 
 Opus supports multiple compression algorithms, and can even use more than one algorithm in the same audio file, since the encoder can choose the bit rate, audio bandwidth, algorithm, and other details of the compression settings for each frame of audio.
 

--- a/files/en-us/web/media/guides/formats/audio_codecs/index.md
+++ b/files/en-us/web/media/guides/formats/audio_codecs/index.md
@@ -1062,7 +1062,7 @@ For patent reasons, Firefox did not directly support MP3 prior to version 71; in
 
 ### Opus
 
-The [Opus](<https://en.wikipedia.org/wiki/Opus_(audio_format)>) audio format was created by the Xiph.org Foundation as a fully open audio format; it has been standardized by [IETF](https://www.ietf.org/) as {{RFC(6716)}}. It's a good general-purpose audio codec that can efficiently handle both low-complexity audio such as speech and music and other high-complexity sounds.
+The [Opus](<https://en.wikipedia.org/wiki/Opus_(audio_format)>) audio format was created by the Xiph.org Foundation as a fully open audio format; it has been standardized by [IETF](https://www.ietf.org/) as {{RFC(6716)}}. It's a good general-purpose audio codec that can efficiently handle low-complexity audio such as speech as well as music and other high-complexity sounds.
 
 Opus supports multiple compression algorithms, and can even use more than one algorithm in the same audio file, since the encoder can choose the bit rate, audio bandwidth, algorithm, and other details of the compression settings for each frame of audio.
 


### PR DESCRIPTION
### Description

Replaces leftover `as well as` with `and` in the three places that still follow `both`.

- MDN link macros: "both code formatted as well as includes" → "both code formatted and includes"
- Building and updating the DOM tree: "both methods for generic document access and manipulation (DOM 1 Core) as well as methods specific to HTML documents" → "both … and methods specific to HTML documents"
- Opus audio codec: "both low-complexity audio such as speech as well as music" → "both … and music"

Lines where `both` already has its own `and` and the trailing `as well as` introduces a third item are left alone, as in #45533.

### Motivation

`both` pairs with `and`. These three were missed by #45533.