### PR TITLE
Use the verb form log in in leftover Django tutorial text

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/admin_site/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/admin_site/index.md
@@ -35,7 +35,7 @@ The Django admin _application_ can use your models to automatically build a site
 
 All the configuration required to include the admin application in your website was done automatically when you [created the skeleton project](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website) (for information about actual dependencies needed, see the [Django docs here](https://docs.djangoproject.com/en/5.0/ref/contrib/admin/)). As a result, all you **must** do to add your models to the admin application is to _register_ them. At the end of this article we'll provide a brief demonstration of how you might further configure the admin area to better display our model data.
 
-After registering the models we'll show how to create a new "superuser", log in to the site, and create some books, authors, book instances, and genres. These will be useful for testing the views and templates we'll start creating in the next tutorial.
+After registering the models we'll show how to create a new "superuser", log into the site, and create some books, authors, book instances, and genres. These will be useful for testing the views and templates we'll start creating in the next tutorial.
 
 ## Registering models
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/admin_site/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/admin_site/index.md
@@ -35,7 +35,7 @@ The Django admin _application_ can use your models to automatically build a site
 
 All the configuration required to include the admin application in your website was done automatically when you [created the skeleton project](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website) (for information about actual dependencies needed, see the [Django docs here](https://docs.djangoproject.com/en/5.0/ref/contrib/admin/)). As a result, all you **must** do to add your models to the admin application is to _register_ them. At the end of this article we'll provide a brief demonstration of how you might further configure the admin area to better display our model data.
 
-After registering the models we'll show how to create a new "superuser", login to the site, and create some books, authors, book instances, and genres. These will be useful for testing the views and templates we'll start creating in the next tutorial.
+After registering the models we'll show how to create a new "superuser", log in to the site, and create some books, authors, book instances, and genres. These will be useful for testing the views and templates we'll start creating in the next tutorial.
 
 ## Registering models
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/authentication/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/authentication/index.md
@@ -106,7 +106,7 @@ Our superuser is already authenticated and has all permissions, so we'll need to
 
 Below we'll first create a group and then a user. Even though we don't have any permissions to add for our library members yet, if we need to later, it will be much easier to add them once to the group than individually to each member.
 
-Start the development server and navigate to the admin site in your local web browser (`http://127.0.0.1:8000/admin/`). Login to the site using the credentials for your superuser account. The top level of the Admin site displays all of your models, sorted by "Django application". From the **Authentication and Authorization** section, you can click the **Users** or **Groups** links to see their existing records.
+Start the development server and navigate to the admin site in your local web browser (`http://127.0.0.1:8000/admin/`). Log in to the site using the credentials for your superuser account. The top level of the Admin site displays all of your models, sorted by "Django application". From the **Authentication and Authorization** section, you can click the **Users** or **Groups** links to see their existing records.
 
 ![Admin site - add groups or users](admin_authentication_add.png)
 
@@ -251,9 +251,9 @@ Create a new HTML file called /**django-locallibrary-tutorial/templates/registra
   {% if next %}
     {% if user.is_authenticated %}
       <p>Your account doesn't have access to this page. To proceed,
-      please login with an account that has access.</p>
+      please log in with an account that has access.</p>
     {% else %}
-      <p>Please login to see this page.</p>
+      <p>Please log in to see this page.</p>
     {% endif %}
   {% endif %}
 
@@ -306,7 +306,7 @@ Create and open **/django-locallibrary-tutorial/templates/registration/logged_ou
 
 {% block content %}
   <p>Logged out!</p>
-  <a href="{% url 'login'%}">Click here to login again.</a>
+  <a href="{% url 'login'%}">Click here to log in again.</a>
 {% endblock %}
 ```
 

--- a/files/en-us/learn_web_development/extensions/server-side/django/authentication/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/authentication/index.md
@@ -8,7 +8,7 @@ sidebar: learnsidebar
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Sessions", "Learn_web_development/Extensions/Server-side/Django/Forms", "Learn_web_development/Extensions/Server-side/Django")}}
 
-In this tutorial, we'll show you how to allow users to log in to your site with their own accounts, and how to control what they can do and see based on whether or not they are logged in and their _permissions_. As part of this demonstration, we'll extend the [LocalLibrary](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) website, adding login and logout pages, and user- and staff-specific pages for viewing books that have been borrowed.
+In this tutorial, we'll show you how to allow users to log into your site with their own accounts, and how to control what they can do and see based on whether or not they are logged in and their _permissions_. As part of this demonstration, we'll extend the [LocalLibrary](/en-US/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) website, adding login and logout pages, and user- and staff-specific pages for viewing books that have been borrowed.
 
 <table>
   <tbody>
@@ -106,7 +106,7 @@ Our superuser is already authenticated and has all permissions, so we'll need to
 
 Below we'll first create a group and then a user. Even though we don't have any permissions to add for our library members yet, if we need to later, it will be much easier to add them once to the group than individually to each member.
 
-Start the development server and navigate to the admin site in your local web browser (`http://127.0.0.1:8000/admin/`). Log in to the site using the credentials for your superuser account. The top level of the Admin site displays all of your models, sorted by "Django application". From the **Authentication and Authorization** section, you can click the **Users** or **Groups** links to see their existing records.
+Start the development server and navigate to the admin site in your local web browser (`http://127.0.0.1:8000/admin/`). Log into the site using the credentials for your superuser account. The top level of the Admin site displays all of your models, sorted by "Django application". From the **Authentication and Authorization** section, you can click the **Users** or **Groups** links to see their existing records.
 
 ![Admin site - add groups or users](admin_authentication_add.png)
 
@@ -413,7 +413,7 @@ This is the last password-reset template, which is displayed to notify you when 
 
 Now that you've added the URL configuration and created all these templates, the authentication pages (other than logout) should now just work!
 
-You can test the new authentication pages by first attempting to log in to your superuser account using the URL `http://127.0.0.1:8000/accounts/login/`.
+You can test the new authentication pages by first attempting to log into your superuser account using the URL `http://127.0.0.1:8000/accounts/login/`.
 You'll be able to test the password reset functionality from the link in the login page. **Be aware that Django will only send reset emails to addresses (users) that are already stored in its database!**
 
 Note that you won't be able to test account logout yet, because logout requests must be sent as a `POST` rather than a `GET` request.

--- a/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/forms/index.md
@@ -790,7 +790,7 @@ The pages are now ready to test!
 
 ### Testing the page
 
-First, log in to the site with an account that has author add, change and delete permissions.
+First, log into the site with an account that has author add, change and delete permissions.
 
 Navigate to any page, and select "Create author" in the sidebar (with URL `http://127.0.0.1:8000/catalog/author/create/`).
 The page should look like the screenshot below.


### PR DESCRIPTION
### Description

Uses the two-word verb `log in` in leftover Django tutorial places that still treat `login` as a verb, and writes `log into` when there is a destination.

- Admin site tutorial: "login to the site" → "log into the site" (matches "To log into the site" later on the same page)
- Authentication tutorial: "Login to the site using the credentials" → "Log into the site"
- Authentication intro and test steps: leftover "log in to your site" / "log in to your superuser account" → "log into"
- Forms tutorial: "log in to the site" → "log into the site"
- `logged_out.html` example: "Click here to login again" → "log in again"
- `permission_denied.html` example: "please login with an account" / "Please login to see this page" → "log in"

"Please log in to see this page" keeps `log in to see`, because `to see` is an infinitive of purpose, not a destination.

Noun uses and URL names are left alone, including `{% url 'login'%}` and the login page.

### Motivation

#45382 already established that `login` is the noun, `log in` is the verb, and a destination is written `log into`. These Django leftovers were missed.