### PR TITLE
Use the verb form set up in leftover tutorial text

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/deployment/index.md
@@ -518,7 +518,7 @@ We'll also configure the default database and collect static files so that they 
 
    Note the details, as you'll need them to test your site.
 
-### Setup the web app
+### Set up the web app
 
 After getting the local library sources and installing the dependencies in a virtual environment, we need to tell PythonAnywhere how to find them and use them as a web app.
 

--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
@@ -624,7 +624,7 @@ After logging in, you'll be taken to the [home](https://cloud.mongodb.com/v2) sc
    ![Go to Databases after setting up Access Rules on MongoDB Atlas](mongodb_atlas_-_accessrules.jpg)
 
 6. You will return to the _Overview_ screen. Click on the _Database_ section under the _Deployment_ menu on the left. Click the **Browse Collections** button.
-   ![Setup a collection on MongoDB Atlas.](mongodb_atlas_-_createcollection.jpg)
+   ![Set up a collection on MongoDB Atlas.](mongodb_atlas_-_createcollection.jpg)
 
 7. This will open the _Collections_ section. Click the **Add My Own Data** button.
    ![Create a database on MongoDB Atlas.](mongodb_atlas_-_adddata.jpg)


### PR DESCRIPTION
### Description

Uses the two-word verb \`set up\` in the leftover places that still treat \`setup\` as a verb.

- Django deployment tutorial heading: "Setup the web app" → "Set up the web app". Nothing links to the old heading anchor.
- Express/Mongoose tutorial alt text: "Setup a collection on MongoDB Atlas." → "Set up a collection"

Code comments that start \`// Setup\` are left alone.

### Motivation

#45408 already established that \`setup\` is the noun and \`set up\` is the verb. These two leftovers were missed.