### PR TITLE
Hyphenate leftover third-party modifiers

### DIFF
--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -126,7 +126,7 @@ Fullscreen mode is controlled by the [Permissions-Policy](/en-US/docs/Web/HTTP/G
 
 The default allowlist for `screen-wake-lock` is `self`.
 This allows fullscreen usage in same-origin nested frames but prevents them in third-party content.
-Third party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third party origin.
+Third-party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third-party origin.
 
 ```http
 Permissions-Policy: fullscreen=(self b.example.com)

--- a/files/en-us/web/api/geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/index.md
@@ -55,7 +55,7 @@ The Geolocation API allows users to programmatically access location information
 
 Access may further be controlled by the [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy) directive {{HTTPHeader("Permissions-Policy/geolocation","geolocation")}}.
 The default allowlist for `geolocation` is `self`, which allows access to location information in same-origin nested frames only.
-Third party usage is enabled by setting a `Permissions-Policy` response header to grant permission to a particular third party origin:
+Third-party usage is enabled by setting a `Permissions-Policy` response header to grant permission to a particular third-party origin:
 
 ```http
 Permissions-Policy: geolocation=(self b.example.com)

--- a/files/en-us/web/api/screen_wake_lock_api/index.md
+++ b/files/en-us/web/api/screen_wake_lock_api/index.md
@@ -128,7 +128,7 @@ Access to the Screen Wake Lock API is controlled by the [Permissions Policy](/en
 
 When using the [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy), the default allowlist for `screen-wake-lock` is `self`.
 This allows lock wake usage in same-origin nested frames but prevents third-party content from using locks.
-Third party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third party origin.
+Third-party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third-party origin.
 
 ```http
 Permissions-Policy: screen-wake-lock=(self b.example.com)


### PR DESCRIPTION
### Description

Hyphenates leftover \`third-party\` modifiers on three Permissions-Policy notes.

- \`Element.requestFullscreen()\`
- Geolocation API
- Screen Wake Lock API

All three say "Third party usage" / "third party origin".

### Motivation

#45508 already hyphenated \`third-party\` when it modifies a noun. These three leftover sentences were missed.