### PR TITLE
Hyphenate leftover real-time modifiers

### DIFF
--- a/files/en-us/web/api/document_object_model/events/index.md
+++ b/files/en-us/web/api/document_object_model/events/index.md
@@ -719,7 +719,7 @@ This topic provides an index to the main _sorts_ of events you might be interest
       </td>
     </tr>
     <tr>
-      <td>RTC (real time communication)</td>
+      <td>RTC (real-time communication)</td>
       <td>
         <p>
           Events related to the

--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -31,7 +31,7 @@ DASH moves lots of logic out of the network protocol and into the client side ap
 
 The two most common use cases for DASH involve watching content "on demand" or "live." On demand allows a developer to take their time transcoding the assets into multiple resolutions of various quality.
 
-Live profile content can introduce latency due to its transcoding and broadcasting, so DASH is not suitable for real time communication like [WebRTC](/en-US/docs/Web/API/WebRTC_API) is. It can however support significantly more client connections than WebRTC.
+Live profile content can introduce latency due to its transcoding and broadcasting, so DASH is not suitable for real-time communication like [WebRTC](/en-US/docs/Web/API/WebRTC_API) is. It can however support significantly more client connections than WebRTC.
 
 There are numerous available free and open source tools for transcoding content and preparing it for use with DASH, DASH file servers, and DASH client libraries written in JavaScript. The [DASH Adaptive Streaming for HTML video](/en-US/docs/Web/API/Media_Source_Extensions_API/DASH_Adaptive_Streaming) article provides an example of how to use DASH with MSE.
 


### PR DESCRIPTION
### Description

Hyphenates leftover \`real-time\` modifiers in two places.

- DOM events table: "RTC (real time communication)" → "real-time communication"
- Media Source Extensions: "not suitable for real time communication" → "real-time communication"

### Motivation

#45462 already hyphenated \`real-time\` when it modifies a following noun. The repository already writes it that way about 117 times. These two leftovers were missed.