### PR TITLE
Use leftover checkbox as one word

### DIFF
--- a/files/en-us/learn_web_development/getting_started/environment_setup/dealing_with_files/index.md
+++ b/files/en-us/learn_web_development/getting_started/environment_setup/dealing_with_files/index.md
@@ -166,7 +166,7 @@ It is not true in all cases, but most files need an extension to be handled prop
 > [!NOTE]
 > It is possible to put more than one dot in a file name, for example `my.cats.html`. In such cases, the last dot is assumed to be the start of the file extension.
 
-On Windows computers, you might have trouble seeing the extensions of some files, because Windows has an option called **Hide extensions for known file types** turned on by default. You can turn this off by going to File Explorer, selecting the **Folder options…** option, unchecking the **Hide extensions for known file types** check box, then clicking **OK**. For more specific information covering your version of Windows, you can search on the web.
+On Windows computers, you might have trouble seeing the extensions of some files, because Windows has an option called **Hide extensions for known file types** turned on by default. You can turn this off by going to File Explorer, selecting the **Folder options…** option, unchecking the **Hide extensions for known file types** checkbox, then clicking **OK**. For more specific information covering your version of Windows, you can search on the web.
 
 ### Best practices for naming files
 


### PR DESCRIPTION
### Description

Uses the one-word noun \`checkbox\` in the leftover place that still writes \`check box\`.

- Dealing with files: "unchecking the **Hide extensions for known file types** check box" → "checkbox"

### Motivation

#45409 already established that \`checkbox\` is the noun form, and the repository uses it about 980 times. This leftover was missed.