### PR TITLE
Hyphenate leftover client-side modifiers

### DIFF
--- a/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
+++ b/files/en-us/learn_web_development/extensions/forms/form_validation/index.md
@@ -75,7 +75,7 @@ There are two different types of client-side validation that you'll encounter on
 - **JavaScript form validation**
   JavaScript is generally included to enhance or customize HTML form validation.
 
-Client side validation can be accomplished with little to no JavaScript. HTML validation is faster than JavaScript, but is less customizable than JavaScript validation. It is generally recommended to begin your forms using robust HTML features, then enhance the user experience with JavaScript as needed.
+Client-side validation can be accomplished with little to no JavaScript. HTML validation is faster than JavaScript, but is less customizable than JavaScript validation. It is generally recommended to begin your forms using robust HTML features, then enhance the user experience with JavaScript as needed.
 
 ## Using built-in form validation
 

--- a/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/what_s_new_in_1.5_alpha/index.md
@@ -69,7 +69,7 @@ This page is based largely on [https://www.squarefree.com/burningedg...eases/](h
 - URIs always sent as UTF8
   - : URIs are now always sent to the server as UTF8, regardless of the linking page's encoding. This fixes images and links on sites with non-ASCII filenames.
 - XForms support
-  - : The [W3C's XML Forms](https://www.w3.org/MarkUp/Forms/) language allows writing complex forms in XML, and includes features that regular HTML forms do not have, such as client side validation against [XML Schema](https://www.w3.org/XML/Schema) and XML submission/retrieval. Support for XForms comes as an extension, see [Mozilla XForms Project Page](https://www-archive.mozilla.org/projects/xforms/).
+  - : The [W3C's XML Forms](https://www.w3.org/MarkUp/Forms/) language allows writing complex forms in XML, and includes features that regular HTML forms do not have, such as client-side validation against [XML Schema](https://www.w3.org/XML/Schema) and XML submission/retrieval. Support for XForms comes as an extension, see [Mozilla XForms Project Page](https://www-archive.mozilla.org/projects/xforms/).
 
 ## New Extension Developer Features
 

--- a/files/en-us/web/accessibility/aria/guides/live_regions/index.md
+++ b/files/en-us/web/accessibility/aria/guides/live_regions/index.md
@@ -143,7 +143,7 @@ Elements with the following [`role="…"`](/en-US/docs/Web/Accessibility/ARIA/Re
   </tr>
   <tr>
    <td>alert</td>
-   <td>Error or warning message that flashes on the screen. Alerts are particularly important for client side validation notices to users. <a href="https://www.w3.org/WAI/ARIA/apg/example-index/alert/alert.html" class="external" rel="noopener">Alert Example.</a></td>
+   <td>Error or warning message that flashes on the screen. Alerts are particularly important for client-side validation notices to users. <a href="https://www.w3.org/WAI/ARIA/apg/example-index/alert/alert.html" class="external" rel="noopener">Alert Example.</a></td>
    <td>To maximize compatibility, some people recommend adding a redundant <code>aria-live="assertive"</code> when using this role. However, adding both <code>aria-live</code> and <code>role="alert"</code> causes double speaking issues in VoiceOver on iOS.</td>
   </tr>
   <tr>

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
@@ -679,4 +679,4 @@ Further reading for you to find out more information if desired.
 - [IDB](https://github.com/jakearchibald/idb): A tiny library that mostly mirrors the IndexedDB API but with small usability improvements.
 - [idb-keyval](https://www.npmjs.com/package/idb-keyval): A super-simple-small (\~600B) promise-based key-value store implemented with IndexedDB
 - [$mol_db](https://github.com/hyoo-ru/mam_mol/tree/master/db): Tiny (\~1.3kB) TypeScript facade with promise-based API and automatic migrations.
-- [RxDB](https://rxdb.info/): A NoSQL client side database that can be used on top of IndexedDB. Supports indexes, compression and replication. Also adds cross tab functionality and observability to IndexedDB.
+- [RxDB](https://rxdb.info/): A NoSQL client-side database that can be used on top of IndexedDB. Supports indexes, compression and replication. Also adds cross tab functionality and observability to IndexedDB.

--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -27,7 +27,7 @@ If you do not require explicit control of video quality over time, the rate at w
 
 Dynamic Adaptive Streaming over HTTP (DASH) is a protocol for specifying how adaptive content should be fetched. It is effectively a layer built on top of MSE for building adaptive bitrate streaming clients. While there are other protocols available (such as HTTP Live Streaming (HLS)), DASH has the most platform support.
 
-DASH moves lots of logic out of the network protocol and into the client side application logic, using the simpler HTTP protocol to fetch files. Indeed, one can support DASH with a simple static file server, which is also great for CDNs. This is in direct contrast with previous streaming solutions that required expensive licenses for proprietary non-standard client/server protocol implementations.
+DASH moves lots of logic out of the network protocol and into the client-side application logic, using the simpler HTTP protocol to fetch files. Indeed, one can support DASH with a simple static file server, which is also great for CDNs. This is in direct contrast with previous streaming solutions that required expensive licenses for proprietary non-standard client/server protocol implementations.
 
 The two most common use cases for DASH involve watching content "on demand" or "live." On demand allows a developer to take their time transcoding the assets into multiple resolutions of various quality.
 

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
@@ -14,7 +14,7 @@ The higher the number of redirects on a page, the longer the page load time. To 
 
 The {{domxref("PerformanceResourceTiming.redirectStart", "redirectStart")}} and {{domxref("PerformanceResourceTiming.redirectEnd", "redirectEnd")}} properties can be used to measure redirection time. Note that they will return `0` for cross-origin redirects.
 
-Note that client side redirects, such as `<meta http-equiv="refresh" content="0; url=https://example.com/">` are not considered here.
+Note that client-side redirects, such as `<meta http-equiv="refresh" content="0; url=https://example.com/">` are not considered here.
 
 ## Value
 

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/javascript_functionality/index.md
@@ -118,7 +118,7 @@ We are using the [Web Storage API](/en-US/docs/Web/API/Web_Storage_API), specifi
 
 [LocalStorage](/en-US/docs/Learn_web_development/Extensions/Client-side_APIs/Client-side_storage#storing_simple_data_—_web_storage) has several limitations, but suffices for our apps needs. We're using localStorage to make this simple and client-side only. This means the data will only be stored on one browser on a single device. Clearing the browser data will also lose all locally stored periods. What may seem like a limitation for many applications may be an asset in the case of this application, as menstrual cycle data is personal, and the user of such an app may very rightly be concerned about privacy.
 
-For a more robust application, other [client side storage](/en-US/docs/Learn_web_development/Extensions/Client-side_APIs/Client-side_storage) options like [IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) (IDB) and, discussed later, service workers, have better performance.
+For a more robust application, other [client-side storage](/en-US/docs/Learn_web_development/Extensions/Client-side_APIs/Client-side_storage) options like [IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) (IDB) and, discussed later, service workers, have better performance.
 
 Limitations of `localStorage` include:
 


### PR DESCRIPTION
### Description

Hyphenates leftover \`client-side\` modifiers in seven places.

- Form validation: "Client side validation"
- Firefox 1.5 notes: "client side validation"
- ARIA live regions: "client side validation notices"
- CycleTracker: "client side storage"
- Using IndexedDB: "client side database"
- Media Source Extensions: "client side application logic"
- \`PerformanceNavigationTiming.redirectCount\`: "client side redirects"

Predicative uses such as "on the client side" are left alone.

### Motivation

#45462 already hyphenated \`client-side\` when it modifies a following noun. The repository already writes it that way about 474 times. These leftovers were missed.