### PR TITLE
Hyphenate leftover well-known modifiers

### DIFF
--- a/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/attestationobject/index.md
@@ -17,7 +17,7 @@ authenticator when it is manufactured.
 As part of the {{domxref("CredentialsContainer.create()")}} call, an authenticator will
 create a new key pair as well as an `attestationObject` for that key pair. The public key
 that corresponds to the private key that has created the attestation signature is well
-known; however, there are various well known attestation public key chains for different
+known; however, there are various well-known attestation public key chains for different
 ecosystems (for example, Android or TPM attestations).
 
 ## Value

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -33,7 +33,7 @@ showDirectoryPicker(options)
       - : A string that defaults to `"read"` for read-only access or `"readwrite"` for read
         and write access to the directory.
     - `startIn` {{optional_inline}}
-      - : A {{domxref("FileSystemHandle")}} or a well known directory (`"desktop"`, `"documents"`,
+      - : A {{domxref("FileSystemHandle")}} or a well-known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
 
 ### Return value

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -38,7 +38,7 @@ showOpenFilePicker(options)
       - : A boolean value that defaults to `false`. When
         set to `true` multiple files may be selected.
     - `startIn` {{Optional_Inline}}
-      - : A {{domxref("FileSystemHandle")}} or a well known directory (`"desktop"`, `"documents"`,
+      - : A {{domxref("FileSystemHandle")}} or a well-known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `types` {{Optional_Inline}}
       - : An {{jsxref('Array')}} of allowed file types to pick. Each

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -35,7 +35,7 @@ showSaveFilePicker(options)
         IDs. If the same ID is used for another picker, the picker opens in the same
         directory.
     - `startIn` {{Optional_Inline}}
-      - : A {{domxref("FileSystemHandle")}} or a well known directory (`"desktop"`, `"documents"`,
+      - : A {{domxref("FileSystemHandle")}} or a well-known directory (`"desktop"`, `"documents"`,
         `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
     - `suggestedName` {{Optional_Inline}}
       - : A {{jsxref('String')}}. The suggested file name.


### PR DESCRIPTION
### Description

Hyphenates leftover \`well-known\` modifiers in four places.

- \`showDirectoryPicker()\`, \`showOpenFilePicker()\`, and \`showSaveFilePicker()\`: "a well known directory" → "a well-known directory"
- \`AuthenticatorAttestationResponse.attestationObject\`: "well known attestation public key chains" → "well-known"

Predicative uses such as "it is well known" are left alone.

### Motivation

Used before a noun this is a compound modifier and takes a hyphen, matching the File System Access "well-known directory" wording and the same hyphenation rule as #45462 and #45463.