### PR TITLE
Hyphenate leftover case-insensitive modifiers

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/django/models/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/django/models/index.md
@@ -324,7 +324,7 @@ class Genre(models.Model):
             UniqueConstraint(
                 Lower('name'),
                 name='genre_name_case_insensitive_unique',
-                violation_error_message = "Genre already exists (case insensitive match)"
+                violation_error_message = "Genre already exists (case-insensitive match)"
             ),
         ]
 ```

--- a/files/en-us/web/http/reference/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/reference/headers/strict-transport-security/index.md
@@ -50,7 +50,7 @@ The host is identified only by its domain name. An IP address cannot be an HSTS 
 HSTS applies to all ports of the host, regardless of what port was used for the request.
 
 Before loading an `http` URL, the browser checks the domain name against its HSTS hosts list.
-If the domain name is a case insensitive match for an HSTS host or is a subdomain of one that specified `includeSubDomains`,
+If the domain name is a case-insensitive match for an HSTS host or is a subdomain of one that specified `includeSubDomains`,
 then the browser replaces the URL scheme with `https`.
 If the URL specifies port 80, the browser changes it to 443.
 Any other explicit port number remains unchanged, and the browser connects to that port using HTTPS.

--- a/files/en-us/web/uri/reference/schemes/urn/index.md
+++ b/files/en-us/web/uri/reference/schemes/urn/index.md
@@ -17,7 +17,7 @@ urn:<NID>:<NSS>
 ```
 
 - `<NID>`
-  - : A NID (Namespace Identifier) is a case insensitive identifier for the namespace (e.g., `ISBN` and `isbn` are equivalent).
+  - : A NID (Namespace Identifier) is a case-insensitive identifier for the namespace (e.g., `ISBN` and `isbn` are equivalent).
     NIDs are maintained by [registries such as IANA](https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml), and their resolution depends on the specific namespace.
     For instance, the `ISBN` NID resolution is handled by [International ISBN Agency](https://www.isbn-international.org/) systems.
 - `<NSS>`

--- a/files/en-us/web/xml/exslt/reference/regexp/match/index.md
+++ b/files/en-us/web/xml/exslt/reference/regexp/match/index.md
@@ -27,7 +27,7 @@ The character flags are:
 - `g`
   - : Global match. The submatches from every match in the string are returned. If this flag isn't specified, only the submatches from the first match are returned.
 - `i`
-  - : Case insensitive match. If this flag is specified, the match is performed in a case insensitive fashion.
+  - : Case-insensitive match. If this flag is specified, the match is performed in a case-insensitive fashion.
 
 ### Return value
 

--- a/files/en-us/web/xml/exslt/reference/regexp/replace/index.md
+++ b/files/en-us/web/xml/exslt/reference/regexp/replace/index.md
@@ -28,8 +28,8 @@ The character flags are:
 
 - `g` - Global replace
   - : If this flag is specified, all occurrences of the regular expression within the `originalString` are replaced. Otherwise only the first occurrence is replaced.
-- `i` - Case insensitive match
-  - : If this flag is specified, the match is performed in a case insensitive fashion.
+- `i` - Case-insensitive match
+  - : If this flag is specified, the match is performed in a case-insensitive fashion.
 
 ### Return value
 

--- a/files/en-us/web/xml/exslt/reference/regexp/test/index.md
+++ b/files/en-us/web/xml/exslt/reference/regexp/test/index.md
@@ -27,7 +27,7 @@ The character flags are:
 - `g`
   - : Global match. Has no effect for this function; it's allowed for consistency with other regexp functions.
 - `i`
-  - : Case insensitive match<. If this flag is specified, the match is performed in a case insensitive fashion.
+  - : Case-insensitive match. If this flag is specified, the match is performed in a case-insensitive fashion.
 
 ### Return value
 


### PR DESCRIPTION
### Description

Hyphenates leftover \`case-insensitive\` modifiers when they precede a noun.

- HSTS: "a case insensitive match"
- URN: "a case insensitive identifier"
- EXSLT \`regexp:match\`, \`regexp:replace\`, and \`regexp:test\`: "Case insensitive match" / "case insensitive fashion"
- Django models example: "Genre already exists (case insensitive match)"

Also drops a stray \`<\` after "match" on the \`regexp:test\` page.

Predicative uses such as "this property is case insensitive" are left alone.

### Motivation

Used before a noun this is a compound modifier and takes a hyphen, matching the same leftover pattern as #45462. The same Django models page already writes "case-insensitive exact match".