### PR TITLE
Hyphenate leftover server-side modifiers

### DIFF
--- a/files/en-us/web/api/private_state_token_api/using/index.md
+++ b/files/en-us/web/api/private_state_token_api/using/index.md
@@ -59,7 +59,7 @@ If you want to become an issuer, and have your website issue private state token
 
 ### Creating an issuer server
 
-To implement the token issuer server you will need to build your own server side application exposing HTTP endpoints. The issuer component is composed of two main modules:
+To implement the token issuer server you will need to build your own server-side application exposing HTTP endpoints. The issuer component is composed of two main modules:
 
 1. The issuer app
 2. The token issuer

--- a/files/en-us/web/progressive_web_apps/tutorials/cycletracker/secure_connection/index.md
+++ b/files/en-us/web/progressive_web_apps/tutorials/cycletracker/secure_connection/index.md
@@ -48,7 +48,7 @@ You can run a local HTTP server using a [VS Code plugin](/en-US/docs/Learn_web_d
 > [!NOTE]
 > The Preview on Web Server extension uses Browsersync. When your development environment is started by this extension, `localhost:3001` provides a user interface for Browsersync, providing an overview of the current server environment.
 
-Learn how to [set up a local testing server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server) using [Python](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server#using_python) or [local server side language](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server#running_server-side_languages_locally) like PHP.
+Learn how to [set up a local testing server](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server) using [Python](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server#using_python) or [local server-side language](/en-US/docs/Learn_web_development/Howto/Tools_and_setup/set_up_a_local_testing_server#running_server-side_languages_locally) like PHP.
 
 ## Localhost with npx
 


### PR DESCRIPTION
### Description

Hyphenates leftover \`server-side\` modifiers in two places.

- Private State Token API: "server side application"
- CycleTracker secure connection: "local server side language" (the hash already uses \`server-side\`)

Predicative uses such as "on the server side", and "Server Side Rendering (SSR)", are left alone.

### Motivation

#45462 already hyphenated \`client-side\` when it modifies a following noun. These are the same leftover on the server-side side of that pair.