### PR TITLE
fix typo

### DIFF
--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -126,7 +126,7 @@ Fullscreen mode is controlled by the [Permissions-Policy](/en-US/docs/Web/HTTP/G
 
 The default allowlist for `screen-wake-lock` is `self`.
 This allows fullscreen usage in same-origin nested frames but prevents them in third-party content.
-Third-party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third-party origin.
+Third-party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission to a particular third-party origin.
 
 ```http
 Permissions-Policy: fullscreen=(self b.example.com)

--- a/files/en-us/web/api/screen_wake_lock_api/index.md
+++ b/files/en-us/web/api/screen_wake_lock_api/index.md
@@ -128,7 +128,7 @@ Access to the Screen Wake Lock API is controlled by the [Permissions Policy](/en
 
 When using the [Permissions Policy](/en-US/docs/Web/HTTP/Guides/Permissions_Policy), the default allowlist for `screen-wake-lock` is `self`.
 This allows lock wake usage in same-origin nested frames but prevents third-party content from using locks.
-Third-party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission a particular third-party origin.
+Third-party usage can be enabled by the server first setting the `Permissions-Policy` header to grant permission to a particular third-party origin.
 
 ```http
 Permissions-Policy: screen-wake-lock=(self b.example.com)


### PR DESCRIPTION
### Description

Adds the missing preposition \`to\` after \`grant permission\` on two leftover Permissions-Policy notes.

- \`Element.requestFullscreen()\`
- Screen Wake Lock API

Both currently say "grant permission a particular third-party origin". The Geolocation API note already has "grant permission to a particular third-party origin".

### Motivation

The verb \`grant permission\` takes \`to\` before the recipient. These two sentences were missed when #45635 hyphenated the leftover \`third-party\` modifiers in the same notes.