### PR TITLE
Use leftover log into when the verb has a destination

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/first_steps/introduction/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/first_steps/introduction/index.md
@@ -148,7 +148,7 @@ Server-side programming allows sites to restrict access to authorized users and 
 Real-world examples include social-networking sites which allow users to determine who can see the content they post to the site, and whose content appears in their feed.
 
 > [!NOTE]
-> Consider other real examples where access to content is controlled. For example, what can you see if you go to the online site for your bank? Log in to your account — what additional information can you see and modify? What information can you see that only the bank can change?
+> Consider other real examples where access to content is controlled. For example, what can you see if you go to the online site for your bank? Log into your account — what additional information can you see and modify? What information can you see that only the bank can change?
 
 ### Store session/state information
 

--- a/files/en-us/web/accessibility/aria/reference/attributes/aria-expanded/index.md
+++ b/files/en-us/web/accessibility/aria/reference/attributes/aria-expanded/index.md
@@ -52,7 +52,7 @@ By default, some roles are hidden or collapsed and other roles are open or expan
   <span aria-hidden="true">?</span>
 </button>
 <p id="username-desc" hidden>
-  Your username is the name that you use to log in to this service.
+  Your username is the name that you use to log into this service.
 </p>
 ```
 


### PR DESCRIPTION
### Description

Writes leftover destination cases as \`log into\`, matching #45382 and #45633.

- Server-side introduction: "Log in to your account" → "Log into your account"
- \`aria-expanded\` example help text: "log in to this service" → "log into this service"

Noun uses such as the login page are left alone.

### Motivation

#45382 established that \`login\` is the noun, \`log in\` is the verb, and a destination is written \`log into\`. These two leftovers were missed.