### PR TITLE
Fix "passed by" links in the Javascript Functions Reference

### DIFF
--- a/files/en-us/web/javascript/reference/functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/index.md
@@ -40,7 +40,7 @@ formatNumber(2);
 
 In this example, the `num` variable is called the function's _parameter_: it's declared in the parenthesis-enclosed list of the function's definition. The function expects the `num` parameter to be a number — although this is not enforceable in JavaScript without writing runtime validation code. In the `formatNumber(2)` call, the number `2` is the function's _argument_: it's the value that is actually passed to the function in the function call. The argument value can be accessed inside the function body through the corresponding parameter name or the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object.
 
-Arguments are always [_passed by value_](https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_reference) and never _passed by reference_. This means that if a function reassigns a parameter, the value won't change outside the function. More precisely, object arguments are [_passed by sharing_](https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing), which means if the object's properties are mutated, the change will impact the outside of the function. For example:
+Arguments are always [_passed by value_](https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_value) and never [_passed by reference_](https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_reference). This means that if a function reassigns a parameter, the value won't change outside the function. More precisely, object arguments are [_passed by sharing_](https://en.wikipedia.org/wiki/Evaluation_strategy#Call_by_sharing), which means if the object's properties are mutated, the change will impact the outside of the function. For example:
 
 ```js
 function updateBrand(obj) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. 🙌 -->

<!--
Add details below to help us review your pull request (PR).
Explain your changes and link to a related issue or pull request.
Your PR may be delayed or closed if you don't provide enough information.
-->

### Description

<!-- ✍️ Summarize your changes in one or two sentences. -->
This PR fixes an inaccurate link and adds a missing link to the [Passing arguments](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#passing_arguments) section of the Javascript Functions Reference.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
The "passed by value" link is incorrectly linking to the "passed by reference" section on Wikipedia, and the "passed by reference" text is not linked to it's section on Wikipedia.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->
- The "passed by sharing" link was accurate and remains unchanged, and
- This PR is 100% human generated.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->
No related issues or pull requests found.

<!-- 🔎 After submitting, the 'Checks' tab of your PR shows the build status. -->
