### PR TITLE
Hyphenate leftover object-oriented modifier

### DIFF
--- a/files/en-us/learn_web_development/extensions/advanced_javascript_objects/object-oriented_programming/index.md
+++ b/files/en-us/learn_web_development/extensions/advanced_javascript_objects/object-oriented_programming/index.md
@@ -236,7 +236,7 @@ That said, constructors and prototypes can be used to implement class-based OOP 
 
 ## Summary
 
-This article has described the basic features of class-based object oriented programming, and briefly looked at how JavaScript constructors and prototypes compare with these concepts.
+This article has described the basic features of class-based object-oriented programming, and briefly looked at how JavaScript constructors and prototypes compare with these concepts.
 
 In the next article, we'll look at the features JavaScript provides to support class-based object-oriented programming.
 


### PR DESCRIPTION
### Description

Hyphenates leftover \`object-oriented\` when it modifies a following noun.

- Object-oriented programming article: "class-based object oriented programming" → "object-oriented programming"

The OOCSS proper name is left alone.

### Motivation

Used before a noun this is a compound modifier and takes a hyphen, matching the leftover pattern of #45462 and #45463. The page slug already uses \`object-oriented_programming\`.