### PR TITLE
Hyphenate leftover high-level modifiers

### DIFF
--- a/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/express_nodejs/mongoose/index.md
@@ -116,7 +116,7 @@ In modern JavaScript callbacks have largely been replaced by [Promises](/en-US/d
 Promises are objects that are (immediately) returned by an asynchronous method that represent its future state.
 When the operation completes, the promise object is "settled", and resolves an object that represents the result of the operation or an error.
 
-There are two main ways you can use promises to run code when a promise is settled, and we highly recommend that you read [How to use promises](/en-US/docs/Learn_web_development/Extensions/Async_JS/Promises) for a high level overview of both approaches.
+There are two main ways you can use promises to run code when a promise is settled, and we highly recommend that you read [How to use promises](/en-US/docs/Learn_web_development/Extensions/Async_JS/Promises) for a high-level overview of both approaches.
 In this tutorial, we'll primarily be using [`await`](/en-US/docs/Web/JavaScript/Reference/Operators/await) to wait on promise completion within an [`async function`](/en-US/docs/Web/JavaScript/Reference/Statements/async_function), because this leads to more readable and understandable asynchronous code.
 
 The way this approach works is that you use the `async function` keyword to mark a function as asynchronous, and then inside that function apply `await` to any method that returns a promise.

--- a/files/en-us/learn_web_development/extensions/server-side/first_steps/web_frameworks/index.md
+++ b/files/en-us/learn_web_development/extensions/server-side/first_steps/web_frameworks/index.md
@@ -315,7 +315,7 @@ It can be used for small problems but its strength is building larger scale appl
 
 ## Summary
 
-This article has shown that web frameworks can make it easier to develop and maintain server-side code. It has also provided a high level overview of a few popular frameworks, and discussed criteria for choosing a web application framework. You should now have at least an idea of how to choose a web framework for your own server-side development. If not, then don't worry — later on in the course we'll give you detailed tutorials on Django and Express to give you some experience of actually working with a web framework.
+This article has shown that web frameworks can make it easier to develop and maintain server-side code. It has also provided a high-level overview of a few popular frameworks, and discussed criteria for choosing a web application framework. You should now have at least an idea of how to choose a web framework for your own server-side development. If not, then don't worry — later on in the course we'll give you detailed tutorials on Django and Express to give you some experience of actually working with a web framework.
 
 For the next article in this module we'll change direction slightly and consider web security.
 


### PR DESCRIPTION
### Description

Hyphenates leftover \`high-level\` modifiers in prose.

- Express/Mongoose tutorial: "a high level overview"
- Web frameworks article: "a high level overview"

\`## High level overview\` headings are left alone so their anchors do not change.

### Motivation

Used before a noun this is a compound modifier and takes a hyphen, matching the leftover pattern of #45462 and #45463.