### PR TITLE
Use e.g. and i.e. in leftover Firefox release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/106/index.md
+++ b/files/en-us/mozilla/firefox/releases/106/index.md
@@ -53,7 +53,7 @@ No notable changes.
 
 - Added support for `wheel` input source for [Actions](https://w3c.github.io/webdriver/webdriver-spec.html#actions), which is associated with a wheel-type input device ([Firefox bug 1746601](https://bugzil.la/1746601)).
 
-- Added support for opening and closing tabs in GeckoView based applications (eg. Firefox for Android) ([Firefox bug 1506782](https://bugzil.la/1506782)).
+- Added support for opening and closing tabs in GeckoView based applications (e.g., Firefox for Android) ([Firefox bug 1506782](https://bugzil.la/1506782)).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/107/index.md
+++ b/files/en-us/mozilla/firefox/releases/107/index.md
@@ -44,7 +44,7 @@ No notable changes
 
 - Added Realm support to `target` argument for `script.evaluate`, `script.callFunction`, and `script.disown` commands ([Firefox bug 1779231](https://bugzil.la/1779231)).
 
-- Added support for JSON serialization of complex objects with container value fields, eg. `WeakMap` and `Uint8Array` ([Firefox bug 1770754](https://bugzil.la/1770754)).
+- Added support for JSON serialization of complex objects with container value fields, e.g., `WeakMap` and `Uint8Array` ([Firefox bug 1770754](https://bugzil.la/1770754)).
 
 - Added support for the `context` parameter of the `browsingContext.create` command, which allows opening a new tab related to an existing one ([Firefox bug 1765619](https://bugzil.la/1765619)).
 

--- a/files/en-us/mozilla/firefox/releases/141/index.md
+++ b/files/en-us/mozilla/firefox/releases/141/index.md
@@ -57,7 +57,7 @@ Firefox 141 was released on [July 22, 2025](https://whattrainisitnow.com/release
 
 #### WebDriver BiDi
 
-- Added support for the "proxy" argument of the `browser.createUserContext` command. This allows clients to set up either a "direct" or "manual" proxy when creating a user context (ie Firefox Container). Support for additional proxy types will be added later on ([Firefox bug 1967653](https://bugzil.la/1967653)).
+- Added support for the "proxy" argument of the `browser.createUserContext` command. This allows clients to set up either a "direct" or "manual" proxy when creating a user context (i.e., Firefox Container). Support for additional proxy types will be added later on ([Firefox bug 1967653](https://bugzil.la/1967653)).
 - Implemented the new `browsingContext.historyUpdated` event which is emitted when `history.pushState()`, `history.replaceState()` or `document.open()` is called within the context of a web page ([Firefox bug 1906051](https://bugzil.la/1906051)).
 - Improved the error message shown when attempting to permanently install an unpacked, unsigned web extension ([Firefox bug 1958723](https://bugzil.la/1958723)).
 - Updated the `browsingContext.navigate` and `browsingContext.reload` commands to wait for the `browsingContext.navigationCommitted` event when using the "wait" condition "none" ([Firefox bug 1967469](https://bugzil.la/1967469)).


### PR DESCRIPTION
### Description

Fixes leftover Latin abbreviations in three Firefox release notes.

- Firefox 106: "(eg. Firefox for Android)" → "(e.g., Firefox for Android)"
- Firefox 107: "eg. \`WeakMap\`" → "e.g., \`WeakMap\`"
- Firefox 141: "(ie Firefox Container)" → "(i.e., Firefox Container)"

### Motivation

The writing style guide uses periods and a following comma: \`e.g.,\` and \`i.e.,\`. Same family as #45511 for \`etc.\`