### PR TITLE
Hyphenate leftover user-defined modifiers

### DIFF
--- a/files/en-us/web/api/file_system_api/index.md
+++ b/files/en-us/web/api/file_system_api/index.md
@@ -186,7 +186,7 @@ async function returnPathDirectories(directoryHandle) {
 
 The following asynchronous function opens the save file picker, which returns a {{domxref('FileSystemFileHandle')}} once a file is selected. A writable stream is then created using the {{domxref('FileSystemFileHandle.createWritable()')}} method.
 
-A user defined {{domxref('Blob')}} is then written to the stream which is subsequently closed.
+A user-defined {{domxref('Blob')}} is then written to the stream which is subsequently closed.
 
 ```js
 async function saveFile() {

--- a/files/en-us/web/css/reference/at-rules/@font-palette-values/index.md
+++ b/files/en-us/web/css/reference/at-rules/@font-palette-values/index.md
@@ -20,7 +20,7 @@ The **`@font-palette-values`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/
 }
 ```
 
-The [&lt;dashed-ident&gt;](/en-US/docs/Web/CSS/Reference/Values/dashed-ident) is a user defined identifier, that while it looks like a [CSS custom property](/en-US/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties) behaves in a different way and is not wrapped in a [CSS var() function](/en-US/docs/Web/CSS/Reference/Values/var).
+The [&lt;dashed-ident&gt;](/en-US/docs/Web/CSS/Reference/Values/dashed-ident) is a user-defined identifier, that while it looks like a [CSS custom property](/en-US/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties) behaves in a different way and is not wrapped in a [CSS var() function](/en-US/docs/Web/CSS/Reference/Values/var).
 
 ### Descriptors
 

--- a/files/en-us/web/css/reference/at-rules/@page/index.md
+++ b/files/en-us/web/css/reference/at-rules/@page/index.md
@@ -141,7 +141,7 @@ The @page rule defines properties of the page box. The `@page` at-rule can be ac
 The `@page` at-rule, allows the user to assign a name to the rule, which is then called in a declaration using the `page` property.
 
 - {{Cssxref("page")}}
-  - : Allows a selector to use a user defined **named page**
+  - : Allows a selector to use a user-defined **named page**
 
 ## Formal syntax
 

--- a/files/en-us/web/css/reference/values/env/index.md
+++ b/files/en-us/web/css/reference/values/env/index.md
@@ -49,7 +49,7 @@ The `env( <environment-variable> | <dashed-ident>, <fallback> | <declaration-val
       - : The dimensions and offset positions of specific viewport segments. The `viewport-segment-*` keyword is followed by two space-separated {{cssxref("&lt;integer>")}} values that indicate the segment's horizontal and vertical position, or indices. The viewport-segment keywords are only defined when the viewport is made up of two or more segments, as with foldable or hinged devices.
 
 - [`<dashed-ident>`](/en-US/docs/Web/CSS/Reference/Values/dashed-ident)
-  - : A `<dashed-ident>` is a user defined variable that can be used as an identifier in the {{cssxref("param")}} CSS function to update the value.
+  - : A `<dashed-ident>` is a user-defined variable that can be used as an identifier in the {{cssxref("param")}} CSS function to update the value.
 
 - `<fallback>` {{optional_inline}}
   - : A fallback value to be inserted if the environment variable referenced in the first argument does not exist. Everything after the first comma is deemed to be the fallback value. This can be a single value, another `env()` function, or a comma-separated list of values.

--- a/files/en-us/web/css/reference/values/param/index.md
+++ b/files/en-us/web/css/reference/values/param/index.md
@@ -28,7 +28,7 @@ param(--color3, green);
 ## Values
 
 - [`<dashed-ident>`](/en-US/docs/Web/CSS/Reference/Values/dashed-ident)
-  - : A `<dashed-ident>` is a user defined variable that is used as an identifier in the {{cssxref("env")}} CSS function to update the value.
+  - : A `<dashed-ident>` is a user-defined variable that is used as an identifier in the {{cssxref("env")}} CSS function to update the value.
 
 - `<declaration_value>` {{optional_inline}}
   - : A `<declaration_value>` is the value of the attribute being updated. If the `<declaration-value>` is omitted, it represents an empty value.


### PR DESCRIPTION
### Description

Hyphenates leftover \`user-defined\` modifiers (\`Blob\`, \`identifier\`, \`variable\`, \`named page\`).

Headings such as \`### User defined disposables\` and \`// Display the user defined video controls\` comments are left alone.

### Motivation

#45462 already hyphenated \`user-defined\` when it modifies a following noun. These leftovers were missed.