### PR TITLE
Hyphenate leftover user-provided modifiers

### DIFF
--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -65,7 +65,7 @@ You can mitigate these issues by always assigning {{domxref("TrustedHTML")}} obj
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup before it is injected.
 
 > [!NOTE]
-> {{domxref("Node.textContent")}} should be used when you know that the user provided content should be plain text.
+> {{domxref("Node.textContent")}} should be used when you know that the user-provided content should be plain text.
 > This prevents it being parsed as HTML.
 
 ## Examples

--- a/files/en-us/web/api/element/insertadjacenthtml/index.md
+++ b/files/en-us/web/api/element/insertadjacenthtml/index.md
@@ -81,7 +81,7 @@ The method does not perform any sanitization to remove XSS-unsafe elements such 
 When inserting HTML into a page using `insertAdjacentHTML()`, you should pass {{domxref("TrustedHTML")}} objects instead of strings, and [enforce trusted types](/en-US/docs/Web/API/Trusted_Types_API#using_a_csp_to_enforce_trusted_types) using the [`require-trusted-types-for`](/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/require-trusted-types-for) CSP directive.
 This ensures that the input is passed through a transformation function, which has the chance to [sanitize](/en-US/docs/Web/Security/Attacks/XSS#sanitization) the input to remove potentially dangerous markup before it is injected.
 
-The {{domxref("Element.insertAdjacentText()")}} method or {{domxref("Node.textContent")}} should be used when you know that the user provided content should be plain text.
+The {{domxref("Element.insertAdjacentText()")}} method or {{domxref("Node.textContent")}} should be used when you know that the user-provided content should be plain text.
 This inserts the input as raw text instead of parsing it as HTML.
 
 ## Examples


### PR DESCRIPTION
### Description

Hyphenates leftover \`user-provided\` modifiers on \`innerHTML\` and \`insertAdjacentHTML\`: "the user provided content" → "the user-provided content".

WCAG "content the user provided to the website" is a verb and is left alone.

### Motivation

#45462 already hyphenated \`user-provided\` when it modifies a following noun. These leftovers were missed.