### PR TITLE
Hyphenate leftover out-of-date modifier

### DIFF
--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -168,7 +168,7 @@ In addition, if a WebRTC error occurs while configuring or accessing the media, 
 
 It's important to keep in mind that you can't create the `parameters` object yourself and expect it to work.
 Instead, you _must_ first call {{domxref("RTCRtpSender.getParameters", "getParameters()")}}, modify the received parameters object, then pass that object into `setParameters()`.
-WebRTC uses the parameters object's `transactionId` property to ensure that when you set parameters, your changes are based on the most recent parameters rather than an out of date configuration.
+WebRTC uses the parameters object's `transactionId` property to ensure that when you set parameters, your changes are based on the most recent parameters rather than an out-of-date configuration.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Hyphenates leftover \`out-of-date\` as a modifier on \`RTCRtpSender.setParameters()\`: "an out of date configuration" → "an out-of-date configuration".

Predicative uses such as "is out of date" are left alone.

### Motivation

Used before a noun this is a compound modifier and takes a hyphen.