### PR TITLE
Clarify constructed stylesheet wording in adoptedStyleSheets intro

### DIFF
--- a/files/en-us/web/api/document/adoptedstylesheets/index.md
+++ b/files/en-us/web/api/document/adoptedstylesheets/index.md
@@ -19,7 +19,7 @@ Changing an adopted stylesheet will affect all the objects that adopt it.
 Stylesheets in the property are evaluated along with the document's other stylesheets using the [CSS cascade algorithm](/en-US/docs/Web/CSS/Guides/Cascade/Introduction).
 Where the resolution of rules considers stylesheet order, `adoptedStyleSheets` are assumed to be ordered after those in [`Document.styleSheets`](/en-US/docs/Web/API/Document/styleSheets).
 
-Only stylesheets created using the [`CSSStyleSheet()` constructor](/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) within the context of the current {{domxref("Document")}} may be adopted.
+Only _constructed stylesheets_ within the context of the current {{domxref("Document")}} may be adopted. You may create constructed stylesheets using the [`CSSStyleSheet()` constructor](/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) or import them as CSS modules.
 
 ## Value
 


### PR DESCRIPTION
### Description

Clarifies the intro paragraph on the `Document.adoptedStyleSheets` page so it's clear that any constructed stylesheet may be adopted, not only ones created directly with the `CSSStyleSheet()` constructor.

### Motivation

The previous wording said only stylesheets "created using the `CSSStyleSheet()` constructor" may be adopted, which reads as excluding constructed stylesheets obtained other ways (e.g. imported as CSS modules), even though those are also constructed stylesheets and are adoptable. Maintainer @Josh-Cena confirmed the page was technically correct but confusing and suggested the replacement wording used here.

### Additional details

_No response_

### Related issues and pull requests

Fixes #45668

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhNBS7g5CdZsp5sg6NrUzw